### PR TITLE
Fix getFunctionLogs orderBy parameter with proper enum validation

### DIFF
--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -334,8 +334,8 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           name: z.string().describe("函数名称"),
           offset: z.number().optional().describe("偏移量"),
           limit: z.number().optional().describe("返回数量"),
-          order: z.string().optional().describe("排序方式"),
-          orderBy: z.string().optional().describe("排序字段"),
+          order: z.enum(["desc", "asc"]).optional().describe("排序方式: desc=降序, asc=升序"),
+          orderBy: z.enum(["function_name", "duration", "mem_usage", "start_time"]).optional().describe("排序字段: function_name=函数名, duration=执行时长, mem_usage=内存使用, start_time=开始时间"),
           startTime: z.string().optional().describe("开始时间"),
           endTime: z.string().optional().describe("结束时间"),
           requestId: z.string().optional().describe("请求ID")

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1086,11 +1086,13 @@
               },
               "order": {
                 "type": "string",
-                "description": "排序方式"
+                "enum": ["desc", "asc"],
+                "description": "排序方式: desc=降序, asc=升序"
               },
               "orderBy": {
                 "type": "string",
-                "description": "排序字段"
+                "enum": ["function_name", "duration", "mem_usage", "start_time"],
+                "description": "排序字段: function_name=函数名, duration=执行时长, mem_usage=内存使用, start_time=开始时间"
               },
               "startTime": {
                 "type": "string",


### PR DESCRIPTION
Fix getFunctionLogs orderBy parameter with proper enum validation

- Update TypeScript implementation to use enum validation for order and orderBy fields
- Add enum constraints to JSON schema for type safety
- orderBy now only accepts: function_name, duration, mem_usage, start_time
- order now only accepts: desc, asc
- Enhanced field descriptions with explanations
- Prevents API errors like "OrderBy取值与规范不符" when using invalid values like "RequestTime"

Fixes #64

🤖 Generated with [Claude Code](https://claude.ai/code)