### PR TITLE
feat(clawhub): ✨ add registry publish workflow

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -1,0 +1,87 @@
+name: Publish ClawHub Registry
+
+on:
+  workflow_dispatch:
+    inputs:
+      targets:
+        description: 'Comma-separated publish targets: miniprogram-development, all-in-one'
+        required: true
+        type: string
+      bump:
+        description: 'Version bump type used by clawhub sync: patch, minor, or major'
+        required: false
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      changelog:
+        description: 'Optional changelog text. If empty, recent commits are appended automatically.'
+        required: false
+        default: ''
+        type: string
+      tags:
+        description: 'Comma-separated tags passed to clawhub publish'
+        required: false
+        default: 'latest'
+        type: string
+      dry_run:
+        description: 'Build and validate only, skip registry publish'
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      TARGETS: ${{ inputs.targets }}
+      BUMP: ${{ inputs.bump }}
+      CHANGELOG: ${{ inputs.changelog }}
+      TAGS: ${{ inputs.tags }}
+      DRY_RUN: ${{ inputs.dry_run }}
+
+    steps:
+      - name: Checkout toolkit repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Build publish artifacts
+        run: node scripts/build-clawhub-publish-artifacts.mjs --targets "$TARGETS"
+
+      - name: Install ClawHub CLI
+        if: ${{ !inputs.dry_run }}
+        run: npm install -g clawhub
+
+      - name: Login to ClawHub
+        if: ${{ !inputs.dry_run }}
+        env:
+          CLAWDHUB_TOKEN: ${{ secrets.CLAWDHUB_TOKEN }}
+        run: clawhub login --token "$CLAWDHUB_TOKEN" --no-browser
+
+      - name: Publish selected targets to ClawHub
+        env:
+          CLAWDHUB_TOKEN: ${{ secrets.CLAWDHUB_TOKEN }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            node scripts/publish-to-clawhub.mjs --manifest .clawhub-publish-output/manifest.json --bump "$BUMP" --changelog "$CHANGELOG" --tags "$TAGS" --dry-run
+          else
+            node scripts/publish-to-clawhub.mjs --manifest .clawhub-publish-output/manifest.json --bump "$BUMP" --changelog "$CHANGELOG" --tags "$TAGS"
+          fi
+
+      - name: Append job summary
+        run: |
+          echo "## ClawHub Publish Summary" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Targets: $TARGETS" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Bump: $BUMP" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tags: $TAGS" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Dry run: $DRY_RUN" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Manifest: .clawhub-publish-output/manifest.json" >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/build-clawhub-publish-artifacts.mjs
+++ b/scripts/build-clawhub-publish-artifacts.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+import {
+  resolvePublishTargets,
+} from "./clawhub-publish-targets.mjs";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+function parseArgs(argv) {
+  let targets = "";
+  let outputDir = path.join(projectRoot, ".clawhub-publish-output");
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--targets") {
+      targets = argv[index + 1] || "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--output-dir") {
+      outputDir = path.resolve(argv[index + 1] || outputDir);
+      index += 1;
+      continue;
+    }
+  }
+
+  return { targets, outputDir };
+}
+
+function ensureDir(dirPath) {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+function cleanDir(dirPath) {
+  fs.rmSync(dirPath, { recursive: true, force: true });
+  ensureDir(dirPath);
+}
+
+function copyDirectoryRecursive(srcDir, destDir) {
+  ensureDir(destDir);
+
+  for (const entry of fs.readdirSync(srcDir, { withFileTypes: true })) {
+    const srcPath = path.join(srcDir, entry.name);
+    const destPath = path.join(destDir, entry.name);
+
+    if (entry.isDirectory()) {
+      copyDirectoryRecursive(srcPath, destPath);
+      continue;
+    }
+
+    if (entry.isFile()) {
+      fs.copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+function parseFrontmatter(skillContent) {
+  const frontmatterMatch = skillContent.match(/^---\n([\s\S]*?)\n---/);
+
+  if (!frontmatterMatch) {
+    throw new Error("SKILL.md 缺少 frontmatter / SKILL.md is missing frontmatter");
+  }
+
+  const frontmatter = frontmatterMatch[1];
+  const nameMatch = frontmatter.match(/^name:\s*(.+)$/m);
+  const descriptionMatch = frontmatter.match(/^description:\s*(.+)$/m);
+
+  if (!nameMatch || !nameMatch[1].trim()) {
+    throw new Error("SKILL.md frontmatter 缺少 name / SKILL.md frontmatter is missing name");
+  }
+
+  if (!descriptionMatch || !descriptionMatch[1].trim()) {
+    throw new Error("SKILL.md frontmatter 缺少 description / SKILL.md frontmatter is missing description");
+  }
+
+  return {
+    name: nameMatch[1].trim(),
+    description: descriptionMatch[1].trim(),
+  };
+}
+
+function validateArtifactDir(targetKey, artifactDir) {
+  const skillFile = path.join(artifactDir, "SKILL.md");
+
+  if (!fs.existsSync(skillFile)) {
+    throw new Error(`${targetKey}: 在 ${artifactDir} 中缺少 SKILL.md / missing SKILL.md in ${artifactDir}`);
+  }
+
+  const metadata = parseFrontmatter(fs.readFileSync(skillFile, "utf8"));
+
+  return {
+    skillFile,
+    metadata,
+  };
+}
+
+function buildLocalSkillTarget(target, destinationDir) {
+  if (!fs.existsSync(target.sourceDir)) {
+    throw new Error(
+      `${target.key}: 源目录不存在 / source directory does not exist: ${target.sourceDir}`,
+    );
+  }
+
+  copyDirectoryRecursive(target.sourceDir, destinationDir);
+
+  return {
+    sourceDir: target.sourceDir,
+  };
+}
+
+function buildAllInOneTarget(target, destinationDir) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawhub-allinone-"));
+
+  try {
+    execFileSync(
+      "node",
+      ["scripts/build-allinone-skill.ts", "--dir", tempRoot],
+      {
+        cwd: projectRoot,
+        stdio: "pipe",
+      },
+    );
+
+    const generatedDir = path.join(tempRoot, target.registrySlug);
+    if (!fs.existsSync(generatedDir)) {
+      throw new Error(
+        `${target.key}: 未找到预期生成目录 / expected generated directory not found: ${generatedDir}`,
+      );
+    }
+
+    copyDirectoryRecursive(generatedDir, destinationDir);
+
+    return {
+      sourceDir: generatedDir,
+    };
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true });
+  }
+}
+
+function buildTargetArtifact(target, outputDir) {
+  const artifactDir = path.join(outputDir, target.key);
+  ensureDir(artifactDir);
+
+  let buildResult;
+  if (target.type === "local-skill") {
+    buildResult = buildLocalSkillTarget(target, artifactDir);
+  } else if (target.type === "generated-allinone") {
+    buildResult = buildAllInOneTarget(target, artifactDir);
+  } else {
+    throw new Error(`${target.key}: 不支持的发布目标类型 / unsupported target type ${target.type}`);
+  }
+
+  const validation = validateArtifactDir(target.key, artifactDir);
+
+  return {
+    targetKey: target.key,
+    registrySlug: target.registrySlug,
+    displayName: target.displayName || validation.metadata.name,
+    artifactDir,
+    sourceType: target.type,
+    sourceDescription: target.sourceDescription,
+    sourceDir: buildResult.sourceDir,
+    metadata: validation.metadata,
+  };
+}
+
+export function buildClawhubPublishArtifacts({ targets, outputDir }) {
+  const resolvedTargets = resolvePublishTargets(targets);
+
+  cleanDir(outputDir);
+
+  const manifest = {
+    generatedAt: new Date().toISOString(),
+    outputDir,
+    targets: resolvedTargets.map((target) => buildTargetArtifact(target, outputDir)),
+  };
+
+  fs.writeFileSync(
+    path.join(outputDir, "manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+    "utf8",
+  );
+
+  return manifest;
+}
+
+function main() {
+  const { targets, outputDir } = parseArgs(process.argv.slice(2));
+  const manifest = buildClawhubPublishArtifacts({ targets, outputDir });
+
+  console.log(
+    `已在 ${manifest.outputDir} 准备 ${manifest.targets.length} 个 ClawHub 发布产物 / Prepared ${manifest.targets.length} ClawHub publish artifact(s) in ${manifest.outputDir}`,
+  );
+
+  for (const target of manifest.targets) {
+    console.log(
+      `- ${target.targetKey} -> ${target.registrySlug} (${target.artifactDir})`,
+    );
+  }
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/scripts/clawhub-publish-targets.mjs
+++ b/scripts/clawhub-publish-targets.mjs
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const projectRoot = path.resolve(__dirname, "..");
+
+export const CLAWHUB_PUBLISH_TARGETS = {
+  "miniprogram-development": {
+    key: "miniprogram-development",
+    type: "local-skill",
+    registrySlug: "miniprogram-development",
+    displayName: "微信小程序开发 / WeChat Mini Program Development",
+    sourceDir: path.join(
+      projectRoot,
+      "config",
+      "source",
+      "skills",
+      "miniprogram-development",
+    ),
+    sourceDescription: "config/source/skills/miniprogram-development",
+  },
+  "all-in-one": {
+    key: "all-in-one",
+    type: "generated-allinone",
+    registrySlug: "cloudbase",
+    displayName: "CloudBase 云开发 / CloudBase",
+    sourceDescription: "generated via scripts/build-allinone-skill.ts",
+  },
+};
+
+export const DEFAULT_CLAWHUB_TARGET_KEYS = Object.freeze(
+  Object.keys(CLAWHUB_PUBLISH_TARGETS),
+);
+
+export function parseTargetInput(rawTargets) {
+  if (!rawTargets || !rawTargets.trim()) {
+    throw new Error(
+      `未提供发布目标 / No publish targets provided. 可用目标 / Allowed targets: ${DEFAULT_CLAWHUB_TARGET_KEYS.join(", ")}`,
+    );
+  }
+
+  const normalized = rawTargets
+    .split(",")
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  const unique = [];
+  for (const target of normalized) {
+    if (!unique.includes(target)) {
+      unique.push(target);
+    }
+  }
+
+  const invalidTargets = unique.filter(
+    (target) => !CLAWHUB_PUBLISH_TARGETS[target],
+  );
+
+  if (invalidTargets.length > 0) {
+    throw new Error(
+      `存在无效发布目标 / Unknown publish targets: ${invalidTargets.join(", ")}。可用目标 / Allowed targets: ${DEFAULT_CLAWHUB_TARGET_KEYS.join(", ")}`,
+    );
+  }
+
+  return unique;
+}
+
+export function resolvePublishTargets(rawTargets) {
+  return parseTargetInput(rawTargets).map(
+    (target) => CLAWHUB_PUBLISH_TARGETS[target],
+  );
+}

--- a/scripts/publish-to-clawhub.mjs
+++ b/scripts/publish-to-clawhub.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+
+import fs from "fs";
+import path from "path";
+import { execFileSync } from "child_process";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const AUTO_CHANGELOG_LIMIT = 5;
+
+function parseArgs(argv) {
+  let manifestPath = "";
+  let dryRun = false;
+  let changelog = "";
+  let tags = "latest";
+  let bump = "minor";
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === "--manifest") {
+      manifestPath = path.resolve(argv[index + 1] || "");
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--dry-run") {
+      dryRun = true;
+      continue;
+    }
+
+    if (arg === "--changelog") {
+      changelog = argv[index + 1] || "";
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--tags") {
+      tags = argv[index + 1] || tags;
+      index += 1;
+      continue;
+    }
+
+    if (arg === "--bump") {
+      bump = argv[index + 1] || bump;
+      index += 1;
+    }
+  }
+
+  if (!manifestPath) {
+    throw new Error("缺少必填参数 --manifest / Missing required --manifest argument");
+  }
+
+  if (!["patch", "minor", "major"].includes(bump)) {
+    throw new Error(
+      `不支持的 bump 类型 / Unsupported bump type: ${bump}. Allowed: patch, minor, major`,
+    );
+  }
+
+  return { manifestPath, dryRun, changelog, tags, bump };
+}
+
+function readManifest(manifestPath) {
+  if (!fs.existsSync(manifestPath)) {
+    throw new Error(`未找到 manifest 文件 / Manifest file not found: ${manifestPath}`);
+  }
+
+  return JSON.parse(fs.readFileSync(manifestPath, "utf8"));
+}
+
+function resolveGitRoot(manifestPath) {
+  try {
+    return execFileSync("git", ["rev-parse", "--show-toplevel"], {
+      cwd: path.dirname(manifestPath),
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return process.cwd();
+  }
+}
+
+function getRecentCommitLines(gitRoot) {
+  try {
+    const output = execFileSync(
+      "git",
+      [
+        "log",
+        `-${AUTO_CHANGELOG_LIMIT}`,
+        "--pretty=format:- %s",
+      ],
+      {
+        cwd: gitRoot,
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      },
+    ).trim();
+
+    return output;
+  } catch {
+    return "";
+  }
+}
+
+function buildChangelogText(manualChangelog, gitRoot) {
+  const normalizedManual = (manualChangelog || "").trim();
+  const recentCommits = getRecentCommitLines(gitRoot);
+
+  if (normalizedManual && recentCommits) {
+    return `${normalizedManual}\n\nRecent commits / 最近提交:\n${recentCommits}`;
+  }
+
+  if (normalizedManual) {
+    return normalizedManual;
+  }
+
+  if (recentCommits) {
+    return `Recent commits / 最近提交:\n${recentCommits}`;
+  }
+
+  return "";
+}
+
+function buildSyncCommand(target, options) {
+  return {
+    command: "clawhub",
+    args: [
+      "sync",
+      "--root",
+      target.artifactDir,
+      "--all",
+      "--bump",
+      options.bump,
+      "--changelog",
+      options.changelog,
+      "--tags",
+      options.tags,
+    ],
+  };
+}
+
+export function publishToClawhub({
+  manifestPath,
+  dryRun = false,
+  changelog = "",
+  tags = "latest",
+  bump = "minor",
+}) {
+  const manifest = readManifest(manifestPath);
+  const gitRoot = resolveGitRoot(manifestPath);
+  const resolvedChangelog = buildChangelogText(changelog, gitRoot);
+  const failures = [];
+  const results = [];
+
+  if (!dryRun && !process.env.CLAWDHUB_TOKEN) {
+    throw new Error("正式发布需要设置 CLAWDHUB_TOKEN / CLAWDHUB_TOKEN is required for non-dry-run publishing");
+  }
+
+  for (const target of manifest.targets || []) {
+    const publishCommand = buildSyncCommand(target, {
+      changelog: resolvedChangelog,
+      tags,
+      bump,
+    });
+
+    console.log(`发布目标 / Publishing target: ${target.targetKey}`);
+    console.log(
+      `执行命令 / Command: ${publishCommand.command} ${publishCommand.args.join(" ")}`,
+    );
+
+    if (dryRun) {
+      publishCommand.args.push("--dry-run");
+      console.log(
+        `Dry run 模式 / Dry-run mode: ${publishCommand.command} ${publishCommand.args.join(" ")}`,
+      );
+      results.push({
+        targetKey: target.targetKey,
+        registrySlug: target.registrySlug,
+        status: "dry-run",
+      });
+      continue;
+    }
+
+    try {
+      execFileSync(publishCommand.command, publishCommand.args, {
+        stdio: "inherit",
+        env: process.env,
+      });
+
+      results.push({
+        targetKey: target.targetKey,
+        registrySlug: target.registrySlug,
+        status: dryRun ? "dry-run" : "published",
+      });
+    } catch (error) {
+      failures.push({
+        targetKey: target.targetKey,
+        registrySlug: target.registrySlug,
+        message: error.message,
+      });
+    }
+  }
+
+  if (failures.length > 0) {
+    for (const failure of failures) {
+      console.error(
+        `发布失败 / Failed to publish ${failure.targetKey} (${failure.registrySlug}): ${failure.message}`,
+      );
+    }
+
+    const error = new Error(
+      `发布到 ClawHub 失败 / Failed to publish ${failures.length} target(s) to ClawHub`,
+    );
+    error.failures = failures;
+    throw error;
+  }
+
+  return results;
+}
+
+function main() {
+  const { manifestPath, dryRun, changelog, tags, bump } = parseArgs(
+    process.argv.slice(2),
+  );
+  const results = publishToClawhub({
+    manifestPath,
+    dryRun,
+    changelog,
+    tags,
+    bump,
+  });
+
+  console.log(`已完成 ${results.length} 个 ClawHub 发布操作 / Completed ${results.length} ClawHub publish operation(s).`);
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/specs/clawhub-public-skill-registry-publish/design.md
+++ b/specs/clawhub-public-skill-registry-publish/design.md
@@ -1,0 +1,211 @@
+# 技术方案
+
+## 概述
+
+本方案新增一条面向 ClawHub public skill registry 的发布链路，但不改动现有 skills repo 发布链路与 all-in-one 仓库同步链路。
+
+发布模型采用“显式发布单元”而不是“扫描全部 Skill 目录”：
+
+- `miniprogram-development`：直接发布原始 skill 源
+- `all-in-one`：复用现有 `scripts/build-allinone-skill.ts` 生成的 `cloudbase` 聚合 Skill 后发布
+
+这样可以满足“按目标发布”的要求，同时避免误把 `config/source/skills/` 下所有 Skill 都发到 ClawHub。
+
+## 架构设计
+
+```mermaid
+flowchart TD
+  A[workflow_dispatch] --> B[Resolve publish targets]
+  B --> C[Build local publish artifacts]
+  C --> C1[miniprogram-development from config/source/skills]
+  C --> C2[all-in-one from build-allinone-skill.ts]
+  C1 --> D[Validate artifact structure and metadata]
+  C2 --> D
+  D --> E[Install clawhub CLI]
+  E --> F[Authenticate with registry secret]
+  F --> G[Publish each selected unit]
+  G --> H[Job summary and failure report]
+```
+
+## 发布单元建模
+
+新增一个集中式发布单元定义脚本，例如 `scripts/clawhub-publish-targets.mjs`，职责如下：
+
+- 维护允许发布的单元白名单
+- 描述每个单元的来源类型、构建方式、最终 registry 名称
+- 统一做目标解析、输入校验和错误提示
+
+建议数据结构：
+
+```js
+{
+  "miniprogram-development": {
+    type: "local-skill",
+    sourceDir: "config/source/skills/miniprogram-development",
+    registryName: "miniprogram-development"
+  },
+  "all-in-one": {
+    type: "generated-allinone",
+    buildCommand: "node scripts/build-allinone-skill.ts --dir <tmp>",
+    outputDir: "<tmp>/cloudbase",
+    registryName: "cloudbase"
+  }
+}
+```
+
+设计理由：
+
+- 避免把发布逻辑散落在 workflow shell 中，后续增删单元更可控
+- `all-in-one` 与普通 skill 的来源形态不同，需要显式区分
+- `setup-cloudbase-openclaw` 已不维护，因此不继续纳入发布单元模型
+
+## 脚本设计
+
+### 1. 新增发布产物准备脚本
+
+新增 `scripts/build-clawhub-publish-artifacts.mjs`，职责：
+
+- 接收目标单元列表，例如 `--targets miniprogram-development,all-in-one`
+- 在临时输出目录下为每个目标单元生成独立发布目录
+- 为每个发布目录执行结构校验
+- 输出一份 machine-readable manifest，供 GitHub Actions 后续步骤消费
+
+建议输出目录：
+
+```text
+.clawhub-publish-output/
+  manifest.json
+  miniprogram-development/
+    SKILL.md
+    references/...
+  all-in-one/
+    SKILL.md
+    references/...
+```
+
+`manifest.json` 建议包含：
+
+- `targetKey`
+- `registryName`
+- `artifactDir`
+- `sourceType`
+- `sourceDescription`
+
+### 2. 复用现有构建链路
+
+`miniprogram-development`：
+
+- 直接从 `config/source/skills/miniprogram-development/` 拷贝
+- 沿用现有 `build-skills-repo.mjs` 的 frontmatter 校验思路
+
+`all-in-one`：
+
+- 直接调用 `scripts/build-allinone-skill.ts --dir <tempDir>`
+- 从 `<tempDir>/cloudbase` 收集产物
+- 不复制 all-in-one 聚合逻辑，避免双份实现漂移
+
+### 3. 校验逻辑
+
+`build-clawhub-publish-artifacts.mjs` 需要至少校验：
+
+- 目标单元是否合法
+- 产物目录是否存在 `SKILL.md`
+- `SKILL.md` 是否含 frontmatter
+- frontmatter 中是否至少存在 `name` 与 `description`
+
+这部分校验失败时直接退出非 0，并输出明确单元名称。
+
+## GitHub Actions 设计
+
+新增 workflow：`.github/workflows/publish-clawhub-registry.yml`
+
+触发方式仅建议 `workflow_dispatch`，避免默认 push 自动发布。
+
+建议输入：
+
+- `targets`：逗号分隔，必填，例如 `miniprogram-development,all-in-one`
+- `dry_run`：可选，是否只构建与校验，不真正发布
+- `bump`：可选，版本升级类型，支持 `patch|minor|major`，默认 `minor`
+- `changelog`：可选，发布说明，可为空
+- `tags`：可选，逗号分隔标签，默认 `latest`
+
+建议 secrets：
+
+- `CLAWDHUB_TOKEN`：ClawHub 发布凭证
+
+工作流步骤：
+
+1. checkout 当前仓库
+2. setup Node.js
+3. 执行 `node scripts/build-clawhub-publish-artifacts.mjs`
+4. 安装 ClawHub CLI，例如 `npm install -g clawhub`
+5. 使用 `clawhub login --token <token> --no-browser` 完成非交互认证
+6. 遍历 `manifest.json`，逐个执行 `clawhub sync --root <artifactDir> --all` 命令
+7. 生成 Job Summary
+
+如果 `dry_run=true`，则跳过真正的 publish，仅输出将要发布的单元与目录。
+
+## ClawHub CLI 集成
+
+当前仓库内没有 ClawHub CLI 现成集成，因此工作流设计采用“最小耦合”方式：
+
+- CLI 安装只放在 workflow 里，不耦合到常规项目依赖
+- publish 命令封装在独立脚本 `scripts/publish-to-clawhub.mjs` 中，避免 workflow shell 过重
+- token 通过环境变量注入，不写入仓库文件
+
+已确认本方案采用的 CLI 同步命令格式为：
+
+```bash
+clawhub sync \
+  --root <artifactDir> \
+  --all \
+  --bump <patch|minor|major> \
+  --changelog <text> \
+  --tags <tags>
+```
+
+`publish-to-clawhub.mjs` 职责：
+
+- 读取 `manifest.json`
+- 根据 `dryRun` 决定是否执行真实发布
+- 使用 `child_process.execFileSync` 调用 `clawhub`
+- 逐单元记录成功/失败
+- 失败时汇总错误并以非 0 退出
+
+脚本需要把 workflow 输入的 `bump`、`changelog`、`tags` 透传到 sync 命令，并让 ClawHub 自己处理版本号递增。
+
+## 测试策略
+
+新增自动化测试，优先覆盖脚本层而不是 workflow 真发布：
+
+1. `tests/build-clawhub-publish-artifacts.test.js`
+   - 指定 `miniprogram-development` 时可生成产物
+   - 指定 `all-in-one` 时可生成 `cloudbase` 聚合产物
+   - 指定非法目标时失败
+
+2. `tests/publish-targets.test.js`
+   - 校验发布单元白名单与 registryName 映射
+   - 防止未来误把“全量 source skills”加入默认发布范围
+
+3. 保留现有 `tests/build-skills-repo.test.js` 与 `tests/build-allinone-skill.test.js`
+   - 作为回归保护，确认新增链路未破坏既有构建能力
+
+## 安全性
+
+- 发布凭证仅通过 GitHub Secrets 注入
+- workflow 不在日志中打印 token
+- 发布目标采用白名单解析，避免任意路径被当作 Skill 发布
+
+## 风险与处理
+
+风险 1：ClawHub CLI 的实际 publish 参数与当前假设不一致
+
+- 处理：把 CLI 调用集中在 `publish-to-clawhub.mjs` 的命令拼装函数中，降低修改面
+
+风险 2：all-in-one 构建依赖 Node 版本
+
+- 处理：workflow 与测试都沿用现有 Node 22/24 约束，优先复用已存在的 all-in-one 构建方式
+
+风险 3：用户误以为此工作流会自动发布全部 skills
+
+- 处理：workflow 输入与日志都显式使用 `targets` 概念，并对未知目标直接失败

--- a/specs/clawhub-public-skill-registry-publish/requirements.md
+++ b/specs/clawhub-public-skill-registry-publish/requirements.md
@@ -1,0 +1,77 @@
+# 需求文档
+
+## 介绍
+
+当前仓库已经具备从 `config/source/skills/` 与 `config/source/guideline/` 构建对外 Skill 产物并推送到独立 skills 仓库的能力，但缺少面向 ClawHub public skill registry 的自动发布流程。
+
+本需求目标是补齐一套 GitHub Actions 发布脚本，使维护者可以基于仓库中的原始 skill 源或受控构建产物，按目标发布单元自动发布到 ClawHub public skill registry，同时保留必要的校验、日志和失败反馈能力。
+
+结合当前仓库结构，已确认需要探索并纳入的发布单元不是“全量 skills”，而是“按目标发布单元”处理，当前范围包括：
+
+- `miniprogram-development`：直接来自 `config/source/skills/miniprogram-development/`
+- `all-in-one`：对应 `scripts/build-allinone-skill.ts` 生成的 `cloudbase` 聚合 Skill
+
+当前草案基于以下探索结论与假设：
+
+- 发布对象以“显式选中的发布单元”为准，而不是默认发布 `config/source/skills/` 下所有 Skill。
+- `miniprogram-development` 可直接从 `config/source/skills/` 发布。
+- `all-in-one` 需要通过 `scripts/build-allinone-skill.ts` 先构建，再作为单独 Skill 发布。
+- `setup-cloudbase-openclaw` 已确认不再维护，不纳入本次 ClawHub 发布范围。
+- 发布动作通过 ClawHub 官方 CLI `clawhub` 执行。
+- GitHub Actions 将通过仓库 Secret 注入发布凭证。
+
+## 需求
+
+### 需求 1 - 按目标发布单元准备发布输入
+
+**用户故事：** 作为维护者，我希望工作流能够按我指定的发布目标准备发布输入，而不是默认发布所有 Skill，这样我可以只发布当前需要的单元。
+
+#### 验收标准
+
+1. When 发布工作流启动时, the CloudBase AI Toolkit shall 仅处理维护者显式指定的发布单元，而不是默认扫描并发布所有 Skill。
+2. When 维护者指定 `miniprogram-development` 时, the CloudBase AI Toolkit shall 从 `config/source/skills/miniprogram-development/` 生成可供 registry 发布的独立输入目录。
+3. When 维护者指定 `all-in-one` 时, the CloudBase AI Toolkit shall 先调用 `scripts/build-allinone-skill.ts` 构建 `cloudbase` 聚合 Skill，再生成可供 registry 发布的独立输入目录。
+4. While 某个发布单元缺少 `SKILL.md` 或必要元数据时, when 工作流准备发布输入, the CloudBase AI Toolkit shall 阻止发布该单元并输出明确的失败原因。
+
+### 需求 2 - 提供可控的 GitHub Actions 发布入口
+
+**用户故事：** 作为维护者，我希望通过 GitHub Actions 触发发布，并控制发布哪些 Skill、何时发布，这样发布过程可追踪且可回放。
+
+#### 验收标准
+
+1. When 维护者手动触发 GitHub Actions 工作流时, the CloudBase AI Toolkit shall 支持通过输入参数指定要发布的目标单元，至少覆盖 `miniprogram-development` 与 `all-in-one`。
+2. When 维护者一次指定多个发布单元时, the CloudBase AI Toolkit shall 按单元逐个构建与发布，并分别记录结果。
+3. When 指定的发布单元名称不存在或当前仓库不支持解析时, the CloudBase AI Toolkit shall 终止工作流并输出无效单元名称列表。
+4. While 发布工作流执行中, when 每个发布单元开始与结束发布时, the CloudBase AI Toolkit shall 在日志中输出对应单元名称、阶段状态和结果。
+
+### 需求 3 - 调用 ClawHub Registry 发布能力
+
+**用户故事：** 作为维护者，我希望工作流直接调用 ClawHub 的发布工具完成 registry 发布，这样可以避免手工在本地重复执行命令。
+
+#### 验收标准
+
+1. When 工作流进入发布阶段时, the CloudBase AI Toolkit shall 在 GitHub Actions 环境中安装或启用 ClawHub CLI。
+2. When 发布某个目标单元时, the CloudBase AI Toolkit shall 使用仓库 Secret 提供的凭证调用 `clawhub sync` 命令，并显式传入 `--root`、`--all`、`--bump`、`--changelog` 与 `--tags` 等参数。
+3. While 发布凭证缺失或无效时, when 工作流尝试发布, the CloudBase AI Toolkit shall 立即失败并输出凭证配置缺失或认证失败提示。
+4. When 某个目标单元发布失败时, the CloudBase AI Toolkit shall 在工作流摘要或日志中保留失败单元名称和错误信息。
+
+### 需求 4 - 保证发布前校验与回归边界
+
+**用户故事：** 作为维护者，我希望发布前至少完成基础校验，避免把结构错误或不完整的 Skill 发布到公共 registry。
+
+#### 验收标准
+
+1. When 发布工作流开始执行时, the CloudBase AI Toolkit shall 在发布前运行与目标单元构建直接相关的本地校验步骤。
+2. While 发布输入目录与目标单元定义的源目录或构建产物存在结构偏差时, when 校验步骤执行, the CloudBase AI Toolkit shall 阻止继续发布并输出差异信息。
+3. When 发布脚本或工作流被修改时, the CloudBase AI Toolkit shall 提供自动化测试或脚本级验证，确保发布单元筛选、构建与发布逻辑可回归。
+
+### 需求 5 - 与现有发布链路保持边界清晰
+
+**用户故事：** 作为维护者，我希望新增的 ClawHub 发布流程不会破坏现有 skills repo、compat config 和文档生成链路。
+
+#### 验收标准
+
+1. When 新增 ClawHub 发布脚本后, the CloudBase AI Toolkit shall 保持现有 `scripts/build-skills-repo.mjs` 与 `push-skills-repo.yaml` 的默认行为不变。
+2. When ClawHub 发布工作流执行时, the CloudBase AI Toolkit shall 仅消费 `config/source/*` 或其受控构建产物，而不要求手工修改 `.skills-repo-output/` 等生成目录。
+3. While 仓库中存在其他未参与发布的变更时, when ClawHub 发布工作流运行, the CloudBase AI Toolkit shall 仅处理被显式选中的发布单元，避免误发布无关内容。
+4. When 发布 `all-in-one` 单元时, the CloudBase AI Toolkit shall 复用现有 all-in-one 构建链路，而不是复制一套独立的聚合逻辑。

--- a/specs/clawhub-public-skill-registry-publish/tasks.md
+++ b/specs/clawhub-public-skill-registry-publish/tasks.md
@@ -1,0 +1,46 @@
+# 实施计划
+
+- [x] 1. 建立 ClawHub 发布单元白名单与目标解析
+  - 新增发布单元定义脚本，集中维护 `miniprogram-development`、`all-in-one` 的元信息
+  - 实现目标名称解析、非法目标报错、registry 名称映射
+  - _需求: 需求 1, 需求 2, 需求 5
+
+- [x] 2. 实现 ClawHub 发布产物构建脚本
+  - 新增 `scripts/build-clawhub-publish-artifacts.mjs`
+  - 支持从 `config/source/skills/miniprogram-development/` 构建独立发布目录
+  - 支持复用 `scripts/build-allinone-skill.ts` 生成 `all-in-one` 发布目录
+  - 输出 `manifest.json` 供后续发布步骤消费
+  - _需求: 需求 1, 需求 4, 需求 5
+
+- [x] 3. 补齐发布前结构与元数据校验
+  - 校验目标单元对应产物目录存在 `SKILL.md`
+  - 校验 frontmatter 中至少包含 `name` 与 `description`
+  - _需求: 需求 1, 需求 4
+
+- [x] 4. 实现 ClawHub CLI 发布执行脚本
+  - 新增 `scripts/publish-to-clawhub.mjs`
+  - 读取 `manifest.json` 并逐单元执行发布
+  - 按真实 CLI 参数传递 `clawhub sync --root --all --bump --changelog --tags`
+  - 预留 `dry-run` 模式，仅打印将要发布的单元和目录
+  - 汇总成功与失败结果，并在失败时返回非 0 退出码
+  - _需求: 需求 2, 需求 3, 需求 4
+
+- [x] 5. 新增 GitHub Actions 发布工作流
+  - 创建 `.github/workflows/publish-clawhub-registry.yml`
+  - 提供 `targets`、`bump`、`changelog`、`tags`、`dry_run` 输入参数
+  - 在 workflow 中安装 `clawhub` CLI 并通过 Secret 注入凭证
+  - 使用非交互 token 登录完成认证
+  - 生成 job summary，输出每个目标单元的发布结果
+  - _需求: 需求 2, 需求 3, 需求 5
+
+- [x] 6. 增加脚本级自动化测试与回归保护
+  - 新增发布单元解析测试，防止默认发布范围回退为全量 skills
+  - 新增产物构建测试，覆盖 `miniprogram-development`、`all-in-one`、非法目标等场景
+  - 保持现有 `build-skills-repo` 与 `build-allinone-skill` 测试不回退
+  - _需求: 需求 4, 需求 5
+
+- [x] 7. 本地验证发布链路的构建与 dry-run 行为
+  - 运行新增测试与必要的现有测试
+  - 本地执行发布产物构建脚本验证 `manifest.json` 与目录结构
+  - 以 `dry-run` 方式验证 workflow 所依赖的发布脚本参数与输出
+  - _需求: 需求 3, 需求 4, 需求 5

--- a/tests/build-clawhub-publish-artifacts.test.js
+++ b/tests/build-clawhub-publish-artifacts.test.js
@@ -1,0 +1,58 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, expect, test } from 'vitest';
+import { buildClawhubPublishArtifacts } from '../scripts/build-clawhub-publish-artifacts.mjs';
+
+const tempDirs = [];
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+test('buildClawhubPublishArtifacts builds miniprogram-development artifact', () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawhub-publish-'));
+  tempDirs.push(outputDir);
+
+  const manifest = buildClawhubPublishArtifacts({
+    targets: 'miniprogram-development',
+    outputDir,
+  });
+
+  expect(manifest.targets).toHaveLength(1);
+  expect(manifest.targets[0].targetKey).toBe('miniprogram-development');
+  expect(
+    fs.existsSync(path.join(outputDir, 'miniprogram-development', 'SKILL.md')),
+  ).toBe(true);
+  expect(fs.existsSync(path.join(outputDir, 'manifest.json'))).toBe(true);
+});
+
+test('buildClawhubPublishArtifacts builds all-in-one artifact', () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawhub-allinone-'));
+  tempDirs.push(outputDir);
+
+  const manifest = buildClawhubPublishArtifacts({
+    targets: 'all-in-one',
+    outputDir,
+  });
+
+  expect(manifest.targets).toHaveLength(1);
+  expect(manifest.targets[0].registrySlug).toBe('cloudbase');
+  expect(fs.existsSync(path.join(outputDir, 'all-in-one', 'SKILL.md'))).toBe(true);
+  expect(
+    fs.existsSync(path.join(outputDir, 'all-in-one', 'references', 'auth-web', 'SKILL.md')),
+  ).toBe(true);
+});
+
+test('buildClawhubPublishArtifacts rejects invalid targets', () => {
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawhub-invalid-'));
+  tempDirs.push(outputDir);
+
+  expect(() =>
+    buildClawhubPublishArtifacts({
+      targets: 'auth-web',
+      outputDir,
+    }),
+  ).toThrow(/Unknown publish targets/);
+});

--- a/tests/publish-targets.test.js
+++ b/tests/publish-targets.test.js
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest';
+import {
+  CLAWHUB_PUBLISH_TARGETS,
+  parseTargetInput,
+  resolvePublishTargets,
+} from '../scripts/clawhub-publish-targets.mjs';
+
+test('parseTargetInput accepts explicit target list and de-duplicates order-preservingly', () => {
+  expect(
+    parseTargetInput('miniprogram-development, all-in-one, miniprogram-development'),
+  ).toEqual(['miniprogram-development', 'all-in-one']);
+});
+
+test('parseTargetInput rejects unknown publish targets', () => {
+  expect(() => parseTargetInput('auth-web')).toThrow(/Unknown publish targets/);
+});
+
+test('resolvePublishTargets only returns whitelisted publish units', () => {
+  const targets = resolvePublishTargets('miniprogram-development,all-in-one');
+
+  expect(targets.map((target) => target.key)).toEqual([
+    'miniprogram-development',
+    'all-in-one',
+  ]);
+  expect(Object.keys(CLAWHUB_PUBLISH_TARGETS)).toEqual([
+    'miniprogram-development',
+    'all-in-one',
+  ]);
+});


### PR DESCRIPTION
## Summary
- add explicit ClawHub publish targets for miniprogram-development and all-in-one
- add artifact build and registry sync scripts plus bilingual logging
- add a manual GitHub workflow and script-level tests for the publish flow

## Verification
- node scripts/build-clawhub-publish-artifacts.mjs --targets "miniprogram-development,all-in-one"
- node scripts/publish-to-clawhub.mjs --manifest .clawhub-publish-output/manifest.json --bump minor --tags latest --dry-run
