### PR TITLE
docs: fix node version

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -65,9 +65,9 @@ Visit [Tencent CloudBase Console](https://tcb.cloud.tencent.com/dev) to create a
 </details>
 
 <details>
-<summary>Install Node.js v18 or Higher</summary>
+<summary>Install Node.js v18.15.0 or Higher</summary>
 
-Make sure Node.js v18 or higher is installed on your computer. You can download and install the latest version from [Node.js official website](https://nodejs.org/).
+Make sure Node.js v18.15.0 or higher is installed on your computer. You can download and install the latest version from [Node.js official website](https://nodejs.org/).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@
 </details>
 
 <details>
-<summary>安装 Node.js v18及以上版本</summary>
+<summary>安装 Node.js v18.15.0及以上版本</summary>
 
-确保您的计算机上安装了 Node.js v18 及以上版本。您可以从 [Node.js 官网](https://nodejs.org/) 下载并安装最新版本。
+确保您的计算机上安装了 Node.js v18.15.0 及以上版本。您可以从 [Node.js 官网](https://nodejs.org/) 下载并安装最新版本。
 
 </details>
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -101,10 +101,19 @@ npm i @cloudbase/cloudbase-mcp@latest -g
 如果在 AI 开发工具的 MCP 列表中看到 cloudbase-mcp 显示工具数量为 0，可以按以下步骤排查：
 
 **1. 检查环境配置**
-- 确保 Node.js 版本为 v18 及以上
+- 确保 Node.js 版本为 v18.15.0 及以上
+- macOS 用户且使用 nvm 管理 Node.js 的，请务必设置默认 Node 版本为 v18.15.0 及以上，避免不同终端版本不一致导致的问题。
+  设置默认版本命令示例：
+  ```bash
+  nvm alias default 18.15.0
+  ```
 - 检查网络连接，建议设置 npm 源为腾讯镜像源：
   ```bash
   npm config set registry https://mirrors.cloud.tencent.com/npm/
+  ```
+- 输入如下命令测试，若无异常报错则为正常启动服务
+  ```bash
+  npx @cloudbase/cloudbase-mcp@latest
   ```
 
 **2. 清理缓存**

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -66,9 +66,9 @@
 ### 前置条件检查
 
 <details>
-<summary>✅ Node.js v18+ 已安装</summary>
+<summary>✅ Node.js v18.15.0+ 已安装</summary>
 
-确保您的计算机上安装了 Node.js v18 及以上版本。检查版本：
+确保您的计算机上安装了 Node.js v18.15.0 及以上版本。检查版本：
 ```bash
 node --version
 ```

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -73,9 +73,9 @@
 </details>
 
 <details>
-<summary>安装 Node.js v18及以上版本</summary>
+<summary>安装 Node.js v18.15.0及以上版本</summary>
 
-确保您的计算机上安装了 Node.js v18 及以上版本。您可以从 [Node.js 官网](https://nodejs.org/) 下载并安装最新版本。
+确保您的计算机上安装了 Node.js v18.15.0 及以上版本。您可以从 [Node.js 官网](https://nodejs.org/) 下载并安装最新版本。
 
 </details>
 


### PR DESCRIPTION
使用mcp server开发过程中，发现node版本不符合要求会影响mcp工具的npx @cloudbase/cloudbase-mcp@latest 启动，原文档表述不严谨，故容易造成误解，尤其是mac用户需注意nvm的node配置