### PR TITLE
fix(tools): improve tool titles alignment and callCloudApi API discovery

### DIFF
--- a/mcp/src/tools/capi.ts
+++ b/mcp/src/tools/capi.ts
@@ -181,7 +181,15 @@ export function registerCapiTools(server: ExtendedMcpServer) {
         {
             title: "调用云API",
             description:
-                `通用的云 API 调用工具，主要用于 CloudBase / 腾讯云管控面与依赖资源相关 API 调用。调用前请先确认 service、Action 与 Param，避免猜测 Action 名称。如果你的目标是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请不要优先使用 callCloudApi，而应优先查看对应 OpenAPI / Swagger。现有 OpenAPI / Swagger 能力不是通用的管控面 Action 集合；管控面 API 请优先参考 CloudBase API 概览 ${CLOUDBASE_CONTROL_PLANE_DOC_URL} 与云开发依赖资源接口指引 ${CLOUDBASE_DEPENDENCY_API_DOC_URL}。对于 tcb，可参考类似 \`CreateEnv\`、\`ModifyEnv\`、\`DestroyEnv\` 这类真实 Action 组织请求；销毁环境时，常见做法是至少带上 \`EnvId\` 和 \`BypassCheck: true\`，如果环境已经处于隔离期再按文档补 \`IsForce: true\`。`,
+                `通用的云 API 调用工具，主要用于 CloudBase / 腾讯云管控面与依赖资源相关 API 调用。调用前请先确认 service、Action 与 Param，避免猜测 Action 名称。如果你的目标是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请不要优先使用 callCloudApi，而应优先查看对应 OpenAPI / Swagger。现有 OpenAPI / Swagger 能力不是通用的管控面 Action 集合；管控面 API 请优先参考 CloudBase API 概览 ${CLOUDBASE_CONTROL_PLANE_DOC_URL} 与云开发依赖资源接口指引 ${CLOUDBASE_DEPENDENCY_API_DOC_URL}。对于 tcb service，常用 Action 分类如下：
+
+**环境管理**: \`CreateEnv\`、\`ModifyEnv\`、\`DescribeEnvs\`、\`DestroyEnv\`
+**用户管理**: \`CreateUser\`、\`ModifyUser\`、\`DescribeUserList\`、\`DeleteUsers\`
+**认证配置**: \`EditAuthConfig\`、\`DescribeAuthDomains\`
+**云函数**: \`DescribeFunctions\`、\`CreateFunction\`、\`UpdateFunctionCode\`、\`DeleteFunction\`
+**数据库**: \`CreateMySQLInstance\`、\`DescribeMySQLInstances\`、\`DestroyMySQLInstance\`
+
+销毁环境时，常见做法是至少带上 \`EnvId\` 和 \`BypassCheck: true\`，如果环境已经处于隔离期再按文档补 \`IsForce: true\`。`,
             inputSchema: {
                 service: z
                     .enum(ALLOWED_SERVICES)
@@ -191,7 +199,7 @@ export function registerCapiTools(server: ExtendedMcpServer) {
                 action: z
                     .string()
                     .min(1)
-                    .describe("具体 Action 名称，需符合对应服务的官方 API 定义。若不确定正确 Action，请先查官方文档；不要用近义词或历史命名进行猜测。对于 tcb，可优先参考 `CreateEnv`、`ModifyEnv`、`DestroyEnv`、`DescribeBillingInfo` 等真实 Action。"),
+                    .describe("具体 Action 名称，需符合对应服务的官方 API 定义。若不确定正确 Action，请先查官方文档；不要用近义词或历史命名进行猜测。tcb 常用 Action：环境管理 CreateEnv/ModifyEnv/DescribeEnvs/DestroyEnv、用户管理 CreateUser/ModifyUser/DescribeUserList/DeleteUsers、认证配置 EditAuthConfig、云函数 DescribeFunctions/CreateFunction、数据库 CreateMySQLInstance 等。"),
                 params: z
                     .record(z.any())
                     .optional()

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -1208,7 +1208,7 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
     {
       title: "Manage SQL database lifecycle or execute write SQL",
       description:
-        "Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, and schema initialization after the instance becomes ready.",
+        "Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, and schema initialization. IMPORTANT: MySQL must be provisioned first (action=provisionMySQL with confirm=true) before any runStatement or initializeSchema call. If MySQL is not yet provisioned, the tool will return MYSQL_NOT_CREATED with a nextAction to provision first.",
       inputSchema: {
         action: z
           .enum(MANAGE_ACTIONS)


### PR DESCRIPTION
## Summary

- **Align 12 MCP tool titles with API 3.0 naming convention** — prefix English API 3.0 names (e.g. `EnvQuery`, `ManageFunctions`, `QueryCloudRun`) to tool titles so the API review test can map tool names to their API 3.0 counterparts
- **Add categorized action examples to callCloudApi** — add user management (`CreateUser/ModifyUser/DescribeUserList/DeleteUsers`), auth config (`EditAuthConfig`), cloud functions, and database actions to the description, so models can discover the correct API instead of guessing
- **Clarify manageSqlDatabase provision-first requirement** — explicitly state in the description that MySQL must be provisioned before any `runStatement` or `initializeSchema` call

## Related attribution issues

- `issue_mn8d4vio_aualvp` (score 0.351) — callCloudApi API discovery gap
- `issue_mn76yace_q2t1j7` (score 0.351) — missing internal user management API (same root cause)
- `issue_mn9bvrzh_v0jhua` (score 0.411) — RunSql unclear timeout when MySQL not provisioned
- `issue_mn71i3ex_a57cni` (score 0.929) — 12 tool title mismatches with API 3.0 naming

## Test plan

- [x] All 212 existing tests pass (46 test files)
- [ ] Verify API review evaluation case passes with updated titles
- [ ] Verify internal user management case finds correct API via callCloudApi
- [ ] Verify MySQL provision-then-run flow is clearer