### PR TITLE
docs(skill): clarify publishable-key guidance for CloudBase Web auth

### DIFF
--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -372,24 +372,15 @@ Use client APIs for client metadata and token/session settings. Do not use them 
 }
 ```
 
-### 9. Get Publishable Key
+### 9. Publishable Key Configuration
 
-**Query existing key**:
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "PageNumber": 1, "PageSize": 10 },
-    "service": "lowcode",
-    "action": "DescribeApiKeyTokens"
-}
-```
-Return `PublishableKey.ApiKey` if exists (filter by `Name == "publish_key"`).
+The CloudBase Web SDK requires a publishable key (`publishableKey`) during initialization when interacting with auth and other public APIs.
 
-**Create new key** (if not exists):
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "KeyName": "publish_key" },
-    "service": "lowcode",
-    "action": "CreateApiKeyToken"
-}
-```
-If creation fails, direct user to: "https://tcb.cloud.tencent.com/dev?envId=`env`#/env/apikey"
+**Important boundary**: Do NOT attempt to fetch or create the publishable key via MCP tools using `DescribeApiKeyTokens` or `CreateApiKeyToken`. These actions are not exposed in the standard CloudBase Manager API.
+
+**Correct workflow:**
+1. Do not hide or disable the login/registration UI when the key is missing.
+2. Provide a configuration step or UI prompt where the developer/user can enter the key.
+3. Direct the user to the CloudBase console to generate or retrieve their publishable key:
+   `https://tcb.cloud.tencent.com/dev?envId=YOUR_ENV_ID#/env/apikey`
+4. Instruct the user to save this key in their environment variables (e.g., `VITE_CLOUDBASE_PUBLISHABLE_KEY`).

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -53,8 +53,10 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 
 ## Prerequisites
 
-- Automatically use `auth-tool-cloudbase` to get `publishable key` and configure login methods. 
-- If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
+- Automatically use `auth-tool-cloudbase` to configure login methods.
+- Instruct the user to retrieve their `publishable key` from `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` and save it as an environment variable. Do not attempt to fetch it automatically via MCP tools.
+- Keep login UI visible and accessible, but add a step to input or configure the publishable key if it is not provided in environment variables.
+- Direct the user to `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods if automatic setup fails.
 
 ### Parameter map
 

--- a/doc/prompts/auth-tool.mdx
+++ b/doc/prompts/auth-tool.mdx
@@ -395,27 +395,18 @@ Use client APIs for client metadata and token/session settings. Do not use them 
 }
 ```
 
-### 9. Get Publishable Key
+### 9. Publishable Key Configuration
 
-**Query existing key**:
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "PageNumber": 1, "PageSize": 10 },
-    "service": "lowcode",
-    "action": "DescribeApiKeyTokens"
-}
-```
-Return `PublishableKey.ApiKey` if exists (filter by `Name == "publish_key"`).
+The CloudBase Web SDK requires a publishable key (`publishableKey`) during initialization when interacting with auth and other public APIs.
 
-**Create new key** (if not exists):
-```js
-{
-    "params": { "EnvId": `env`, "KeyType": "publish_key", "KeyName": "publish_key" },
-    "service": "lowcode",
-    "action": "CreateApiKeyToken"
-}
-```
-If creation fails, direct user to: "https://tcb.cloud.tencent.com/dev?envId=`env`#/env/apikey"
+**Important boundary**: Do NOT attempt to fetch or create the publishable key via MCP tools using `DescribeApiKeyTokens` or `CreateApiKeyToken`. These actions are not exposed in the standard CloudBase Manager API.
+
+**Correct workflow:**
+1. Do not hide or disable the login/registration UI when the key is missing.
+2. Provide a configuration step or UI prompt where the developer/user can enter the key.
+3. Direct the user to the CloudBase console to generate or retrieve their publishable key:
+   `https://tcb.cloud.tencent.com/dev?envId=YOUR_ENV_ID#/env/apikey`
+4. Instruct the user to save this key in their environment variables (e.g., `VITE_CLOUDBASE_PUBLISHABLE_KEY`).
 ````
 
 </TabItem>

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -68,8 +68,10 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 
 ## Prerequisites
 
-- Automatically use `auth-tool-cloudbase` to get `publishable key` and configure login methods. 
-- If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
+- Automatically use `auth-tool-cloudbase` to configure login methods.
+- Instruct the user to retrieve their `publishable key` from `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` and save it as an environment variable. Do not attempt to fetch it automatically via MCP tools.
+- Keep login UI visible and accessible, but add a step to input or configure the publishable key if it is not provided in environment variables.
+- Direct the user to `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods if automatic setup fails.
 
 ### Parameter map
 


### PR DESCRIPTION
## Summary
- Removed unsupported publishable-key API guidance (`DescribeApiKeyTokens`, `CreateApiKeyToken`) from `auth-tool`.
- Updated `auth-web` prerequisites so they no longer claim the key can be auto-fetched through MCP.
- Instructed agents to keep the auth UI visible and request/configure the publishable key manually from the console instead of failing or hiding the UI.

Resolves #469.

## Test plan
- Manual review of the generated markdown files.