### PR TITLE
fix(web-sdk): surface the latest CloudBase Web SDK CDN early

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -35,6 +35,13 @@ Read this section first. The routing contract uses stable skill identifiers such
 - Native App failures are usually caused by reading Web SDK paths, not by missing HTTP API knowledge.
 - Mini program failures are usually caused by treating `wx.cloud` like Web auth or Web SDK.
 
+### Web SDK quick reminder
+
+- In CloudBase Web + BaaS scenarios, surface the official Web SDK CDN early: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+- For React, Vue, Vite, Webpack, and other modern frontend projects, prefer `npm install @cloudbase/js-sdk`
+- For static HTML, no-build demos, README snippets, or low-friction prototypes, the CDN form is acceptable
+- Read `web-development` first for Web SDK integration, then `auth-web` when login or session handling is involved
+
 ## 💡 Recommended: MCP Installation
 
 **For enhanced CloudBase development experience, we recommend installing CloudBase MCP (Model Context Protocol).**
@@ -180,6 +187,9 @@ Prefer long-term memory when available: write the scenarios and working rules th
    - NoSQL: `no-sql-web-sdk` skill
    - MySQL: `relational-database-web` and `relational-database-tool` skills
 4. **UI Design** (Recommended): Read the `ui-design` skill for better UI/UX design guidelines
+5. **Quick SDK reference**:
+   - npm / bundler projects: `npm install @cloudbase/js-sdk`
+   - static page / CDN: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 
 ### When Developing a Mini Program Project:
 1. **Platform**: Read the `miniprogram-development` skill for project structure, WeChat Developer Tools, and wx.cloud usage

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -40,7 +40,9 @@ alwaysApply: false
 
 **Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
 **Key Benefits**: Compatible with `supabase-js` API, supports phone, email, anonymous, username/password, and third-party login methods
-**`@cloudbase/js-sdk` cdn source**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+**Official `@cloudbase/js-sdk` CDN**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+
+Use the same CDN address as `web-development`. Prefer npm installation in modern bundler projects, and use the CDN form for static HTML, no-build demos, or low-friction examples.
 
 ## Prerequisites
 

--- a/config/source/skills/web-development/SKILL.md
+++ b/config/source/skills/web-development/SKILL.md
@@ -59,6 +59,7 @@ Use this skill for **Web frontend project development** when you need to:
    - Always use SDK built-in authentication features
    - Never implement login logic in cloud functions
    - Use `envQuery` tool to get environment ID
+   - Mention the official CDN early when the user needs a static HTML or no-build integration
 
 3. **Deploy and preview properly**
    - Build project first (ensure `npm install` is executed)
@@ -104,6 +105,19 @@ Use this skill for **Web frontend project development** when you need to:
 
 1. **SDK Integration**:
    - If user's project needs database, cloud functions, and other features, need to introduce `@cloudbase/js-sdk@latest` in the web application
+   - Official CDN: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+   - Prefer npm for React, Vue, Vite, Webpack, and other bundler-based projects
+   - Prefer the CDN only for static HTML pages, quick demos, embedded snippets, or README examples where a build step is unnecessary
+
+**CDN quick start (static HTML / no-build)**:
+```html
+<script src="https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js"></script>
+<script>
+const app = cloudbase.init({
+  env: "xxxx-yyy",
+});
+</script>
+```
 
 **Important: Authentication must use SDK built-in features. It is strictly forbidden to implement login authentication logic using cloud functions!**
 

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -20,6 +20,31 @@ import AIDevelopmentPrompt from '../components/AIDevelopmentPrompt';
 ## Skill 
 
 ````markdown title="rule.md"
+## Activation Contract
+
+### Use this first when
+
+- The task is a CloudBase Web login, registration, session, or user profile flow built with `@cloudbase/js-sdk`.
+
+### Read before writing code if
+
+- The user needs a login page, auth modal, session handling, or protected Web route. Read `auth-tool` first to ensure providers are enabled.
+
+### Then also read
+
+- `../auth-tool/SKILL.md` for provider setup
+- `../web-development/SKILL.md` for Web project structure and deployment
+
+### Do NOT use for
+
+- Mini program auth, native App auth, or server-side auth setup.
+
+### Common mistakes / gotchas
+
+- Skipping publishable key and provider checks.
+- Replacing built-in Web auth with cloud function login logic.
+- Reusing this flow in Flutter, React Native, or native iOS/Android code.
+
 ## Overview
 
 **Prerequisites**: CloudBase environment ID (`env`)
