### PR TITLE
feat(miniprogram): 🛠️ 添加微信开发者工具 CLI 打开项目规则

### DIFF
--- a/config/.augment-guidelines
+++ b/config/.augment-guidelines
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.clinerules/cloudbase-rules.mdc
+++ b/config/.clinerules/cloudbase-rules.mdc
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.comate/rules/cloudbase-rules.mdr
+++ b/config/.comate/rules/cloudbase-rules.mdr
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.cursor/rules/cloudbase-rules.mdc
+++ b/config/.cursor/rules/cloudbase-rules.mdc
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.gemini/GEMINI.md
+++ b/config/.gemini/GEMINI.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.github/copilot-instructions.md
+++ b/config/.github/copilot-instructions.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.lingma/rules/cloudbaase-rules.md
+++ b/config/.lingma/rules/cloudbaase-rules.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.qwen/QWEN.md
+++ b/config/.qwen/QWEN.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.roo/rules/cloudbaase-rules.md
+++ b/config/.roo/rules/cloudbaase-rules.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.rules/cloudbase-rules.md
+++ b/config/.rules/cloudbase-rules.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.trae/rules/cloudbase-rules.md
+++ b/config/.trae/rules/cloudbase-rules.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/.windsurf/rules/cloudbase-rules.md
+++ b/config/.windsurf/rules/cloudbase-rules.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -1,5 +1,5 @@
 ---
-cloudbaseAIVersion：1.8.22
+cloudbaseAIVersion：1.8.26
 description: CloudBase AI 开发规则索引 - 防止不同开发场景的规则互相干扰
 globs: *
 alwaysApply: true
@@ -75,6 +75,7 @@ alwaysApply: true
 ### rules/miniprogram-development.mdc  
 描述微信小程序开发的专业规则，包含：
 - 小程序项目结构和配置
+- 微信开发者工具 CLI 打开项目方法
 - 微信云开发能力集成
 - 小程序特有的 API 和权限处理
 - 适用于微信小程序开发时参考

--- a/config/rules/miniprogram-development.mdc
+++ b/config/rules/miniprogram-development.mdc
@@ -11,6 +11,14 @@ alwaysApply: false
 2. 小程序的项目遵循微信云开发的最佳实践，小程序一般在 miniprogram目录下，如果要开发云函数，则可以存放在 cloudfunctions 目录下，小程序的 project.config.json 需要指定miniprogramRoot这些
 3. 生成小程序页面的时候，必须包含页面的配置文件例如index.json等，要符合规范，避免编译出错
 
+## 开发工具
+**微信开发者工具 CLI 打开项目**：
+- 当检测到当前项目为小程序项目时，建议用户使用微信开发者工具进行预览调试和发布
+- 使用 CLI 命令打开项目（指向 project.config.json 所在目录）：
+  - Windows: `"C:\Program Files (x86)\Tencent\微信web开发者工具\cli.bat" open --project "项目根目录路径"`
+  - macOS: `/Applications/wechatwebdevtools.app/Contents/MacOS/cli open --project "/path/to/project/root"`
+- 项目根目录路径为包含 project.config.json 文件的目录
+
 ## 云开发集成
 1. 小程序 wx.cloud 的时候，需要指定环境 Id，环境 id 可以通过 envQuery 工具来查询
 2. 生成小程序代码的时候，如果需要用到素材图片，比如 tabbar 的 iconPath 等地方，可以从 unsplash 通过 url 来下载，可以参考工作流程中的下载远程资源流程，在生成小程序代码的时候，如果用到了iconPath 这些，必须同时帮用户下载图标，避免构建报错
@@ -59,3 +67,8 @@ for await (let str of res.textStream) {
 - 建议用户在微信开发者工具中右键选择云函数，选择"云端安装依赖"
 - 对于需要云调用权限的函数（如微信步数解密），建议通过开发者工具手动部署一次以获取完整权限
 - 如遇到权限问题，提示用户检查云函数的服务授权和API权限配置
+
+## 开发流程指导
+- 当完成小程序项目开发后，主动建议用户使用微信开发者工具进行预览调试和发布
+- 如果用户同意，使用 CLI 命令打开微信开发者工具，指向 project.config.json 所在的项目根目录
+- 提醒用户在微信开发者工具中进行真机预览、调试和发布操作


### PR DESCRIPTION
## 功能描述

为小程序开发规则添加微信开发者工具 CLI 打开项目功能，提升开发体验。

## 主要变更

### ✨ 新增功能
- 在小程序开发规则中添加微信开发者工具 CLI 调用方法
- 支持 Windows 和 macOS 平台的 CLI 命令格式
- 明确指向 project.config.json 所在的项目根目录

### 📝 规则优化
- 更新规则索引描述，明确包含 CLI 打开项目方法
- 添加开发流程指导，AI 完成小程序开发后主动建议用户使用微信开发者工具
- 提供完整的操作流程：检测 → 建议 → 执行 → 提醒

### 🔧 技术细节
- Windows: `"C:\Program Files (x86)\Tencent\微信web开发者工具\cli.bat" open --project "项目根目录路径"`
- macOS: `/Applications/wechatwebdevtools.app/Contents/MacOS/cli open --project "/path/to/project/root"`

## 使用场景
当 AI 完成小程序项目开发后，会主动建议用户使用微信开发者工具进行预览调试和发布，如果用户同意，则使用 CLI 命令打开项目。

## 测试
- [x] 硬链接同步验证
- [x] 规则索引更新验证
- [x] 多平台 CLI 命令格式验证