### PR TITLE
docs(skills): 📝 add closure preflight and sub-agent orchestration rules

### DIFF
--- a/skills/mcp-attribution-worktree/SKILL.md
+++ b/skills/mcp-attribution-worktree/SKILL.md
@@ -37,8 +37,9 @@ Use this skill to:
 6. If the issue is actionable in repo code or skills content, do not stop at attribution triage. Open or link the matching GitHub issue, create a dedicated Worktrunk worktree, implement the fix, validate it, and prepare a PR.
 7. If review comments, review decisions, or later evidence show the direction is wrong, start another focused iteration from the existing GitHub issue or PR context and continue improving instead of treating the first PR as final.
 8. Update attribution fields through the report API after you have the right evidence, and update them again when the GitHub issue, PR, or evaluation result becomes available.
-9. When a real evaluation interface exists, run a post-PR evaluation and use the result to decide whether to continue iterating or mark the issue closed.
-10. Only stop after the issue is either clearly non-actionable or has been carried through the repair loop as far as the current environment allows.
+9. Before changing an attribution to `resolved`, run a closure preflight on the linked GitHub artifact again: reread the latest PR comments, review comments, review decisions, and issue comments after the most recent code push or evaluation result.
+10. When a real evaluation interface exists, run a post-PR evaluation and use the result plus the closure preflight to decide whether to continue iterating or mark the issue closed.
+11. Only stop after the issue is either clearly non-actionable or has been carried through the repair loop as far as the current environment allows.
 
 ## Common requests
 
@@ -58,14 +59,17 @@ Use this skill to:
 | Create GitHub issues, use Worktrunk, and repair the repo in isolation | `references/worktree-repair.md` |
 | Continue from review feedback or real evaluation results after a PR already exists | `references/iteration-loop.md` |
 | Trigger real evaluation runs and interpret the result | `references/evaluation-verification.md` |
+| Dispatch one issue per worker and enforce closure-sweep rules in sub-agent prompts | `references/subagent-orchestration.md` |
 
 ## Operating rules
 
 - Only update attribution issues through the local report API.
 - Treat `owner` as fixed: always set it to `codex` when you patch an attribution.
 - Before any new iteration, always inspect the latest attribution `notes`, `externalUrl`, linked GitHub issue or PR status, and any available PR comments or review decisions.
+- Before moving any issue to `resolved`, always perform a fresh closure sweep on the linked issue or PR after the latest push or evaluation has completed. Do not rely on an earlier preflight.
 - Do not change `resolutionStatus` until you have read at least one related run's `result` and `trace`.
 - Do not mark an issue `resolved` without clear closure evidence such as an existing GitHub issue, PR, merged fix, or a verified duplicate that already has external tracking.
+- Do not mark an issue `resolved` if there are unread or unaddressed PR comments, review comments, review decisions, or issue comments that arrived after the last time you inspected the linked artifact.
 - Keep `notes` short but auditable. Include the representative run, the main failing signal, and the code or tool signal that supports the conclusion.
 - If the evidence is incomplete, keep the issue `todo` or move it to `in_progress` and explicitly state what is still missing.
 - For a real and repairable issue in `mcp/src` or `config/source/skills`, the default expectation is full follow-through: attribution triage, GitHub issue linkage, isolated worktree repair, validation, and PR creation.
@@ -92,6 +96,16 @@ Before starting a fresh diagnosis or code iteration for an attribution issue, co
 4. If `externalUrl` points to a PR, check whether it is open, merged, closed, or superseded.
 5. Read PR comments, review comments, and review decisions before deciding whether to continue the same branch or start a new iteration.
 6. Only after that, pick the representative run and continue into `result`, `trace`, and `evaluation-trace`.
+
+## Required closure preflight
+
+Before changing an attribution to `resolved`, complete this checklist in order even if you already did the normal preflight earlier:
+
+1. Reopen the linked GitHub issue or PR.
+2. Re-read the latest top-level comments, review comments, and review decisions.
+3. Confirm whether any comment arrived after the latest code push, PR update, or evaluation result.
+4. If new feedback exists, keep the attribution `in_progress` and continue the loop.
+5. Only if there is no newer unresolved feedback, evaluate whether closure evidence is now strong enough.
 
 ## Quick commands
 
@@ -122,3 +136,4 @@ curl -s -X POST http://127.0.0.1:5174/api/evaluations
 - If I patched the attribution, did I keep the change limited to `resolutionStatus`, `owner`, `notes`, and `externalUrl` when relevant?
 - If I started a fix, does it live in its own Worktrunk worktree and branch?
 - If I marked something `resolved`, is there explicit closure evidence?
+- If I marked something `resolved`, did I re-read the latest PR comments, review comments, review decisions, and issue comments immediately before closing it?