@@ -31,8 +56,9 @@ import AIDevelopmentPrompt from '../components/AIDevelopmentPrompt';
 
 **Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
 **Key Benefits**: Compatible with `supabase-js` API, supports phone, email, anonymous, username/password, and third-party login methods
-**`@cloudbase/js-sdk` cdn source**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+**Official `@cloudbase/js-sdk` CDN**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 
+Use the same CDN address as `web-development`. Prefer npm installation in modern bundler projects, and use the CDN form for static HTML, no-build demos, or low-friction examples.
 
 ## Prerequisites
 

--- a/doc/prompts/web-development.mdx
+++ b/doc/prompts/web-development.mdx
@@ -20,6 +20,32 @@ import AIDevelopmentPrompt from '../components/AIDevelopmentPrompt';
 ## Skill 
 
 ````markdown title="rule.md"
+## Activation Contract
+
+### Use this first when
+
+- The request is for a CloudBase Web app, static hosting site, frontend page, or Web SDK integration.
+
+### Read before writing code if
+
+- The task includes frontend structure, build config, deployment, routing, or Web SDK usage.
+
+### Then also read
+
+- Login flow -&gt; `../auth-tool/SKILL.md`, then `../auth-web/SKILL.md`
+- UI work -&gt; `../ui-design/SKILL.md` first
+- NoSQL / MySQL data work -&gt; matching database skill
+
+### Do NOT use for
+
+- Mini programs, native Apps, or container backend services.
+
+### Common mistakes / gotchas
+
+- Treating cloud functions as the default solution for Web authentication.
+- Starting UI implementation before reading `ui-design`.
+- Routing native App requests into Web SDK code paths.
+
 ## When to use this skill
 
 Use this skill for **Web frontend project development** when you need to:
@@ -49,6 +75,7 @@ Use this skill for **Web frontend project development** when you need to:
    - Always use SDK built-in authentication features
    - Never implement login logic in cloud functions
    - Use `envQuery` tool to get environment ID
+   - Mention the official CDN early when the user needs a static HTML or no-build integration
 
 3. **Deploy and preview properly**
    - Build project first (ensure `npm install` is executed)
@@ -94,6 +121,19 @@ Use this skill for **Web frontend project development** when you need to:
 
 1. **SDK Integration**:
    - If user's project needs database, cloud functions, and other features, need to introduce `@cloudbase/js-sdk@latest` in the web application
