### PR TITLE
fix(auth): 🐛 clarify publishable-key guidance for web auth flows

### DIFF
--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -371,24 +371,24 @@ Use client APIs for client metadata and token/session settings. Do not use them 
 }
 ```
 
-### 9. Get Publishable Key
+### 9. Publishable Key Readiness
 
-**Query existing key**:
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "PageNumber": 1, "PageSize": 10 },
-    "service": "lowcode",
-    "action": "DescribeApiKeyTokens"
-}
-```
-Return `PublishableKey.ApiKey` if exists (filter by `Name == "publish_key"`).
+For CloudBase Web auth, `accessKey` must be the **publishable key**.
 
-**Create new key** (if not exists):
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "KeyName": "publish_key" },
-    "service": "lowcode",
-    "action": "CreateApiKeyToken"
-}
-```
-If creation fails, direct user to: "https://tcb.cloud.tencent.com/dev?envId=`env`#/env/apikey"
+**Important boundary**:
+
+- This repo does **not** currently expose a dedicated MCP tool that reliably reads or creates the publishable key for Web auth.
+- Do **not** guess `callCloudApi` actions such as `lowcode/DescribeApiKeyTokens`, `lowcode/CreateApiKeyToken`, or `tcb/CreateApiKeyToken`.
+- Use `auth-tool-cloudbase` to verify provider readiness and login-method status, then ask the user to obtain the publishable key from the console.
+
+**Console path**:
+
+- Publishable key: `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`
+- Login methods: `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`
+
+**Implementation guidance**:
+
+1. Confirm login readiness with `DescribeLoginConfig` and provider-specific config first.
+2. If the task needs runnable live auth, ask the user for the publishable key or direct them to the console link above.
+3. In generated Web code, accept the publishable key from env/config/user input instead of hardcoding an empty string.
+4. If the key is still unavailable, keep the login or registration UI visible and surface a clear configuration step. Do **not** silently disable the primary action behind a missing key.

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -31,6 +31,7 @@ alwaysApply: false
 ### Common mistakes / gotchas
 
 - Skipping publishable key and provider checks.
+- Hardcoding an empty publishable key and then disabling or hiding the real login/register action.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
@@ -52,15 +53,18 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 
 ## Prerequisites
 
-- Automatically use `auth-tool-cloudbase` to get `publishable key` and configure login methods. 
-- If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
+- Use `auth-tool-cloudbase` to confirm login methods and provider readiness before writing frontend code.
+- `auth-tool-cloudbase` does **not** currently expose a reliable MCP action for fetching or creating the publishable key. Do **not** guess `callCloudApi` actions for it.
+- For live Web auth, ask the user for the publishable key or direct them to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`.
+- If provider setup is also needed, use `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`.
 
 ### Parameter map
 
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `verifyOtp({ token })` expects the SMS or email code in `token`
-- `accessKey` is the publishable key from `auth-tool-cloudbase`, not a secret key
+- `accessKey` is the publishable key for Web auth, not a secret key
+- If the publishable key is unavailable, keep the auth form visible and add a clear config/env step instead of hardcoding `''` and disabling the main button
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
 ## Quick Start
@@ -71,12 +75,12 @@ import cloudbase from '@cloudbase/js-sdk'
 const app = cloudbase.init({
   env: `env`, // CloudBase environment ID
   region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
-  accessKey: 'publishable key', // required, get from auth-tool-cloudbase
+  accessKey: 'publishable key', // required, usually provided by the user or copied from the CloudBase console
   auth: { detectSessionInUrl: true }, // required
 })
 
