### PR TITLE
fix(auth): ✨ return complete device verification url

### DIFF
--- a/mcp/src/auth.test.ts
+++ b/mcp/src/auth.test.ts
@@ -172,3 +172,64 @@ describe("auth config resolution", () => {
     );
   });
 });
+
+describe("device auth challenge helpers", () => {
+  it("should append user_code to standard verification_uri", async () => {
+    const { buildVerificationUriComplete } = await import("./auth.js");
+
+    expect(
+      buildVerificationUriComplete({
+        user_code: "WDJB-MJHT",
+        verification_uri: "https://example.com/device",
+      }),
+    ).toBe("https://example.com/device?user_code=WDJB-MJHT");
+  });
+
+  it("should append user_code inside hash route query", async () => {
+    const { buildVerificationUriComplete } = await import("./auth.js");
+
+    expect(
+      buildVerificationUriComplete({
+        user_code: "48NK-MSUK",
+        verification_uri:
+          "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+      }),
+    ).toBe(
+      "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device&user_code=48NK-MSUK",
+    );
+  });
+
+  it("should prefer explicit verification_uri_complete without modification", async () => {
+    const { buildVerificationUriComplete } = await import("./auth.js");
+
+    expect(
+      buildVerificationUriComplete({
+        user_code: "48NK-MSUK",
+        verification_uri:
+          "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+        verification_uri_complete:
+          "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device&user_code=48NK-MSUK",
+      }),
+    ).toBe(
+      "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device&user_code=48NK-MSUK",
+    );
+  });
+
+  it("should build challenge payload with complete URL", async () => {
+    const { buildDeviceAuthChallengePayload } = await import("./auth.js");
+
+    expect(
+      buildDeviceAuthChallengePayload({
+        user_code: "WDJB-MJHT",
+        verification_uri: "https://example.com/device",
+        device_code: "device-code",
+        expires_in: 600,
+      }),
+    ).toEqual({
+      user_code: "WDJB-MJHT",
+      verification_uri: "https://example.com/device",
+      verification_uri_complete: "https://example.com/device?user_code=WDJB-MJHT",
+      expires_in: 600,
+    });
+  });
+});

--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -32,6 +32,7 @@ export interface EnsureLoginOptions extends AuthOptions {
 export interface DeviceFlowAuthInfo {
   user_code: string;
   verification_uri?: string;
+  verification_uri_complete?: string;
   device_code: string;
   expires_in: number;
 }
@@ -64,6 +65,68 @@ function normalizeOptionalString(value?: string | null) {
 
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export function buildVerificationUriComplete(
+  deviceAuthInfo?: Pick<
+    DeviceFlowAuthInfo,
+    "verification_uri" | "verification_uri_complete" | "user_code"
+  >,
+) {
+  const explicitComplete = normalizeOptionalString(
+    deviceAuthInfo?.verification_uri_complete,
+  );
+  if (explicitComplete) {
+    return explicitComplete;
+  }
+
+  const verificationUri = normalizeOptionalString(deviceAuthInfo?.verification_uri);
+  const userCode = normalizeOptionalString(deviceAuthInfo?.user_code);
+  if (!verificationUri || !userCode) {
+    return undefined;
+  }
+
+  try {
+    const url = new URL(verificationUri);
+    const hash = url.hash.startsWith("#") ? url.hash.slice(1) : url.hash;
+
+    if (hash) {
+      const [hashPath, hashQuery = ""] = hash.split("?");
+      const hashParams = new URLSearchParams(hashQuery);
+      if (!hashParams.has("user_code")) {
+        hashParams.set("user_code", userCode);
+      }
+      url.hash = hashParams.toString()
+        ? `#${hashPath}?${hashParams.toString()}`
+        : `#${hashPath}`;
+      return url.toString();
+    }
+
+    if (!url.searchParams.has("user_code")) {
+      url.searchParams.set("user_code", userCode);
+    }
+    return url.toString();
+  } catch {
+    if (verificationUri.includes("user_code=")) {
+      return verificationUri;
+    }
+
+    const separator = verificationUri.includes("?") ? "&" : "?";
+    return `${verificationUri}${separator}user_code=${encodeURIComponent(userCode)}`;
+  }
+}
+
+export function buildDeviceAuthChallengePayload(deviceAuthInfo?: DeviceFlowAuthInfo) {
+  if (!deviceAuthInfo) {
+    return undefined;
+  }
+
+  return {
+    user_code: deviceAuthInfo.user_code,
+    verification_uri: deviceAuthInfo.verification_uri,
+    verification_uri_complete: buildVerificationUriComplete(deviceAuthInfo),
+    expires_in: deviceAuthInfo.expires_in,
+  };
 }
 
 function normalizeAuthMode(value?: string | null): AuthFlowMode | undefined {

--- a/mcp/src/cloudbase-manager.test.ts
+++ b/mcp/src/cloudbase-manager.test.ts
@@ -3,12 +3,25 @@ import { ToolPayloadError } from "./utils/tool-result.js";
 
 const mockCloudBaseCtor = vi.fn();
 const mockAuthGetProgressState = vi.fn();
+const mockBuildDeviceAuthChallengePayload = vi.fn((info: any) =>
+  info
+    ? {
+        user_code: info.user_code,
+        verification_uri: info.verification_uri,
+        verification_uri_complete:
+          info.verification_uri_complete ??
+          `${info.verification_uri}${info.verification_uri?.includes("?") ? "&" : "?"}user_code=${encodeURIComponent(info.user_code)}`,
+        expires_in: info.expires_in,
+      }
+    : undefined,
+);
 const mockPeekLoginState = vi.fn();
 const mockEnsureLogin = vi.fn();
 const mockCommonServiceCall = vi.fn();
 const mockListEnvs = vi.fn();
 
 vi.mock("./auth.js", () => ({
+  buildDeviceAuthChallengePayload: mockBuildDeviceAuthChallengePayload,
   getAuthProgressState: mockAuthGetProgressState,
   peekLoginState: mockPeekLoginState,
   getLoginState: mockEnsureLogin,
@@ -79,6 +92,7 @@ describe("cloudbase manager auth gate", () => {
         code: "AUTH_PENDING",
         auth_challenge: expect.objectContaining({
           user_code: "WDJB-MJHT",
+          verification_uri_complete: "https://example.com/device?user_code=WDJB-MJHT",
         }),
         next_step: expect.objectContaining({
           tool: "auth",

--- a/mcp/src/cloudbase-manager.ts
+++ b/mcp/src/cloudbase-manager.ts
@@ -1,5 +1,6 @@
 import CloudBase from "@cloudbase/manager-node";
 import {
+    buildDeviceAuthChallengePayload,
     getAuthProgressState,
     peekLoginState,
     getLoginState,
@@ -112,13 +113,7 @@ async function throwPendingAuthError() {
         ok: false,
         code: "AUTH_PENDING",
         message: authState.lastError || "设备码授权进行中，请先完成登录后再重试当前工具。",
-        auth_challenge: authState.authChallenge
-            ? {
-                user_code: authState.authChallenge.user_code,
-                verification_uri: authState.authChallenge.verification_uri,
-                expires_in: authState.authChallenge.expires_in,
-            }
-            : undefined,
+        auth_challenge: buildDeviceAuthChallengePayload(authState.authChallenge),
         next_step: buildAuthNextStep("status", {
             suggestedArgs: {
                 action: "status",

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -4,6 +4,8 @@ import type { ExtendedMcpServer } from "../server.js";
 
 const {
   mockBuildAuthConfigSummary,
+  mockBuildDeviceAuthChallengePayload,
+  mockBuildVerificationUriComplete,
   mockGetAuthConfigValidationError,
   mockSupervisorLoginByWebAuth,
   mockEnsureLogin,
@@ -26,6 +28,27 @@ const {
     oauth_custom: options.oauthCustom ?? false,
     uses_toolbox_defaults: options.usesToolboxDefaults ?? false,
   })),
+  mockBuildVerificationUriComplete: vi.fn((info: any) => {
+    if (info?.verification_uri_complete) {
+      return info.verification_uri_complete;
+    }
+    if (!info?.verification_uri || !info?.user_code) {
+      return undefined;
+    }
+    return `${info.verification_uri}${info.verification_uri.includes("?") ? "&" : "?"}user_code=${encodeURIComponent(info.user_code)}`;
+  }),
+  mockBuildDeviceAuthChallengePayload: vi.fn((info: any) =>
+    info
+      ? {
+          user_code: info.user_code,
+          verification_uri: info.verification_uri,
+          verification_uri_complete:
+            info.verification_uri_complete ??
+            `${info.verification_uri}${info.verification_uri?.includes("?") ? "&" : "?"}user_code=${encodeURIComponent(info.user_code)}`,
+          expires_in: info.expires_in,
+        }
+      : undefined,
+  ),
   mockGetAuthConfigValidationError: vi.fn((options: any) => {
     if (
       options.authMode === "web" &&
@@ -88,6 +111,8 @@ vi.mock("@cloudbase/toolbox", () => ({
 
 vi.mock("../auth.js", () => ({
   buildAuthConfigSummary: mockBuildAuthConfigSummary,
+  buildDeviceAuthChallengePayload: mockBuildDeviceAuthChallengePayload,
+  buildVerificationUriComplete: mockBuildVerificationUriComplete,
   ensureLogin: mockEnsureLogin,
   getAuthConfigValidationError: mockGetAuthConfigValidationError,
   peekLoginState: mockPeekLoginState,
@@ -321,6 +346,7 @@ describe("env tools - auth", () => {
     expect(payload.auth_challenge).toMatchObject({
       user_code: "WDJB-MJHT",
       verification_uri: "https://example.com/device",
+      verification_uri_complete: "https://example.com/device?user_code=WDJB-MJHT",
       expires_in: 600,
     });
     expect(payload.next_step).toMatchObject({
@@ -532,6 +558,7 @@ describe("env tools - auth", () => {
     expect(payload.auth_challenge).toMatchObject({
       user_code: "WDJB-MJHT",
       verification_uri: "https://example.com/device",
+      verification_uri_complete: "https://example.com/device?user_code=WDJB-MJHT",
       expires_in: 600,
     });
     expect(payload.next_step).toMatchObject({
@@ -573,6 +600,36 @@ describe("env tools - auth", () => {
       "https://custom.example.com/oauth",
     );
     expect(callArgs.custom).toBe(true);
+  });
+
+  it("auth(action=start_auth) should surface complete hash-route verification URL", async () => {
+    mockSupervisorLoginByWebAuth.mockImplementation(
+      async ({ onDeviceCode }: { onDeviceCode: (info: any) => void }) => {
+        onDeviceCode({
+          user_code: "48NK-MSUK",
+          verification_uri:
+            "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+          verification_uri_complete:
+            "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device&user_code=48NK-MSUK",
+          device_code: "device-code",
+          expires_in: 600,
+        });
+        return new Promise(() => {});
+      },
+    );
+
+    const result = await tools.auth.handler({
+      action: "start_auth",
+      authMode: "device",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.auth_challenge).toMatchObject({
+      verification_uri:
+        "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+      verification_uri_complete:
+        "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device&user_code=48NK-MSUK",
+    });
   });
 
   it("auth(action=start_auth) should reject oauthCustom without endpoint", async () => {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -2,6 +2,8 @@ import { AuthSupervisor } from "@cloudbase/toolbox";
 import { z } from "zod";
 import {
   buildAuthConfigSummary,
+  buildDeviceAuthChallengePayload,
+  buildVerificationUriComplete,
   ensureLogin,
   getAuthConfigValidationError,
   getAuthProgressState,
@@ -194,6 +196,7 @@ function formatDeviceAuthHint(deviceAuthInfo?: DeviceFlowAuthInfo): string {
     return "";
   }
 
+  const verificationUriComplete = buildVerificationUriComplete(deviceAuthInfo);
   const lines = [
     "",
     "### Device Flow 授权信息",
@@ -203,10 +206,13 @@ function formatDeviceAuthHint(deviceAuthInfo?: DeviceFlowAuthInfo): string {
   if (deviceAuthInfo.verification_uri) {
     lines.push(`- verification_uri: ${deviceAuthInfo.verification_uri}`);
   }
+  if (verificationUriComplete) {
+    lines.push(`- verification_uri_complete: ${verificationUriComplete}`);
+  }
   lines.push(`- expires_in: ${deviceAuthInfo.expires_in}s`);
   lines.push(
     "",
-    "请在另一台可用浏览器设备打开 `verification_uri` 并输入 `user_code` 完成授权。",
+    "请优先向用户展示完整的 `verification_uri_complete`，不要截断或改写 URL。",
   );
   return lines.join("\n");
 }
@@ -768,14 +774,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         setPendingAuthProgressState(info, "device");
         // emitDeviceAuthNotice(server, info);
       };
-      const authChallenge = () =>
-        deviceAuthInfo
-          ? {
-            user_code: deviceAuthInfo.user_code,
-            verification_uri: deviceAuthInfo.verification_uri,
-            expires_in: deviceAuthInfo.expires_in,
-          }
-          : undefined;
+      const authChallenge = () => buildDeviceAuthChallengePayload(deviceAuthInfo);
 
       try {
         if (!supportedAuthActions.includes(action)) {
@@ -831,12 +830,8 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                   ...buildEnvCandidatePayload([]),
                 }),
             auth_challenge:
-              authFlowState.status === "PENDING" && authFlowState.authChallenge
-                ? {
-                    user_code: authFlowState.authChallenge.user_code,
-                    verification_uri: authFlowState.authChallenge.verification_uri,
-                    expires_in: authFlowState.authChallenge.expires_in,
-                  }
+              authFlowState.status === "PENDING"
+                ? buildDeviceAuthChallengePayload(authFlowState.authChallenge)
                 : undefined,
             message,
             next_step:
@@ -861,11 +856,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               code: "AUTH_PENDING",
               message:
                 "设备码授权进行中，请在浏览器中打开 verification_uri 并输入 user_code 完成授权。",
-              auth_challenge: {
-                user_code: authFlowState.authChallenge.user_code,
-                verification_uri: authFlowState.authChallenge.verification_uri,
-                expires_in: authFlowState.authChallenge.expires_in,
-              },
+              auth_challenge: buildDeviceAuthChallengePayload(
+                authFlowState.authChallenge,
+              ),
               next_step: buildAuthNextStep("status", {
                 suggestedArgs: { action: "status" },
               }),

--- a/mcp/src/tools/interactive.ts
+++ b/mcp/src/tools/interactive.ts
@@ -88,6 +88,7 @@ export async function _promptAndSetEnvironmentId(
     onDeviceCode?: (info: {
       user_code: string;
       verification_uri?: string;
+      verification_uri_complete?: string;
       device_code: string;
       expires_in: number;
     }) => void;


### PR DESCRIPTION
## Summary - add verification_uri_complete to auth challenge payloads so agents can show the full login URL without truncation; - surface the full URL from auth status/start_auth and AUTH_PENDING manager errors; - add regression coverage for standard and hash-route device-login URLs. ## Testing - cd mcp && npx vitest run src/auth.test.ts src/tools/env.test.ts src/cloudbase-manager.test.ts