+   - Official CDN: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+   - Prefer npm for React, Vue, Vite, Webpack, and other bundler-based projects
+   - Prefer the CDN only for static HTML pages, quick demos, embedded snippets, or README examples where a build step is unnecessary
+
+**CDN quick start (static HTML / no-build)**:
+```html
+&lt;script src="https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js"&gt;&lt;/script&gt;
+&lt;script&gt;
+const app = cloudbase.init({
+  env: "xxxx-yyy",
+});
+&lt;/script&gt;
+```
 
 **Important: Authentication must use SDK built-in features. It is strictly forbidden to implement login authentication logic using cloud functions!**
 

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -489,7 +489,7 @@ curl 'http://127.0.0.1:3000/v1/aibot/bots/${botId}/send-message' \\
 
 ### Web 调用
 \`\`\`html
-<script src="//static.cloudbase.net/cloudbase-js-sdk/2.9.0/cloudbase.full.js"></script>
+<script src="https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js"></script>
 <script>
 const app = cloudbase.init({ env: "your-env-id" });
 const auth = app.auth();

--- a/specs/web-sdk-cdn-guidance/design.md
+++ b/specs/web-sdk-cdn-guidance/design.md
@@ -1,0 +1,117 @@
+# 技术方案设计
+
+## 概述
+
+本次需求同时覆盖两层问题：
+
+1. **规则层**：让 AI 在 CloudBase Web + BaaS 场景进入实现前，就能在入口规则中看到正确的 Web SDK CDN 地址。
+2. **模板层**：修正仍然输出旧 CDN 地址的生成模板，避免旧地址继续通过脚手架或 README 传播。
+
+本次以“单一语义源优先”为原则，优先修改 `config/source/` 下的源规则文件；模板问题则直接修复对应源码与测试。
+
+## 目标文件
+
+### 规则层
+
+- `config/source/guideline/cloudbase/SKILL.md`
+- `config/source/skills/web-development/SKILL.md`
+- `config/source/skills/auth-web/SKILL.md`
+
+### 模板层
+
+- `mcp/src/tools/cloudrun.ts`
+- 对应测试文件（若主分支不存在，则补充新测试）
+
+## 设计原则
+
+### 1. 把 CDN 地址放到“足够靠前”的位置
+
+问题的核心不是仓库里完全没有正确地址，而是它没有在所有高频入口中足够早地出现。
+
+因此本次将采用以下放置策略：
+
+- `cloudbase` 总入口：增加一条 Web SDK 快速提醒，告知 CloudBase Web 项目接入 BaaS 时优先查看 `web-development` / `auth-web`，并直接给出 CDN 地址
+- `web-development`：在 `CloudBase Web SDK Usage` 前置写明 npm 与 CDN 两种接入方式，并给出正确 CDN 地址
+- `auth-web`：保留现有正确地址，并补一句“与 `web-development` 保持一致”
+
+### 2. 明确 npm 与 CDN 的适用边界
+
+仅写一个 CDN 地址还不够，AI 还需要知道何时用它。
+
+规则中明确：
+
+- **npm 包**：适用于 Vite、Webpack、Next.js、React、Vue 等现代工程化 Web 项目
+- **CDN**：适用于无构建、静态 HTML、快速验证、低代码嵌入或 README 示例
+
+这样既能满足“第一时间知道网址”，也不至于让 AI 在现代前端工程里默认退回 `<script>` 引入。
+
+### 3. 模板层统一最新地址
+
+`cloudrun.ts` 中 `createAgent` README 模板当前仍包含旧版 CDN 字符串。这里直接替换为：
+
+`https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+
+同时增加或保留回归测试，确保后续模板不会回退到固定旧版本路径。
+
+## 变更内容
+
+### 规则层变更
+
+#### `config/source/guideline/cloudbase/SKILL.md`
+
+在 Web 项目相关入口附近加入“CloudBase Web SDK quick reminder”：
+
+- 提醒 Web + BaaS 场景优先查看 `web-development` 与 `auth-web`
+- 明确官方 CDN 地址
+- 提示工程化项目优先 npm，纯静态页/快速接入可使用 CDN
+
+#### `config/source/skills/web-development/SKILL.md`
+
+在 `CloudBase Web SDK Usage` 章节前置增加：
+
+- 官方 CDN 地址
+- npm 与 CDN 的选择原则
+- 如果用户需要“立刻可运行的静态页示例”，允许优先给 CDN 版本
+
+#### `config/source/skills/auth-web/SKILL.md`
+
+保持现有 CDN 地址，并略微强化：
+
+- 标注这是当前官方 CDN
+- 说明该地址应与 `web-development` 的描述一致
+
+### 模板层变更
+
+#### `mcp/src/tools/cloudrun.ts`
+
+替换 `createAgent` 生成 README 内嵌的旧地址：
+
+- 从 `//static.cloudbase.net/cloudbase-js-sdk/2.9.0/cloudbase.full.js`
+- 改为 `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
+
+#### 测试
+
+如果主分支缺少对应测试，则新增一个聚焦回归测试，检查生成 README 片段包含最新地址而非旧版本地址。
+
+## 验证策略
+
+### 文档检查
+
+1. `cloudbase` / `web-development` / `auth-web` 中出现一致的正确 CDN 地址
+2. `web-development` 明确说明 npm 与 CDN 的适用边界
+3. 不新增互相冲突的描述
+
+### 代码检查
+
+1. `cloudrun.ts` 不再包含旧 `2.9.0` 地址
+2. 模板测试覆盖最新地址
+3. 仓库全文检索不再命中旧 CloudBase Web SDK CDN 固定版本地址
+
+## 公开产物策略
+
+本次优先修改源规则与模板源码。
+
+- 若用户要求只修源规则，可暂不生成 `doc/prompts/*`
+- 若本次要把规则修正对外同步，则需要补跑 prompts 生成流程
+
+默认先按源文件与模板源码交付，再根据用户要求决定是否同步公开 prompt 产物。

--- a/specs/web-sdk-cdn-guidance/requirements.md
+++ b/specs/web-sdk-cdn-guidance/requirements.md
@@ -1,0 +1,49 @@
+# 需求文档
+
+## 介绍
+
+当前 `#361` 仅修复了 CloudRun `createAgent` 生成 README 时使用旧版 CloudBase Web SDK CDN 地址的问题，但这只覆盖了单一模板产物。更核心的问题是：当 AI 在 CloudBase Web + BaaS 场景下工作时，应该在进入实现阶段的第一时间就知道正确的 CloudBase Web SDK CDN 地址，并优先使用最新的官方地址，而不是依赖旧模板、猜测地址或继续传播历史版本链接。
+
+本需求的目标是将“CloudBase Web SDK CDN 地址”提升为 CloudBase Web 开发规则中的前置知识，使 AI 在涉及 Web SDK、Web 登录、静态站点或前后端一体 BaaS 集成时，能够尽早使用正确的 CDN 地址。
+
+## 需求
+
+### 需求 1 - Web + BaaS 场景优先暴露正确 CDN 地址
+
+**用户故事：** 作为使用 CloudBase 开发 Web 应用的开发者，我希望 AI 在涉及 CloudBase Web SDK 集成时，第一时间给出正确的官方 CDN 地址，而不是旧地址或模糊说法。
+
+#### 验收标准
+
+1. When AI 开发工具识别到用户正在开发 CloudBase Web 应用并需要接入 CloudBase BaaS 能力时，the CloudBase 规则体系 shall 在靠前位置提供当前官方 CloudBase Web SDK CDN 地址。
+2. When AI 开发工具为 Web 项目提供 CloudBase SDK 接入示例时，the 示例 shall 使用当前官方 CDN 地址 `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`。
+3. When AI 开发工具需要在 npm 包安装与 CDN 引入之间做选择时，the 规则 shall 说明 CDN 适用于无需构建或快速接入场景，而 npm 依赖适用于现代工程化项目。
+
+### 需求 2 - 入口规则与专题规则保持一致
+
+**用户故事：** 作为维护者，我希望 CloudBase 总入口规则与 Web/Auth 专题规则对 SDK CDN 的描述一致，避免 AI 读到不同来源时产生冲突。
+
+#### 验收标准
+
+1. When CloudBase 总入口规则涉及 Web 开发或 Web SDK 集成时，the guideline shall 明确指出需要读取 Web 相关 skill，并可快速获取正确 CDN 地址。
+2. When `web-development` skill 描述 CloudBase Web SDK 集成时，the skill shall 明确给出正确 CDN 地址，并说明适用场景。
+3. When `auth-web` skill 描述 Web 认证初始化时，the skill shall 保持与 `web-development` skill 一致的 CDN 地址，不得出现旧版本地址。
+
+### 需求 3 - 生成类模板和示例不再传播旧地址
+
+**用户故事：** 作为使用工具生成项目模板的开发者，我希望任何自动生成的 CloudBase Web SDK 示例都不会继续输出历史 CDN 地址。
+
+#### 验收标准
+
+1. When 工具生成 CloudBase Web SDK 接入示例或 README 模板时，the generated content shall 使用当前官方 CDN 地址。
+2. When 仓库内存在与 CloudBase Web SDK CDN 地址相关的固定字符串模板时，the implementation shall 检查并修正仍在使用旧地址的模板。
+3. When 维护者完成本次修正时，the implementation shall 至少覆盖当前已知的 CloudRun `createAgent` 模板场景，避免 Issue #343 再次出现。
+
+### 需求 4 - 变更范围与验收方式清晰
+
+**用户故事：** 作为维护者，我希望这次修正明确区分“规则层修正”和“模板层修正”，便于后续审查和回归。
+
+#### 验收标准
+
+1. When 本次需求进入实现阶段时，the implementation shall 明确列出需要修改的源规则文件与模板文件。
+2. When 维护者验证本次需求时，the verification shall 检查规则文件中的 CDN 地址与模板中的 CDN 地址保持一致。
+3. When 本次需求完成时，the implementation shall 说明是否同步更新公开 prompt 产物；若未同步，shall 明确指出未同步范围。

--- a/specs/web-sdk-cdn-guidance/tasks.md
+++ b/specs/web-sdk-cdn-guidance/tasks.md
@@ -1,0 +1,27 @@
+# 实施计划
+
+- [x] 1. 强化 CloudBase Web 入口规则中的 CDN 提示
+  - 更新 `config/source/guideline/cloudbase/SKILL.md`
+  - 在 Web + BaaS 场景入口中补充官方 Web SDK CDN 地址与路由提醒
+  - _需求: 需求 1, 需求 2
+
+- [x] 2. 更新 Web 相关源 skill 的 SDK 接入说明
+  - 更新 `config/source/skills/web-development/SKILL.md`
+  - 补充 npm 与 CDN 的适用边界
+  - 检查并修正 `config/source/skills/auth-web/SKILL.md` 中的对应描述，确保一致
+  - _需求: 需求 1, 需求 2
+
+- [x] 3. 修正 CloudRun 模板中的旧 CDN 地址
+  - 更新 `mcp/src/tools/cloudrun.ts` 中 `createAgent` 生成 README 的 CDN 链接
+  - 检查仓库内是否仍存在旧的固定版本 CloudBase Web SDK CDN 地址
+  - _需求: 需求 3
+
+- [x] 4. 增加或更新回归测试
+  - 为 CloudRun README 模板补充或更新聚焦测试
+  - 验证生成内容包含最新地址且不包含旧版本地址
+  - _需求: 需求 3, 需求 4
+
+- [x] 5. 完成自检并说明产物同步范围
+  - 自检源规则、模板源码与测试的一致性
+  - 明确本次是否同步 `doc/prompts/*` 公开产物
+  - _需求: 需求 4

--- a/tests/cloudrun-agent-readme.test.js
+++ b/tests/cloudrun-agent-readme.test.js
@@ -1,0 +1,19 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, test } from 'vitest';
+
+describe('CloudRun createAgent README template', () => {
+  test('uses the latest CloudBase Web SDK CDN URL', () => {
+    const cloudrunSource = fs.readFileSync(
+      path.resolve(process.cwd(), 'mcp/src/tools/cloudrun.ts'),
+      'utf8',
+    );
+
+    expect(cloudrunSource).toContain(
+      'https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js',
+    );
+    expect(cloudrunSource).not.toContain(
+      '//static.cloudbase.net/cloudbase-js-sdk/2.9.0/cloudbase.full.js',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- surface the official CloudBase Web SDK CDN URL earlier in the CloudBase, web-development, and auth-web source skills
- clarify when to prefer npm installation versus CDN usage for Web + BaaS scenarios
- replace the stale CloudRun createAgent README CDN example with the latest official URL and add a focused regression test

## Issue
- closes #343

## Validation
- ran `node scripts/generate-prompts-data.mjs`
- ran `node scripts/generate-prompts.mjs`
- ran `npx vitest run tests/cloudrun-agent-readme.test.js`
- verified `config/source`, `doc/prompts`, and `mcp/src/tools/cloudrun.ts` no longer contain the old fixed `2.9.0` CDN URL

## Notes
- this PR covers both rule-layer guidance and the current known CloudRun template regression
- only the directly related prompt artifacts were kept in the diff to avoid bundling unrelated prompt drift