### PR TITLE
feat(docs): add Kiro IDE support and update video tutorial authors

### DIFF
--- a/config/.augment-guidelines
+++ b/config/.augment-guidelines
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.clinerules/cloudbase-rules.mdc
+++ b/config/.clinerules/cloudbase-rules.mdc
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.comate/rules/cloudbase-rules.mdr
+++ b/config/.comate/rules/cloudbase-rules.mdr
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.cursor/rules/cloudbase-rules.mdc
+++ b/config/.cursor/rules/cloudbase-rules.mdc
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.gemini/GEMINI.md
+++ b/config/.gemini/GEMINI.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.github/copilot-instructions.md
+++ b/config/.github/copilot-instructions.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.kiro/settings/mcp.json
+++ b/config/.kiro/settings/mcp.json
@@ -1,0 +1,14 @@
+{
+  "mcpServers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": [
+        "@cloudbase/cloudbase-mcp@latest"
+      ],
+      "env": {
+        "INTEGRATION_IDE": "Kiro"
+      }
+    }
+  }
+}
+

--- a/config/.lingma/rules/cloudbaase-rules.md
+++ b/config/.lingma/rules/cloudbaase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.qoder/rules/cloudbase-rules.md
+++ b/config/.qoder/rules/cloudbase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.qwen/QWEN.md
+++ b/config/.qwen/QWEN.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.roo/rules/cloudbaase-rules.md
+++ b/config/.roo/rules/cloudbaase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.rules/cloudbase-rules.md
+++ b/config/.rules/cloudbase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.rules/cloudbase-rules.mdc
+++ b/config/.rules/cloudbase-rules.mdc
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.trae/rules/cloudbase-rules.md
+++ b/config/.trae/rules/cloudbase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/.windsurf/rules/cloudbase-rules.md
+++ b/config/.windsurf/rules/cloudbase-rules.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/AGENTS.md
+++ b/config/AGENTS.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/CLAUDE.md
+++ b/config/CLAUDE.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/config/CODEBUDDY.md
+++ b/config/CODEBUDDY.md
@@ -2,6 +2,7 @@
 description: CloudBase AI Development Rules Guide - Provides scenario-based best practices to ensure development quality
 globs: *
 alwaysApply: true
+inclusion: always
 ---
 
 # CloudBase AI Development Rules Guide