--- a/skills/mcp-attribution-worktree/references/iteration-loop.md
+++ b/skills/mcp-attribution-worktree/references/iteration-loop.md
@@ -28,6 +28,19 @@ When an attribution already has `externalUrl` or notes pointing to previous work
 
 Do not start a new branch, worktree, or diagnosis pass until this check is complete.
 
+## Closure sweep
+
+Before you change an attribution from `in_progress` to `resolved`, repeat the artifact check one more time even if you already did it at the start of the iteration.
+
+You must re-read:
+
+1. the latest top-level PR comments
+2. review comments
+3. review decisions
+4. linked issue comments when relevant
+
+Treat any newer unresolved feedback as a new iteration signal. Do not close the attribution off an older snapshot of the PR.
+
 ## Continue vs restart
 
 ### Continue the same PR
@@ -76,6 +89,7 @@ Move to `resolved` only when:
 
 - the PR or linked issue provides explicit closure
 - and any available fresh evaluation no longer shows the original failure mode
+- and the closure sweep found no newer unresolved PR comments, review comments, review decisions, or issue comments
 
 ### Move to `invalid`
 
@@ -105,3 +119,5 @@ Before each new iteration:
 4. read comments and review decisions
 5. decide continue vs restart
 6. only then inspect the next representative run
+
+Before `resolved`, repeat steps 2-4 after the latest push or evaluation result so the closure decision is based on a fresh artifact read rather than an older preflight snapshot.

--- a/skills/mcp-attribution-worktree/references/report-api-workflow.md
+++ b/skills/mcp-attribution-worktree/references/report-api-workflow.md
@@ -85,6 +85,21 @@ Do not skip this preflight just because the attribution already has a linked PR.
 - update the linked issue first
 - start a new worktree and branch because the previous direction is stale or wrong
 
+## Closure preflight
+
+Do this again immediately before moving an attribution to `resolved`, even if you already completed the normal preflight earlier in the same session.
+
+Check:
+
+1. the latest linked GitHub issue or PR state
+2. top-level PR comments
+3. review comments
+4. review decisions
+5. issue comments when `externalUrl` points to an issue
+6. whether any of the above arrived after the latest code push, PR update, or fresh evaluation result
+
+If new unresolved feedback exists, do not mark the attribution `resolved`. Move it back to or keep it at `in_progress` and continue the repair loop.
+
 ## Working set rules
 
 Build the default working set from two buckets:
@@ -193,6 +208,8 @@ Never mark `resolved` from intuition alone.
 
 Do not mark `resolved` just because you understand the bug. Mark it only after you have explicit closure evidence.
 
+Do not mark `resolved` from a stale artifact read. If a linked PR or issue exists, you must complete the closure preflight immediately before patching `resolved`.
+
 If a post-PR evaluation interface is available, prefer using that fresh evaluation result as part of the closure evidence.
 
 ### `invalid`
@@ -237,3 +254,5 @@ Stop and keep the issue unclosed if any of these are true:
 - you cannot tell whether the problem lives in MCP code, the environment, or the grader
 
 Also stop short of `resolved` if you have not yet completed the GitHub issue / worktree / PR loop for an actionable repo bug.
+
+Also stop short of `resolved` if there are newer PR comments, review comments, review decisions, or issue comments that have not been re-read after the latest push or evaluation.

