### PR TITLE
fix(functions): 🐛 add null guard for getFunctionDetail in updateFunctionConfig

### DIFF
--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -1018,6 +1018,11 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       const functionDetail = await cloudbase.functions.getFunctionDetail(
         input.functionName,
       );
+
+      if (!functionDetail) {
+        throw new Error(`函数 ${input.functionName} 不存在或无法获取详情`);
+      }
+
       const currentVpc =
         typeof functionDetail.VpcConfig === "object" &&
         functionDetail.VpcConfig !== null &&


### PR DESCRIPTION
## Summary
- Add null check after `getFunctionDetail` call in the `updateFunctionConfig` case to prevent "Cannot read properties of null (reading 'reduce')" crash.
- This was the **top crash** in telemetry (212 occurrences across v2.14.2 and multiple Node.js versions).

## Root cause
`getFunctionDetail` may return `null` when the function does not exist or the API request fails. The `updateFunctionConfig` handler immediately accessed `functionDetail.VpcConfig` and `functionDetail.Environment?.Variables` without checking for null.

## Fix
Add a null guard with a clear error message before accessing any properties on `functionDetail`.

## Test plan
- [ ] Verify `updateFunctionConfig` with a non-existent function name now returns a clear error instead of crashing
- [ ] Verify `updateFunctionConfig` with a valid function name still works correctly