### PR TITLE
WIP feat(cms): add CMS strategy spec and skill scaffold

### DIFF
--- a/config/source/skills/cms/SKILL.md
+++ b/config/source/skills/cms/SKILL.md
@@ -1,0 +1,142 @@
+---
+name: cms
+description: Content management system planning and implementation guidance for websites, landing pages, event pages, mini programs, mini games, customer portals, and operational backends. This skill should be used when users ask to build, design, review, restructure, or improve a CMS, headless CMS, content schema, editorial workflow, publishing flow, content admin system, campaign content backend, or project-based content platform, especially when the solution may use CloudBase delivery, CloudBase CMS, cloud functions, storage, or a PG-based content core.
+alwaysApply: false
+---
+
+# CMS
+
+This skill turns vague "build a CMS" requests into a route selection, a reusable CMS archetype, and an implementation-ready plan instead of treating every request as a custom system from scratch.
+
+## Activation Contract
+
+### Use this first when
+
+- The request is primarily about content modeling, content admin systems, editorial workflows, publishing, media management, content APIs, campaign configuration, or project-based content backends.
+
+### Read before writing code if
+
+- The user needs a route recommendation between CloudBase-native, PG-based, and Hybrid architectures.
+- The request mixes websites, mini programs, mini games, portals, or campaign operations with content administration.
+
+### Then also read
+
+- CloudBase platform rules -> `../cloudbase-platform/SKILL.md`
+- Mini program delivery -> `../miniprogram-development/SKILL.md`
+- Web implementation -> `../web-development/SKILL.md`
+- Visual/admin UX work -> `../ui-design/SKILL.md`
+- Relational database design -> `../relational-database-tool/SKILL.md`
+
+### Do NOT use for
+
+- Generic business app planning where content management is not the core problem.
+- Pure copywriting, SEO writing, or content marketing tasks.
+- Database-only questions without CMS workflow or content-admin context.
+- Product-specific tutorials for third-party CMS platforms.
+
+### Common mistakes / gotchas
+
+- Treating every CMS request as a full custom platform build.
+- Recommending CloudBase-native for complex RBAC, workflow, or multi-tenant requirements by default.
+- Assuming PG/RLS can replace CMS service-layer authorization.
+- Skipping route selection and archetype selection before proposing data models.
+
+## What this skill does
+
+- Chooses the right route: `CloudBase-native`, `PG-based`, or `Hybrid`
+- Maps the request to a stable CMS archetype before designing details
+- Reuses fixed schema, workflow, media, permission, and webhook snippets
+- Explains how CloudBase and PG should divide responsibility
+- Produces implementation-ready output that can move into product or engineering work
+
+## When to use this skill
+
+Use this skill when the user needs:
+
+- A website, campaign, mini program, or mini game content backend
+- A CMS or headless CMS for publishing, media, and content APIs
+- Editorial workflow, review, publishing, preview, or webhook planning
+- Content schemas, content collections, blocks, taxonomies, or media libraries
+- A route decision between CloudBase-first and PG-enhanced CMS architectures
+
+## Do NOT use for
+
+- Pure MVP application planning where the main challenge is forms, orders, or business process logic rather than content administration
+- Simple CRUD dashboards that do not involve content workflows
+- Questions limited to MySQL/Postgres schema tuning without CMS behavior
+- UI-only design explorations without CMS or content-ops context
+
+## How to use this skill (for a coding agent)
+
+1. **Confirm the problem is really CMS-shaped**
+   - Identify whether the core problem is content management, publishing, campaign operations, or a content admin backend.
+   - If the request is broader than CMS, decide whether `app-builder` would be the better primary skill.
+
+2. **Choose the architecture route before proposing implementation**
+   - Use the route matrix in [decision matrix](references/decision-matrix.md).
+   - Decide between `CloudBase-native`, `PG-based`, and `Hybrid` before going deep on schemas or APIs.
+
+3. **Choose an archetype before inventing data structures**
+   - Use [CMS archetypes](references/archetypes.md) to map the request to a stable pattern.
+   - Prefer reusing archetypes and snippets over starting from a blank model.
+
+4. **Apply snippets and platform mapping**
+   - Use [snippets](references/snippets.md) for common fields, permissions, workflow, and hooks.
+   - Use [CloudBase and PG mapping](references/cloudbase-mapping.md) to place responsibilities correctly.
+
+5. **Produce a structured result**
+   - Output route choice, archetype, schema direction, roles, workflow, APIs, delivery path, and implementation sequence.
+   - Do not stop at generic product advice.
+
+## Operating Rules
+
+1. First action after trigger:
+   - Decide whether the request belongs to CMS and whether the user needs route selection.
+
+2. What to inspect before acting:
+   - Delivery surfaces: website, admin portal, mini program, mini game, customer portal
+   - Complexity: roles, review/publish flow, multi-project, external customers, reporting
+   - Data sensitivity: project-level or customer-level visibility
+
+3. What must never be skipped:
+   - Route selection
+   - Archetype selection
+   - Separation of storage/data concerns from service-layer authorization
+
+4. When to load references:
+   - Always read [decision matrix](references/decision-matrix.md) first for architecture choice.
+   - Read [archetypes](references/archetypes.md) when choosing the CMS pattern.
+   - Read [snippets](references/snippets.md) when producing content models and workflows.
+   - Read [CloudBase and PG mapping](references/cloudbase-mapping.md) when recommending platform responsibilities.
+   - Read [evaluation](references/evaluation.md) when testing trigger quality and behavior.
+
+5. When to stop and ask for clarification:
+   - Only if the user’s request is truly ambiguous between CMS and a general business app, or if the delivery surfaces and permission model fundamentally change the route.
+
+## Routing
+
+| Task | Read | Why |
+| --- | --- | --- |
+| Decide CloudBase-native vs PG-based vs Hybrid | `references/decision-matrix.md` | Route selection is the first architectural decision |
+| Choose the right CMS pattern | `references/archetypes.md` | Prevent blank-sheet design and reuse stable patterns |
+| Define fields, workflow, permissions, and hooks | `references/snippets.md` | Reuse tested building blocks instead of improvising |
+| Place capabilities on CloudBase, PG, or service layer | `references/cloudbase-mapping.md` | Keep responsibilities aligned with platform strengths |
+| Validate trigger quality and output behavior | `references/evaluation.md` | Ensure the skill stays useful and distinct from neighbors |
+
+## Quick workflow
+
+1. Confirm the request is CMS-shaped.
+2. Choose `CloudBase-native`, `PG-based`, or `Hybrid`.
+3. Choose the closest CMS archetype.
+4. Compose schemas, workflow, permissions, and APIs from snippets.
+5. Map responsibilities to CloudBase, PG, and service layer.
+6. Output implementation-ready structure and next steps.
+7. Run the self-check.
+
+## Minimum self-check
+
+- Did I choose the route before suggesting implementation details?
+- Did I avoid treating CloudBase collections or PG tables as the product concept?
+- Did I use a stable archetype instead of inventing a one-off CMS?
+- Did I keep complex RBAC and workflow logic in the service layer?
+- Did I clearly separate this from generic app planning or pure data modeling?

