### PR TITLE
fix(cloud-functions): 🎯 prefer MCP deployment tools for cloud functions

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -73,7 +73,9 @@ Use this skill for **cloud function operations** when you need to:
 3. **Deploy functions correctly**
    - **Preferred MCP Tools**: Use `queryFunctions` for reads, `manageFunctions(action="createFunction")` for creation, and `manageFunctions(action="updateFunctionCode")` for code deployment
    - **Legacy compatibility**: If older prompts mention `createFunction` / `updateFunctionCode`, map them to the `manageFunctions` actions above
-   - **CLI**: Use `tcb fn deploy` (Event) or `tcb fn deploy --httpFn` (HTTP)
+   - **CLI**: Use `tcb fn deploy` (Event) or `tcb fn deploy --httpFn` (HTTP) only as a fallback when MCP tools are unavailable
+   - In agent / non-interactive runs, never default to CLI login flows for deployment; keep the flow on `manageFunctions`
+   - For HTTP functions, create or update them through `manageFunctions` with `func.type="HTTP"` as the primary path
    - HTTP Functions require `scf_bootstrap` file in the function directory
    - Provide correct `functionRootPath` (parent directory of function folder)
 

--- a/mcp/src/config/claude-prompt.ts
+++ b/mcp/src/config/claude-prompt.ts
@@ -97,7 +97,9 @@ As the most important part of application development, the following four core c
 
 ### 4. Backend Deployment (Cloud Functions or CloudRun)
 **Refer to \`rules/cloudrun-development/rule.md\`**
-- **Cloud Function Deployment**: Prefer \`queryFunctions\` to inspect current state, then use \`manageFunctions\` with \`action="createFunction"\` or \`action="updateFunctionCode"\`
+- **Cloud Function Deployment**: Prefer \`queryFunctions\` to inspect current state, then use \`manageFunctions\` with \`action="createFunction"\` or \`action="updateFunctionCode"\`.
+- In agent / non-interactive runs, treat \`manageFunctions\` as the default deployment path for both Event and HTTP functions; do not fall back to CLI login flows unless MCP tools are unavailable.
+- For HTTP functions, create or update them through \`manageFunctions\` with \`func.type="HTTP"\` instead of relying on \`tcb fn deploy\` as the primary path.
 - **CloudRun Deployment**: Use \`manageCloudRun\` tool for containerized deployment
 - Ensure backend code supports CORS, prepare Dockerfile (for container type)
 
@@ -196,7 +198,7 @@ If remote links are needed in the application, can continue to call uploadFile t
 
 ### Deployment Process
 
-1. **Cloud Function Deployment Process**: Prefer \`queryFunctions\` to query current functions, then call \`manageFunctions\` with \`action="createFunction"\` or \`action="updateFunctionCode"\` to deploy cloud function code. Only need to point \`functionRootPath\` to the parent directory of the cloud function directory (for example, the absolute path of the \`cloudfunctions\` directory). No need for code compression or other preprocessing.
+1. **Cloud Function Deployment Process**: Prefer \`queryFunctions\` to query current functions, then call \`manageFunctions\` with \`action="createFunction"\` or \`action="updateFunctionCode"\` to deploy cloud function code. In agent / non-interactive runs, keep deployment on MCP tools instead of CLI login flows. For HTTP functions, set \`func.type="HTTP"\` when creating them. Only need to point \`functionRootPath\` to the parent directory of the cloud function directory (for example, the absolute path of the \`cloudfunctions\` directory). No need for code compression or other preprocessing.
 
 2. **CloudRun Deployment Process**: For non-cloud function backend services (Java, Go, PHP, Python, Node.js, etc.), use manageCloudRun tool for deployment. Ensure backend code supports CORS, prepare Dockerfile, then call manageCloudRun for containerized deployment. For details, refer to \`rules/cloudrun-development/rule.md\`
 


### PR DESCRIPTION
## Summary

- Strengthen cloud function deployment guidance so agent / non-interactive runs stay on MCP tools instead of CLI login flows
- Make HTTP function deployment explicitly use manageFunctions with func.type="HTTP" as the primary path
- Keep CLI deployment as a fallback only when MCP tools are unavailable

## Signal

- Attribution: issue_mn451rxn_jishrz
- Run: atomic-js-cloudbase-http-function-deploy/2026-03-24T04-47-37-6c1301
- Score: 0.26, 5/6 checks failed
- GitHub Issue: #408

## Validation

- npm run build:mcp

## Notes

- This is a guidance fix, not a new deployment capability
- It complements the existing manageFunctions deployment path in mcp/src/tools/functions.ts
