### PR TITLE
fix(manager): resolve env region from envCandidates to avoid INVALID_REGION

### DIFF
--- a/mcp/src/cloudbase-manager.ts
+++ b/mcp/src/cloudbase-manager.ts
@@ -350,9 +350,9 @@ export async function getCloudBaseManager(options: GetManagerOptions = {}): Prom
 
     try {
         // Get region from environment variable for auth URL
-        const region = cloudBaseOptions?.region ?? process.env.TCB_REGION;
+        const fallbackRegion = cloudBaseOptions?.region ?? process.env.TCB_REGION;
         const loginState = authStrategy === 'ensure'
-            ? await getLoginState({ region })
+            ? await getLoginState({ region: fallbackRegion })
             : await peekLoginState();
 
         if (!loginState) {
@@ -404,13 +404,29 @@ export async function getCloudBaseManager(options: GetManagerOptions = {}): Prom
 
         // envId priority: envManager.cachedEnvId > envManager.getEnvId() > loginState.envId > undefined
         // Note: envManager.cachedEnvId has highest priority as it reflects user's latest environment switch
-        // Region priority: process.env.TCB_REGION > undefined (use SDK default)
-        // At this point, cloudBaseOptions is undefined (checked above), so only use env var if present
-        // Reuse region variable declared above (line 259) for CloudBase initialization
+        // Region priority: envCandidates[].region (actual env region) > process.env.TCB_REGION > undefined
+        // Resolving the environment's own region avoids INVALID_REGION errors when TCB_REGION
+        // is set to a different region than the target environment.
+        const resolvedEnvId = finalEnvId || loginEnvId;
+        let region = fallbackRegion;
+        if (resolvedEnvId && !cloudBaseOptions?.region) {
+            try {
+                const envCandidates = await listAvailableEnvCandidates({ loginState });
+                const matchedEnv = envCandidates.find(c => c.envId === resolvedEnvId);
+                if (matchedEnv?.region) {
+                    region = matchedEnv.region;
+                    debug('使用环境实际 region:', { envId: resolvedEnvId, region });
+                }
+            } catch {
+                // If env listing fails, fall back to TCB_REGION / undefined
+                debug('无法获取环境列表，使用 fallback region');
+            }
+        }
+
         const manager = new CloudBase({
             secretId,
             secretKey,
-            envId: finalEnvId || loginEnvId,
+            envId: resolvedEnvId,
             token,
             proxy: process.env.http_proxy,
             region,


### PR DESCRIPTION
## Summary

- When TCB_REGION is set to a different region than the actual CloudBase environment (e.g. TCB_REGION=ap-guangzhou but env is in ap-shanghai), the CloudBase manager was initialized with the wrong region
- This caused INVALID_REGION errors in manageStorage and NoSuchKey errors in uploadFiles
- This PR resolves the environment's actual region from envCandidates after envId is determined, using it for CloudBase manager initialization

## Signal

- Attribution: issue_mmyv176v_qq0hjw
- Run: atomic-js-cloudbase-static-hosting-deploy/2026-03-21T12-16-06-nw4b2k
- Score: 0.293 (3/4 tests failed) — lowest among all tool issues
- GitHub Issue: #384

## Why this is actionable

- **Relevant module:** mcp/src/cloudbase-manager.ts (getCloudBaseManager)
- **Current behavior:** Region resolved only from TCB_REGION env var or cloudBaseOptions, ignoring the environment's actual region from envCandidates
- **Expected behavior:** Use the environment's actual region from DescribeEnvs when available, falling back to TCB_REGION only as a secondary option

## Region priority after fix

envCandidates[].region > cloudBaseOptions.region > TCB_REGION > undefined (SDK default)

## Test plan

- [x] Webpack build passes (0 errors)
- [x] Existing tests unchanged (3 pre-existing failures unrelated to this change)
- [ ] Eval case atomic-js-cloudbase-static-hosting-deploy should pass after merge