--- a/config/source/skills/cms/assets/campaign-cms-template.md
+++ b/config/source/skills/cms/assets/campaign-cms-template.md
@@ -1,0 +1,36 @@
+# Campaign CMS Output Template
+
+## Route
+
+- Selected route:
+- Why:
+
+## Archetype
+
+- Primary archetype: `campaign-cms`
+- Channels:
+
+## Campaign Objects
+
+- Campaign:
+- Page/config blocks:
+- Rewards/tasks:
+- Schedule and visibility:
+
+## Workflow and Hooks
+
+- States:
+- Runtime updates:
+- Hook / webhook plan:
+
+## Delivery
+
+- Mini program / mini game / web surfaces:
+- CloudBase responsibilities:
+- PG or service-layer responsibilities:
+
+## Implementation Order
+
+1.
+2.
+3.

--- a/config/source/skills/cms/assets/collection-cms-template.md
+++ b/config/source/skills/cms/assets/collection-cms-template.md
@@ -1,0 +1,36 @@
+# Collection CMS Output Template
+
+## Route
+
+- Selected route:
+- Why:
+
+## Archetype
+
+- Primary archetype: `collection-cms`
+- Secondary needs:
+
+## Content Model
+
+- Entry types:
+- Required fields:
+- Taxonomy:
+- Media:
+
+## Workflow
+
+- States:
+- Roles:
+- Publish and review rules:
+
+## Delivery
+
+- Admin backend:
+- Public API or frontend consumers:
+- CloudBase or PG responsibilities:
+
+## Implementation Order
+
+1.
+2.
+3.

--- a/config/source/skills/cms/assets/hybrid-architecture-template.md
+++ b/config/source/skills/cms/assets/hybrid-architecture-template.md
@@ -1,0 +1,42 @@
+# Hybrid CMS Architecture Template
+
+## Why Hybrid
+
+- CloudBase delivery needs:
+- PG core-data needs:
+
+## Domain Split
+
+- Project/workspace:
+- Content types:
+- Entries:
+- Media:
+- Roles and policies:
+- Workflow:
+
+## CloudBase Layer
+
+- Mini program / mini game delivery:
+- Storage:
+- Cloud functions:
+- Hosting:
+
+## PG Layer
+
+- Core relational data:
+- Audit and versioning:
+- Reporting:
+- Isolation model:
+
+## Service Layer
+
+- RBAC:
+- Workflow authorization:
+- Hook and webhook policy:
+- AI/report orchestration:
+
+## Risks and Migration Notes
+
+- Data ownership:
+- Synchronization:
+- Upgrade path from CloudBase-native:

--- a/config/source/skills/cms/references/archetypes.md
+++ b/config/source/skills/cms/references/archetypes.md
@@ -1,0 +1,125 @@
+# CMS Archetypes
+
+Choose an archetype before designing fields or APIs.
+
+## Purpose
+
+A good CMS design usually belongs to a small number of repeatable patterns. Reuse these archetypes instead of treating each request as a custom platform.
+
+## Archetype 1: `collection-cms`
+
+Best for:
+
+- Blogs
+- News and articles
+- Event pages
+- Cases, resources, FAQs, announcements
+
+Core objects:
+
+- Content entry
+- Category
+- Tag
+- Author
+- Media assets
+- SEO metadata
+- Publish state
+
+Common outputs:
+
+- Content model
+- Taxonomy model
+- Publishing flow
+- Public content API
+
+## Archetype 2: `page-builder-cms`
+
+Best for:
+
+- Official websites
+- Landing pages
+- Campaign pages
+- Microsites
+
+Core objects:
+
+- Page
+- Section or block
+- Navigation
+- Theme or layout settings
+- Preview configuration
+
+Common outputs:
+
+- Block schema
+- Page composition rules
+- Preview / publish flow
+- Website delivery path
+
+## Archetype 3: `campaign-cms`
+
+Best for:
+
+- Campaign operations
+- Mini program campaign pages
+- Mini game activity configuration
+- Event and reward operations
+
+Core objects:
+
+- Campaign
+- Activity page
+- Popup / banner / CTA
+- Reward rules
+- Task definitions
+- Schedule and channel visibility
+
+Common outputs:
+
+- Campaign config schema
+- Operational lifecycle
+- Hook/webhook plan
+- Delivery to mini program or mini game
+
+## Archetype 4: `portal-cms`
+
+Best for:
+
+- Customer-facing content portals
+- Project-based document portals
+- Reporting-oriented content backends
+
+Core objects:
+
+- Workspace or project
+- Customer-visible entry
+- Access policy
+- View model
+- Report and export configuration
+
+Common outputs:
+
+- Project/customer visibility model
+- Portal access model
+- Content + reporting integration
+- PG-based or Hybrid route recommendation
+
+## Choosing Between Archetypes
+
+Use this shortcut:
+
+- Repeated article-like records -> `collection-cms`
+- Page composition and blocks -> `page-builder-cms`
+- Operations and campaign configuration -> `campaign-cms`
+- Customer/project visibility and reporting -> `portal-cms`
+
+If a request spans more than one archetype:
+
+1. Choose the primary archetype first
+2. Add secondary snippets instead of merging archetypes into a vague custom category
+
+## Mapping Notes
+
+- `collection-cms` and `campaign-cms` fit `CloudBase-native` most often
+- `portal-cms` is the strongest signal for `PG-based` or `Hybrid`
+- `page-builder-cms` can be either `CloudBase-native` or `Hybrid` depending on workflow and permission complexity

