### PR TITLE
docs(skills): clarify dual skills architecture

### DIFF
--- a/specs/dual-skills-sources/design.md
+++ b/specs/dual-skills-sources/design.md
@@ -1,0 +1,122 @@
+# 技术方案设计
+
+## 概述
+
+本方案将仓库当前的“`skills/` 为主源、`config/.claude/skills/` 为镜像”的实现，调整为“两套独立 skills 资产”的实现。
+
+目标模型：
+
+- `skills/`
+  - 本项目开发消费
+  - 本项目内部维护
+- `config/.claude/skills/`
+  - 对外分发给用户项目消费
+  - 面向用户项目的独立维护目录
+
+因此，本方案的关键不是迁移 skill 内容本身，而是去除仓库中关于“镜像”与“自动同步覆盖”的错误假设。
+
+## 目标
+
+- 明确两套 skills 的职责边界
+- 删除文档中的镜像表述
+- 调整脚本注释、命名、行为或适用范围说明
+- 调整相关测试，避免继续验证错误的单向同步关系
+
+## 非目标
+
+- 不要求本次统一重写两套目录下全部 skill 内容
+- 不要求本次建立两套目录之间的复杂双向同步
+- 不要求本次决定所有 skill 应该属于哪一套，只建立规则和基础设施边界
+
+## 当前问题
+
+当前仓库存在以下单源假设：
+
+- `config/README.md` 将 `config/.claude/skills/` 描述为由 `skills/` 生成的 compatibility mirror
+- `scripts/sync-claude-skills-mirror.mjs` 默认执行 `skills/ -> config/.claude/skills/`
+- 相关测试验证 `config/.claude/skills/` 与 `skills/` 一致
+
+这些实现和维护者期望的双源模型冲突。
+
+## 设计原则
+
+### 1. 角色优先于目录相似性
+
+虽然两套目录都叫 “skills”，但它们服务对象不同，因此不应基于路径相似性推导出镜像关系。
+
+### 2. 禁止隐式覆盖另一套资产
+
+任何脚本如果会写入另一套 skills 目录，都必须重新评估。默认情况下，应避免自动覆盖另一套技能资产。
+
+### 3. 文档先于自动化
+
+先把仓库文档、注释、脚本说明和测试假设调整正确，再决定是否需要新的自动化。
+
+## 需要调整的内容
+
+### 文档
+
+- `config/README.md`
+  - 改为说明 `config/.claude/skills/` 是对外分发目录
+  - 删除 mirror / generated from `skills/` 的表述
+
+### 脚本
+
+- `scripts/sync-claude-skills-mirror.mjs`
+  - 不应再以默认工具身份保留“同步到 `config/.claude/skills/`”的语义
+  - 可选方向：
+    - 删除
+    - 重命名并限制为某个显式转换用途
+    - 保留但默认不再写入 `config/.claude/skills/`
+
+- `scripts/build-skills-repo.mjs`
+  - 需要明确它构建的是哪一套 skills
+  - 若它只服务根目录 `skills/`，应在注释和输出中说明
+
+### 测试
+
+- `tests/sync-claude-skills-mirror.test.js`
+  - 当前测试建立在镜像假设上，需要删除或重写
+
+## 迁移策略
+
+### Phase 1
+
+- 修正文档
+- 修正脚本注释与默认语义
+- 删除或调整镜像一致性测试
+
+### Phase 2
+
+- 在维护流程文档中明确：
+  - 本项目开发 skill 改 `skills/`
+  - 对外分发 skill 改 `config/.claude/skills/`
+
+### Phase 3
+
+- 针对具体 skill 再决定归属和迁移路径
+
+## 测试策略
+
+1. 文档验证
+   - 核对 `config/README.md` 不再声明镜像关系
+
+2. 脚本验证
+   - 核对 skills 相关脚本不再默认覆盖 `config/.claude/skills/`
+
+3. 测试验证
+   - 删除或重构与镜像一致性绑定的测试
+
+## 风险与缓解
+
+风险：
+
+- 旧脚本仍被误用，覆盖分发 skill
+- 维护者短期内继续沿用旧认知
+- 两套目录职责虽已分开，但没有形成实际流程约束
+
+缓解：
+
+- 文档、脚本、测试同时调整
+- 在脚本输出中明确警告适用范围
+- 后续针对维护流程补充更清晰的说明文档

