### PR TITLE
docs(install): 🧹 Remove curl and PowerShell install scripts, keep npm only

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -85,10 +85,6 @@ In AI IDEs that support MCP (Cursor, WindSurf, CodeBuddy, etc.), just add one li
 > One-click installation, automatic configuration, supports multiple AI programming tools:
 > 
 > ```bash
-> # Mac/Linux/WSL
-> curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-> 
-> # Windows PowerShell
 > npm install @cloudbase/cli@latest -g
 > ```
 > 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -85,10 +85,6 @@ AI 编程工具（如 Cursor、Copilot）解决了**代码生成**的难题。
 > 一键安装，自动配置，支持多种 AI 编程工具：
 > 
 > ```bash
-> # Mac/Linux/WSL
-> curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-> 
-> # Windows PowerShell
 > npm install @cloudbase/cli@latest -g
 > ```
 > 

--- a/README.md
+++ b/README.md
@@ -85,10 +85,6 @@ AI 编程工具（如 Cursor、Copilot）解决了**代码生成**的难题。
 > 一键安装，自动配置，支持多种 AI 编程工具：
 > 
 > ```bash
-> # Mac/Linux/WSL
-> curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-> 
-> # Windows PowerShell
 > npm install @cloudbase/cli@latest -g
 > ```
 > 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -125,16 +125,10 @@ AI 会自动下载并更新最新的规则配置到你的项目目录。
 
 #### 快速安装步骤
 
-**1. 使用一键安装脚本**
+**1. 使用 npm 安装**
 
-Mac/Linux/Windows WSL 用户：
 ```bash
-curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-```
-
-Windows PowerShell 用户：
-```powershell
-irm https://static.cloudbase.net/cli/install/install.ps1 | iex
+npm install @cloudbase/cli@latest -g
 ```
 
 **2. 验证安装**
@@ -224,10 +218,8 @@ CloudBase AI CLI 支持通过环境变量进行无浏览器授权，完美解决
 
 #### 安装 CloudBase AI CLI
 
-使用 CloudBase AI CLI 的快速安装脚本：
-
 ```bash
-curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
+npm install @cloudbase/cli@latest -g
 ```
 
 安装完成后会自动生成 `cloudbase-mcp` 全局命令。

--- a/doc/getting-started.md
+++ b/doc/getting-started.md
@@ -30,11 +30,7 @@
 
 **一键安装**
 ```bash
-# Mac/Linux/Windows 的 WSL
-curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-
-# Windows PowerShell
-irm https://static.cloudbase.net/cli/install/install.ps1 | iex
+npm install @cloudbase/cli@latest -g
 ```
 
 **开始使用**

--- a/doc/index.md
+++ b/doc/index.md
@@ -62,11 +62,7 @@ CloudBase AI CLI 是一个集成多种主流 AI 编程工具的统一命令行�
 
 **一键安装**
 ```bash
-# Mac/Linux/Windows 的 WSL
-curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-
-# Windows PowerShell
-irm https://static.cloudbase.net/cli/install/install.ps1 | iex
+npm install @cloudbase/cli@latest -g
 ```
 
 **开始使用**

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -85,10 +85,6 @@ AI 编程工具（如 Cursor、Copilot）解决了**代码生成**的难题。
 > 一键安装，自动配置，支持多种 AI 编程工具：
 > 
 > ```bash
-> # Mac/Linux/WSL
-> curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
-> 
-> # Windows PowerShell
 > npm install @cloudbase/cli@latest -g
 > ```
 > 

--- a/scripts/releases/github-release.md
+++ b/scripts/releases/github-release.md
@@ -24,8 +24,8 @@
 
 ### 💻 快速开始
 ```bash
-# 一键安装
-curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash
+# 安装
+npm install @cloudbase/cli@latest -g
 
 # 开始使用
 tcb ai


### PR DESCRIPTION
## Changes

- Remove Mac/Linux/WSL curl installation commands (`curl https://static.cloudbase.net/cli/install/install.sh -fsS | bash`)
- Remove Windows PowerShell installation commands (`irm https://static.cloudbase.net/cli/install/install.ps1 | iex`)
- Keep `npm install @cloudbase/cli@latest -g` as the unified installation method
- Update all documentation files consistently (README, docs, releases)

## Files Updated

- README-ZH.md
- README-EN.md
- README.md
- mcp/README.md
- doc/faq.md
- doc/getting-started.md
- doc/index.md
- scripts/releases/github-release.md

## Benefits

- Simplified installation instructions
- Consistent installation method across all platforms
- Reduced maintenance overhead