### PR TITLE
feat(mcp): ⚡️ upgrade @cloudbase/manager-node to ^5.1.0

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cloudbase/cals": "^1.2.23",
         "@cloudbase/functions-framework": "^1.14.0",
-        "@cloudbase/manager-node": "^4.10.2",
+        "@cloudbase/manager-node": "^5.1.0",
         "@cloudbase/mcp": "^1.0.0-beta.25",
         "@cloudbase/toolbox": "^0.7.17",
         "@modelcontextprotocol/sdk": "1.13.1",
@@ -2508,9 +2508,9 @@
       }
     },
     "node_modules/@cloudbase/manager-node": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@cloudbase/manager-node/-/manager-node-4.10.2.tgz",
-      "integrity": "sha512-I5HTi49Vhymln3VOPpxC8Gm726y6mzSjSeB7h6x/cg6Ew1d1EZ8aeSSVLL7L3CAp4g1oiz4tH3xQg8GqP6cfVQ==",
+      "version": "5.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/manager-node/-/manager-node-5.1.0.tgz",
+      "integrity": "sha512-YUW6onmrWUe2ZnQt+R83vYREEo21r/Vs3+Y5l/3YL6hKNpWJRHhyHCfS5gBfOQjBbxHXgMItcQb/bMMWCHQCRw==",
       "license": "ISC",
       "dependencies": {
         "@cloudbase/database": "^0.6.2",
@@ -2525,7 +2525,20 @@
         "node-fetch": "^2.6.0",
         "query-string": "^6.8.3",
         "unzipper": "^0.12.3",
+        "uuid": "^9.0.0",
         "walkdir": "^0.4.1"
+      }
+    },
+    "node_modules/@cloudbase/manager-node/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://mirrors.tencent.com/npm/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/@cloudbase/mcp": {
@@ -21188,9 +21201,9 @@
       "integrity": "sha512-IteJl7RjPYjsqQbmSr6Vr0el6I19SzI1ya6Nw1ov4KEHxXdwrjJ2uubBeUK4mc54kmzFmvTwqBuyJdhUQ/YDXA=="
     },
     "@cloudbase/manager-node": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/@cloudbase/manager-node/-/manager-node-4.10.2.tgz",
-      "integrity": "sha512-I5HTi49Vhymln3VOPpxC8Gm726y6mzSjSeB7h6x/cg6Ew1d1EZ8aeSSVLL7L3CAp4g1oiz4tH3xQg8GqP6cfVQ==",
+      "version": "5.1.0",
+      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/manager-node/-/manager-node-5.1.0.tgz",
+      "integrity": "sha512-YUW6onmrWUe2ZnQt+R83vYREEo21r/Vs3+Y5l/3YL6hKNpWJRHhyHCfS5gBfOQjBbxHXgMItcQb/bMMWCHQCRw==",
       "requires": {
         "@cloudbase/database": "^0.6.2",
         "archiver": "^3.1.1",
@@ -21204,7 +21217,15 @@
         "node-fetch": "^2.6.0",
         "query-string": "^6.8.3",
         "unzipper": "^0.12.3",
+        "uuid": "^9.0.0",
         "walkdir": "^0.4.1"
+      },
+      "dependencies": {
+        "uuid": {
+          "version": "9.0.1",
+          "resolved": "https://mirrors.tencent.com/npm/uuid/-/uuid-9.0.1.tgz",
+          "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
+        }
       }
     },
     "@cloudbase/mcp": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -65,7 +65,7 @@
   "dependencies": {
     "@cloudbase/cals": "^1.2.23",
     "@cloudbase/functions-framework": "^1.14.0",
-    "@cloudbase/manager-node": "^4.10.2",
+    "@cloudbase/manager-node": "^5.1.0",
     "@cloudbase/mcp": "^1.0.0-beta.25",
     "@cloudbase/toolbox": "^0.7.17",
     "@modelcontextprotocol/sdk": "1.13.1",


### PR DESCRIPTION
## Summary

- Upgrade `@cloudbase/manager-node` from `^4.10.2` to `^5.1.0`
- 113 tests passed - backward compatible with 5.1.0 SDK

## Test plan

- [x] All 23 test files, 113 tests pass
- [x] Backward compatible - existing V2 methods still work
- [ ] CI check
- [ ] Review feedback