### PR TITLE
fix(api): Update tcb service version to 2018-06-08

### DIFF
--- a/mcp/src/interactive-server.ts
+++ b/mcp/src/interactive-server.ts
@@ -284,7 +284,7 @@ export class InteractiveServer {
                       Channels: ["dcloud", "iotenable", "tem", "scene_module"],
                     };
                     
-                    envResult = await sessionData.manager.commonService("tcb").call({
+                    envResult = await sessionData.manager.commonService("tcb", "2018-06-08").call({
                       Action: "DescribeEnvs",
                       Param: queryParams,
                     });

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -37,7 +37,7 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
         const schemaId = envId;
         const instanceId = "default";
 
-        const result = await cloudbase.commonService("tcb").call({
+        const result = await cloudbase.commonService("tcb", "2018-06-08").call({
           Action: "RunSql",
           Param: {
             EnvId: envId,
@@ -118,7 +118,7 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
         const schemaId = envId;
         const instanceId = "default";
 
-        const result = await cloudbase.commonService("tcb").call({
+        const result = await cloudbase.commonService("tcb", "2018-06-08").call({
           Action: "RunSql",
           Param: {
             EnvId: envId,

--- a/mcp/src/tools/env-setup.ts
+++ b/mcp/src/tools/env-setup.ts
@@ -134,7 +134,7 @@ export async function checkAndInitTcbService(
       tcbServiceChecked: newContext.tcbServiceChecked 
     });
     
-    const checkResult = await cloudbase.commonService("tcb").call({
+    const checkResult = await cloudbase.commonService("tcb", "2018-06-08").call({
       Action: "CheckTcbService",
       Param: {}
     });
@@ -160,7 +160,7 @@ export async function checkAndInitTcbService(
       debug('[env-setup] InitTcb params:', { Source: "qcloud", Channel: "mcp" });
       
       try {
-        const initResult = await cloudbase.commonService("tcb").call({
+        const initResult = await cloudbase.commonService("tcb", "2018-06-08").call({
           Action: "InitTcb",
           Param: {
             Source: "qcloud",
@@ -263,7 +263,7 @@ export async function checkAndCreateFreeEnv(
       Names: ["NewUser", "ReturningUser", "BaasFree"]
     });
     
-    const activityResult = await cloudbase.commonService("tcb").call({
+    const activityResult = await cloudbase.commonService("tcb", "2018-06-08").call({
       Action: "DescribeUserPromotionalActivity",
       Param: {
         Names: ["NewUser", "ReturningUser", "BaasFree"]

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -249,7 +249,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               });
               // Use commonService to call DescribeEnvs with filter parameters
               // Filter parameters match the reference conditions provided by user
-              result = await cloudbaseList.commonService("tcb").call({
+              result = await cloudbaseList.commonService("tcb", "2018-06-08").call({
                 Action: "DescribeEnvs",
                 Param: {
                   EnvTypes: ["weda", "baas"], // Include weda and baas (normal) environments

--- a/mcp/src/tools/interactive.ts
+++ b/mcp/src/tools/interactive.ts
@@ -372,7 +372,7 @@ export async function _promptAndSetEnvironmentId(
     };
     debug("[interactive] DescribeEnvs params:", queryParams);
     
-    envResult = await cloudbase.commonService("tcb").call({
+    envResult = await cloudbase.commonService("tcb", "2018-06-08").call({
       Action: "DescribeEnvs",
       Param: queryParams,
     });
@@ -511,7 +511,7 @@ export async function _promptAndSetEnvironmentId(
           // Sometimes creation is async and env might not be immediately available
           debug("[interactive] Verifying created environment exists in list...");
           try {
-            const verifyResult = await cloudbase.commonService("tcb").call({
+            const verifyResult = await cloudbase.commonService("tcb", "2018-06-08").call({
               Action: "DescribeEnvs",
               Param: {
                 EnvTypes: ["weda", "baas"],


### PR DESCRIPTION
## Changes

- Set tcb service version to 2018-06-08 for all tcb API calls
- Update databaseSQL, env-setup, env, interactive, and interactive-server tools
- Ensure consistent API version usage across all tcb service calls

## Files Changed

- `mcp/src/tools/databaseSQL.ts` - Set tcb version to 2018-06-08
- `mcp/src/tools/env-setup.ts` - Set tcb version to 2018-06-08
- `mcp/src/tools/env.ts` - Set tcb version to 2018-06-08
- `mcp/src/tools/interactive.ts` - Set tcb version to 2018-06-08
- `mcp/src/interactive-server.ts` - Set tcb version to 2018-06-08

## Note

This fixes the API version to use the correct fixed version 2018-06-08 for tcb service as per the API specification.