### PR TITLE
fix(skills): correct langgraph reference path in Python agent skill

### DIFF
--- a/config/source/skills/cloudbase-agent/py/skill.md
+++ b/config/source/skills/cloudbase-agent/py/skill.md
@@ -176,7 +176,7 @@ Based on what the user needs, read the corresponding reference document.
 |-----------|-----------|---------------|
 | **Deploying agent to CloudBase** | Read [agent-deployment](agent-deployment.md) | **manageAgent MCP tool (MUST USE)**, 4-step blocking pipeline, Python 3.10, env/ build, verification |
 | Server setup, deployment, middleware, multi-agent, CORS | Read `references/server.md` | AgentServiceApp 3 deployment methods, middleware (generator/yield/onion model), multi-agent server, Agent Creator pattern, health checks |
-| LangGraph agent, callbacks, tool proxy, HITL, checkpoints | Read `references/langgraph.md` | LangGraphAgent constructor, AgentCallback protocol, ToolProxy, human-in-the-loop with interrupt(), TDAICheckpointSaver, client-defined tools |
+| LangGraph agent, callbacks, tool proxy, HITL, checkpoints | Read [adapter-langgraph](adapter-langgraph.md) | LangGraphAgent constructor, AgentCallback protocol, ToolProxy, human-in-the-loop with interrupt(), TDAICheckpointSaver, client-defined tools |
 | Tools: bash, filesystem, code execution, MCP, custom tools | Read `references/tools.md` | create_bash_tool, 8 file tools, code executors, MCPToolkit/CloudBaseMCPServer, @tool decorator, BaseTool, framework adapters |
 | Memory, persistence, short/long-term, MySQL, MongoDB | Read `references/storage.md` | InMemoryMemory, TDAIMemory, MySQLMemory, MongoDBMemory, TDAILongTermMemory, Mem0LongTermMemory, LangGraph checkpoint |
 | Tracing, monitoring, Langfuse, OpenTelemetry | Read `references/observability.md` | ConsoleTraceConfig, OTLPTraceConfig, setup_observability, env vars, manual observation spans |


### PR DESCRIPTION
## Summary

- Fixed wrong file path in Python Agent skill `py/skill.md` Reference Documents table
- `references/langgraph.md` → `adapter-langgraph.md` (correct path)
- This single path error caused models to fail reading adapter docs in **3 evaluation runs** across the same test case

## Impact

The incorrect path caused a cascade of failures in `atomic-py-none-cloudbase-agent-comprehensive`:

| Attribution Issue | Score | Root Cause |
|---|---|---|
| `issue_mnatjeit_dkzmbr` | 0.732 (3 runs) | Missing `create_send_message_adapter` example |
| `issue_mnatrigw_yqzno6` | 0.849 | Insufficient concept guidance |
| `issue_mnatmq8l_rxkdt1` | 0.818 | Wrong dependency info |

All 3 traced back to the model trying to read `references/langgraph.md` (doesn't exist), getting a "file not found" error, and proceeding without proper adapter documentation.

## Test plan

- [ ] Verify `adapter-langgraph.md` is accessible from the routing table
- [ ] Re-run `atomic-py-none-cloudbase-agent-comprehensive` to validate score improvement
- [ ] Check that no other Reference Documents table entries have wrong paths