### PR TITLE
fix(cloudrun): 🔧 align CloudRun schema with Manager SDK interface

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbase/cloudbase-mcp",
-  "version": "1.8.42",
+  "version": "1.8.43",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbase/cloudbase-mcp",
-      "version": "1.8.42",
+      "version": "1.8.43",
       "license": "MIT",
       "dependencies": {
         "@cloudbase/cals": "^1.2.18-alpha.1",

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cloudbase/cloudbase-mcp",
-  "version": "1.8.43",
+  "version": "1.8.44",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@cloudbase/cloudbase-mcp",
-      "version": "1.8.43",
+      "version": "1.8.44",
       "license": "MIT",
       "dependencies": {
         "@cloudbase/cals": "^1.2.18-alpha.1",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbase/cloudbase-mcp",
-  "version": "1.8.43",
+  "version": "1.8.44",
   "description": "腾讯云开发 MCP Server，通过AI提示词和MCP协议+云开发，让开发更智能、更高效,当你在Cursor/ VSCode GitHub Copilot/WinSurf/CodeBuddy/Augment Code/Claude Code等AI编程工具里写代码时，它能自动帮你生成可直接部署的前后端应用+小程序，并一键发布到腾讯云开发 CloudBase。",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbase/cloudbase-mcp",
-  "version": "1.8.42",
+  "version": "1.8.43",
   "description": "腾讯云开发 MCP Server，通过AI提示词和MCP协议+云开发，让开发更智能、更高效,当你在Cursor/ VSCode GitHub Copilot/WinSurf/CodeBuddy/Augment Code/Claude Code等AI编程工具里写代码时，它能自动帮你生成可直接部署的前后端应用+小程序，并一键发布到腾讯云开发 CloudBase。",
   "main": "./dist/index.cjs",
   "module": "./dist/index.js",

--- a/tests/cloudrun.test.js
+++ b/tests/cloudrun.test.js
@@ -1,9 +1,9 @@
 // CloudRun plugin integration tests
-import { test, expect, describe, beforeAll, afterAll } from 'vitest';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
-import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+import { afterAll, beforeAll, describe, expect, test } from 'vitest';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -350,7 +350,7 @@ describe('CloudRun Plugin Unit Tests', () => {
       Mem: 1,
       MinNum: 1,
       MaxNum: 10,
-      OpenAccessTypes: ['WEB'],
+      OpenAccessTypes: ['PUBLIC'],
       Port: 3000,
       EntryPoint: 'index.js',
       EnvParams: { NODE_ENV: 'production' }
@@ -373,7 +373,7 @@ describe('CloudRun Plugin Unit Tests', () => {
 
   test('CloudRun service types are correctly defined', () => {
     const expectedServiceTypes = ['function', 'container'];
-    const expectedAccessTypes = ['WEB', 'VPC', 'PRIVATE'];
+    const expectedAccessTypes = ['OA', 'PUBLIC', 'MINIAPP', 'VPC'];
 
     expectedServiceTypes.forEach(type => {
       expect(typeof type).toBe('string');


### PR DESCRIPTION
## 🔧 CloudRun Schema 修复

This PR aligns the CloudRun tool schema with the Manager SDK interface specification.

### 🛠️ 修复内容

#### 1. 访问类型更新
- 更新 CLOUDRUN_ACCESS_TYPES 从旧的访问类型到新的访问类型
- 更新相关描述和测试用例

#### 2. 字段类型修正
- PolicyDetails: 添加完整的扩缩容配置数组类型
- EnvParams: 从 Record 改为 string (JSON字符串格式)
- InternalAccess: 从 boolean 改为 string
- EntryPoint/Cmd: 从 string 改为 string[] 数组

#### 3. 新增字段
- InternalDomain: 内网域名配置
- CustomLogs: 自定义日志配置

#### 4. 部署参数修复
- 修复 serverConfig 参数传递方式

### 📁 文件变更
- mcp/src/tools/cloudrun.ts - 主要 schema 修复
- tests/cloudrun.test.js - 测试用例更新
- mcp/package.json & mcp/package-lock.json - 依赖更新

### ✅ 验证结果
- 所有字段类型现在与 Manager SDK 接口完全匹配
- 代码语法检查通过，无 linter 错误
- 测试用例已更新以反映新的访问类型值

### 🎯 影响
- 确保 CloudRun 部署功能能够正确传递服务配置参数
- 避免因类型不匹配导致的部署失败
- 提升开发体验和 API 一致性