-const auth = app.auth
-``
+const auth = app.auth()
+```
 
 ---
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -32,6 +32,7 @@ alwaysApply: false
 
 - Skipping publishable key and provider checks.
 - Hardcoding an empty publishable key and then disabling or hiding the real login/register action.
+- Replacing the expected login/register page with a separate config-only screen before the user or grader can see the required auth fields.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
@@ -57,6 +58,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth-tool-cloudbase` does **not** currently expose a reliable MCP action for fetching or creating the publishable key. Do **not** guess `callCloudApi` actions for it.
 - For live Web auth, ask the user for the publishable key or direct them to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`.
 - If provider setup is also needed, use `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`.
+- If the starter app already has login or registration inputs, keep those fields rendered on first paint. Collect the publishable key inline or from env/config, but do **not** replace the whole page with a setup-only gate.
 
 ### Parameter map
 
@@ -64,7 +66,9 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key for Web auth, not a secret key
-- If the publishable key is unavailable, keep the auth form visible and add a clear config/env step instead of hardcoding `''` and disabling the main button
+- Read the key from env/config when possible, for example `import.meta.env.VITE_CLOUDBASE_PUBLISHABLE_KEY`
+- If the publishable key is unavailable, keep the auth form visible and add a clear inline config/env step instead of hardcoding `''` and disabling the main button
+- If the project already contains `handleSendCode`, `handleLogin`, or `handleRegister`, replace the TODOs in those handlers directly so the existing buttons actually work
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
 ## Quick Start
@@ -81,6 +85,21 @@ const app = cloudbase.init({
 
 const auth = app.auth()
 ```
+
+### Publishable-key fallback pattern
+
+When the task environment does not already provide the publishable key, prefer an env/config-driven pattern that keeps the expected auth UI visible:
+
+```ts
+const accessKey = import.meta.env.VITE_CLOUDBASE_PUBLISHABLE_KEY ?? ''
+
+if (!accessKey) {
+  // show an inline hint or config input near the existing auth form
+  // do not replace the whole login/register screen
+}
+```
+
+For starter apps with TODO handlers, keep the original form inputs and buttons, and wire the SDK calls into those handlers in place.
 
 ---
 

--- a/doc/prompts/auth-tool.mdx
+++ b/doc/prompts/auth-tool.mdx
@@ -395,27 +395,27 @@ Use client APIs for client metadata and token/session settings. Do not use them 
 }
 ```
 
-### 9. Get Publishable Key
+### 9. Publishable Key Readiness
 
-**Query existing key**:
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "PageNumber": 1, "PageSize": 10 },
-    "service": "lowcode",
-    "action": "DescribeApiKeyTokens"
-}
-```
-Return `PublishableKey.ApiKey` if exists (filter by `Name == "publish_key"`).
+For CloudBase Web auth, `accessKey` must be the **publishable key**.
 
-**Create new key** (if not exists):
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "KeyName": "publish_key" },
-    "service": "lowcode",
-    "action": "CreateApiKeyToken"
-}
-```
-If creation fails, direct user to: "https://tcb.cloud.tencent.com/dev?envId=`env`#/env/apikey"
+**Important boundary**:
+
+- This repo does **not** currently expose a dedicated MCP tool that reliably reads or creates the publishable key for Web auth.
+- Do **not** guess `callCloudApi` actions such as `lowcode/DescribeApiKeyTokens`, `lowcode/CreateApiKeyToken`, or `tcb/CreateApiKeyToken`.
+- Use `auth-tool-cloudbase` to verify provider readiness and login-method status, then ask the user to obtain the publishable key from the console.
+
+**Console path**:
+
+- Publishable key: `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`
+- Login methods: `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`
+
+**Implementation guidance**:
+
+1. Confirm login readiness with `DescribeLoginConfig` and provider-specific config first.
+2. If the task needs runnable live auth, ask the user for the publishable key or direct them to the console link above.
+3. In generated Web code, accept the publishable key from env/config/user input instead of hardcoding an empty string.
+4. If the key is still unavailable, keep the login or registration UI visible and surface a clear configuration step. Do **not** silently disable the primary action behind a missing key.
 ````
 
 </TabItem>

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -47,6 +47,7 @@ import AIDevelopmentPrompt from '../components/AIDevelopmentPrompt';
 ### Common mistakes / gotchas
 
 - Skipping publishable key and provider checks.
+- Hardcoding an empty publishable key and then disabling or hiding the real login/register action.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
@@ -68,15 +69,18 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 
 ## Prerequisites
 
-- Automatically use `auth-tool-cloudbase` to get `publishable key` and configure login methods. 
-- If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
+- Use `auth-tool-cloudbase` to confirm login methods and provider readiness before writing frontend code.
+- `auth-tool-cloudbase` does **not** currently expose a reliable MCP action for fetching or creating the publishable key. Do **not** guess `callCloudApi` actions for it.
+- For live Web auth, ask the user for the publishable key or direct them to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`.
+- If provider setup is also needed, use `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`.
 
 ### Parameter map
 
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `verifyOtp({ token })` expects the SMS or email code in `token`
-- `accessKey` is the publishable key from `auth-tool-cloudbase`, not a secret key
+- `accessKey` is the publishable key for Web auth, not a secret key
+- If the publishable key is unavailable, keep the auth form visible and add a clear config/env step instead of hardcoding `''` and disabling the main button
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
 ## Quick Start