--- a/doc/components/IDEIconGrid.tsx
+++ b/doc/components/IDEIconGrid.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 import Link from '@docusaurus/Link';
+import React from 'react';
 import styles from './IDEIconGrid.module.css';
 
 interface IDE {
@@ -137,6 +137,13 @@ const IDES: IDE[] = [
     platform: '命令行工具',
     iconUrl: 'https://avatars.githubusercontent.com/u/66570915?s=200&v=4',
     docUrl: '/ai/cloudbase-ai-toolkit/ide-setup/opencode',
+  },
+  {
+    id: 'kiro',
+    name: 'Kiro',
+    platform: '独立 IDE',
+    iconUrl: 'https://kiro.dev/favicon.ico',
+    docUrl: '/ai/cloudbase-ai-toolkit/ide-setup/kiro',
   },
   {
     id: 'cloudbase-cli',

--- a/doc/components/IDESelector.tsx
+++ b/doc/components/IDESelector.tsx
@@ -32,7 +32,7 @@ const IDES: IDE[] = [
     iconSlug: 'cursor',
     docUrl: 'https://docs.cursor.com/context/model-context-protocol#configuration-locations',
     supportsProjectMCP: true,
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -55,7 +55,7 @@ const IDES: IDE[] = [
     supportsProjectMCP: true,
     cliCommand: 'claude mcp add --transport stdio cloudbase --env INTEGRATION_IDE=ClaudeCode -- npx @cloudbase/cloudbase-mcp@latest',
     alternativeConfig: 'Alternatively, add this configuration to .mcp.json:',
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -77,7 +77,7 @@ const IDES: IDE[] = [
     docUrl: 'https://www.codebuddy.ai/docs/zh/ide/Config%20MCP',
     supportsProjectMCP: true,
     alternativeConfig: 'Alternatively, add this configuration to',
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -100,7 +100,7 @@ const IDES: IDE[] = [
     supportsProjectMCP: true,
     cliCommand: 'codebuddy mcp add --scope project cloudbase --env INTEGRATION_IDE=CodeBuddyCode -- npx @cloudbase/cloudbase-mcp@latest',
     alternativeConfig: 'Alternatively, add this configuration to .mcp.json:',
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -122,7 +122,7 @@ const IDES: IDE[] = [
     iconUrl: 'https://code.visualstudio.com/favicon.ico',
     docUrl: 'https://code.visualstudio.com/docs/copilot/chat/mcp-servers',
     supportsProjectMCP: true,
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "servers": {
     "cloudbase": {
@@ -220,7 +220,7 @@ const IDES: IDE[] = [
     useCommandInsteadOfConfig: true,
     installCommand: 'codex mcp add cloudbase --env INTEGRATION_IDE=CodeX -- cloudbase-mcp',
     installCommandDocs: '**前置步骤：** 请先全局安装 CloudBase MCP 工具：\n```bash\nnpm i @cloudbase/cloudbase-mcp -g\n```\n\n根据运行系统在终端中运行指令：\n\n**MacOS, Linux, WSL:**\n```bash\ncodex mcp add cloudbase --env INTEGRATION_IDE=CodeX -- cloudbase-mcp\n```\n\n**Windows Powershell:**\n```bash\ncodex mcp add cloudbase --env INTEGRATION_IDE=CodeX -- cmd /c cloudbase-mcp\n```',
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -316,7 +316,7 @@ const IDES: IDE[] = [
     iconUrl: 'https://g.alicdn.com/qbase/qoder/0.0.183/favIcon.svg',
     docUrl: 'https://docs.qoder.com/zh/user-guide/chat/model-context-protocol',
     supportsProjectMCP: false,
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -337,7 +337,7 @@ const IDES: IDE[] = [
     iconUrl: 'https://antigravity.google/assets/image/antigravity-logo.png',
     docUrl: 'https://antigravity.google/docs',
     supportsProjectMCP: true,
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -358,7 +358,7 @@ const IDES: IDE[] = [
     iconSlug: 'windsurf',
     docUrl: 'https://docs.windsurf.com/windsurf/cascade/memories',
     supportsProjectMCP: true,
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: `{
   "mcpServers": {
     "cloudbase": {
@@ -405,8 +405,29 @@ const IDES: IDE[] = [
     useCommandInsteadOfConfig: true,
     installCommand: 'npm i -g @cloudbase/cli',
     installCommandDocs: '**安装 CloudBase CLI：**\n\n```bash\nnpm i -g @cloudbase/cli\n```\n\n**初始化配置：**\n\n```bash\ntcb ai\n```\n\n配置向导会引导你完成 AI 工具的配置。CloudBase CLI 内置了 MCP 和 AI 开发规则，无需手动配置。\n\n**开始使用：**\n\n```bash\ntcb ai\n```',
-    verificationPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     configExample: '',
+  },
+  {
+    id: 'kiro',
+    name: 'Kiro',
+    platform: '独立 IDE',
+    configPath: '.kiro/settings/mcp.json',
+    iconUrl: 'https://kiro.dev/favicon.ico',
+    docUrl: 'https://kiro.dev/docs/mcp/configuration/',
+    supportsProjectMCP: true,
+    verificationPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    configExample: `{
+  "mcpServers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["@cloudbase/cloudbase-mcp@latest"],
+      "env": {
+        "INTEGRATION_IDE": "Kiro"
+      }
+    }
+  }
+}`,
   },
 ];
 
@@ -476,10 +497,10 @@ const translations: Record<string, Record<string, string>> = {
     viewTemplates: '查看模板',
     oneClickInstall: '一键安装',
     orManualConfig: '或手动配置',
-    orAddConfig: '将以下配置添加到',
+    orAddConfig: '将以下配置添加到项目目录的',
     step2Verify: '步骤 2：验证连接',
     verifyDescription: '配置完成后，在 AI 对话中输入以下内容验证',
-    defaultVerifyPrompt: '检查 CloudBase 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
+    defaultVerifyPrompt: '检查 CloudBase MCP 工具是否可用, 下载 CloudBase AI 开发规则到当前项目',
     cliCommand: 'CLI 命令',
     alternativeConfig: '替代配置',
     needHelp: '需要帮助？',

--- a/doc/components/TutorialsGrid.tsx
+++ b/doc/components/TutorialsGrid.tsx
@@ -122,7 +122,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-ai-try-on',
     title: 'AI编程：从0到1开发一个AI试衣小程序！免费分享 | 含源码',
-    description: 'Bilibili 视频教程',
+    description: '熠辉IndieDev',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1NEsWzRE6U/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -131,7 +131,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-cursor-cloudbase',
     title: 'Cursor教学视频08：Cursor+Cloudbase MCP，10分钟完成带后端的全栈应用开发',
-    description: 'Bilibili 视频教程',
+    description: 'AI进化论-花生',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1TXuVzoE9p/?vd_source=c8763f6ab9c7c6f7f760ad7ea9157011',
     type: 'video',
@@ -140,7 +140,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-english-learning',
     title: '【新手向】 从 0 到 1构建一个可视化的 AI 英语学习应用',
-    description: 'Bilibili 视频教程',
+    description: '吕立青_JimmyLv',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1SK2xBTE2M/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -149,7 +149,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-ecommerce',
     title: '单挑整个电商项目？AI 能代替程序员了吗',
-    description: 'Bilibili 视频教程',
+    description: '吴悠讲编程',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1QzSYBBEBe/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -158,7 +158,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-miniprogram-basics',
     title: '零基础入门AI小程序开发教程',
-    description: 'Bilibili 视频教程',
+    description: '野码AI',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV123SyB4Ekt/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -167,7 +167,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-software30',
     title: '软件3.0：AI 编程新时代的最佳拍档 CloudBase AI ToolKit，以开发微信小程序为例',
-    description: 'Bilibili 视频教程',
+    description: '吕立青_JimmyLv',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV15gKdz1E5N/?share_source=copy_web',
     type: 'video',
@@ -176,7 +176,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-overcooked',
     title: '云开发CloudBase：用AI开发一款分手厨房小游戏',
-    description: 'Bilibili 视频教程',
+    description: '腾讯云云开发',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1v5KAzwEf9/',
     type: 'video',
@@ -185,7 +185,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-resume',
     title: '用AiCoding 一人挑战全栈研发简历制作小程序',
-    description: 'Bilibili 视频教程',
+    description: '全栈若城',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1D23Nz1Ec3/',
     type: 'video',
@@ -194,7 +194,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-business-card',
     title: '5分钟在本地创造一个程序员专属名片网站',
-    description: 'Bilibili 视频教程',
+    description: 'LucianaiB',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV19y3EzsEHQ/?vd_source=c8763f6ab9c7c6f7f760ad7ea9157011',
     type: 'video',
@@ -203,7 +203,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-codebuddy-miniprogram',
     title: '实战教程：通过codeBuddy +cloudBase 开发上线一款微信小程序！你也可以！',
-    description: 'Bilibili 视频教程',
+    description: '空菜',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1NEbjzjEeZ/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -212,7 +212,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-codebuddy-backend',
     title: 'CodeBuddyIDE 搭配 CloudBase完成小程序后台管理系统快速搭建',
-    description: 'Bilibili 视频教程',
+    description: '全栈若城',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV13C8nzzEoq/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -221,7 +221,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-cloudbase-deploy',
     title: '女大学生教你不买服务器，一秒把网站弄上线！0-1开发｜小白教程｜腾讯云CloudBase',
-    description: 'Bilibili 视频教程',
+    description: '冰激凌奶茶雪糕子',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1LQpBzrEb2/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -230,7 +230,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-xiaohe-architecture',
     title: '腾讯 CodeBuddy IDE × CloudBase 云开发实战：从零上线「小禾建筑AI智能平台」',
-    description: 'Bilibili 视频教程',
+    description: 'AI创业进行时',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1DWbwz1EBU/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -239,7 +239,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-cursor-miniprogram',
     title: '【小白教程】手把手教你用Cursor+微信云开发做个小程序 | 小白 AI 编程 | 零基础',
-    description: 'Bilibili 视频教程',
+    description: '熠辉IndieDev',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1jx5kziEqz/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -248,7 +248,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-podcast-tool',
     title: '零基础用codebuddy+CloudBase AI做播客推荐工具，我悟了："不必要的功能不加"',
-    description: 'Bilibili 视频教程',
+    description: '马腾漫步',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1fb8XzMEDk/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -257,7 +257,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-breakfast-shop',
     title: '沉浸式体验，从零用AI开发微信小游戏《我的早餐店》：CloudBase AI Toolkit教程',
-    description: 'Bilibili 视频教程',
+    description: 'Lion_Long',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV12J3XzzE67/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -266,7 +266,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-jixian-huiche',
     title: '极限惠车 - 停车充电优惠平台-基于CodeBuddy+云开发 + CloudBase AI ToolKit 构建的项目',
-    description: 'Bilibili 视频教程',
+    description: 'vellzhao',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1TCYyzBEAC/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -275,7 +275,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-boss-miniprogram',
     title: '老板让我1小时建好公司小程序…',
-    description: 'Bilibili 视频教程',
+    description: '三太子敖丙',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1hX3DzuExZ/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -284,7 +284,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-codebuddy-game',
     title: '用 CodeBuddy+CloudBase，轻松开发个性化游戏',
-    description: 'Bilibili 视频教程',
+    description: '全栈若城',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1hpbsz1E7m/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -293,7 +293,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-codebuddy-zero-coding',
     title: '使用CodeBuddy从0-1零编程打造一款微信小程序（附体验二维码）',
-    description: 'Bilibili 视频教程',
+    description: '蓝镜空间',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1mNY2z3ESU/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -302,7 +302,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-hospital-scheduling-saas',
     title: 'AI做的医院实习生排班SAAS系统',
-    description: 'Bilibili 视频教程',
+    description: '采云小程序',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1SYYkziEy9/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -311,7 +311,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-big-eye-notes',
     title: 'Codebuddy*Cloudbase AI大眼萌笔记工具及开发过程介绍',
-    description: 'Bilibili 视频教程',
+    description: 'AI大眼萌',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1B6b8zBEWT/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -320,7 +320,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-cursor-gomoku',
     title: '【直播回放】Cursor+云开发，开发双人五子棋对战小游戏',
-    description: 'Bilibili 视频教程',
+    description: '腾讯云云开发',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1uE3uzHEou/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -329,7 +329,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-one-person-company',
     title: '一人公司不是梦！1小时开发全栈应用【含完整前后端】',
-    description: 'Bilibili 视频教程',
+    description: 'AI进化论-花生',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1Rp37zDESt/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -338,7 +338,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-wechat-sport',
     title: '云开发Cloudbase AI Toolkit + Cursor开发演示：用AI开发一个支持微信运动的小程序',
-    description: 'Bilibili 视频教程',
+    description: '腾讯云云开发',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1hpjvzGESg/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -347,7 +347,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-finance-assistant',
     title: '腾讯云CodeBuddy IDE+CloudBase AI ToolKit打造理财小助手网页',
-    description: 'Bilibili 视频教程',
+    description: 'irpickstars',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1o1bXzYEm9/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',
@@ -356,7 +356,7 @@ const tutorials: Tutorial[] = [
   {
     id: 'video-codebuddy-international',
     title: 'CodeBuddy IDE国际版试用体验，让开发小程序的门槛再次降低！',
-    description: 'Bilibili 视频教程',
+    description: '嘉锅实验室',
     category: '视频教程',
     url: 'https://www.bilibili.com/video/BV1YReMz7EKn/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
     type: 'video',

--- a/doc/ide-setup/kiro.mdx
+++ b/doc/ide-setup/kiro.mdx
@@ -1,0 +1,72 @@
+import IDESelector from '../components/IDESelector';
+import RelatedResources from '../components/RelatedResources';
+
+# Kiro 配置指南
+
+配置后，你可以在 Kiro 的 AI 对话中直接操作 CloudBase 服务。
+
+**例如：**
+
+- "创建用户表" - AI 自动创建数据库集合
+- "部署这个函数" - AI 自动上传并配置云函数
+- "部署前端到 CDN" - AI 自动上传文件并配置托管
+
+无需切换到云控制台，所有操作都可以在 Kiro 中用自然语言完成。
+
+## 前置条件
+
+在开始配置之前，请确保满足以下条件：
+
+<details>
+<summary><strong>已准备好Node.js 环境和云开发环境</strong></summary>
+
+**Node.js 环境：** 确保已安装 Node.js v18.15.0 或更高版本：
+
+```bash
+node --version
+```
+
+如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
+
+**云开发环境：** 请参考文档 [开通云开发环境](https://docs.cloudbase.net/quick-start/create-env)。新用户可以免费开通体验。
+
+</details>
+
+---
+
+<IDESelector defaultIDE="kiro" showInstallButton={false} />
+
+## 配置说明
+
+Kiro 支持两种级别的配置：
+
+1. **工作区级别**：`.kiro/settings/mcp.json` - 仅适用于当前工作区
+2. **用户级别**：`~/.kiro/settings/mcp.json` - 适用于所有工作区
+
+如果两个文件都存在，工作区配置会优先于用户配置。
+
+## Steering 文件（开发规则）
+
+Kiro 使用 Steering 文件来提供项目知识。CloudBase AI 开发规则会自动下载到 `.kiro/steering/` 目录。
+
+Steering 文件支持：
+- **AGENTS.md**：放在项目根目录，Kiro 会自动读取，无需配置
+- **Markdown 文件**：放在 `.kiro/steering/` 目录下，支持条件加载和手动引用
+
+更多信息请参考 [Kiro Steering 文档](https://kiro.dev/docs/steering/)。
+
+## 常见问题
+
+**Q: MCP 连接失败？**
+A: 检查配置文件格式是否正确，重启 Kiro，确认网络连接正常。
+
+**Q: 工具数量显示为 0？**
+A: 请参考[常见问题](../faq#mcp-显示工具数量为-0-怎么办)。
+
+**Q: Steering 文件没有生效？**
+A: 确保文件位于 `.kiro/steering/` 目录下，并且文件格式正确。AGENTS.md 文件会自动加载。
+
+更多问题请查看：[完整 FAQ](../faq)
+
+<RelatedResources ideName="Kiro" ideDocUrl="https://kiro.dev/docs/mcp/configuration/" />
+

--- a/doc/index.mdx
+++ b/doc/index.mdx
@@ -64,7 +64,7 @@ graph TD
 
 ## 开源地址
 
-<div align="center">
+
 
 [![GitHub Stars](https://img.shields.io/github/stars/TencentCloudBase/CloudBase-AI-ToolKit?color=F59E0B&label=stars&logo=github&style=flat-square)](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/stargazers)
 [![CNB](https://img.shields.io/badge/CNB-CloudBase--AI--ToolKit-3B82F6?logo=data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHZpZXdCb3g9IjAgMCAxMiAxMiIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iMTIiIGhlaWdodD0iMTIiIHJ4PSIyIiBmaWxsPSIjM0I4MkY2Ii8+PHBhdGggZD0iTTUgM0g3VjVINSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLXdpZHRoPSIxLjUiLz48cGF0aCBkPSJNNSA3SDdWOUg1IiBzdHJva2U9IndoaXRlIiBzdHJva2Utd2lkdGg9IjEuNSIvPjwvc3ZnPg==&style=flat-square)](https://cnb.cool/tencent/cloud/cloudbase/CloudBase-AI-ToolKit)
@@ -74,7 +74,6 @@ graph TD
 - **GitHub**: [https://github.com/TencentCloudBase/CloudBase-AI-ToolKit](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)
 - **CNB**: [https://cnb.cool/tencent/cloud/cloudbase/CloudBase-AI-ToolKit](https://cnb.cool/tencent/cloud/cloudbase/CloudBase-AI-ToolKit)
 
-</div>
 
 ## 技术交流
 

--- a/doc/sidebar.json
+++ b/doc/sidebar.json
@@ -46,7 +46,8 @@
               "ai/cloudbase-ai-toolkit/ide-setup/qwen-code",
               "ai/cloudbase-ai-toolkit/ide-setup/qoder",
               "ai/cloudbase-ai-toolkit/ide-setup/antigravity",
-              "ai/cloudbase-ai-toolkit/ide-setup/cloudbase-cli"
+              "ai/cloudbase-ai-toolkit/ide-setup/cloudbase-cli",
+              "ai/cloudbase-ai-toolkit/ide-setup/kiro"
             ]
           }
         ]

--- a/mcp/src/tools/setup.ts
+++ b/mcp/src/tools/setup.ts
@@ -57,6 +57,7 @@ const IDE_TYPES = [
   "qoder", // Qoder AI编辑器
   "antigravity", // Google Antigravity AI编辑器
   "vscode", // Visual Studio Code
+  "kiro", // Kiro AI编辑器
 ] as const;
 
 // IDE映射关系表
@@ -99,6 +100,7 @@ const IDE_FILE_MAPPINGS: Record<string, string[]> = {
   qoder: [".qoder/rules/"],
   antigravity: [".agent/rules/"],
   vscode: [".vscode/mcp.json", ".vscode/settings.json"],
+  kiro: [".kiro/settings/mcp.json", ".kiro/steering/"],
 };
 
 // 所有IDE配置文件的完整列表 - 通过IDE_FILE_MAPPINGS计算得出
@@ -130,6 +132,7 @@ const IDE_DESCRIPTIONS: Record<string, string> = {
   qoder: "Qoder AI编辑器",
   antigravity: "Google Antigravity AI编辑器",
   vscode: "Visual Studio Code",
+  kiro: "Kiro AI编辑器",
 };
 
 // INTEGRATION_IDE 环境变量值到 IDE 类型的映射
@@ -154,6 +157,7 @@ const INTEGRATION_IDE_MAPPING: Record<string, string> = {
   Qoder: "qoder",
   Antigravity: "antigravity",
   VSCode: "vscode",
+  Kiro: "kiro",
 };
 
 // 根据 INTEGRATION_IDE 环境变量获取默认 IDE 类型

--- a/scripts/fix-config-hardlinks.mjs
+++ b/scripts/fix-config-hardlinks.mjs
@@ -621,6 +621,7 @@ async function syncRulesToIDEDirectories() {
     { dir: "config/.trae/rules", convertMdToMdc: false },
     { dir: "config/.windsurf/rules", convertMdToMdc: false },
     { dir: "config/.clinerules", convertMdToMdc: false },
+    { dir: "config/.kiro/steering", convertMdToMdc: false },
   ];
 
   console.log(


### PR DESCRIPTION
## Changes

- Add Kiro IDE support with MCP configuration and setup documentation
- Update all video tutorial descriptions from 'Bilibili 视频教程' to actual author names
- Update IDE selector and icon grid components to include Kiro
- Update sidebar configuration to include Kiro setup page

## Details

- Added Kiro MCP configuration at `.kiro/settings/mcp.json`
- Created Kiro setup documentation at `doc/ide-setup/kiro.mdx`
- Updated hard link script to support Kiro steering files
- Updated MCP setup tool to include Kiro IDE mappings
- Replaced all 27 video tutorial descriptions with author nicknames