### PR TITLE
fix(tools): 🛠️ add propagation delay warning to createAccess response

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -107,6 +107,8 @@ describe("gateway tools", () => {
     });
     expect(payload).toMatchObject({
       success: true,
+      message:
+        "已为目标 helloFn 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。",
       data: {
         action: "createAccess",
         targetType: "function",
@@ -117,6 +119,7 @@ describe("gateway tools", () => {
         expect.objectContaining({
           tool: "queryGateway",
           action: "getAccess",
+          reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
         }),
       ],
     });

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -207,12 +207,12 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           path: accessPath,
           raw: result,
         },
-        `已为目标 ${input.targetName} 创建网关访问路径。注意：路由配置传播可能需要等待几秒到一分钟，请勿立即访问。`,
+        `已为目标 ${input.targetName} 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。`,
         [
           {
             tool: "queryGateway",
             action: "getAccess",
-            reason: "等待 30-60 秒后确认访问入口是否已生效",
+            reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
           },
         ],
       );


### PR DESCRIPTION
Fixes #390

## Changes
- Added propagation delay warning to manageGateway createAccess response
- Routes may take several seconds to propagate on CDN/edge after successful creation

## Attribution
- Issue: issue_mmywbpii_vz2k6j
- Run: atomic-js-cloudbase-http-service-config/2026-03-20T12-48-08-wf14su
- Score: 0.933