### PR TITLE
fix(tools): 🛠️ add CdnDomain and Bucket to envQuery hosting response

### DIFF
--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -376,4 +376,67 @@ describe("env tools - envQuery", () => {
     expect(filtered.EnvList).toEqual([{ EnvId: "env-other", Alias: "other" }]);
     expect(filtered.AppliedFilters.currentEnvOnly).toBe(false);
   });
+
+  it("envQuery(hosting) should read CdnDomain and Bucket from StaticStorages", async () => {
+    mockGetCloudBaseManager.mockResolvedValue({
+      hosting: {
+        getWebsiteConfig: vi.fn().mockResolvedValue({
+          IndexDocument: "index.html",
+          ErrorDocument: "404.html",
+        }),
+      },
+      env: {
+        getEnvInfo: vi.fn().mockResolvedValue({
+          EnvInfo: {
+            StaticStorages: [
+              {
+                StaticDomain: "static.example.com",
+                Bucket: "hosting-bucket",
+              },
+            ],
+            Storages: [
+              {
+                Bucket: "storage-bucket",
+              },
+            ],
+          },
+        }),
+      },
+    });
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse((await tools.envQuery.handler({ action: "hosting" })).content[0].text);
+
+    expect(payload).toMatchObject({
+      IndexDocument: "index.html",
+      ErrorDocument: "404.html",
+      CdnDomain: "static.example.com",
+      Bucket: "hosting-bucket",
+    });
+    expect(payload.Bucket).not.toBe("storage-bucket");
+  });
+
+  it("envQuery(hosting) should keep website config when env enrichment fails", async () => {
+    mockGetCloudBaseManager.mockResolvedValue({
+      hosting: {
+        getWebsiteConfig: vi.fn().mockResolvedValue({
+          IndexDocument: "index.html",
+          ErrorDocument: "404.html",
+        }),
+      },
+      env: {
+        getEnvInfo: vi.fn().mockRejectedValue(new Error("env info timeout")),
+      },
+    });
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse((await tools.envQuery.handler({ action: "hosting" })).content[0].text);
+
+    expect(payload).toMatchObject({
+      IndexDocument: "index.html",
+      ErrorDocument: "404.html",
+      CdnDomain: null,
+      Bucket: null,
+    });
+  });
 });

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -817,21 +817,29 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             const cloudbaseHosting = await getManager();
             const websiteConfig = await cloudbaseHosting.hosting.getWebsiteConfig();
             logCloudBaseResult(server.logger, websiteConfig);
+            const hostingResult = {
+              ...(websiteConfig as Record<string, unknown>),
+              CdnDomain: (websiteConfig as Record<string, unknown>).CdnDomain ?? null,
+              Bucket: (websiteConfig as Record<string, unknown>).Bucket ?? null,
+            };
 
-            // Also fetch env info to get CdnDomain and Bucket
-            const envInfo = await cloudbaseHosting.env.getEnvInfo() as {
-              EnvInfo?: {
-                StaticStorages?: Array<{ StaticDomain?: string }>;
-                Storages?: Array<{ Bucket?: string }>;
+            try {
+              const envInfo = await cloudbaseHosting.env.getEnvInfo() as {
+                EnvInfo?: {
+                  StaticStorages?: Array<{ StaticDomain?: string; Bucket?: string }>;
+                };
               };
-            };
-            logCloudBaseResult(server.logger, envInfo);
+              logCloudBaseResult(server.logger, envInfo);
 
-            result = {
-              ...websiteConfig,
-              CdnDomain: envInfo.EnvInfo?.StaticStorages?.[0]?.StaticDomain || null,
-              Bucket: envInfo.EnvInfo?.Storages?.[0]?.Bucket || null,
-            };
+              hostingResult.CdnDomain = envInfo.EnvInfo?.StaticStorages?.[0]?.StaticDomain ?? hostingResult.CdnDomain;
+              hostingResult.Bucket = envInfo.EnvInfo?.StaticStorages?.[0]?.Bucket ?? hostingResult.Bucket;
+            } catch (hostingInfoError) {
+              debug("Failed to enrich hosting envQuery result with env info", {
+                error: hostingInfoError,
+              });
+            }
+
+            result = hostingResult;
             break;
           }
 


### PR DESCRIPTION
Fixes #388

## Changes
- Extended envQuery(action=hosting) to also return CdnDomain and Bucket from getEnvInfo()
- Previously only returned WebsiteConfiguration from getWebsiteConfig()

## Attribution
- Issue: issue_mn1aftau_jkqg0y
- Run: atomic-js-none-describe-static-hosting/2026-03-23T04-18-22-3fa978
- Score: 0.648