### PR TITLE
feat(auth-web): ✨ wire SDK calls into form handlers

### DIFF
--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -28,6 +28,7 @@ alwaysApply: false
 - Skipping publishable key and provider checks.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
+- Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
 
 ## Overview
 
@@ -100,6 +101,29 @@ const { data: loginData, error: loginError } = await data.verifyOtp({ token: '12
 // Phone Otp
 const { data, error } = await auth.signUp({ phone: '13800138000', nickname: 'User' })
 const { data: loginData, error: loginError } = await data.verifyOtp({ token: '123456' })
+```
+
+When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
+
+```tsx
+const handleSendCode = async () => {
+  const { data, error } = await auth.signUp({
+    email,
+    name: username || email.split('@')[0],
+  })
+  if (error) throw error
+  setSignUpData(data)
+}
+
+const handleRegister = async () => {
+  if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
+  const { error } = await signUpData.verifyOtp({
+    email,
+    token: code,
+    type: 'signup',
+  })
+  if (error) throw error
+}
 ```
 
 **5. Anonymous**


### PR DESCRIPTION
## Summary

- Fixes the guidance gap behind attribution `issue_mn47mb08_la997y`.
- Strengthens `auth-web` so agents connect `auth.signUp` / `verifyOtp` directly inside existing form handlers instead of leaving SDK calls isolated in a helper file.

## Evidence

- Representative run: `application-js-react-cloudbase-signup/2026-03-24T05-54-11-lc4z2m`
- Failure signal: `调用 CloudBase SDK` remained the only failed check because the UI handlers in `App.tsx` were still TODO while the SDK calls lived in a detached helper path.

## Validation

- Rebuilt compat config from the local skill source.
- Rebuilt `mcp` package so a fresh evaluation can reference a local `dist/cli.cjs`.