### PR TITLE
fix(readme): 🔗 Sync trending shield link format across all README files

### DIFF
--- a/README-EN.md
+++ b/README-EN.md
@@ -29,9 +29,9 @@ The bridge that connects your AI IDE (Cursor, Copilot, etc.) directly to Tencent
 
 <sup>The shortest path from AI prompt to live application</sup>
 
-[![][github-trending-shield]][github-trending-url]
+[![][github-trending-shield]](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)
 
-![][image-overview]
+[<img width="791" height="592" alt="Clipboard_Screenshot_1763724670" src="https://github.com/user-attachments/assets/f769beb7-5710-4397-8854-af2b7e452f70" />](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/tutorials)
 
 </div>
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -29,9 +29,9 @@
 
 <sup>从 AI 提示词到应用上线的最短路径</sup>
 
-[![][github-trending-shield]][github-trending-url]
+[![][github-trending-shield]](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)
 
-![][image-overview]
+[<img width="791" height="592" alt="Clipboard_Screenshot_1763724670" src="https://github.com/user-attachments/assets/f769beb7-5710-4397-8854-af2b7e452f70" />](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/tutorials)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
 
 <img width="1148" height="389" alt="Clipboard_Screenshot_1764660604" src="https://github.com/user-attachments/assets/86294f88-632e-46b5-958f-94d8c8b85070" />
 
-[![][github-trending-shield]][github-trending-url]
+[![][github-trending-shield]](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)
 
 [<img width="791" height="592" alt="Clipboard_Screenshot_1763724670" src="https://github.com/user-attachments/assets/f769beb7-5710-4397-8854-af2b7e452f70" />](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/tutorials)
 

--- a/doc/ide-setup/cursor.md
+++ b/doc/ide-setup/cursor.md
@@ -55,9 +55,8 @@
 > [!TIP] 
 > 如果安装以后工具数量一直为 0，请参考[常见问题](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/faq#mcp-%E6%98%BE%E7%A4%BA%E5%B7%A5%E5%85%B7%E6%95%B0%E9%87%8F%E4%B8%BA-0-%E6%80%8E%E4%B9%88%E5%8A%9E)
 
-**一键安装（推荐）：**
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/install-mcp?name=cloudbase&config=JTdCJTIyY29tbWFuZCUyMiUzQSUyMm5weCUyMG5wbS1nbG9iYWwtZXhlYyU0MGxhdGVzdCUyMCU0MGNsb3VkYmFzZSUyRmNsb3VkYmFzZS1tY3AlNDBsYXRlc3QlMjIlMkMlMjJlbnYlMjIlM0ElN0IlMjJJTlRFR1JBVElPTl9JREUlMjIlM0ElMjJDdXJzb3IlMjIlN0QlN0Q%3D)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-dark.svg)](https://cursor.com/en-US/install-mcp?name=cloudbase&config=eyJlbnYiOnsiSU5URUdSQVRJT05fSURFIjoiQ3Vyc29yIn0sImNvbW1hbmQiOiJucHggbnBtLWdsb2JhbC1leGVjQGxhdGVzdCBAY2xvdWRiYXNlL2Nsb3VkYmFzZS1tY3BAbGF0ZXN0In0%3D)
 
 **手动配置：**
 

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -29,7 +29,7 @@
 
 <sup>从 AI 提示词到应用上线的最短路径</sup>
 
-[![][github-trending-shield]][github-trending-url]
+[![][github-trending-shield]](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)
 
 [<img width="791" height="592" alt="Clipboard_Screenshot_1763724670" src="https://github.com/user-attachments/assets/f769beb7-5710-4397-8854-af2b7e452f70" />](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/tutorials)
 


### PR DESCRIPTION
## Changes

- Update github-trending-shield link to direct GitHub URL format
- Sync image link format across all README files
- Ensure consistency across README.md, README-ZH.md, README-EN.md, mcp/README.md, and doc/ide-setup/cursor.md

## Files Updated

- README.md
- README-ZH.md
- README-EN.md
- mcp/README.md
- doc/ide-setup/cursor.md