### PR TITLE
Fix #367: MCP工具错误: createFunction

### DIFF
--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -127,6 +127,28 @@ describe("functions tool helpers", () => {
     expect(() => resolveEventFunctionRuntime("Ruby3.2")).toThrow(/Python3.9/);
   });
 
+  it("passes isWaitInstall to createFunction when specified", async () => {
+    await tools.manageFunctions.handler({
+      action: "createFunction",
+      func: {
+        name: "receivable",
+        timeout: 10,
+        runtime: "Nodejs18.15",
+        handler: "index.main",
+        isWaitInstall: false,
+        installDependency: true,
+      },
+      functionRootPath: "/tmp/cloudfunctions",
+      force: true,
+    });
+
+    expect(mockCreateFunction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isWaitInstall: false,
+      }),
+    );
+  });
+
   it("guides HTTP functions through anonymous-access follow-up without auto-creating gateway access", async () => {
     const result = await tools.manageFunctions.handler({
       action: "createFunction",

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -886,6 +886,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           func,
           functionRootPath: processedRootPath,
           force: Boolean(input.force),
+          ...(func.isWaitInstall !== undefined && { isWaitInstall: func.isWaitInstall }),
         } as any);
       } catch (error) {
         throw wrapFunctionOperationError(


### PR DESCRIPTION
Closes #367

Passes `isWaitInstall` through to the underlying `createFunction` call when the caller explicitly provides it.

## Changes

**`mcp/src/tools/functions.ts`** — In the `registerFunctionTools` handler's `createFunction` action, a conditional spread `...(func.isWaitInstall !== undefined && { isWaitInstall: func.isWaitInstall })` was added to the options object passed to `createFunction`. Previously, `isWaitInstall` was silently dropped even when supplied in `func`, so the dependency installation wait behavior was never forwarded to the API.

**`mcp/src/tools/functions.test.ts`** — Added a test case that calls the `createFunction` action with `isWaitInstall: false` and asserts that `mockCreateFunction` receives an object containing `isWaitInstall: false`, confirming the field is no longer swallowed.

## Motivation

Users setting `isWaitInstall: false` (or `true`) in the `func` parameter received a misleading `依赖安装失败` (dependency install failed) error because the field was never forwarded to the CloudBase API. The `func` object was destructured and passed through, but the explicit `createFunction` call in `functions.ts` only spread `func`, `functionRootPath`, and `force` — omitting any `isWaitInstall` value. The conditional spread fixes this without breaking callers that omit the field entirely (the `undefined` guard prevents injecting a spurious `isWaitInstall: undefined`).

## Testing

The new unit test in `functions.test.ts` directly covers the fix: it invokes the handler with `isWaitInstall: false` and verifies via `expect(mockCreateFunction).toHaveBeenCalledWith(expect.objectContaining({ isWaitInstall: false }))`. This test would have failed against the previous code, confirming the regression is caught.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*