### PR TITLE
fix(mcp): clarify nested object dot-notation in writeNoSqlDatabaseContent

### DIFF
--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -619,7 +619,7 @@ deleteCollection: 删除集合`),
     {
       title: "修改 NoSQL 数据库数据记录",
       description:
-        "修改 NoSQL 数据库数据记录。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 $set/$inc/$push 等更新操作符；如果直接传 { field: value } 这类普通对象，底层会把它当作替换内容，存在覆盖整条文档的风险。",
+        "修改 NoSQL 数据库数据记录。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 $set/$inc/$push 等更新操作符；如果直接传 { field: value } 这类普通对象，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径（如 { \"$set\": { \"address.city\": \"shenzhen\" } }），若写成 { \"$set\": { \"address\": { \"city\": \"shenzhen\" } } } 则整个 address 对象会被替换，同级其他字段将丢失。",
       inputSchema: {
         action: z
           .enum(["insert", "update", "delete"])
@@ -639,7 +639,7 @@ deleteCollection: 删除集合`),
           .union([z.object({}).passthrough(), z.string()])
           .optional()
           .describe(
-            "更新内容(对象或字符串,推荐对象)(update 操作必填)。按 MongoDB 更新语义传入 MgoUpdate：部分更新请使用 $set/$inc/$unset/$push 等操作符，例如 { \"$set\": { \"status\": \"pending\" } }；不要直接传 { \"status\": \"pending\" }，否则可能替换整条文档。",
+            "更新内容(对象或字符串,推荐对象)(update 操作必填)。按 MongoDB 更新语义传入 MgoUpdate：部分更新请使用 $set/$inc/$unset/$push 等操作符，例如 { \"$set\": { \"status\": \"pending\" } }；不要直接传 { \"status\": \"pending\" }，否则可能替换整条文档。更新嵌套字段时必须用点号路径，如 { \"$set\": { \"address.city\": \"shenzhen\" } }，不要写成 { \"$set\": { \"address\": { \"city\": \"shenzhen\" } } }（会替换整个 address 对象）。",
           ),
         isMulti: z
           .boolean()


### PR DESCRIPTION
## Summary
- Added explicit warning about nested object update semantics to `writeNoSqlDatabaseContent` tool description and `update` parameter description
- Model was using `{"$set": {"shipping": {"city": "x"}}}` which replaces the entire nested object; dot notation `{"$set": {"shipping.city": "x"}}` is required for partial nested-field updates

## Attribution
- Issue: `issue_mnas8dg7_42vghx` — writeNoSqlDatabaseContent 嵌套对象更新语义不明确导致字段覆盖
- Run: `atomic-js-none-update-nosql-nested-object-implicit / 2026-03-28T20-26-57-wu6r99`
- Score: 0.956 — only 1/6 tests failed (nested field preservation check)

## Test plan
- [x] Existing 9 NoSQL database tests pass
- [x] `npm run build` succeeds in both root and mcp/
- [ ] Post-PR evaluation run to verify nested object update handling