### PR TITLE
feat(env): 🚀 skip prompt message for CodeBuddy IDE and unify IDE detection logic

### DIFF
--- a/mcp/src/interactive-server.ts
+++ b/mcp/src/interactive-server.ts
@@ -6,8 +6,9 @@ import { debug, error, info, warn } from './utils/logger.js';
 
 // 动态导入 open 模块，兼容 ESM/CJS 环境
 async function openUrl(url: string, options?: any, server?: any) {
-  // 检查是否为 CodeBuddy IDE
-  if (process.env.INTEGRATION_IDE === 'CodeBuddy' && server) {
+  // 检查是否为 CodeBuddy IDE (优先使用 server.ide，回退到环境变量)
+  const currentIde = server?.ide || process.env.INTEGRATION_IDE;
+  if (currentIde === 'CodeBuddy' && server) {
     try {
       // 发送通知而不是直接打开网页
       server.server.sendLoggingMessage({ 

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -44,13 +44,16 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         }
 
         if (selectedEnvId) {
-          // Get CLAUDE.md prompt content
+          // Get CLAUDE.md prompt content (skip for CodeBuddy IDE)
           let promptContent = "";
-          try {
-            promptContent = await getClaudePrompt();
-          } catch (promptError) {
-            debug("Failed to get CLAUDE prompt", { error: promptError });
-            // Continue with login success even if prompt fetch fails
+          const currentIde = server.ide || process.env.INTEGRATION_IDE;
+          if (currentIde !== "CodeBuddy") {
+            try {
+              promptContent = await getClaudePrompt();
+            } catch (promptError) {
+              debug("Failed to get CLAUDE prompt", { error: promptError });
+              // Continue with login success even if prompt fetch fails
+            }
           }
 
           const successMessage = `✅ 登录成功，当前环境: ${selectedEnvId}`;
@@ -198,8 +201,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
 
         let responseText = JSON.stringify(result, null, 2);
 
-        // For info action, append CLAUDE.md prompt content
-        if (action === "info") {
+        // For info action, append CLAUDE.md prompt content (skip for CodeBuddy IDE)
+        const currentIde = server.ide || process.env.INTEGRATION_IDE;
+        if (action === "info" && currentIde !== "CodeBuddy") {
           try {
             const promptContent = await getClaudePrompt();
             if (promptContent) {

--- a/mcp/src/tools/rag.ts
+++ b/mcp/src/tools/rag.ts
@@ -42,7 +42,7 @@ function safeStringify(obj: any) {
 }
 
 // Download and extract web template, return extract directory path
-// Implements caching: only downloads if extractDir doesn't exist
+// Always downloads and overwrites existing template
 export async function downloadWebTemplate(): Promise<string> {
   const baseDir = path.join(os.homedir(), ".cloudbase-mcp");
   const zipPath = path.join(baseDir, "web-cloudbase-project.zip");
@@ -51,17 +51,6 @@ export async function downloadWebTemplate(): Promise<string> {
     "https://static.cloudbase.net/cloudbase-examples/web-cloudbase-project.zip";
 
   await fs.mkdir(baseDir, { recursive: true });
-
-  // Check if extractDir already exists (cache hit)
-  try {
-    const stats = await fs.stat(extractDir);
-    if (stats.isDirectory()) {
-      // Directory exists, return it directly (use cache)
-      return extractDir;
-    }
-  } catch (error) {
-    // Directory doesn't exist, proceed with download
-  }
 
   // Download zip to specified path (overwrite)
   const response = await fetch(url);


### PR DESCRIPTION
## Changes

- Skip CLAUDE.md prompt content for CodeBuddy IDE in login and envQuery tools
- Unify IDE detection to use server.ide with fallback to INTEGRATION_IDE env var
- Remove template caching mechanism to always fetch latest template

## Related Files
- `mcp/src/tools/env.ts` - CodeBuddy prompt skip logic
- `mcp/src/interactive-server.ts` - Unified IDE detection
- `mcp/src/tools/rag.ts` - Template cache removal