--- a/config/source/skills/cms/references/cloudbase-mapping.md
+++ b/config/source/skills/cms/references/cloudbase-mapping.md
@@ -1,0 +1,95 @@
+# CloudBase and PG Mapping
+
+Use this reference after the route and archetype are chosen.
+
+## Purpose
+
+This file assigns responsibilities to CloudBase, PG, and the service layer so the design stays realistic and maintainable.
+
+## CloudBase Responsibilities
+
+CloudBase is strongest when handling:
+
+- Mini program and mini game delivery
+- Static hosting and website delivery
+- Cloud storage for media and exported files
+- Cloud functions for integration, orchestration, and lightweight hooks
+- Campaign and configuration-oriented content backends
+- Tencent ecosystem integration
+
+Use `CloudBase-native` by default for:
+
+- Lightweight content systems
+- Campaign operations
+- Mini program / mini game configuration
+- Fast MVP delivery
+
+## PG Responsibilities
+
+PG is strongest when handling:
+
+- Complex content relationships
+- Multi-project or multi-customer isolation
+- Workflow state persistence
+- Audit logs and version history
+- Complex querying and reporting
+- Stronger permission primitives through relational modeling and RLS
+
+Use `PG-based` or `Hybrid` by default for:
+
+- Portals with customer-visible data
+- Compliance-like or ledger-like systems
+- Enterprise approval flows
+- Reporting-heavy CMS platforms
+
+## Service-Layer Responsibilities
+
+Always keep these in the service layer:
+
+- CMS RBAC and policy decisions
+- Status transition permissions
+- Field editability rules
+- Bulk actions
+- Hook / webhook triggering policies
+- AI summary, report generation, and orchestration
+
+Do not rely on:
+
+- CloudBase security rules alone
+- PG/RLS alone
+
+to fully express CMS authorization behavior.
+
+## Route Templates
+
+### CloudBase-native
+
+- Content and config documents -> CloudBase collections or managed content structures
+- Media -> Cloud Storage
+- Hook execution -> Cloud Functions
+- Delivery -> mini program, mini game, static hosting, or admin frontend on CloudBase
+
+### PG-based
+
+- Core content records -> PG
+- Roles, memberships, and policies -> PG + service authz
+- Workflow and audit -> PG
+- Delivery frontends -> separate app or service, optionally still integrated with CloudBase-facing channels
+
+### Hybrid
+
+- Core relational data, workflows, and permissions -> PG
+- Assets, mini program delivery, campaign distribution, and Tencent-facing endpoints -> CloudBase
+- Service layer bridges the two systems
+
+## Practical Recommendation
+
+If the team asks "Can we publish now without PG?":
+
+- Yes, for CloudBase-native scenarios
+- No, if they expect complex enterprise-grade authorization and workflow from day one
+
+If the team asks "Will PG fix CMS permissions automatically?":
+
+- No, but it improves the data layer significantly
+- Service-layer authorization still remains required

--- a/config/source/skills/cms/references/decision-matrix.md
+++ b/config/source/skills/cms/references/decision-matrix.md
@@ -1,0 +1,84 @@
+# Decision Matrix
+
+Use this reference first when a CMS request needs architecture direction.
+
+## Purpose
+
+The route decision comes before schema design. This skill supports three routes:
+
+- `CloudBase-native`
+- `PG-based`
+- `Hybrid`
+
+## Route Selection Rules
+
+### Choose `CloudBase-native` when
+
+- The request is a lightweight or medium-complexity CMS
+- Delivery is centered on websites, mini programs, mini games, or campaign operations
+- The core need is content entry, media, publishing, and basic APIs
+- Roles are simple, such as admin/editor/operator
+- Multi-tenant isolation is not the main challenge
+
+Typical examples:
+
+- Official website CMS
+- Campaign content backend
+- Mini program content backend
+- Mini game operational configuration console
+
+### Choose `PG-based` when
+
+- The core challenge is complex authorization, workflow, relationships, or customer isolation
+- The CMS doubles as a data portal or reporting backend
+- There are strong requirements for audit, versioning, or state transitions
+- The request needs more than lightweight document-style querying
+
+Typical examples:
+
+- Multi-customer content portal
+- Compliance or ledger-style content system
+- Enterprise review and publishing workflow
+- Large content platform with reporting and customer visibility rules
+
+### Choose `Hybrid` when
+
+- CloudBase is still the best delivery path for mini programs, mini games, storage, or hosting
+- But PG is better suited for core content, permissions, workflow, or reporting
+- The team needs an incremental migration path instead of a full rewrite
+
+Typical examples:
+
+- A mini program content portal backed by PG content and permissions
+- A campaign CMS where CloudBase handles assets and delivery, while PG handles workflow and audit
+- A portal that serves customers through CloudBase-facing apps but stores core data in PG
+
+## Escalation Triggers
+
+If any of these appear, default away from pure `CloudBase-native`:
+
+- Complex RBAC or field-level editing constraints
+- Multi-project or multi-customer visibility boundaries
+- Approval chains or multiple publish states
+- Audit logs and version history as explicit requirements
+- Heavy reporting, dashboards, or AI-driven data analysis on top of content records
+
+## Important Constraint
+
+`PG-based` does not mean "the database solves authorization by itself."
+
+Even with PG and RLS:
+
+- Service-layer RBAC still owns business authorization
+- Workflow permissions still belong in the service layer
+- Hook / webhook triggering rules still belong in the service layer
+
+## Output Contract
+
+Every route decision should state:
+
+1. Selected route
+2. Why that route fits
+3. Why the other routes are weaker for this request
+4. What CloudBase still does in the chosen route
+5. What PG or service-layer logic is needed if the route is `PG-based` or `Hybrid`