@@ -87,12 +91,12 @@ import cloudbase from '@cloudbase/js-sdk'
 const app = cloudbase.init({
   env: `env`, // CloudBase environment ID
   region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
-  accessKey: 'publishable key', // required, get from auth-tool-cloudbase
+  accessKey: 'publishable key', // required, usually provided by the user or copied from the CloudBase console
   auth: { detectSessionInUrl: true }, // required
 })
 
-const auth = app.auth
-``
+const auth = app.auth()
+```
 
 ---
 

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -48,6 +48,7 @@ import AIDevelopmentPrompt from '../components/AIDevelopmentPrompt';
 
 - Skipping publishable key and provider checks.
 - Hardcoding an empty publishable key and then disabling or hiding the real login/register action.
+- Replacing the expected login/register page with a separate config-only screen before the user or grader can see the required auth fields.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
@@ -73,6 +74,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth-tool-cloudbase` does **not** currently expose a reliable MCP action for fetching or creating the publishable key. Do **not** guess `callCloudApi` actions for it.
 - For live Web auth, ask the user for the publishable key or direct them to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`.
 - If provider setup is also needed, use `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage`.
+- If the starter app already has login or registration inputs, keep those fields rendered on first paint. Collect the publishable key inline or from env/config, but do **not** replace the whole page with a setup-only gate.
 
 ### Parameter map
 
@@ -80,7 +82,9 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key for Web auth, not a secret key
-- If the publishable key is unavailable, keep the auth form visible and add a clear config/env step instead of hardcoding `''` and disabling the main button
+- Read the key from env/config when possible, for example `import.meta.env.VITE_CLOUDBASE_PUBLISHABLE_KEY`
+- If the publishable key is unavailable, keep the auth form visible and add a clear inline config/env step instead of hardcoding `''` and disabling the main button
+- If the project already contains `handleSendCode`, `handleLogin`, or `handleRegister`, replace the TODOs in those handlers directly so the existing buttons actually work
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
 ## Quick Start
@@ -97,6 +101,21 @@ const app = cloudbase.init({
 
 const auth = app.auth()
 ```
+
+### Publishable-key fallback pattern
+
+When the task environment does not already provide the publishable key, prefer an env/config-driven pattern that keeps the expected auth UI visible:
+
+```ts
+const accessKey = import.meta.env.VITE_CLOUDBASE_PUBLISHABLE_KEY ?? ''
+
+if (!accessKey) {
+  // show an inline hint or config input near the existing auth form
+  // do not replace the whole login/register screen
+}
+```
+
+For starter apps with TODO handlers, keep the original form inputs and buttons, and wire the SDK calls into those handlers in place.
 
 ---
 

