### PR TITLE
feat(mcp): ✨ clarify uploadFiles is static-hosting only

### DIFF
--- a/config/source/editor-config/guides/cloudbase-rules.mdc
+++ b/config/source/editor-config/guides/cloudbase-rules.mdc
@@ -214,6 +214,7 @@ As the most important part of application development, the following four core c
 **Refer to deployment process in `rules/web-development/rule.md`**
 - Use CloudBase static hosting after build completion
 - Deploy using `uploadFiles` tool
+- `uploadFiles` is for static hosting only; use `manageStorage` / `queryStorage` when the task needs a COS object that must be queried by the storage SDK
 - Remind users that CDN has a few minutes of cache after deployment
 - Generate markdown format access links with random queryString
 

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -237,6 +237,7 @@ Prefer long-term memory when available: write the scenarios and working rules th
 **Static Hosting (Web):**
 - Use CloudBase static hosting after build completion
 - Refer to the `web-development` skill for deployment process
+- `uploadFiles` is for static hosting only; if the task needs a COS object that must be queried or polled with the storage SDK, use `manageStorage` / `queryStorage`
 - Remind users that CDN has a few minutes of cache after deployment
 
 **Backend Deployment:**

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -75,6 +75,7 @@ Use this skill for **CloudBase platform knowledge** when you need to:
    - Generally, publicly accessible files can be stored in static hosting, which provides a public web address
    - Static hosting supports custom domain configuration (requires console operation)
    - Cloud storage is suitable for files with privacy requirements, can get temporary access addresses via temporary file URLs
+   - If the task needs COS SDK polling, file metadata lookup, or temporary URLs for an uploaded object, use cloud storage tools (`manageStorage` / `queryStorage`), not `uploadFiles`
 
 2. **Static Hosting Domain**:
    - CloudBase static hosting domain can be obtained via `getWebsiteConfig` tool

--- a/mcp/src/config/claude-prompt.ts
+++ b/mcp/src/config/claude-prompt.ts
@@ -92,6 +92,7 @@ As the most important part of application development, the following four core c
 **Refer to deployment process in \`rules/web-development/rule.md\`**
 - Use CloudBase static hosting after build completion
 - Deploy using \`uploadFiles\` tool
+- \`uploadFiles\` is for static hosting only; if the task needs a COS object that must be queried or polled with the storage SDK, use \`manageStorage\` / \`queryStorage\`
 - Remind users that CDN has a few minutes of cache after deployment
 - Generate markdown format access links with random queryString
 
@@ -200,7 +201,7 @@ If remote links are needed in the application, can continue to call uploadFile t
 
 2. **CloudRun Deployment Process**: For non-cloud function backend services (Java, Go, PHP, Python, Node.js, etc.), use manageCloudRun tool for deployment. Ensure backend code supports CORS, prepare Dockerfile, then call manageCloudRun for containerized deployment. For details, refer to \`rules/cloudrun-development/rule.md\`
 
-3. **Static Hosting Deployment Process**: Deploy using uploadFiles tool. After deployment, remind users that CDN has a few minutes of cache. Can generate markdown format access links with random queryString. For details, refer to \`rules/web-development/rule.md\`
+3. **Static Hosting Deployment Process**: Deploy using uploadFiles tool for static hosting only. If the task needs a COS object that must be queried or polled with the storage SDK, use \`manageStorage\` / \`queryStorage\` instead. After deployment, remind users that CDN has a few minutes of cache. Can generate markdown format access links with random queryString. For details, refer to \`rules/web-development/rule.md\`
 
 ### Documentation Generation Rules
 


### PR DESCRIPTION
Closes #415

This change clarifies the routing between static-hosting deployment and COS object verification.

Evidence:
- Attribution: issue_mn43agnc_c861wz
- Failing run: atomic-js-cloudbase-chain-storage-upload-helloworld-and-poll/2026-03-24T04-00-21-nm1gqi
- Fixed evaluation: atomic-js-cloudbase-chain-storage-upload-helloworld-and-poll/2026-03-24T13-19-22-14d4f6
- Result: pass, score 0.935

Scope:
- `config/source/skills/cloudbase-platform/SKILL.md`
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/editor-config/guides/cloudbase-rules.mdc`
- `mcp/src/config/claude-prompt.ts`