--- a/config/source/skills/cms/references/evaluation.md
+++ b/config/source/skills/cms/references/evaluation.md
@@ -1,0 +1,34 @@
+# Evaluation
+
+Use this file to test trigger quality and route-selection behavior.
+
+## Should-trigger prompts
+
+1. Help me design a CMS for a company website with articles, cases, event pages, and an editor review flow.
+2. We need a mini program content backend for campaign pages, banners, and activity configuration.
+3. Design a customer-facing project portal where each client can view project content, reports, and exported summaries.
+4. I want a standard ledger database where customers can view project-collected data in a mini program and ask for charts and written reports through chat.
+
+## Should-not-trigger prompts
+
+1. Help me build an order management system for sales staff.
+2. I need a generic dashboard to manage invoices and finance approvals.
+3. Tune this PostgreSQL query and add indexes to improve performance.
+
+## Closest-neighbor comparison
+
+Prompt:
+
+- Build an event registration platform with an admin console, public pages, and customer progress tracking.
+
+Interpretation:
+
+- Use `cms` when the core challenge is content pages, campaign content configuration, publishing, and customer-visible content delivery.
+- Prefer a general app-planning skill when the core challenge is registration flow, transactional data, and business process logic.
+
+## Acceptance checks
+
+- The skill should choose `CloudBase-native` for lightweight campaign and content backends.
+- The skill should choose `PG-based` or `Hybrid` for customer-facing portals with reporting and visibility constraints.
+- The skill should not swallow generic CRUD or backend planning requests that are not content-management problems.
+- The ledger + visualization + multi-user + mini program prompt should push the skill toward `PG-based` or `Hybrid`, not a naive CloudBase-only CMS recommendation.

--- a/config/source/skills/cms/references/snippets.md
+++ b/config/source/skills/cms/references/snippets.md
@@ -1,0 +1,124 @@
+# Snippets
+
+Use these fixed building blocks after selecting the route and archetype.
+
+## Core Field Snippets
+
+### Identity and SEO
+
+- `title`
+- `slug`
+- `summary`
+- `seoTitle`
+- `seoDescription`
+
+### Publishing
+
+- `status`
+- `publishedAt`
+- `scheduledAt`
+- `reviewedBy`
+
+### Ownership and audit
+
+- `author`
+- `editor`
+- `createdAt`
+- `updatedAt`
+- `changeNote`
+
+### Taxonomy
+
+- `categoryIds`
+- `tagIds`
+
+### Media
+
+- `cover`
+- `gallery`
+- `attachments`
+
+### Visibility
+
+- `workspaceId`
+- `projectId`
+- `channel`
+- `locale`
+- `audience`
+
+## Workflow Snippets
+
+### Basic publish workflow
+
+- `draft`
+- `review`
+- `published`
+- `archived`
+
+Recommended when:
+
+- The team has editors and reviewers
+- The user asks for preview or approval
+
+### Campaign schedule workflow
+
+- `draft`
+- `ready`
+- `live`
+- `ended`
+
+Recommended when:
+
+- The request involves mini program or mini game operations
+- Timing and channel visibility matter
+
+## Permission Snippets
+
+### Lightweight roles
+
+- `admin`
+- `editor`
+- `operator`
+
+Use for `CloudBase-native` when:
+
+- Role boundaries are simple
+- Complex field-level editing is not needed
+
+### Extended roles
+
+- `admin`
+- `editor`
+- `reviewer`
+- `operator`
+- `customerViewer`
+
+Use for `PG-based` or `Hybrid` when:
+
+- The request includes review or external customer visibility
+
+## Hook and Webhook Snippets
+
+### Content publish hooks
+
+- Refresh cache
+- Rebuild static pages
+- Notify downstream systems
+
+### Campaign hooks
+
+- Activate rewards
+- Push schedules to runtime config
+- Trigger content distribution updates
+
+### Reporting hooks
+
+- Generate summary snapshots
+- Queue report exports
+- Trigger AI summary generation
+
+## Use Rules
+
+- Prefer a small number of stable snippets
+- Do not generate exotic field sets unless the user needs them
+- Escalate to `PG-based` or `Hybrid` when snippets imply customer isolation, audit, or complex workflow

