### PR TITLE
fix(permissions): 🧭 detect missing storage buckets in queryPermissions

### DIFF
--- a/mcp/src/tools/permissions.storage-not-found.test.ts
+++ b/mcp/src/tools/permissions.storage-not-found.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { registerPermissionTools } from "./permissions.js";
+import type { ExtendedMcpServer } from "../server.js";
+
+const {
+  mockGetCloudBaseManager,
+  mockGetEnvId,
+  mockDescribeResourcePermission,
+  mockGetEnvInfo,
+} = vi.hoisted(() => ({
+  mockGetCloudBaseManager: vi.fn(),
+  mockGetEnvId: vi.fn(),
+  mockDescribeResourcePermission: vi.fn(),
+  mockGetEnvInfo: vi.fn(),
+}));
+
+vi.mock("../cloudbase-manager.js", () => ({
+  getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
+  logCloudBaseResult: vi.fn(),
+}));
+
+function createMockServer() {
+  const tools: Record<string, { handler: (args: any) => Promise<any> }> = {};
+
+  const server: ExtendedMcpServer = {
+    cloudBaseOptions: { envId: "env-test", region: "ap-guangzhou" },
+    logger: vi.fn(),
+    registerTool: vi.fn((name, _meta, handler) => {
+      tools[name] = { handler };
+    }),
+  } as unknown as ExtendedMcpServer;
+
+  registerPermissionTools(server);
+  return tools;
+}
+
+describe("queryPermissions storage not found", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetEnvId.mockResolvedValue("env-test");
+    mockGetEnvInfo.mockResolvedValue({
+      EnvInfo: {
+        Storages: [{ Bucket: "existing-bucket" }],
+        StaticStorages: [{ Bucket: "hosting-bucket" }],
+      },
+    });
+    mockDescribeResourcePermission.mockResolvedValue({
+      Data: {
+        TotalCount: 1,
+        PermissionList: [
+          {
+            ResourceType: "storage",
+            Resource: "nonexistent-bucket",
+            Permission: "ADMINWRITE",
+          },
+        ],
+      },
+      RequestId: "req-resource-perm",
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      env: {
+        getEnvInfo: mockGetEnvInfo,
+      },
+      permission: {
+        describeResourcePermission: mockDescribeResourcePermission,
+      },
+      user: {},
+    });
+  });
+
+  it("returns an error envelope when a storage bucket does not exist in the bound env", async () => {
+    const tools = createMockServer();
+    const result = await tools.queryPermissions.handler({
+      action: "getResourcePermission",
+      resourceType: "storage",
+      resourceId: "nonexistent-bucket",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockGetEnvInfo).toHaveBeenCalledTimes(1);
+    expect(mockDescribeResourcePermission).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      success: false,
+      error: 'Storage bucket "nonexistent-bucket" does not exist in env "env-test"',
+      message: 'Storage bucket "nonexistent-bucket" does not exist in env "env-test"',
+    });
+  });
+});

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -34,6 +34,8 @@ type ToolEnvelope = {
   success: boolean;
   data: Record<string, unknown>;
   message: string;
+  error?: string;
+  errorCode?: string;
 };
 
 function buildEnvelope(data: Record<string, unknown>, message: string): ToolEnvelope {
@@ -45,10 +47,12 @@ function buildEnvelope(data: Record<string, unknown>, message: string): ToolEnve
 }
 
 function buildErrorEnvelope(error: unknown): ToolEnvelope {
+  const message = error instanceof Error ? error.message : String(error);
   return {
     success: false,
     data: {},
-    message: error instanceof Error ? error.message : String(error),
+    message,
+    error: message,
   };
 }
 
@@ -71,6 +75,48 @@ function normalizeRecordArray(value: unknown, label: string) {
     throw new Error(`${label} 必须是数组`);
   }
   return value as Array<Record<string, unknown>>;
+}
+
+function extractStorageBuckets(envInfo: unknown): string[] {
+  const typedEnvInfo = envInfo as {
+    EnvInfo?: {
+      Storages?: Array<{ Bucket?: string }>;
+      StaticStorages?: Array<{ Bucket?: string }>;
+    };
+  };
+
+  const buckets = [
+    ...(typedEnvInfo.EnvInfo?.Storages ?? []),
+    ...(typedEnvInfo.EnvInfo?.StaticStorages ?? []),
+  ]
+    .map((item) => item.Bucket)
+    .filter((bucket): bucket is string => typeof bucket === "string" && bucket.length > 0);
+
+  return Array.from(new Set(buckets));
+}
+
+async function ensureStorageBucketExists(params: {
+  cloudbase: Awaited<ReturnType<typeof getCloudBaseManager>>;
+  envId: string;
+  resourceType: LegacyResourceType;
+  resourceId: string;
+}) {
+  if (params.resourceType !== "storage") {
+    return;
+  }
+
+  const envService = params.cloudbase?.env;
+  if (!envService?.getEnvInfo) {
+    return;
+  }
+
+  const envInfo = await envService.getEnvInfo();
+  const knownBuckets = extractStorageBuckets(envInfo);
+  if (knownBuckets.length > 0 && !knownBuckets.includes(params.resourceId)) {
+    throw new Error(
+      `Storage bucket "${params.resourceId}" does not exist in env "${params.envId}"`,
+    );
+  }
 }
 
 export function registerPermissionTools(server: ExtendedMcpServer) {
@@ -146,6 +192,12 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
             if (!resourceType || !resourceId) {
               throw new Error("action=getResourcePermission 时必须提供 resourceType 和 resourceId");
             }
+            await ensureStorageBucketExists({
+              cloudbase,
+              envId,
+              resourceType,
+              resourceId,
+            });
             const result = await cloudbase.permission.describeResourcePermission({
               resourceType: mapResourceType(resourceType),
               resources: [resourceId],


### PR DESCRIPTION
## Summary
- validate storage bucket existence against env metadata before queryPermissions(action="getResourcePermission") returns a success payload
- add explicit error field to permission error envelopes so RESULT.json can preserve failure semantics directly
- add a regression test covering nonexistent storage buckets

## Attribution
- issue: issue_mnoyd73x_516z19
- representative run: atomic-js-none-describe-storage-acl-not-found/2026-04-07T18-26-55-ymwnt3

## Verification
- cd mcp && npx vitest run src/tools/permissions.storage-not-found.test.ts
- cd mcp && npx vitest run src/tools/permissions.test.ts src/tools/permissions.storage-not-found.test.ts
- cd mcp && npm run build
- report-api evaluation: atomic-js-none-describe-storage-acl-not-found/2026-04-08T02-45-41-d59647 (RESULT.json error check now passes; remaining failure is grader/environment mismatch because direct DescribeStorageSafeRule still returns READONLY for the fake bucket outside MCP code)
