### PR TITLE
feat(mcp): clarify writeSecurityRule rule format and errors

### DIFF
--- a/mcp/src/tools/security-rule.test.ts
+++ b/mcp/src/tools/security-rule.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildSecurityRuleErrorMessage,
+  normalizeCustomSecurityRule,
+} from "./security-rule.js";
+
+describe("security rule helpers", () => {
+  it("normalizes object input into JSON string for CUSTOM rules", () => {
+    expect(
+      normalizeCustomSecurityRule("function", {
+        "*": {
+          invoke: true,
+        },
+      }),
+    ).toBe('{"*":{"invoke":true}}');
+  });
+
+  it("rejects bare string values with a readable hint", () => {
+    expect(() => normalizeCustomSecurityRule("function", "true")).toThrow(
+      /JSON 对象/,
+    );
+  });
+
+  it("wraps backend failures with a format hint", () => {
+    const message = buildSecurityRuleErrorMessage(
+      "writeSecurityRule",
+      "function",
+      "CUSTOM",
+      new Error("[ModifySecurityRule] [INVALID_VALUE] 错误的值 start: 1"),
+    );
+
+    expect(message).toContain("writeSecurityRule");
+    expect(message).toContain("JSON 对象");
+    expect(message).toContain("invoke");
+  });
+});

--- a/mcp/src/tools/security-rule.ts
+++ b/mcp/src/tools/security-rule.ts
@@ -19,11 +19,16 @@ export type AclTag =
 
 /**
  * 资源类型（resourceType）
- * - database：数据库集合
+ * - noSqlDatabase：数据库集合
+ * - sqlDatabase：SQL 数据库表
  * - function：云函数
  * - storage：存储桶
  */
