### PR TITLE
feat(brand): 🎨 Unify brand name to CloudBase MCP

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -2,7 +2,7 @@
 
 ![](scripts/assets/toolkit-better.gif)
 
-<h1>CloudBase AI ToolKit</h1>
+<h1>CloudBase MCP</h1>
 
 **🪐 Go from AI prompt to live app in one click**<br/>
 The bridge that connects your AI IDE (Cursor, Copilot, etc.) directly to Tencent CloudBase
@@ -35,13 +35,13 @@ The bridge that connects your AI IDE (Cursor, Copilot, etc.) directly to Tencent
 
 </div>
 
-## Why You Need CloudBase AI ToolKit
+## Why You Need CloudBase MCP
 
 AI programming tools (like Cursor, Copilot) solve the **code generation** challenge.
 
 However, there's still a gap between "generating code" and "application going live" (deployment, database configuration, CDN, domain setup).
 
-**CloudBase AI ToolKit bridges this gap.**
+**CloudBase MCP** (formerly CloudBase AI ToolKit) bridges this gap.
 
 You no longer need:
 - ❌ Complex DevOps configuration and YAML files
@@ -405,7 +405,7 @@ When an app has issues, AI automatically views logs, analyzes errors, and genera
 
 ## Contributors
 
-Thanks to all the developers who have contributed to CloudBase AI ToolKit!
+Thanks to all the developers who have contributed to CloudBase MCP!
 
 [![Contributors](https://contrib.rocks/image?repo=TencentCloudBase/CloudBase-AI-ToolKit)](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/graphs/contributors)
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -2,7 +2,7 @@
 
 ![](scripts/assets/toolkit-better.gif)
 
-<h1>CloudBase AI ToolKit</h1>
+<h1>CloudBase MCP</h1>
 
 **🪐 AI 编程，一键上线**<br/>
 连接 AI IDE 与腾讯云 CloudBase 的部署桥梁，让你的 AI 应用即刻上线
@@ -35,13 +35,13 @@
 
 </div>
 
-## 为什么你需要 CloudBase AI ToolKit？
+## 为什么你需要 CloudBase MCP？
 
 AI 编程工具（如 Cursor、Copilot）解决了**代码生成**的难题。
 
 但是，从"生成代码"到"应用上线"（部署、配置数据库、CDN、域名），依然存在一条鸿沟。
 
-**CloudBase AI ToolKit 填补了这条鸿沟。**
+**CloudBase MCP**（原 CloudBase AI ToolKit）填补了这条鸿沟。
 
 你不再需要：
 - ❌ 繁琐的 DevOps 配置和 YAML 文件
@@ -405,7 +405,7 @@ CodeBuddy 已内置 CloudBase MCP，无需配置即可使用。
 
 ## Contributors
 
-感谢所有为 CloudBase AI ToolKit 做出贡献的开发者！
+感谢所有为 CloudBase MCP 做出贡献的开发者！
 
 [![Contributors](https://contrib.rocks/image?repo=TencentCloudBase/CloudBase-AI-ToolKit)](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/graphs/contributors)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![](scripts/assets/toolkit-better.gif)
 
-<h1>CloudBase AI ToolKit</h1>
+<h1>CloudBase MCP</h1>
 
 **🪐 AI 编程，一键上线**<br/>
 连接 AI IDE 与腾讯云 CloudBase 的部署桥梁，让你的 AI 应用即刻上线
@@ -35,13 +35,13 @@
 
 </div>
 
-## 为什么你需要 CloudBase AI ToolKit？
+## 为什么你需要 CloudBase MCP？
 
 AI 编程工具（如 Cursor、Copilot）解决了**代码生成**的难题。
 
 但是，从"生成代码"到"应用上线"（部署、配置数据库、CDN、域名），依然存在一条鸿沟。
 
-**CloudBase AI ToolKit 填补了这条鸿沟。**
+**CloudBase MCP**（原 CloudBase AI ToolKit）填补了这条鸿沟。
 
 你不再需要：
 - ❌ 繁琐的 DevOps 配置和 YAML 文件
@@ -405,7 +405,7 @@ CodeBuddy 已内置 CloudBase MCP，无需配置即可使用。
 
 ## Contributors
 
-感谢所有为 CloudBase AI ToolKit 做出贡献的开发者！
+感谢所有为 CloudBase MCP 做出贡献的开发者！
 
 [![Contributors](https://contrib.rocks/image?repo=TencentCloudBase/CloudBase-AI-ToolKit)](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/graphs/contributors)
 


### PR DESCRIPTION
## Changes

- Update main title from CloudBase AI ToolKit to CloudBase MCP
- Keep CloudBase AI ToolKit as reference in description for compatibility
- Optimize brand consistency across README files (ZH, EN, default)
- Improve brand clarity and searchability

## Benefits

- Better searchability with 'CloudBase MCP' keyword
- Direct alignment with competitor naming (Supabase MCP)
- Clearer brand positioning in MCP ecosystem
- Maintains compatibility with existing references