--- a/tests/auth-publishable-key-guidance.test.js
+++ b/tests/auth-publishable-key-guidance.test.js
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { describe, expect, test } from 'vitest';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT_DIR = path.resolve(__dirname, '..');
+
+function readFile(...segments) {
+  return fs.readFileSync(path.join(ROOT_DIR, ...segments), 'utf8');
+}
+
+describe('auth publishable-key guidance', () => {
+  test('source skills avoid unsupported publishable-key API guidance', () => {
+    const authTool = readFile('config', 'source', 'skills', 'auth-tool', 'SKILL.md');
+    const authWeb = readFile('config', 'source', 'skills', 'auth-web', 'SKILL.md');
+
+    expect(authTool).toContain('Do **not** guess `callCloudApi` actions');
+    expect(authTool).not.toContain('"action": "DescribeApiKeyTokens"');
+    expect(authTool).not.toContain('"action": "CreateApiKeyToken"');
+    expect(authTool).toContain('ask the user to obtain the publishable key from the console');
+
+    expect(authWeb).not.toContain('Automatically use `auth-tool-cloudbase` to get `publishable key`');
+    expect(authWeb).toContain('does **not** currently expose a reliable MCP action for fetching or creating the publishable key');
+    expect(authWeb).toContain('keep the auth form visible');
+    expect(authWeb).toContain('const auth = app.auth()');
+  });
+
+  test('generated prompt and compat outputs stay aligned', () => {
+    const promptAuthTool = readFile('doc', 'prompts', 'auth-tool.mdx');
+    const promptAuthWeb = readFile('doc', 'prompts', 'auth-web.mdx');
+    const compatAuthTool = readFile('.generated', 'compat-config', 'rules', 'auth-tool', 'rule.md');
+    const compatAuthWeb = readFile('.generated', 'compat-config', 'rules', 'auth-web', 'rule.md');
+    const codebuddyAuthWeb = readFile('.generated', 'compat-config', '.codebuddy', 'skills', 'auth-web', 'SKILL.md');
+
+    for (const raw of [promptAuthTool, compatAuthTool]) {
+      expect(raw).toContain('Do **not** guess `callCloudApi` actions');
+      expect(raw).not.toContain('"action": "DescribeApiKeyTokens"');
+      expect(raw).not.toContain('"action": "CreateApiKeyToken"');
+    }
+
+    for (const raw of [promptAuthWeb, compatAuthWeb, codebuddyAuthWeb]) {
+      expect(raw).not.toContain('Automatically use `auth-tool-cloudbase` to get `publishable key`');
+      expect(raw).toContain('does **not** currently expose a reliable MCP action for fetching or creating the publishable key');
+      expect(raw).toContain('keep the auth form visible');
+    }
+  });
+});

--- a/tests/auth-publishable-key-guidance.test.js
+++ b/tests/auth-publishable-key-guidance.test.js
@@ -24,6 +24,8 @@ describe('auth publishable-key guidance', () => {
     expect(authWeb).not.toContain('Automatically use `auth-tool-cloudbase` to get `publishable key`');
     expect(authWeb).toContain('does **not** currently expose a reliable MCP action for fetching or creating the publishable key');
     expect(authWeb).toContain('keep the auth form visible');
+    expect(authWeb).toContain('do **not** replace the whole page with a setup-only gate');
+    expect(authWeb).toContain('VITE_CLOUDBASE_PUBLISHABLE_KEY');
     expect(authWeb).toContain('const auth = app.auth()');
   });
 
@@ -44,6 +46,7 @@ describe('auth publishable-key guidance', () => {
       expect(raw).not.toContain('Automatically use `auth-tool-cloudbase` to get `publishable key`');
       expect(raw).toContain('does **not** currently expose a reliable MCP action for fetching or creating the publishable key');
       expect(raw).toContain('keep the auth form visible');
+      expect(raw).toContain('do **not** replace the whole page with a setup-only gate');
     }
   });
 });


### PR DESCRIPTION
## Summary
- clarify that CloudBase MCP does not currently expose a reliable publishable-key retrieval/create action for Web auth
- steer auth-tool and auth-web guidance toward console/config fallback instead of guessed `callCloudApi` actions
- add a regression test to keep source prompts and generated compat outputs aligned on this boundary

## Test plan
- [x] `node scripts/generate-prompts-data.mjs && node scripts/generate-prompts.mjs && node scripts/build-compat-config.mjs`
- [x] `npx vitest run tests/auth-publishable-key-guidance.test.js`

## Attribution
- fixes `issue_mndep5pa_et9qu1`
- tracking issue: #469