--- a/skills/mcp-attribution-worktree/references/subagent-orchestration.md
+++ b/skills/mcp-attribution-worktree/references/subagent-orchestration.md
@@ -1,0 +1,108 @@
+# Sub-agent Orchestration
+
+## Purpose
+
+Use this reference when you are dispatching one or more sub-agents to process MCP attribution issues.
+
+The goal is to keep each worker issue-scoped, audit-friendly, and resistant to premature closure.
+
+## Core rule
+
+One sub-agent owns exactly one attribution issue.
+
+Do not give one worker multiple issues.
+Do not mix worktrees, evidence, or PR context across issues.
+
+## Dispatcher responsibilities
+
+The parent agent or dispatcher must:
+
+1. fetch the backlog
+2. deduplicate issues
+3. assign one issue per worker
+4. include the exact `issueId` and title in the worker prompt
+5. require the worker to read the skill plus the relevant references first
+6. require the worker to report back:
+   - attribution conclusion
+   - current attribution status
+   - worktree and branch
+   - GitHub issue or PR URL
+   - latest evaluation case and run when relevant
+   - touched files
+   - remaining blockers
+
+The dispatcher must not assume a worker is done just because it returned a PR URL.
+
+## Worker contract
+
+Every worker prompt should explicitly require this sequence:
+
+1. read attribution detail
+2. read current `notes`
+3. read `externalUrl` when present
+4. read linked GitHub issue or PR state
+5. read top-level PR comments, review comments, and review decisions when a PR exists
+6. only then read representative run `result` and `trace`
+7. decide actionable vs invalid
+8. if actionable, use `wt` to create an isolated worktree
+9. implement the fix and run the smallest relevant validation
+10. create or update the GitHub issue or PR
+11. run a real evaluation when available
+12. perform a closure sweep before changing anything to `resolved`
+13. patch attribution only through the report API
+
+## Required worker prompt clauses
+
+Include clauses like these in every worker prompt:
+
+- "You are responsible for exactly one issue."
+- "Do not process any other issue."
+- "Do not use the shared checkout for code edits."
+- "Use Worktrunk for any repairable issue."
+- "Read PR comments, review comments, and review decisions before deciding next steps."
+- "Before marking the attribution `resolved`, re-read the latest PR comments, review comments, review decisions, and issue comments after the latest push or evaluation result."
+- "If unresolved newer feedback exists, keep the attribution `in_progress`."
+- "Update attribution only through `http://127.0.0.1:5174/api/...`."
+- "`owner` must be `codex`."
+
+## Recommended worker output format
+
+Ask workers to return:
+
+```text
+issue conclusion:
+attribution status:
+worktree / branch:
+GitHub issue / PR:
+evaluation caseId / runId / result:
+modified files:
+remaining blockers:
+```
+
+This makes it easy for the dispatcher to apply closure-sweep checks consistently.
+
+## Closure-sweep rule for dispatchers
+
+Even if a worker says the issue is closed:
+
+1. reopen the linked PR or issue yourself
+2. check whether there are newer comments or review signals
+3. only then accept a `resolved` recommendation
+
+If the dispatcher finds newer unresolved feedback, override the worker's closure and move the issue back to `in_progress`.
+
+## Failure modes to guard against
+
+- worker reads run evidence but skips PR comments
+- worker closes after a passing evaluation without re-reading the PR
+- worker treats a PR URL as sufficient closure
+- worker continues an old PR without checking whether review changed the direction
+- worker edits code in the shared checkout instead of a worktree
+- worker handles multiple issues in one prompt and contaminates context
+
+## Minimal dispatcher checklist
+
+- Did each worker get exactly one `issueId`?
+- Did each worker prompt require preflight before run diagnosis?
+- Did each worker prompt require closure sweep before `resolved`?
+- Did I independently verify any worker-proposed `resolved` state against the latest PR or issue feedback?

--- a/skills/mcp-attribution-worktree/references/worktree-repair.md
+++ b/skills/mcp-attribution-worktree/references/worktree-repair.md
@@ -111,6 +111,8 @@ If the PR already exists:
 - prefer continuing the existing PR when the fix direction is still fundamentally correct
 - start a new iteration only when review or new evidence shows the approach itself was wrong
 
+Before changing the attribution to `resolved`, read the PR state, top-level comments, review comments, and review decisions again after the latest push or evaluation result. Do not close from a stale read.
+
 Do not mark the attribution `resolved` until the closure link is real and the repair path is clear.
 
 If real evaluation is available, do not treat PR creation alone as closure. Use the fresh evaluation result to decide whether another repair loop is needed.
@@ -139,6 +141,7 @@ Use `resolved` when:
 
 - there is an exact GitHub issue or PR link in `externalUrl`
 - or the fix is already landed and the closure is explicit in `notes`
+- and there is no newer unresolved PR comment, review comment, or review decision waiting on follow-up
 
 ## Evidence template for GitHub issue creation
 
@@ -172,3 +175,4 @@ Before closing the attribution loop, verify:
 - `notes` explain why the current status is justified
 - the agent did not stop at attribution state changes when repo repair was possible
 - if a PR or issue already existed, the agent incorporated that context into the new iteration
+- if the attribution was marked `resolved`, the agent re-read the latest PR comments and review state immediately before closing it


### PR DESCRIPTION
## Summary
- Add mandatory **closure preflight** checklist to the attribution skill: before marking any issue `resolved`, re-read PR comments, review comments, review decisions, and issue comments after the latest push or evaluation result.
- Add new **sub-agent orchestration** reference (`subagent-orchestration.md`) that scopes one issue per worker and requires closure-sweep clauses in every worker prompt.
- Enforce the closure-sweep rule consistently across `iteration-loop.md`, `report-api-workflow.md`, `worktree-repair.md`, and the main `SKILL.md`.

## Test plan
- [ ] Verify all references correctly link the new closure-sweep steps
- [ ] Verify sub-agent orchestration reference is reachable from the main SKILL.md table
- [ ] Verify no stale preflight language remains that could skip the closure re-read