### PR TITLE
fix(interactive): use same host as page for WebSocket in remote IDE

### DIFF
--- a/mcp/src/templates/env-setup/scripts.ts
+++ b/mcp/src/templates/env-setup/scripts.ts
@@ -63,8 +63,10 @@ export function getJavaScripts(wsPort: number): string {
     }
   }
 
-  // WebSocket connection
-  const ws = new WebSocket('ws://localhost:${wsPort}');
+  // WebSocket: same host as page so it works in remote VS Code / Cloud IDE (no localhost)
+  const wsScheme = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = wsScheme + '//' + window.location.host;
+  const ws = new WebSocket(wsUrl);
   
   ws.onopen = () => {
     console.log('[env-setup] WebSocket connected');


### PR DESCRIPTION
## Summary
Fixes WebSocket connection failure when the env-setup page is opened in **remote VS Code / Cloud IDE** (e.g. Cloud Studio). The page URL is on the remote host (e.g. `https://xxx.gz.cloudide.woa.com/env-setup/...`) but the script was connecting to `ws://localhost:3721`, which points to the user's local machine and fails.

## Changes
- Build WebSocket URL from `window.location.protocol` and `window.location.host` (same origin as the page)
- Local: `http://localhost:3721` → `ws://localhost:3721` (unchanged)
- Remote: `https://xxx.cloudide.woa.com/...` → `wss://xxx.cloudide.woa.com` (connection goes to remote host)

No CORS issue: same-origin connection.

Made with [Cursor](https://cursor.com)