### PR TITLE
docs(auth): align auth-nodejs prompt with stable skill ids

### DIFF
--- a/doc/prompts/auth-nodejs.mdx
+++ b/doc/prompts/auth-nodejs.mdx
@@ -40,8 +40,8 @@ Use this skill whenever the task involves **server-side authentication or identi
 
 **Do NOT use this skill for:**
 
-- Frontend Web login / sign-up flows using `@cloudbase/js-sdk` (handle those with the **CloudBase Web Auth** skill at `skills/web-auth-skill`, not this Node skill).
-- Direct HTTP auth API integrations (this skill does not describe raw HTTP endpoints; use the **CloudBase HTTP Auth** skill at `skills/auth-http-api-skill` instead).
+- Frontend Web login / sign-up flows using `@cloudbase/js-sdk` (handle those with the **auth-web** skill, not this Node skill).
+- Direct HTTP auth API integrations (this skill does not describe raw HTTP endpoints; use the **http-api** skill instead).
 - Database or storage operations that do not involve identity (use database/storage docs or skills).
 
 When the user request mixes frontend and backend concerns (e.g. "build a web login page and a Node API that knows the user"), treat them separately:


### PR DESCRIPTION
Closes #424

## Summary

- Replace stale `skills/web-auth-skill` and `skills/auth-http-api-skill` references in `doc/prompts/auth-nodejs.mdx` with stable skill ids (`auth-web`, `http-api`).
- Source skill already uses the stable ids; this change aligns the public prompt with the source of truth.

## Attribution

- issue_mn42n1jt_nsudlc
- Representative run: atomic-js-cloudbase-api-review/2026-03-24T03-25-57-k4g70x (unrelated tool failure / trace endpoint noise)
