### PR TITLE
fix(github): 🩹 harden issue auto processor PR reporting

### DIFF
--- a/.github/workflows/issue-auto-processor-simple.yml
+++ b/.github/workflows/issue-auto-processor-simple.yml
@@ -193,7 +193,7 @@ jobs:
                 .filter((issue) => new Date(issue.created_at).getTime() <= cutoffMs)
                 .filter((issue) => {
                   const labels = (issue.labels || []).map((label) => typeof label === 'string' ? label : label.name);
-                  return !labels.includes('ai-processed') && !labels.includes('ai-processing') && !labels.includes('no-ai');
+                  return !labels.includes('ai-processed') && !labels.includes('ai-processing') && !labels.includes('ai-failed') && !labels.includes('no-ai');
                 })
                 .slice(0, maxIssues);
 
@@ -354,6 +354,7 @@ jobs:
             local title=""
             local issue_url=""
             local pr_url=""
+            local pr_output=""
             local is_bug="false"
             local requested_action=""
             local command=""
@@ -460,16 +461,19 @@ jobs:
                 write_file_from_env /tmp/pr-body.md
 
                 set +e
-                pr_url=$(gh pr create --base "$DEFAULT_BRANCH" --head "$branch" --title "fix: 🤖 attempt fix for issue #$number" --body-file /tmp/pr-body.md)
+                pr_output=$(gh pr create --base "$DEFAULT_BRANCH" --head "$branch" --title "fix: 🤖 attempt fix for issue #$number" --body-file /tmp/pr-body.md 2>&1)
                 exit_code=$?
                 set -e
+                pr_url=$(printf '%s' "$pr_output" | node scripts/issue-auto-processor.cjs extract-pr-url)
                 if [ $exit_code -ne 0 ] || ! has_nonempty_text "$pr_url"; then
                   fail_with_comment "$number" '## 🤖 AI Fix Attempt Failed' 'Automation created and pushed a fix branch, but PR creation did not return a valid URL. Please inspect the workflow logs before retrying.'
                   return 0
                 fi
               fi
 
-              write_issue_comment_file '## 🤖 AI Fix Attempt' "I created a PR for this bug: $pr_url\n\nPlease review the generated changes before merging." ''
+              local comment_body=""
+              comment_body=$(printf 'I created a PR for this bug: %s\n\nPlease review the generated changes before merging.' "$pr_url")
+              write_issue_comment_file '## 🤖 AI Fix Attempt' "$comment_body" ''
               post_file_comment "$number" /tmp/issue-comment.md
               update_issue_labels "$number" remove:ai-processing add:ai-processed add:ai-fix remove:ai-failed
               cleanup_repo

--- a/scripts/issue-auto-processor.cjs
+++ b/scripts/issue-auto-processor.cjs
@@ -11,6 +11,7 @@ const BUG_TEXT_PATTERNS = [
   /\b(bug|error|errors|crash|crashes|broken|breaks|fail|fails|failed|failing|not working)\b/i,
   /报错|错误|异常|失败|崩溃|无法|不能|不生效|有问题|未生效|失效/,
 ];