-export type ResourceType = "database" | "function" | "storage";
+export type ResourceType =
+  | "noSqlDatabase"
+  | "sqlDatabase"
+  | "function"
+  | "storage";
 
 /**
  * 读取安全规则参数
@@ -40,11 +45,96 @@ export interface WriteSecurityRuleParams {
   resourceType: ResourceType;
   resourceId: string;
   aclTag: AclTag;
-  rule?: string;
+  rule?: string | Record<string, unknown>;
 }
 
 export const READ_SECURITY_RULE = "readSecurityRule";
 export const WRITE_SECURITY_RULE = "writeSecurityRule";
+
+const FUNCTION_CUSTOM_RULE_EXAMPLE = JSON.stringify(
+  {
+    "*": {
+      invoke: true,
+    },
+  },
+  null,
+  2,
+);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value)
+  );
+}
+
+function formatSecurityRuleInputHint(resourceType: ResourceType): string {
+  if (resourceType === "function") {
+    return `函数自定义安全规则应传 JSON 对象或 JSON 字符串，例如 ${FUNCTION_CUSTOM_RULE_EXAMPLE}。`;
+  }
+  if (resourceType === "noSqlDatabase") {
+    return "NoSQL 自定义安全规则应传 JSON 对象或 JSON 字符串，例如 {\"read\":\"true\",\"write\":\"true\"}。";
+  }
+  return "自定义安全规则应传 JSON 对象或 JSON 字符串，并与 readSecurityRule 返回的规则结构保持一致。";
+}
+
+export function normalizeCustomSecurityRule(
+  resourceType: ResourceType,
+  rule: string | Record<string, unknown> | undefined,
+): string {
+  if (rule === undefined) {
+    throw new Error(`resourceType=${resourceType} 且 aclTag=CUSTOM 时必须提供 rule 字段`);
+  }
+
+  if (typeof rule === "string") {
+    try {
+      const parsed = JSON.parse(rule);
+      if (!isPlainObject(parsed)) {
+        throw new Error(
+          `rule 必须是 JSON 对象，不支持 ${Array.isArray(parsed) ? "数组" : typeof parsed}。`,
+        );
+      }
+      return JSON.stringify(parsed);
+    } catch (error) {
+      const baseMessage =
+        error instanceof Error ? error.message : "rule 不是合法的 JSON 字符串";
+      throw new Error(`${baseMessage} ${formatSecurityRuleInputHint(resourceType)}`);
+    }
+  }
+
+  if (!isPlainObject(rule)) {
+    throw new Error(
+      `rule 必须是 JSON 对象或 JSON 字符串。${formatSecurityRuleInputHint(resourceType)}`,
+    );
+  }
+
+  return JSON.stringify(rule);
+}
+
+export function buildSecurityRuleErrorMessage(
+  operation: "readSecurityRule" | "writeSecurityRule",
+  resourceType: ResourceType,
+  aclTag: AclTag,
+  error: unknown,
+): string {
+  const baseMessage = error instanceof Error ? error.message : String(error);
+  const suggestions: string[] = [];
+
+  if (operation === "writeSecurityRule" && aclTag === "CUSTOM") {
+    suggestions.push(formatSecurityRuleInputHint(resourceType));
+  }
+
+  if (/INVALID_VALUE|ModifySecurityRule|错误的值|JSON/i.test(baseMessage)) {
+    suggestions.push("请先把 CUSTOM 规则整理成 JSON 对象，再传给 writeSecurityRule。");
+  }
+
+  if (suggestions.length === 0) {
+    suggestions.push("请检查 resourceType、aclTag 和 rule 是否与官方安全规则格式一致后重试。");
+  }
+
+  return `[${operation}] 调用失败: ${baseMessage}\n建议：${suggestions.join(" ")}`;
+}
 
 /**
  * 注册安全规则相关 Tool
@@ -171,9 +261,11 @@ export function registerSecurityRuleTools(server: ExtendedMcpServer) {
           .enum(["READONLY", "PRIVATE", "ADMINWRITE", "ADMINONLY", "CUSTOM"])
           .describe("权限类别"),
         rule: z
-          .string()
+          .union([z.string(), z.record(z.any())])
           .optional()
-          .describe("自定义安全规则内容，仅当 aclTag 为 CUSTOM 时必填"),
+          .describe(
+            `自定义安全规则内容，仅当 aclTag 为 CUSTOM 时必填。可以直接传 JSON 对象，或者传可解析为 JSON 对象的字符串。函数示例：${FUNCTION_CUSTOM_RULE_EXAMPLE}`,
+          ),
       },
       annotations: {
         readOnlyHint: false,
@@ -182,145 +274,151 @@ export function registerSecurityRuleTools(server: ExtendedMcpServer) {
       },
     },
     async ({ resourceType, resourceId, aclTag, rule }) => {
-      const cloudbase = await getManager();
-      const envId = await getEnvId(cloudBaseOptions);
-      let result;
-      if (resourceType === "noSqlDatabase") {
-        if (aclTag === "CUSTOM") {
-          if (!rule)
-            throw new Error(
-              "noSQL 数据库自定义安全规则（CUSTOM）必须提供 rule 字段",
-            );
-          result = await cloudbase.commonService().call({
-            Action: "ModifySafeRule",
-            Param: {
-              CollectionName: resourceId,
-              EnvId: envId,
-              AclTag: aclTag,
-              Rule: rule,
-            },
-          });
-          logCloudBaseResult(server.logger, result);
-        } else {
-          result = await cloudbase.commonService().call({
-            Action: "ModifyDatabaseACL",
-            Param: {
-              CollectionName: resourceId,
-              EnvId: envId,
-              AclTag: aclTag,
-            },
-          });
-          logCloudBaseResult(server.logger, result);
-        }
-      } else if (resourceType === "function") {
-        if (aclTag !== "CUSTOM")
-          throw new Error("云函数安全规则仅支持 CUSTOM 权限类别");
-        if (!rule)
-          throw new Error("云函数自定义安全规则（CUSTOM）必须提供 rule 字段");
-        result = await cloudbase.commonService().call({
-          Action: "ModifySecurityRule",
-          Param: {
-            AclTag: aclTag,
-            EnvId: envId,
-            ResourceType: "FUNCTION",
-            Rule: rule,
-          },
-        });
-        logCloudBaseResult(server.logger, result);
-      } else if (resourceType === "storage") {
-        if (aclTag === "CUSTOM") {
-          if (!rule)
-            throw new Error("存储自定义安全规则（CUSTOM）必须提供 rule 字段");
-          result = await cloudbase.commonService().call({
-            Action: "ModifyStorageSafeRule",
-            Param: {
-              Bucket: resourceId,
-              EnvId: envId,
-              AclTag: aclTag,
-              Rule: rule,
-            },
-          });
-          logCloudBaseResult(server.logger, result);
-        } else {
-          result = await cloudbase.commonService().call({
-            Action: "ModifyStorageSafeRule",
-            Param: {
-              Bucket: resourceId,
-              EnvId: envId,
-              AclTag: aclTag,
-            },
-          });
-          logCloudBaseResult(server.logger, result);
-        }
-      } else if (resourceType === "sqlDatabase") {
-        if (aclTag === "CUSTOM") {
-          throw new Error("SQL 数据库不支持自定义安全规则（CUSTOM）");
-        }
-
-        const schema = envId;
-        const tableName = resourceId;
-        const instanceId = "default";
-        const resource = `${instanceId}#${schema}#${tableName}`;
-        const resourceType = "table";
-        const effect = "allow";
-
-        const policyList = [
-          "allUser",
-          "anonymousUser",
-          "externalUser",
-          "internalUser",
-        ].map((roleIdentity) => ({
-          RoleIdentity: roleIdentity,
-          ResourceType: resourceType,
-          ResourceId: resource,
-          RowPermission: [] as ReturnType<typeof getRowPermission>,
-          Effect: effect,
-        }));
-
-        policyList[0].RowPermission = getRowPermission(aclTag);
-
-        result = await cloudbase.commonService("lowcode").call({
-          Action: "BatchCreateResourcePolicy",
-          Param: {
-            EnvId: envId,
-            PolicyList: policyList,
-          },
-        });
-        logCloudBaseResult(server.logger, result);
-
-        function getRowPermission(
-          policy: "READONLY" | "PRIVATE" | "ADMINWRITE" | "ADMINONLY",
-        ) {
-          return {
-            READONLY: [
-              { Key: "all", Value: "r" },
-              { Key: "me", Value: "rw" },
-            ],
-            PRIVATE: [{ Key: "me", Value: "rw" }],
-            ADMINWRITE: [{ Key: "all", Value: "r" }],
-            ADMINONLY: [],
-          }[policy];
-        }
-      } else {
-        throw new Error(`不支持的资源类型: ${resourceType}`);
-      }
-      return {
-        content: [
-          {
-            type: "text",
-            text: JSON.stringify(
-              {
-                success: true,
-                requestId: result.RequestId,
-                raw: result,
-                message: "安全规则写入成功",
+      try {
+        const cloudbase = await getManager();
+        const envId = await getEnvId(cloudBaseOptions);
+        let result;
+        if (resourceType === "noSqlDatabase") {
+          if (aclTag === "CUSTOM") {
+            const normalizedRule = normalizeCustomSecurityRule(resourceType, rule);
+            result = await cloudbase.commonService().call({
+              Action: "ModifySafeRule",
+              Param: {
+                CollectionName: resourceId,
+                EnvId: envId,
+                AclTag: aclTag,
+                Rule: normalizedRule,
               },
-              null,
-              2,
-            ),
-          },
-        ],
-      };
+            });
+            logCloudBaseResult(server.logger, result);
+          } else {
+            result = await cloudbase.commonService().call({
+              Action: "ModifyDatabaseACL",
+              Param: {
+                CollectionName: resourceId,
+                EnvId: envId,
+                AclTag: aclTag,
+              },
+            });
+            logCloudBaseResult(server.logger, result);
+          }
+        } else if (resourceType === "function") {
+          if (aclTag !== "CUSTOM")
+            throw new Error("云函数安全规则仅支持 CUSTOM 权限类别");
+          const normalizedRule = normalizeCustomSecurityRule(resourceType, rule);
+          result = await cloudbase.commonService().call({
+            Action: "ModifySecurityRule",
+            Param: {
+              AclTag: aclTag,
+              EnvId: envId,
+              ResourceType: "FUNCTION",
+              Rule: normalizedRule,
+            },
+          });
+          logCloudBaseResult(server.logger, result);
+        } else if (resourceType === "storage") {
+          if (aclTag === "CUSTOM") {
+            const normalizedRule = normalizeCustomSecurityRule(resourceType, rule);
+            result = await cloudbase.commonService().call({
+              Action: "ModifyStorageSafeRule",
+              Param: {
+                Bucket: resourceId,
+                EnvId: envId,
+                AclTag: aclTag,
+                Rule: normalizedRule,
+              },
+            });
+            logCloudBaseResult(server.logger, result);
+          } else {
+            result = await cloudbase.commonService().call({
+              Action: "ModifyStorageSafeRule",
+              Param: {
+                Bucket: resourceId,
+                EnvId: envId,
+                AclTag: aclTag,
+              },
+            });
+            logCloudBaseResult(server.logger, result);
+          }
+        } else if (resourceType === "sqlDatabase") {
+          if (aclTag === "CUSTOM") {
+            throw new Error("SQL 数据库不支持自定义安全规则（CUSTOM）");
+          }
+
+          const schema = envId;
+          const tableName = resourceId;
+          const instanceId = "default";
+          const resource = `${instanceId}#${schema}#${tableName}`;
+          const resourceType = "table";
+          const effect = "allow";
+
+          const policyList = [
+            "allUser",
+            "anonymousUser",
+            "externalUser",
+            "internalUser",
+          ].map((roleIdentity) => ({
+            RoleIdentity: roleIdentity,
+            ResourceType: resourceType,
+            ResourceId: resource,
+            RowPermission: [] as ReturnType<typeof getRowPermission>,
+            Effect: effect,
+          }));
+
+          policyList[0].RowPermission = getRowPermission(aclTag);
+
+          result = await cloudbase.commonService("lowcode").call({
+            Action: "BatchCreateResourcePolicy",
+            Param: {
+              EnvId: envId,
+              PolicyList: policyList,
+            },
+          });
+          logCloudBaseResult(server.logger, result);
+
+          function getRowPermission(
+            policy: "READONLY" | "PRIVATE" | "ADMINWRITE" | "ADMINONLY",
+          ) {
+            return {
+              READONLY: [
+                { Key: "all", Value: "r" },
+                { Key: "me", Value: "rw" },
+              ],
+              PRIVATE: [{ Key: "me", Value: "rw" }],
+              ADMINWRITE: [{ Key: "all", Value: "r" }],
+              ADMINONLY: [],
+            }[policy];
+          }
+        } else {
+          throw new Error(`不支持的资源类型: ${resourceType}`);
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                {
+                  success: true,
+                  requestId: result.RequestId,
+                  raw: result,
+                  message: "安全规则写入成功",
+                },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      } catch (error) {
+        throw new Error(
+          buildSecurityRuleErrorMessage(
+            "writeSecurityRule",
+            resourceType,
+            aclTag,
+            error,
+          ),
+        );
+      }
     },
   );
 }


### PR DESCRIPTION
## Summary
- Clarify CUSTOM `writeSecurityRule` rule input so agents can pass a JSON object or JSON string instead of a bare boolean-like string.
- Wrap tool failures with a readable format hint that points to the expected rule shape.
- Add unit coverage for normalization and error formatting.

## Evidence
- Attribution: issue_mn4mgy7e_xt4jkw
- Representative run: atomic-js-cloudbase-http-function-deploy/2026-03-24T12-52-09-be44d3
- Failure signal: `writeSecurityRule` rejected `rule="true"` with an unreadable backend `INVALID_VALUE` error

## Validation
- `npm run build`
- `npx vitest run src/tools/security-rule.test.ts`