--- a/specs/cms-platform-strategy/design.md
+++ b/specs/cms-platform-strategy/design.md
@@ -1,0 +1,343 @@
+# 技术方案设计
+
+## 概述
+
+本方案为 CloudBase CMS 路线提供一套 `CloudBase-first / PG-ready` 的分层设计，用于支撑两类目标：
+
+- 允许团队在当前 CloudBase 能力边界内先发布一个真实可用的 CMS v1
+- 从第一天起为 PG / Supabase 类能力预留演进路径，避免未来因为底层实现切换而推翻产品概念、API 和 skill 路由
+
+方案重点不在于立即实现完整 CMS，而在于先稳定以下内容：
+
+- v1 与 v2 的产品边界
+- 核心领域模型与命名
+- CloudBase、PG 与服务层的分工
+- 后续 `cms` skill、参考资料与实现任务可复用的决策矩阵
+
+## 目标
+
+- 定义可首发的 `CloudBase CMS v1`
+- 定义后续 `PG-enhanced CMS v2`
+- 建立存储无关的领域模型
+- 建立 `CloudBase-native`、`PG-based`、`Hybrid` 三种推荐路线
+- 让后续 `cms` skill 不再默认“从零造一个 CMS”，而是先做路线选择和范式推荐
+
+## 非目标
+
+- 不在本阶段实现新的 CMS 产品代码
+- 不在本阶段选定唯一的 PG 产品方案
+- 不要求立即完成 CloudBase 到 PG 的迁移实现
+- 不将 CloudBase 现有数据模型定义为未来 CMS 的唯一真相源
+
+## 已知约束
+
+### CloudBase 侧约束
+
+- 文档型数据库安全规则更适合轻量文档/行级控制，不适合作为复杂 CMS 授权系统的唯一基础
+- 云函数与服务端逻辑可以绕过数据库侧限制，因此复杂 RBAC、工作流和业务授权仍需在服务层实现
+- CloudBase 更擅长承接微信小程序、小游戏、静态托管、文件存储、云函数编排和腾讯生态交付
+
+### PG 侧约束
+
+- PG / RLS 更适合复杂关系建模、多租户/多项目隔离、复杂查询、审计和工作流状态建模
+- RLS 不能替代 CMS 业务层 RBAC、状态流转权限和领域服务授权
+- PG 是否由 CloudBase 原生提供类似 Supabase 的统一 API 仍非当前可依赖前提，因此本方案不能把 PG 作为 v1 前置
+
+## 产品路线
+
+### v1 - CloudBase CMS
+
+定位：
+
+- CloudBase-first
+- 面向内容管理、活动运营、小程序/小游戏配置和轻量项目后台
+- 可基于 CloudBase 现有能力发布
+
+适合承诺的能力：
+
+- 内容类型定义与基础内容录入
+- 项目级内容与资源管理
+- 基础角色控制
+- 基础 API 暴露
+- 基础 webhook / hook
+- 小程序、小游戏、活动页和轻量内容门户接入
+
+不在 v1 强承诺的能力：
+
+- 复杂企业级 RBAC
+- 多租户 SaaS 级隔离
+- 复杂审批与版本工作流
+- 字段级细粒度权限
+- 高复杂分析查询和报表引擎
+
+### v2 - PG-enhanced CMS
+
+定位：
+
+- PG-ready 路线的增强版本
+- 用于承接复杂权限、复杂工作流、复杂关系和多项目/多客户隔离
+
+适合增强的能力：
+
+- 多租户/多客户数据隔离
+- 复杂 RBAC / policy
+- 工作流、版本、审计
+- 复杂查询、统计与数据门户
+- 更强的 API 策略和外部系统集成
+
+## 核心架构
+
+```mermaid
+flowchart TD
+  A[CMS Product Surface] --> B[Domain Model Layer]
+  B --> C[Service / Authorization Layer]
+  C --> D1[CloudBase Adapter]
+  C --> D2[PG Adapter]
+  D1 --> E1[Mini Program / Mini Game / Hosting / Storage / Functions]
+  D2 --> E2[Postgres / RLS / Complex Relations / Audit]
+```
+
+说明：
+
+- `CMS Product Surface`
+  - 指产品功能、控制台、API、skill 路由和对外能力描述
+- `Domain Model Layer`
+  - 存储无关的领域模型，定义核心概念
+- `Service / Authorization Layer`
+  - 负责 CMS 业务授权、工作流、hook、批量操作和编排
+- `CloudBase Adapter`
+  - 负责 CloudBase 上的内容、存储、函数和腾讯生态交付
+- `PG Adapter`
+  - 负责关系数据、复杂权限隔离、审计和复杂查询
+
+## 领域模型设计
+
+为避免 CloudBase collection 或 PG table 直接泄漏为产品概念，先定义稳定的领域模型：
+
+- `workspace` / `project`
+- `contentType` / `schema`
+- `entry`
+- `mediaAsset`
+- `role`
+- `policy`
+- `workflow`
+- `webhook`
+- `apiToken`
+- `auditLog`
+
+这些概念必须满足两条要求：
+
+1. 能先映射到 CloudBase v1
+2. 后续可以迁移或并行映射到 PG
+
+### v1 中的 CloudBase 映射
+
+- `workspace/project` → CloudBase 中的项目配置集合
+- `contentType/schema` → schema 配置集合或受控数据模型定义
+- `entry` → collection 文档
+- `mediaAsset` → Cloud Storage 文件对象 + 元数据文档
+- `role/policy` → 角色文档 + 服务层授权逻辑
+- `workflow` → 云函数或服务层状态机逻辑
+- `webhook` → webhook 配置集合 + 云函数 / HTTP 触发
+- `apiToken` → API token 配置与服务层校验
+
+### v2 中的 PG 映射
+
+- `workspace/project` → projects / tenants / memberships
+- `contentType/schema` → typed metadata tables
+- `entry` → normalized relational content tables
+- `role/policy` → membership / role / policy tables + RLS + service authz
+- `workflow` → workflow / task / transition tables
+- `auditLog` → append-only audit tables
+
+## 分层职责
+
+### 1. 产品层
+
+负责：
+
+- CMS 控制台与配置体验
+- 路线选择文案与能力边界
+- 后续 `cms` skill 的触发与推荐结果
+
+原则：
+
+- 不暴露底层实现细节作为产品主概念
+- 不把 “collection” 或 “table” 当作对用户的唯一产品语言
+
+### 2. 领域与服务层
+
+负责：
+
+- 领域对象定义
+- RBAC / policy 判断
+- 状态流转权限
+- 批量操作与内容发布逻辑
+- webhook / hook 触发策略
+- 报告、AI 问答和异步任务编排
+
+原则：
+
+- 所有复杂授权都在这一层收口
+- CloudBase ACL / 安全规则与 PG RLS 只作为下层能力，不替代这一层
+
+### 3. CloudBase Adapter
+
+负责：
+
+- 小程序与小游戏前端接入
+- 文件存储与静态资源托管
+- 云函数执行与轻量 hook
+- CloudBase 原生内容和运营配置能力
+
+适用：
+
+- v1 首发
+- 内容、活动、配置类后台
+- 腾讯生态交付
+
+### 4. PG Adapter
+
+负责：
+
+- 复杂关系建模
+- 多租户 / 多客户隔离
+- 审计、版本、复杂工作流状态
+- 复杂查询和聚合
+
+适用：
+
+- v2 增强
+- 更复杂的门户、报表、工作流和授权
+
+## 路线决策矩阵
+
+后续 `cms` skill 和产品规划统一使用三种路线：
+
+### CloudBase-native
+
+适用于：
+
+- 轻量内容管理
+- 活动运营
+- 小程序/小游戏配置
+- 基础 API 暴露
+- 轻量后台
+
+推荐原因：
+
+- 快速
+- 交付链条短
+- 腾讯生态接入顺畅
+
+### PG-based
+
+适用于：
+
+- 复杂 RBAC
+- 多项目/多客户隔离
+- 工作流、审计、版本
+- 复杂查询与统计
+
+推荐原因：
+
+- 关系模型更强
+- 权限和查询能力更适合长期系统
+
+### Hybrid
+
+适用于：
+
+- 小程序/小游戏前端和交付仍依赖 CloudBase
+- 核心数据与权限逐步转向 PG
+- 需要平衡现有 CloudBase 资产与未来能力升级
+
+推荐原因：
+
+- 支持渐进演进
+- 避免一次性重构
+
+## 对 `cms` skill 的影响
+
+后续 `cms` skill 不再默认输出“从零造一个 CMS”，而改为：
+
+1. 先判断需求复杂度与场景
+2. 选择 `CloudBase-native`、`PG-based` 或 `Hybrid`
+3. 套用固定 CMS archetype
+4. 再输出 CloudBase / PG 映射建议
+
+建议 `cms` skill 参考资料结构：
+
+```text
+config/source/skills/cms/
+├── SKILL.md
+├── references/
+│   ├── archetypes.md
+│   ├── snippets.md
+│   ├── cloudbase-mapping.md
+│   └── decision-matrix.md
+└── assets/
+    ├── collection-cms-template.md
+    ├── campaign-cms-template.md
+    └── hybrid-architecture-template.md
+```
+
+其中：
+
+- `decision-matrix.md` 复用本方案中的路线决策逻辑
+- `cloudbase-mapping.md` 复用本方案中的 CloudBase / PG 分层职责
+
+## 测试与验证策略
+
+本阶段不做产品代码测试，改为做方案级验证：
+
+1. 场景验证
+   - 轻量内容管理需求应落到 `CloudBase-native`
+   - 复杂 RBAC / 多客户门户需求应落到 `PG-based` 或 `Hybrid`
+
+2. 概念验证
+   - 领域模型命名不依赖 collection / table
+   - v1/v2 边界可被清楚解释
+
+3. skill 复用验证
+   - 后续 `cms` skill 能根据本矩阵给出一致的架构推荐
+
+## 推荐实施优先级
+
+基于当前样板结果，建议执行顺序如下：
+
+1. `CloudBase CMS v1` 策略资料与 `cms` skill 样板
+   - 先稳定路线矩阵、CMS archetype、snippet、CloudBase/PG mapping
+   - 用于统一产品规划、skill 触发和方案输出
+
+2. `CloudBase-native` 首发场景验证
+   - 重点覆盖官网 CMS、活动运营后台、小程序/小游戏配置后台
+   - 验证这些场景是否足以支撑一个真实可发的 v1
+
+3. 高复杂场景样例回放
+   - 使用“台账 + 可视化 + 多用户 + 小程序 + 对话式数据访问”等样例复查边界
+   - 将这类需求明确归入 `PG-based` 或 `Hybrid`
+
+4. PG-enhanced 路线预研
+   - 在不阻塞 v1 的前提下，规划 PG 侧的内容、权限、工作流和审计模型
+   - 明确后续是否采用自建服务层、Directus 类平台，或其他 PG-based CMS 组合
+
+结论：
+
+- 先做 `CloudBase-first` 的 v1 资料与样板是合理的
+- 不应为了等待 PG 完整方案而阻塞 CMS 首发方向
+- 但所有高复杂场景必须从第一天起被显式标记为 `PG-ready` 或 `Hybrid-ready`
+
+## 风险与缓解
+
+风险 1：v1 边界定义过宽，导致团队误以为 CloudBase-only 可以承接复杂 CMS
+
+- 缓解：在需求与 skill 决策矩阵中明确列出 v1 不强承诺的能力
+
+风险 2：团队过早绑定某一种 PG 产品实现，反而把产品概念做窄
+
+- 缓解：设计阶段先稳定领域模型与路线矩阵，不将某个产品实现上升为产品主概念
+
+风险 3：未来 `cms` skill 再次退化成“大而全说明文档”
+
+- 缓解：要求 skill 主文档聚焦行为规则与路由，将路线矩阵、范式和映射拆到 references

