### PR TITLE
fix(rag): default vector knowledge base to cloudbase

### DIFF
--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -654,7 +654,7 @@ API名：storage API介绍：Storage API - 云存储 HTTP API
 <tr><td><code>docName</code></td><td>string</td><td></td><td>mode=doc 时指定。文档名称。 可填写的值: "ai-model-nodejs", "ai-model-web", "ai-model-wechat", "auth-http-api", "auth-nodejs", "auth-tool", "auth-web", "auth-wechat", "cloud-functions", "cloud-storage-web", "cloudbase-platform", "cloudrun-development", "data-model-creation", "http-api", "miniprogram-development", "no-sql-web-sdk", "no-sql-wx-mp-sdk", "relational-database-tool", "relational-database-web", "spec-workflow", "ui-design", "web-development"</td></tr>
 <tr><td><code>apiName</code></td><td>string</td><td></td><td>mode=openapi 时指定。API 名称。 可填写的值: "mysqldb", "functions", "auth", "cloudrun", "storage"</td></tr>
 <tr><td><code>threshold</code></td><td>number</td><td></td><td>mode=vector 时指定。相似性检索阈值 默认值: 0.5</td></tr>
-<tr><td><code>id</code></td><td>string</td><td></td><td>mode=vector 时指定。知识库范围，cloudbase=云开发全量知识，scf=云开发的云函数知识, miniprogram=小程序知识（不包含云开发与云函数知识） 可填写的值: "cloudbase", "scf", "miniprogram"</td></tr>
+<tr><td><code>id</code></td><td>string</td><td></td><td>mode=vector 时可选。知识库范围，默认值: <code>cloudbase</code>。cloudbase=云开发全量知识，scf=云开发的云函数知识, miniprogram=小程序知识（不包含云开发与云函数知识） 可填写的值: "cloudbase", "scf", "miniprogram"</td></tr>
 <tr><td><code>content</code></td><td>string</td><td></td><td>mode=vector 时指定。检索内容</td></tr>
 <tr><td><code>options</code></td><td>object</td><td></td><td>mode=vector 时指定。其他选项</td></tr>
 <tr><td><code>options.chunkExpand</code></td><td>array of number</td><td></td><td>指定返回的文档内容的展开长度,例如 [3,3]代表前后展开长度 默认值: [3,3]</td></tr>

--- a/mcp/src/tools/rag.test.ts
+++ b/mcp/src/tools/rag.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it, vi } from "vitest";
+import type { ExtendedMcpServer } from "../server.js";
+import { registerRagTools } from "./rag.js";
+
+function createMockServer() {
+  const tools: Record<string, { meta: any; handler: (args: any) => Promise<any> }> = {};
+
+  const server: ExtendedMcpServer = {
+    registerTool: vi.fn(
+      (name: string, meta: any, handler: (args: any) => Promise<any>) => {
+        tools[name] = { meta, handler };
+      },
+    ),
+  } as unknown as ExtendedMcpServer;
+
+  return { server, tools };
+}
+
+describe("rag tools", () => {
+  it("searchKnowledgeBase no longer requires id when mode=vector", async () => {
+    const { server, tools } = createMockServer();
+
+    await registerRagTools(server);
+
+    await expect(
+      tools.searchKnowledgeBase.handler({
+        mode: "vector",
+      }),
+    ).rejects.toThrow("检索内容不能为空");
+  });
+});

--- a/mcp/src/tools/rag.ts
+++ b/mcp/src/tools/rag.ts
@@ -561,8 +561,8 @@ export async function registerRagTools(server: ExtendedMcpServer) {
           .default(0.5)
           .optional()
           .describe("mode=vector 时指定。相似性检索阈值"),
-        id: KnowledgeBaseEnum.optional().describe(
-          "mode=vector 时指定。知识库范围，cloudbase=云开发全量知识，scf=云开发的云函数知识, miniprogram=小程序知识（不包含云开发与云函数知识）",
+        id: KnowledgeBaseEnum.default("cloudbase").optional().describe(
+          "mode=vector 时指定。知识库范围，默认 cloudbase。cloudbase=云开发全量知识，scf=云开发的云函数知识, miniprogram=小程序知识（不包含云开发与云函数知识）",
         ),
         content: z.string().describe("mode=vector 时指定。检索内容").optional(),
         options: z
@@ -639,12 +639,9 @@ export async function registerRagTools(server: ExtendedMcpServer) {
       }
 
       // 向量检索模式下必须提供 id 和 content，避免后端报「知识库名称不能为空」
+      const vectorKnowledgeBaseId = id ?? "cloudbase";
+
       if (mode === "vector") {
-        if (!id) {
-          throw new Error(
-            "知识库名称不能为空: please provide `id` when mode=vector (cloudbase / scf / miniprogram).",
-          );
-        }
         if (!content || !content.trim()) {
           throw new Error(
             "检索内容不能为空: please provide non-empty `content` when mode=vector.",
@@ -654,7 +651,8 @@ export async function registerRagTools(server: ExtendedMcpServer) {
 
       // 枚举到后端 id 映射
       const backendId =
-        KnowledgeBaseIdMap[id as keyof typeof KnowledgeBaseIdMap] || id;
+        KnowledgeBaseIdMap[vectorKnowledgeBaseId as keyof typeof KnowledgeBaseIdMap] ||
+        vectorKnowledgeBaseId;
       const signInRes = await fetch(
         "https://tcb-advanced-a656fc.api.tcloudbasegateway.com/auth/v1/signin/anonymously",
         {


### PR DESCRIPTION
## Summary
- default `searchKnowledgeBase(mode=vector)` to the `cloudbase` knowledge base when `id` is omitted
- keep `content` as the only required vector-search payload field
- update the MCP tools documentation and add a focused unit test for the new default behavior

## Issue
- closes #309

## Validation
- ran `npx vitest run mcp/src/tools/rag.test.ts`
- verified vector mode without `id` now falls through to content validation instead of throwing the old "知识库名称不能为空" error

## Notes
- this keeps explicit `scf` and `miniprogram` routing intact while making the default vector search path easier to use