+const GITHUB_PULL_REQUEST_URL_PATTERN = /https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/pull\/\d+/i;
 
 function normalizeMultilineText(value) {
   if (typeof value !== 'string') {
@@ -154,6 +155,16 @@ function extractResultText(rawOutput) {
   return normalizeMultilineText(rawOutput);
 }
 
+function extractPullRequestUrl(rawOutput) {
+  const normalized = normalizeMultilineText(rawOutput);
+  if (!normalized) {
+    return '';
+  }
+
+  const match = normalized.match(GITHUB_PULL_REQUEST_URL_PATTERN);
+  return match ? match[0] : '';
+}
+
 function parseIssueCommentCommand({ body, authorAssociation, hasPullRequest }) {
   if (hasPullRequest) {
     return null;
@@ -293,6 +304,12 @@ function runCli() {
     return;
   }
 
+  if (command === 'extract-pr-url') {
+    const rawOutput = fs.readFileSync(0, 'utf8');
+    process.stdout.write(extractPullRequestUrl(rawOutput));
+    return;
+  }
+
   const issueFile = process.argv[3];
   if (!issueFile) {
     throw new Error(`Missing issue JSON file for command: ${command}`);
@@ -327,6 +344,7 @@ module.exports = {
   buildAnalysisPrompt,
   buildBugPrompt,
   extractResultText,
+  extractPullRequestUrl,
   isBugIssue,
   parseIssueCommentCommand,
 };

--- a/tests/issue-auto-processor.test.js
+++ b/tests/issue-auto-processor.test.js
@@ -6,6 +6,7 @@ import issueAutoProcessorHelpers from '../scripts/issue-auto-processor.cjs';
 
 const {
   extractResultText,
+  extractPullRequestUrl,
   parseIssueCommentCommand,
   buildAnalysisPrompt,
   isBugIssue,
@@ -39,6 +40,24 @@ test('extractResultText returns latest assistant text from array payload', () =>
 
 test('extractResultText falls back to plain text output', () => {
   expect(extractResultText('plain text output')).toBe('plain text output');
+});
+
+test('extractPullRequestUrl returns the PR URL from plain gh output', () => {
+  expect(
+    extractPullRequestUrl('https://github.com/TencentCloudBase/CloudBase-MCP/pull/499'),
+  ).toBe('https://github.com/TencentCloudBase/CloudBase-MCP/pull/499');
+});
+
+test('extractPullRequestUrl finds the first PR URL in noisy gh output', () => {
+  const output = [
+    'warning: something noisy on stderr',
+    'https://github.com/TencentCloudBase/CloudBase-MCP/pull/499',
+    'created pull request successfully',
+  ].join('\n');
+
+  expect(extractPullRequestUrl(output)).toBe(
+    'https://github.com/TencentCloudBase/CloudBase-MCP/pull/499',
+  );
 });
 
 test('parseIssueCommentCommand only accepts maintainer slash commands', () => {
@@ -119,6 +138,9 @@ test('workflow hardens fix path with git identity and PR creation guards', () =>
   expect(raw).toContain('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
   expect(raw).toContain("fail_with_comment \"$number\" '## 🤖 AI Fix Attempt Failed' 'Automation created a branch diff, but git commit failed before a PR could be opened. Please inspect the workflow logs before retrying.'");
   expect(raw).toContain("fail_with_comment \"$number\" '## 🤖 AI Fix Attempt Failed' 'Automation created and pushed a fix branch, but PR creation did not return a valid URL. Please inspect the workflow logs before retrying.'");
+  expect(raw).toContain('pr_output=$(gh pr create --base "$DEFAULT_BRANCH" --head "$branch" --title "fix: 🤖 attempt fix for issue #$number" --body-file /tmp/pr-body.md 2>&1)');
+  expect(raw).toContain("pr_url=$(printf '%s' \"$pr_output\" | node scripts/issue-auto-processor.cjs extract-pr-url)");
+  expect(raw).not.toContain('I created a PR for this bug: $pr_url\\n\\nPlease review the generated changes before merging.');
 });
 
 test('workflow creates fix branches from the default branch baseline', () => {
@@ -128,6 +150,12 @@ test('workflow creates fix branches from the default branch baseline', () => {
   expect(raw).toContain('git fetch origin "$DEFAULT_BRANCH"');
   expect(raw).toContain('git switch -C "$branch" "origin/$DEFAULT_BRANCH"');
   expect(raw).toContain('gh pr create --base "$DEFAULT_BRANCH" --head "$branch"');
+});
+
+test('workflow scheduled collection does not retry ai-failed issues automatically', () => {
+  const raw = fs.readFileSync(WORKFLOW_FILE, 'utf8');
+
+  expect(raw).toContain("!labels.includes('ai-failed')");
 });
 
 test('workflow isolates batch iteration from CLI stdin consumption', () => {


### PR DESCRIPTION
## Summary
- stop scheduled retries for `ai-failed` issues so the same failure comment does not get posted repeatedly
- parse the PR URL from `gh pr create` output instead of assuming stdout is a clean URL string
- write the success issue comment with real newlines so GitHub does not fold `\\n\\nPlease` into the PR link
- add regression tests for URL extraction, workflow guards, and retry filtering

## Testing
- `npx vitest run tests/issue-auto-processor.test.js`

## Context
This fixes the frequent badcase seen around issue auto-processor comments, including malformed PR links and repeated `AI Fix Attempt Failed` comments.
