### PR TITLE
fix(gateway): 🧭 improve function HTTP access guidance

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -1,0 +1,107 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtendedMcpServer } from "../server.js";
+import { registerGatewayTools } from "./gateway.js";
+
+const {
+  mockCreateAccess,
+  mockGetCloudBaseManager,
+  mockGetEnvId,
+  mockLogCloudBaseResult,
+} = vi.hoisted(() => ({
+  mockCreateAccess: vi.fn(),
+  mockGetCloudBaseManager: vi.fn(),
+  mockGetEnvId: vi.fn(),
+  mockLogCloudBaseResult: vi.fn(),
+}));
+
+vi.mock("../cloudbase-manager.js", () => ({
+  getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
+  logCloudBaseResult: mockLogCloudBaseResult,
+}));
+
+function createMockServer(overrides?: { region?: string }) {
+  const tools: Record<
+    string,
+    {
+      meta: any;
+      handler: (args: any) => Promise<any>;
+    }
+  > = {};
+
+  const server: ExtendedMcpServer = {
+    cloudBaseOptions: {
+      envId: "env-test",
+      region: overrides && "region" in overrides ? overrides.region : "ap-guangzhou",
+    },
+    logger: vi.fn(),
+    registerTool: vi.fn(
+      (name: string, meta: any, handler: (args: any) => Promise<any>) => {
+        tools[name] = { meta, handler };
+      },
+    ),
+  } as unknown as ExtendedMcpServer;
+
+  registerGatewayTools(server);
+
+  return { tools };
+}
+
+describe("gateway tools", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCreateAccess.mockResolvedValue({ APIId: "api-123" });
+    mockGetCloudBaseManager.mockResolvedValue({
+      access: {
+        createAccess: mockCreateAccess,
+      },
+    });
+    mockGetEnvId.mockResolvedValue("env-test");
+  });
+
+  it("should expose createFunctionHTTPAccess tool", () => {
+    const { tools } = createMockServer();
+    expect(typeof tools.createFunctionHTTPAccess?.handler).toBe("function");
+  });
+
+  it("should normalize path and return invoke guidance", async () => {
+    const { tools } = createMockServer();
+
+    const result = await tools.createFunctionHTTPAccess.handler({
+      name: "demo",
+      path: "api/hello",
+      type: "HTTP",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCreateAccess).toHaveBeenCalledWith({
+      name: "demo",
+      path: "/api/hello",
+      type: 6,
+    });
+    expect(payload).toMatchObject({
+      ok: true,
+      code: "HTTP_ACCESS_CREATED",
+      function_name: "demo",
+      function_type: "HTTP",
+      env_id: "env-test",
+      region: "ap-guangzhou",
+      path: "/api/hello",
+      invoke_url: "https://env-test.ap-guangzhou.app.tcloudbase.com/api/hello",
+    });
+    expect(payload.next_steps[0]).toContain("https://env-test.ap-guangzhou.app.tcloudbase.com/api/hello");
+  });
+
+  it("should explain missing region when invoke url cannot be generated", async () => {
+    const { tools } = createMockServer({ region: undefined });
+
+    const result = await tools.createFunctionHTTPAccess.handler({
+      name: "demo",
+      path: "/ready",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.invoke_url).toBeNull();
+    expect(payload.next_steps[0]).toContain("Region is unavailable");
+  });
+});

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -1,6 +1,10 @@
 import { z } from "zod";
-import { getCloudBaseManager, logCloudBaseResult } from '../cloudbase-manager.js';
-import { ExtendedMcpServer } from '../server.js';
+import {
+  getCloudBaseManager,
+  getEnvId,
+  logCloudBaseResult,
+} from "../cloudbase-manager.js";
+import { ExtendedMcpServer } from "../server.js";
 
 export function registerGatewayTools(server: ExtendedMcpServer) {
   // 获取 cloudBaseOptions，如果没有则为 undefined
@@ -13,43 +17,90 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     "createFunctionHTTPAccess",
     {
       title: "创建云函数HTTP访问",
-      description: "创建云函数的 HTTP 访问",
+      description: "创建云函数的 HTTP 访问，并返回可直接使用的访问地址提示",
       inputSchema: {
         name: z.string().describe("函数名"),
         path: z.string().describe("HTTP 访问路径"),
         type: z
           .enum(["Event", "HTTP"])
           .optional()
-          .describe("函数类型，Event 为事件型云函数（默认），HTTP 为 HTTP 云函数")
+          .describe("函数类型，Event 为事件型云函数（默认），HTTP 为 HTTP 云函数"),
       },
       annotations: {
         readOnlyHint: false,
         destructiveHint: false,
         idempotentHint: false,
-        openWorldHint: true,
-        category: "gateway"
-      }
+        openWorldHint: true as const,
+        category: "gateway",
+      },
     },
-    async ({ name, path, type }: { name: string; path: string; type?: "Event" | "HTTP" }) => {
-      const cloudbase = await getManager()
+    async ({
+      name,
+      path,
+      type,
+    }: {
+      name: string;
+      path: string;
+      type?: "Event" | "HTTP";
+    }) => {
+      const cloudbase = await getManager();
+      const normalizedPath = `/${path.trim().replace(/^\/+/, "")}`;
+
+      if (normalizedPath === "/" && path.trim() === "") {
+        throw new Error("HTTP 访问路径不能为空");
+      }
 
       // Event 云函数 type=1，HTTP 云函数 type=6
       const accessType = type === "HTTP" ? 6 : 1;
 
       const result = await cloudbase.access.createAccess({
-        type: accessType as 1 | 2,  // HTTP 云函数使用 type=6，需要类型断言
+        type: accessType as 1 | 6,
         name,
-        path
+        path: normalizedPath,
       });
       logCloudBaseResult(server.logger, result);
+
+      const envId = await getEnvId(cloudBaseOptions);
+      const region = cloudBaseOptions?.region ?? process.env.TCB_REGION ?? null;
+      const invokeUrl = region
+        ? `https://${envId}.${region}.app.tcloudbase.com${normalizedPath}`
+        : null;
+
+      const payload = {
+        ok: true,
+        code: "HTTP_ACCESS_CREATED",
+        message: "云函数 HTTP 访问创建成功。",
+        function_name: name,
+        function_type: type ?? "Event",
+        access_type: accessType,
+        env_id: envId,
+        region,
+        path: normalizedPath,
+        invoke_url: invokeUrl,
+        readiness: {
+          status: "created",
+          note: "HTTP 服务激活可能有短暂延迟；若首次访问失败，请稍后重试。",
+        },
+        next_steps: invokeUrl
+          ? [
+              `Use GET ${invokeUrl} to verify the entrypoint.`,
+              "If the gateway reports activation/not-ready errors, retry after the service finishes provisioning.",
+            ]
+          : [
+              "Region is unavailable, so the default invoke URL could not be generated.",
+              "Set cloudBaseOptions.region or TCB_REGION to enable direct invoke URL guidance.",
+            ],
+        raw_result: result,
+      };
+
       return {
         content: [
           {
             type: "text",
-            text: JSON.stringify(result, null, 2)
-          }
-        ]
+            text: JSON.stringify(payload, null, 2),
+          },
+        ],
       };
-    }
+    },
   );
 }


### PR DESCRIPTION
## Summary
- normalize HTTP access paths before creating the gateway entry
- return env/region-aware invoke guidance and readiness notes
- add focused tests for invoke URL and missing-region behavior

Fixes #333