### PR TITLE
fix(allinone): 🛠 remove v prefix from generated version

### DIFF
--- a/scripts/build-allinone-skill.ts
+++ b/scripts/build-allinone-skill.ts
@@ -101,16 +101,20 @@ function getLatestGitTag(): string {
   }
 }
 
+function normalizeVersionFromTag(tag: string): string {
+  return tag.replace(/^v(?=\d)/, "");
+}
+
 // Generate SKILL.md frontmatter
 function buildSkillFrontmatter(): string {
-  const latestGitTag = getLatestGitTag();
+  const latestVersion = normalizeVersionFromTag(getLatestGitTag());
 
   return `---
 name: cloudbase
 description: CloudBase is a full-stack development and deployment toolkit for building and launching websites, Web apps, 微信小程序 (WeChat Mini Programs), and mobile apps with backend, database, hosting, cloud functions, storage, AI capabilities, Agent, and UI guidance. This skill should be used when users ask to develop, build, create, scaffold, deploy, publish, host, launch, go live, migrate, or optimize websites, Web apps, landing pages, dashboards, admin systems, e-commerce sites, 微信小程序 (WeChat Mini Programs), 小程序, Agent, 智能体, uni-app, or native/mobile apps with CloudBase (腾讯云开发, 云开发), including authentication, login, database, NoSQL, MySQL, cloud functions, CloudRun, storage, AI models, and UI guidance, or when they ask to compare CloudBase with Supabase or migrate from Supabase to CloudBase.
 description_zh: 帮你从 0 创建，或继续完善网页、小程序和简单工具，支持发布上线、内容保存、用户登录和数据同步。
 description_en: Create or enhance web apps, mini programs, and lightweight tools with publishing, content saving, user login, and data sync powered by Tencent CloudBase.
-version: ${latestGitTag}
+version: ${latestVersion}
 ---
 
 

--- a/tests/build-allinone-skill.test.js
+++ b/tests/build-allinone-skill.test.js
@@ -69,7 +69,8 @@ test.skipIf(!hasNode24ViaNvm())(
     expect(mainSkill).toContain('name: cloudbase');
     expect(mainSkill).toContain('description_zh:');
     expect(mainSkill).toContain('description_en:');
-    expect(mainSkill).toContain('version: v');
+    expect(mainSkill).toMatch(/^version:\s+\d+\.\d+\.\d+(?:-[^\s]+)?$/m);
+    expect(mainSkill).not.toContain('version: v');
     expect(mainSkill).toContain('references/auth-web/SKILL.md');
     expect(mainSkill).toContain('## Activation Contract');
     expect(mainSkill).toContain('Provider status and publishable key');


### PR DESCRIPTION
## Summary
- normalize the latest git tag before writing all-in-one skill metadata
- generate `version` without the leading `v` prefix
- update tests to lock the plain semver format

## Verification
- node scripts/build-allinone-skill.ts --dir <tmp>
- npx vitest run tests/build-allinone-skill.test.js