--- a/specs/cms-platform-strategy/requirements.md
+++ b/specs/cms-platform-strategy/requirements.md
@@ -1,0 +1,71 @@
+# 需求文档
+
+## 介绍
+
+CloudBase 后续需要规划一条可持续演进的 CMS 产品路线，用于支撑内容管理、活动运营、小程序/小游戏配置、项目级数据展示，以及后续可能扩展到更复杂的台账、可视化、报告和多角色后台场景。
+
+当前已确认的背景与约束如下：
+
+- CloudBase 现有文档型数据库 ACL 与安全规则可以支撑轻量场景，但在复杂 RBAC、工作流、字段级控制、多项目隔离等场景下扩展性有限。
+- 历史 `cloudbase-extension-cms` 已通过云函数和服务层自建了 `project`、`schema`、`webhook`、`role`、`permission` 等核心骨架，证明 CloudBase CMS 的复杂能力不能完全依赖底层 ACL 直接表达。
+- 后续团队计划引入 PG / Supabase 类能力，以提升关系建模、复杂权限、工作流和多租户支撑能力，但当前公开能力与交付节奏尚不适合作为 CloudBase CMS 首发的唯一前提。
+- 因此需要一条清晰的产品与架构策略，明确：CMS 是否可以先以 CloudBase-first 方式发布、何时需要 PG 增强、如何从第一天起保持 PG-ready 的兼容设计。
+
+本需求目标不是立即实现完整 CMS，而是沉淀一套正式的产品路线、架构边界与验收标准，为后续 `cms` skill、CMS 产品功能规划和实现任务拆分提供统一依据。
+
+## 需求
+
+### 需求 1 - 明确 CloudBase-first 的 CMS v1 发布边界
+
+**用户故事：** 作为产品和研发决策者，我希望明确 CMS v1 在不依赖 PG 的前提下可以承诺哪些能力、不能承诺哪些能力，这样团队可以在当前能力边界内先发布一个真实可用的版本，而不是被未来 PG 规划阻塞。
+
+#### 验收标准
+
+1. When 团队定义 CMS v1 时，CloudBase AI Toolkit shall 将 v1 定位为可基于 CloudBase 现有能力发布的 CloudBase-first 版本，而不是要求 PG 成为首发前置条件。
+2. When 团队评估 CMS v1 范围时，CloudBase AI Toolkit shall 明确列出适合 v1 首发的核心场景，至少覆盖内容管理、活动运营、小程序/小游戏配置、基础 API 暴露、基础 hook/webhook 与轻量角色控制。
+3. When 团队评估复杂企业级 CMS 能力时，CloudBase AI Toolkit shall 明确列出不应在 v1 中强承诺的能力，至少包括复杂 RBAC、多租户 SaaS 级隔离、复杂审批工作流、字段级细粒度权限和高复杂分析查询。
+4. While 团队讨论是否必须等待 PG 才能发布 CMS 时, when 当前目标能力落在 CloudBase 可承接范围内，CloudBase AI Toolkit shall 给出“允许先发 v1”的结论与依据。
+
+### 需求 2 - 定义 PG-enhanced 的 CMS v2 方向与升级触发条件
+
+**用户故事：** 作为产品和架构设计者，我希望明确哪些能力应当进入 PG-enhanced 的 CMS v2，以及什么情况下需要从 CloudBase-first 路线升级到 PG 路线，这样后续演进方向和资源投入更可控。
+
+#### 验收标准
+
+1. When 团队定义 CMS v2 时，CloudBase AI Toolkit shall 将 v2 定位为 PG-enhanced 版本，用于承接复杂关系建模、复杂 RBAC、工作流、审计、版本和多租户等能力。
+2. When 团队评估某个需求是否超出 v1 范围时，CloudBase AI Toolkit shall 提供从 v1 升级到 PG-enhanced 路线的触发条件，至少覆盖复杂权限、多项目/多客户隔离、复杂工作流、复杂报表聚合和大规模 API 暴露。
+3. When 团队规划 v2 时，CloudBase AI Toolkit shall 说明 PG/RLS 只能增强底层数据隔离与查询能力，而不能替代 CMS 业务层的 RBAC、工作流权限和领域服务授权。
+4. While 团队讨论“上 PG 后是否能自然解决 CMS 权限问题”时, when 需求涉及状态流转、字段级可编辑性、工作流审批或 webhook 触发策略，CloudBase AI Toolkit shall 明确要求保留服务层授权逻辑。
+
+### 需求 3 - 保持 CloudBase-first / PG-ready 的领域模型兼容设计
+
+**用户故事：** 作为架构设计者，我希望从 CMS 第一天起就保持核心概念和领域模型的稳定性，这样 v1 使用 CloudBase 实现时不会把未来切换或兼容 PG 的路径锁死。
+
+#### 验收标准
+
+1. When 团队定义 CMS 核心模型时，CloudBase AI Toolkit shall 先定义与底层存储无关的领域概念，而不是直接把 CloudBase collection 或 PG table 当作产品概念。
+2. When 团队规划 CMS 核心概念时，CloudBase AI Toolkit shall 至少包含 `workspace/project`、`content type/schema`、`entry`、`media asset`、`role`、`policy`、`workflow`、`webhook` 和 `api token` 等兼容性概念。
+3. When 团队规划 v1 的实现时，CloudBase AI Toolkit shall 允许这些领域概念先由 CloudBase collection、云函数和存储承接，同时保留迁移或并行映射到 PG 的空间。
+4. While 团队为 v1 设计 API 或操作入口时, when 某个能力名称暴露了 CloudBase 专属实现细节，CloudBase AI Toolkit shall 要求将其重构为稳定的领域能力名称，以保证后续双后端兼容。
+
+### 需求 4 - 定义 CloudBase 与 PG 的分层职责
+
+**用户故事：** 作为架构设计者，我希望明确 CloudBase、PG 和服务层分别负责什么，这样系统不会把所有授权、数据和交付能力混在一层里，导致后续演进困难。
+
+#### 验收标准
+
+1. When 团队规划 CloudBase-first / PG-ready 架构时，CloudBase AI Toolkit shall 明确区分“产品领域层、服务授权层、数据层、交付接入层”的职责边界。
+2. When 团队规划 CloudBase 在 CMS 中的角色时，CloudBase AI Toolkit shall 优先将其定位为小程序/小游戏接入、文件存储、云函数编排、静态托管和腾讯生态交付能力承接层。
+3. When 团队规划 PG 在 CMS 中的角色时，CloudBase AI Toolkit shall 优先将其定位为复杂关系建模、多租户/多项目隔离、复杂查询、工作流状态和审计数据的核心数据层。
+4. When 团队规划服务层时，CloudBase AI Toolkit shall 明确服务层需要承担 CMS 领域 RBAC、状态流转授权、批量操作、hook/webhook 触发策略和 AI/报告编排，而不是完全依赖底层 ACL 或 RLS。
+
+### 需求 5 - 形成面向产品规划与 skill 设计的决策矩阵
+
+**用户故事：** 作为 skill 维护者和产品设计者，我希望后续 `cms` skill、CMS 方案输出和实现规划都能基于同一套决策矩阵工作，这样面对不同复杂度的 CMS 需求时，agent 能稳定地推荐合适路线，而不是默认从零造一个系统。
+
+#### 验收标准
+
+1. When 后续 `cms` skill 处理用户请求时，CloudBase AI Toolkit shall 能根据需求复杂度在 `CloudBase-native`、`PG-based` 与 `Hybrid` 路线之间做出明确推荐。
+2. When 用户需求属于轻量内容管理、活动页运营或小程序/小游戏配置时，CloudBase AI Toolkit shall 默认优先推荐 CloudBase-native 路线。
+3. When 用户需求涉及复杂权限、多客户隔离、复杂工作流、复杂报表或高复杂查询时，CloudBase AI Toolkit shall 默认优先推荐 PG-based 或 Hybrid 路线。
+4. When 团队后续编写 `cms` skill 参考材料时，CloudBase AI Toolkit shall 基于本需求定义的路线、边界、核心概念和分层职责构建对应的 archetype、snippet 和 CloudBase mapping 资料，而不是再次从零定义路线。

