### PR TITLE
feat(cloud-functions): ✨ clarify HTTP vs Event function writing modes

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -28,6 +28,8 @@ alwaysApply: false
 ### Common mistakes / gotchas
 
 - Picking the wrong function type and trying to compensate later.
+- Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port 9000).
+- Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first solution for Web login.
 
@@ -41,6 +43,12 @@ Use this skill when developing, deploying, and managing CloudBase cloud function
 
 - **Event Functions (普通云函数)**: Traditional serverless functions triggered by events (SDK calls, timers)
 - **HTTP Functions (HTTP 云函数)**: Web service functions triggered by HTTP requests, supporting multiple languages
+
+### Writing mode at a glance
+
+- If the request is for a normal CloudBase function triggered by SDK calls, timers, or other events, write an **Event Function** with `exports.main = async (event, context) => {}`.
+- If the request is for an HTTP endpoint, REST API, SSE, or WebSocket service, write an **HTTP Function** that listens on port `9000` and handles `req` / `res`.
+- If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
 
 ## When to use this skill
 
@@ -64,6 +72,7 @@ Use this skill for **cloud function operations** when you need to:
 1. **Choose the right function type**
    - **Event Function**: For SDK calls, scheduled tasks, event-driven scenarios
    - **HTTP Function**: For Web APIs, REST services, SSE/WebSocket, multi-language support
+   - If the prompt says "HTTP 云函数", use the HTTP Function model first; if it says "触发器云函数" or omits HTTP, default to the Event Function model.
 
 2. **Understand runtime limitations**
    - Runtime **CANNOT be changed** after function creation
@@ -190,6 +199,12 @@ Use `manageFunctions(action="updateFunctionCode")`:
 ### HTTP Function Overview
 
 HTTP Functions are optimized for Web service scenarios, supporting standard HTTP request/response patterns.
+
+**HTTP Function coding model**
+- Use a web-server style handler with `req` / `res`
+- Parse query, headers, and body from the HTTP request directly
+- Return HTTP status codes and response bodies explicitly
+- Do not use `exports.main(event, context)` as the primary HTTP Function shape
 
 **Key Characteristics:**
 - **Must listen on port 9000** (platform requirement)
@@ -451,6 +466,7 @@ Use CloudBase HTTP API to invoke event functions:
 
 - **HTTP API**: Uses CloudBase API endpoint with authentication token
 - **HTTP Access**: Creates direct HTTP/HTTPS endpoint for standard REST API access without SDK
+- **Important**: This section applies to Event Functions only. It does not change an HTTP Function into an Event Function or vice versa.
 
 **Creating HTTP Access:**
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -5,6 +5,8 @@ Use this checklist before creating or updating a CloudBase function.
 ## Required checks
 
 1. Decide whether this is an Event Function or an HTTP Function.
+   - Event Function: `exports.main(event, context)`, SDK/timer driven
+   - HTTP Function: `req` / `res`, listens on port `9000`
 2. Pick the runtime before creation and state it explicitly.
 3. For HTTP Functions, confirm `scf_bootstrap` exists and the service listens on port `9000`.
 4. Confirm the function root path points to the parent directory, not the function directory itself.
@@ -13,6 +15,7 @@ Use this checklist before creating or updating a CloudBase function.
 ## Common failure patterns
 
 - Choosing the wrong function type and compensating later.
+- Mixing Event Function and HTTP Function handler shapes in the same implementation.
 - Forgetting that runtime cannot be changed after creation.
 - Treating Cloud Functions as the default answer for Web authentication.
 


### PR DESCRIPTION
## Summary

- Clarify the distinction between Event Functions and HTTP Functions in `config/source/skills/cloud-functions/SKILL.md`
- Add explicit writing-mode guidance so HTTP requests use `req` / `res` on port 9000, while trigger-driven functions keep `exports.main(event, context)`
- Make the checklist and HTTP access notes call out the separation more directly

## Attribution

- Issue: `issue_mn44l571_gymehz`
- Run: `atomic-js-cloudbase-http-function-params/2026-03-24T04-35-23-t2qds0`
- Result: fail, score 0.316
- Root signal: the agent mixed HTTP function request/response handling with event-function style guidance

## Validation

- `git diff --check`

## Notes

- This is a skill-source change only; no `mcp/src` code changed
- The goal is to reduce confusion between HTTP function coding mode and trigger-driven cloud functions