--- a/specs/dual-skills-sources/requirements.md
+++ b/specs/dual-skills-sources/requirements.md
@@ -1,0 +1,54 @@
+# 需求文档
+
+## 介绍
+
+调整当前 skills 架构，明确区分两套不同的 skills 资产，而不是将 `config/.claude/skills/` 视为由根目录 `skills/` 生成的镜像。
+
+新的目标是：
+
+- 根目录 `skills/` 仅用于本项目开发时消费与维护
+- `config/.claude/skills/` 仅用于对外分发给用户项目消费与维护
+
+两者服务对象不同、生命周期不同、内容允许不同，因此不应再被建模为单向镜像关系。
+
+## 需求
+
+### 需求 1 - 明确两套 skills 资产的职责边界
+
+**用户故事：** 作为仓库维护者，我希望根目录 `skills/` 和 `config/.claude/skills/` 的职责被明确区分，这样团队在修改 skill 时不会混淆“本项目开发用”和“用户分发用”的边界。
+
+#### 验收标准
+
+1. When 维护者查看仓库说明文档时，CloudBase AI Toolkit shall 明确说明根目录 `skills/` 用于本项目开发消费与维护。
+2. When 维护者查看仓库说明文档时，CloudBase AI Toolkit shall 明确说明 `config/.claude/skills/` 用于对外分发给用户项目消费与维护。
+3. When 维护者选择修改某个 skill 时，CloudBase AI Toolkit shall 不再默认假设两处目录是镜像关系。
+
+### 需求 2 - 移除单向镜像假设
+
+**用户故事：** 作为仓库维护者，我希望现有脚本和文档不再把 `config/.claude/skills/` 当作 `skills/` 的镜像产物，这样不会继续误导维护流程。
+
+#### 验收标准
+
+1. When 仓库脚本或文档描述 `skills/` 与 `config/.claude/skills/` 的关系时，CloudBase AI Toolkit shall 不再使用“mirror”或“generated from `skills/`”作为默认模型。
+2. When 维护者阅读 `config/README.md` 时，CloudBase AI Toolkit shall 不再声明 `config/.claude/skills/` 不应手工修改。
+3. When 维护者执行与 skills 相关的脚本时，CloudBase AI Toolkit shall 避免隐式覆盖 `config/.claude/skills/` 的独立内容。
+
+### 需求 3 - 调整 skills 相关脚本与测试
+
+**用户故事：** 作为仓库维护者，我希望 skills 相关脚本和测试符合新的双源模型，这样自动化不会继续按错误假设运行。
+
+#### 验收标准
+
+1. When 运行 skills 构建或同步相关脚本时，CloudBase AI Toolkit shall 明确区分“本项目 skills”与“分发 skills”的输入输出语义。
+2. When 现有脚本仅适用于某一套 skills 资产时，CloudBase AI Toolkit shall 在脚本命名、注释或输出中明确说明其适用范围。
+3. When 现有测试验证 `skills/` 与 `config/.claude/skills/` 一致性时，CloudBase AI Toolkit shall 移除或重构这些测试，以适配新的双源模型。
+
+### 需求 4 - 为后续迁移保留清晰演进路径
+
+**用户故事：** 作为仓库维护者，我希望这次调整不仅是文档修正，还能为后续技能迁移和维护建立稳定规则，这样后续 PR 不会继续在错误目录假设上反复返工。
+
+#### 验收标准
+
+1. When 维护者新增或修改本项目开发用 skill 时，CloudBase AI Toolkit shall 引导其修改根目录 `skills/`。
+2. When 维护者新增或修改对外分发 skill 时，CloudBase AI Toolkit shall 引导其修改 `config/.claude/skills/`。
+3. When 后续需要说明某个 skill 属于哪套体系时，CloudBase AI Toolkit shall 提供清晰、可执行的判定规则。

--- a/specs/dual-skills-sources/tasks.md
+++ b/specs/dual-skills-sources/tasks.md
@@ -1,0 +1,27 @@
+# 实施计划
+
+- [ ] 1. 修正 skills 双源模型的需求与设计说明
+  - 明确 `skills/` 与 `config/.claude/skills/` 是两套不同资产
+  - 删除“镜像”作为默认架构假设
+  - _需求: 需求1, 需求2
+
+- [ ] 2. 更新仓库文档
+  - 修改 `config/README.md`
+  - 明确两套目录各自的消费对象与维护规则
+  - _需求: 需求1, 需求2, 需求4
+
+- [ ] 3. 调整 skills 相关脚本语义
+  - 评估并修改 `scripts/sync-claude-skills-mirror.mjs`
+  - 明确 `scripts/build-skills-repo.mjs` 构建的是哪一套 skills
+  - 避免脚本默认覆盖 `config/.claude/skills/`
+  - _需求: 需求2, 需求3
+
+- [ ] 4. 调整相关测试
+  - 删除或重构基于镜像一致性的测试
+  - 确保测试符合双源模型
+  - _需求: 需求3
+
+- [ ] 5. 验证新的目录职责边界
+  - 检查文档、脚本、测试的表述是否一致
+  - 确认不会再把 `config/.claude/skills/` 视作 `skills/` 的镜像
+  - _需求: 需求1, 需求2, 需求3, 需求4


### PR DESCRIPTION
## Summary
- define skills/ and config/.claude/skills as two different skill systems
- document that the current mirror assumption conflicts with the intended maintenance model
- add a focused spec for the follow-up documentation, script, and test changes

## Scope
- requirements, design, and task breakdown only
- no script or behavior changes yet