--- a/specs/cms-platform-strategy/tasks.md
+++ b/specs/cms-platform-strategy/tasks.md
@@ -1,0 +1,43 @@
+# 实施计划
+
+- [x] 1. 固化 CMS 产品路线与决策矩阵资料
+  - 基于本 spec 将 `CloudBase-native`、`PG-based`、`Hybrid` 三条路线整理为可复用的决策矩阵
+  - 明确 `CloudBase CMS v1` 与 `PG-enhanced CMS v2` 的能力边界、适用场景与升级触发条件
+  - 为后续 `cms` skill 和产品方案复用统一术语：`workspace/project`、`contentType/schema`、`entry`、`workflow`、`webhook` 等
+  - _需求: 需求1, 需求2, 需求3, 需求4, 需求5
+
+- [x] 2. 在 `config/source/skills/` 中规划 CMS skill 的目标目录与结构
+  - 确定 `config/source/skills/cms/` 作为新 skill 的单一语义源目录
+  - 设计主 `SKILL.md`、`references/` 与 `assets/` 的职责划分
+  - 预留至少 `archetypes.md`、`snippets.md`、`cloudbase-mapping.md`、`decision-matrix.md` 等参考文件位置
+  - _需求: 需求3, 需求4, 需求5
+
+- [x] 3. 产出 `cms` skill 的样板定义稿
+  - 按 `skill-authoring` 标准编写 `cms` 的 `name`、`description`、边界、行为规则与路由
+  - 将 skill 默认行为改为“先选路线、再选 archetype、最后给出 CloudBase / PG 映射”，而不是默认从零设计 CMS
+  - 明确 `cms` 与 `app-builder`、`headless-cms`、`wechat-miniprogram` 等近邻 skill 的边界
+  - _需求: 需求3, 需求5
+
+- [x] 4. 沉淀 CMS archetype 与固定片段库
+  - 提炼至少 `collection-cms`、`campaign-cms`、`page-builder-cms` 等 archetype
+  - 为字段、发布流程、媒体、权限、webhook 等能力整理可复用 snippets
+  - 将历史 `cloudbase-extension-cms` 中值得复用的 `project`、`schema`、`webhook`、`role` 等产品骨架转化为参考资料，而不是直接复制实现
+  - _需求: 需求1, 需求3, 需求4, 需求5
+
+- [x] 5. 编写 CloudBase 与 PG 的映射规则
+  - 明确哪些能力优先映射到 CloudBase：小程序/小游戏、存储、函数、托管、轻量内容配置
+  - 明确哪些能力优先映射到 PG：复杂关系、多租户、多客户隔离、审计、工作流状态、复杂查询
+  - 明确哪些授权逻辑必须留在服务层：RBAC、状态流转、批量操作、hook/webhook 触发策略
+  - _需求: 需求2, 需求3, 需求4, 需求5
+
+- [x] 6. 建立 CMS 路线的评测集与验收样例
+  - 为 `cms` skill 设计至少 3 个 `should-trigger`、3 个 `should-not-trigger` 和 1 个最近邻对比样例
+  - 加入真实用户声音样例，例如“台账 + 可视化 + 多用户 + 小程序 + 对话式数据访问”
+  - 验证轻量需求会落到 `CloudBase-native`，复杂权限/门户需求会落到 `PG-based` 或 `Hybrid`
+  - _需求: 需求1, 需求2, 需求5
+
+- [x] 7. 用样板结果回推 v1/v2 产品规划与后续实现优先级
+  - 基于 `cms` skill 样板复查 v1 首发能力是否足够真实可用
+  - 基于复杂场景样例复查 v2 PG 增强边界是否清晰
+  - 输出后续产品实现优先级建议，例如“先做 CloudBase CMS v1 策略资料与样板 skill，再评估 PG-enhanced 能力进入产品路线图”
+  - _需求: 需求1, 需求2, 需求4, 需求5


### PR DESCRIPTION
## Summary
- add a formal `cms-platform-strategy` spec with requirements, design, and tasks
- scaffold a new `config/source/skills/cms/` skill with route selection, archetypes, snippets, CloudBase/PG mapping, and evaluation prompts
- add reusable output templates for collection CMS, campaign CMS, and hybrid architecture planning

## Why
- capture the agreed `CloudBase-first / PG-ready` CMS direction in repo-native spec docs
- give the team a reusable CMS skill sample instead of treating every CMS request as a blank-sheet design
- establish a shared decision matrix for `CloudBase-native`, `PG-based`, and `Hybrid` recommendations

## Testing
- structural self-review of skill boundaries, routing, and spec alignment
- no automated tests run in this change set