### PR TITLE
fix(cloudrun): refresh generated CloudBase Web SDK CDN example

### DIFF
--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -489,7 +489,7 @@ curl 'http://127.0.0.1:3000/v1/aibot/bots/${botId}/send-message' \\
 
 ### Web 调用
 \`\`\`html
-<script src="//static.cloudbase.net/cloudbase-js-sdk/2.9.0/cloudbase.full.js"></script>
+<script src="https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js"></script>
 <script>
 const app = cloudbase.init({ env: "your-env-id" });
 const auth = app.auth();

--- a/tests/cloudrun-agent-readme.test.js
+++ b/tests/cloudrun-agent-readme.test.js
@@ -1,0 +1,18 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { expect, test } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+test('cloudrun createAgent README uses current CloudBase Web SDK CDN URL', () => {
+  const cloudrunSource = fs.readFileSync(
+    path.join(ROOT_DIR, 'mcp', 'src', 'tools', 'cloudrun.ts'),
+    'utf8',
+  );
+
+  expect(cloudrunSource).toContain('https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js');
+  expect(cloudrunSource).not.toContain('//static.cloudbase.net/cloudbase-js-sdk/2.9.0/cloudbase.full.js');
+});


### PR DESCRIPTION
## Summary
- update the CloudRun `createAgent` README template to use the current CloudBase Web SDK CDN URL
- stop generating the stale `2.9.0` script tag in agent scaffolding output
- add a focused regression test that guards the generated README source snippet

## Issue
- closes #343

## Validation
- added a focused regression test at `tests/cloudrun-agent-readme.test.js`
- verified the CloudRun createAgent template now points to `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`

## Residual Risk
- I did not run `vitest` in this worktree because the current local environment does not have the required root-level test dependencies available, and previous bare `npx vitest` startup was affected by an external `vite.config.ts`
