### PR TITLE
chore(cloudbase): 🔧 refine entry guardrails and bump toolbox

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -3,7 +3,7 @@ name: cloudbase
 description: CloudBase is a full-stack development and deployment toolkit for building and launching websites, Web apps, 微信小程序 (WeChat Mini Programs), and mobile apps with backend, database, hosting, cloud functions, storage, AI capabilities, Agent, and UI guidance. This skill should be used when users ask to develop, build, create, scaffold, deploy, publish, host, launch, go live, migrate, or optimize websites, Web apps, landing pages, dashboards, admin systems, e-commerce sites, 微信小程序 (WeChat Mini Programs), 小程序, Agent, 智能体, uni-app, or native/mobile apps with CloudBase (腾讯云开发, 云开发), including authentication, login, database, NoSQL, MySQL, cloud functions, CloudRun, storage, AI models, and UI guidance, or when they ask to compare CloudBase with Supabase or migrate from Supabase to CloudBase.
 description_zh: 为你的小程序和 Web/H5 提供一体化运行与部署环境，包括数据库、云函数、云存储、身份权限和静态托管
 description_en: An all-in-one runtime and deployment environment for WeChat Mini Programs and Web/H5 apps, including database, cloud functions, cloud storage, identity and access control, and static hosting.
-version: 2.17.0
+version: 2.17.1
 ---
 
 # CloudBase Development Guidelines
@@ -31,6 +31,12 @@ If a skill points to its own `references/...` files, keep following those relati
 - If the task includes UI, read `ui-design` first and output the design specification before interface code.
 - If the task includes login, registration, or auth configuration, read `auth-tool` first and enable required providers before frontend implementation.
 - Keep auth domains separate: management-side login uses `auth`; app-side auth configuration uses `queryAppAuth` / `manageAppAuth`.
+
+### Universal guardrails
+
+- If the same implementation path fails 2-3 times, stop retrying and reroute. Re-check the selected platform skill, runtime, auth domain, permission model, and SDK boundary before editing more code.
+- Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment, implicit defaults, or copied local state.
+- Keep scenario-specific pitfall lists in the matching child skills instead of expanding this entry file.
 
 ### High-priority routing
 

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-all-in-one
 description: Unified CloudBase execution guide for all-in-one skill installs. Use this as the first entry point for CloudBase app tasks, especially existing applications that already contain TODOs, fixed pages, and active handlers.
-version: 2.16.1
+version: 2.16.2
 alwaysApply: true
 ---
 
@@ -34,6 +34,11 @@ alwaysApply: true
 - Browser-side document database CRUD -> `./no-sql-web-sdk/SKILL.md`
 - Browser-side file upload -> `./cloud-storage-web/SKILL.md`
 - Platform overview only when capability selection is still unclear -> `./cloudbase-platform/SKILL.md`
+
+### High-yield guardrails
+
+- If the same path fails 2-3 times, stop retrying and reroute. Check platform skill, auth domain, runtime, and permission model before editing more code.
+- Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment or implicit defaults.
 
 ### Do NOT use this as
 

--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -13,7 +13,7 @@
         "@cloudbase/functions-framework": "^1.14.0",
         "@cloudbase/manager-node": "^5.1.0",
         "@cloudbase/mcp": "^1.0.0-beta.25",
-        "@cloudbase/toolbox": "^0.7.19",
+        "@cloudbase/toolbox": "^0.7.20",
         "@modelcontextprotocol/sdk": "1.13.1",
         "@types/adm-zip": "^0.5.7",
         "adm-zip": "^0.5.16",
@@ -331,9 +331,9 @@
       }
     },
     "node_modules/@cloudbase/toolbox": {
-      "version": "0.7.19",
-      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/toolbox/-/toolbox-0.7.19.tgz",
-      "integrity": "sha512-0nenSK3Lh2/6HaHRv3GZkqR5Gb5Rbf1cuZoCLQt/cs9k5LUMTH4dARTxM48cvcfUzy5zL1gxqQcP21GGrcNRLA==",
+      "version": "0.7.20",
+      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/toolbox/-/toolbox-0.7.20.tgz",
+      "integrity": "sha512-c91DMBYAkKtPThOh/KYRYZwOJ30M2if98pJA0k9lHWRaBCxZT/qL/sKu8AekcYL3LbdbXG377346DPvG3GkBxA==",
       "license": "ISC",
       "dependencies": {
         "@cloudbase/cloud-api": "^0.5.5",
@@ -11304,9 +11304,9 @@
       }
     },
     "@cloudbase/toolbox": {
-      "version": "0.7.19",
-      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/toolbox/-/toolbox-0.7.19.tgz",
-      "integrity": "sha512-0nenSK3Lh2/6HaHRv3GZkqR5Gb5Rbf1cuZoCLQt/cs9k5LUMTH4dARTxM48cvcfUzy5zL1gxqQcP21GGrcNRLA==",
+      "version": "0.7.20",
+      "resolved": "https://mirrors.tencent.com/npm/@cloudbase/toolbox/-/toolbox-0.7.20.tgz",
+      "integrity": "sha512-c91DMBYAkKtPThOh/KYRYZwOJ30M2if98pJA0k9lHWRaBCxZT/qL/sKu8AekcYL3LbdbXG377346DPvG3GkBxA==",
       "requires": {
         "@cloudbase/cloud-api": "^0.5.5",
         "@types/lowdb": "^1.0.9",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -67,7 +67,7 @@
     "@cloudbase/functions-framework": "^1.14.0",
     "@cloudbase/manager-node": "^5.1.0",
     "@cloudbase/mcp": "^1.0.0-beta.25",
-    "@cloudbase/toolbox": "^0.7.19",
+    "@cloudbase/toolbox": "^0.7.20",
     "@modelcontextprotocol/sdk": "1.13.1",
     "@types/adm-zip": "^0.5.7",
     "adm-zip": "^0.5.16",


### PR DESCRIPTION
## Summary
- refine CloudBase entry skills to keep only universal guardrails
- require explicit `EnvId` in code, config, and command examples
- bump `@cloudbase/toolbox` in `mcp/` from `^0.7.19` to `^0.7.20`

## Verification
- `cd mcp && npm run build`

## Notes
- opened from a fresh branch because the previous working branch already had a merged PR