### PR TITLE
ci(npm): prerelease tags publish with beta dist-tag

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -1,10 +1,11 @@
 name: Publish to npm
 
 on:
-  # 1. Tag 触发规则
+  # Tag push: stable (v1.2.3) and semver prerelease (v1.2.3-beta.1)
   push:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-*"
 
   workflow_dispatch:
 
@@ -41,6 +42,28 @@ jobs:
         working-directory: ./mcp
         run: npm run build
 
+      - name: Resolve npm dist-tag
+        id: npm_tag
+        working-directory: ./mcp
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            SUFFIX="${GITHUB_REF#refs/tags/v}"
+            if [[ "$SUFFIX" == *-* ]]; then
+              DIST_TAG=beta
+            else
+              DIST_TAG=latest
+            fi
+          else
+            VERSION=$(node -p "require('./package.json').version")
+            if [[ "$VERSION" == *-* ]]; then
+              DIST_TAG=beta
+            else
+              DIST_TAG=latest
+            fi
+          fi
+          echo "tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
+          echo "Using npm dist-tag: $DIST_TAG"
+
       - name: Publish to npm
         working-directory: ./mcp
-        run: NODE_AUTH_TOKEN="" npm publish --provenance --access public --verbose
+        run: NODE_AUTH_TOKEN="" npm publish --provenance --access public --tag "${{ steps.npm_tag.outputs.tag }}" --verbose


### PR DESCRIPTION
## Summary
- Match semver prerelease git tags (e.g. `v2.15.0-beta.1`) in `npm-publish` workflow
- Use npm dist-tag `beta` for prereleases; `latest` for stable
- `workflow_dispatch` uses `package.json` version to pick dist-tag

Made with [Cursor](https://cursor.com)