### PR TITLE
fix(sql-database): 🛠 route MySQL provisioning polling to describeCreateResult

### DIFF
--- a/config/source/skills/relational-database-tool/SKILL.md
+++ b/config/source/skills/relational-database-tool/SKILL.md
@@ -144,6 +144,7 @@ When destroying MySQL, confirm:
    - `querySqlDatabase(action="describeCreateResult")`
    - `querySqlDatabase(action="describeTaskStatus")`
 4. Only continue when the returned lifecycle status is `READY`.
+5. For MySQL provisioning, prefer `describeCreateResult`; reserve `describeTaskStatus` for destroy flows whose task response carries `TaskName`.
 
 ### Scenario 2: Safely inspect data in a table
 

--- a/mcp/src/tools/databaseSQL.test.ts
+++ b/mcp/src/tools/databaseSQL.test.ts
@@ -255,6 +255,53 @@ describe("SQL database tools", () => {
     });
   });
 
+  it("querySqlDatabase(describeCreateResult) suggests polling the create result again", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+          Data: {
+            Status: "doing",
+            TaskId: "38661",
+          },
+        };
+      }
+      return {
+        RequestId: "req-1",
+      };
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.querySqlDatabase.handler({
+      action: "describeCreateResult",
+      request: { TaskId: "38661" },
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        status: "PENDING",
+        rawStatus: "doing",
+        task: {
+          request: {
+            TaskId: "38661",
+          },
+        },
+      },
+    });
+    expect(payload.nextActions?.[0]).toMatchObject({
+      tool: "querySqlDatabase",
+      action: "describeCreateResult",
+      suggested_args: {
+        action: "describeCreateResult",
+        request: {
+          TaskId: "38661",
+        },
+      },
+    });
+  });
+
   it("querySqlDatabase(describeTaskStatus) suggests getInstanceInfo for destroy tasks", async () => {
     mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
       if (Action === "DescribeMySQLTaskStatus") {
@@ -376,9 +423,9 @@ describe("SQL database tools", () => {
     });
     expect(payload.nextActions?.[0]).toMatchObject({
       tool: "querySqlDatabase",
-      action: "describeTaskStatus",
+      action: "describeCreateResult",
       suggested_args: {
-        action: "describeTaskStatus",
+        action: "describeCreateResult",
         request: {
           TaskId: "38661",
         },

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -510,9 +510,11 @@ function buildProvisionNextActions(
   return [
     buildNextAction(
       QUERY_SQL_DATABASE,
-      "describeTaskStatus",
-      "MySQL provisioning is still running. Check task status before initializing schema.",
-      request ? { action: "describeTaskStatus", request } : { action: "describeTaskStatus" },
+      "describeCreateResult",
+      "MySQL provisioning is still running. Check the create result again before initializing schema.",
+      request
+        ? { action: "describeCreateResult", request }
+        : { action: "describeCreateResult" },
     ),
   ];
 }


### PR DESCRIPTION
## Summary
- change SQL provisioning polling to continue with `querySqlDatabase(action="describeCreateResult")`
- keep `describeTaskStatus` reserved for destroy-task polling
- add regression coverage for the create-result polling path

## Context
- Attribution: issue_mn454ulk_shc50d
- Representative run: atomic-js-none-chain-mysql-from-none-to-usable/2026-03-24T04-51-36-ah5kkh
- GitHub issue: #409

## Validation
- `cd mcp && npm test -- --run src/tools/databaseSQL.test.ts`
- fresh evaluation is running for `atomic-js-none-chain-mysql-from-none-to-usable/2026-03-24T13-10-27-db4646`
