### PR TITLE
feat(docs): 📚 expand tutorials section in sidebar by default

### DIFF
--- a/doc/sidebar.json
+++ b/doc/sidebar.json
@@ -120,7 +120,7 @@
         "type": "category",
         "label": "入门教程",
         "collapsible": true,
-        "collapsed": true,
+        "collapsed": false,
         "items": [
           "ai/cloudbase-ai-toolkit/tutorials",
           "ai/cloudbase-ai-toolkit/templates",


### PR DESCRIPTION
- Set tutorials category collapsed to false for better visibility
- Users can now see tutorials section expanded by default