### PR TITLE
fix(workflow): 🤖 repair issue processor yaml

### DIFF
--- a/.github/workflows/issue-auto-processor-simple.yml
+++ b/.github/workflows/issue-auto-processor-simple.yml
@@ -229,15 +229,7 @@ jobs:
 
           truncate_text_for_pr_body() {
             local max_chars="${1:-12000}"
-            python - "$max_chars" <<'PY'
-import sys
-
-limit = int(sys.argv[1])
-text = sys.stdin.read()
-if len(text) > limit:
-    text = text[:limit].rstrip() + "\n\n_[truncated by automation to keep PR creation stable]_"
-sys.stdout.write(text)
-PY
+            python3 -c 'import sys; limit = int(sys.argv[1]); text = sys.stdin.read(); sys.stdout.write(text if len(text) <= limit else text[:limit].rstrip() + "\n\n_[truncated by automation to keep PR creation stable]_")' "$max_chars"
           }
 
           lookup_open_pr_url() {

--- a/tests/issue-auto-processor.test.js
+++ b/tests/issue-auto-processor.test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { expect, test } from 'vitest';
+import { loadYamlModule } from '../scripts/lib/load-yaml-module.mjs';
 import issueAutoProcessorHelpers from '../scripts/issue-auto-processor.cjs';
 
 const {
@@ -21,6 +22,16 @@ const WORKFLOW_FILE = path.join(
   'workflows',
   'issue-auto-processor-simple.yml',
 );
+
+const yaml = await loadYamlModule(ROOT_DIR);
+
+test('issue auto processor workflow remains valid YAML', () => {
+  const raw = fs.readFileSync(WORKFLOW_FILE, 'utf8');
+  const parsed = yaml.load(raw);
+
+  expect(parsed).toBeTruthy();
+  expect(parsed.jobs['process-issues'].steps.length).toBeGreaterThan(0);
+});
 
 test('extractResultText returns result from top-level object payload', () => {
   const raw = JSON.stringify({ result: 'Structured response' });
@@ -137,6 +148,7 @@ test('workflow hardens fix path with git identity and PR creation guards', () =>
   expect(raw).toContain('git config user.name "github-actions[bot]"');
   expect(raw).toContain('git config user.email "41898282+github-actions[bot]@users.noreply.github.com"');
   expect(raw).toContain('truncate_text_for_pr_body() {');
+  expect(raw).toContain('python3 -c');
   expect(raw).toContain('lookup_open_pr_url() {');
   expect(raw).toContain('write_pr_body_file() {');
   expect(raw).toContain("summary=$(printf '%s' \"$result_text\" | truncate_text_for_pr_body 12000)");


### PR DESCRIPTION
## Summary
- replace the inline Python here-doc in `issue-auto-processor-simple.yml` with a single-line `python3 -c` truncation helper
- restore valid YAML structure for the `run: |` block
- add a regression test that parses the workflow as YAML before asserting workflow behavior

## Root cause
The previous patch introduced unindented here-doc body lines inside the workflow `run: |` block, which made the workflow file invalid YAML before GitHub Actions could even start the job.

## Validation
- `node --input-type=module -e "import fs from 'fs'; import yaml from 'js-yaml'; yaml.load(fs.readFileSync('.github/workflows/issue-auto-processor-simple.yml', 'utf8')); console.log('workflow yaml ok');"`
- `npx vitest run tests/issue-auto-processor.test.js`

Fixes the invalid workflow syntax introduced around `truncate_text_for_pr_body()`.
