### PR TITLE
fix: default function code updates to functionRootPath

### DIFF
--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -392,7 +392,7 @@ classDiagram
 <tr><td><code>functionRootPath</code></td><td>string</td><td></td><td>函数根目录（父目录绝对路径）</td></tr>
 <tr><td><code>force</code></td><td>boolean</td><td></td><td>createFunction 时是否覆盖</td></tr>
 <tr><td><code>functionName</code></td><td>string</td><td></td><td>函数名称。大多数 action 使用该字段作为统一目标</td></tr>
-<tr><td><code>zipFile</code></td><td>string</td><td></td><td>代码包的 base64 编码</td></tr>
+<tr><td><code>zipFile</code></td><td>string</td><td></td><td>仅兼容特殊场景：预先准备好的代码包 base64 编码。普通 createFunction/updateFunctionCode 默认不要先压缩 zip，优先使用 functionRootPath。</td></tr>
 <tr><td><code>handler</code></td><td>string</td><td></td><td>函数入口</td></tr>
 <tr><td><code>timeout</code></td><td>number</td><td></td><td>配置更新时的超时时间</td></tr>
 <tr><td><code>envVariables</code></td><td>object</td><td></td><td>配置更新时要合并的环境变量</td></tr>

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -1441,14 +1441,16 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           .describe("写操作类型，例如 createFunction、invokeFunction、attachLayer"),
         func: CREATE_FUNCTION_SCHEMA.optional().describe("createFunction 操作的函数配置"),
         functionRootPath: z.string().optional().describe(
-          "函数根目录（父目录绝对路径）。" +
+          "创建或更新函数代码时默认推荐的本地目录方式。函数根目录（父目录绝对路径）。" +
           "本地应按 cloudfunctions/<functionName>/index.js 布局，" +
           "此参数传 cloudfunctions 目录的绝对路径（如 /abs/path/cloudfunctions），不要传到函数名子目录。" +
-          "SDK 会自动拼接函数名子目录。",
+          "SDK 会自动拼接函数名子目录，无需预先压缩 zip 或 base64 编码。",
         ),
         force: z.boolean().optional().describe("createFunction 时是否覆盖"),
         functionName: z.string().optional().describe("函数名称。大多数 action 使用该字段作为统一目标"),
-        zipFile: z.string().optional().describe("代码包的 base64 编码"),
+        zipFile: z.string().optional().describe(
+          "仅兼容特殊场景：预先准备好的代码包 base64 编码。普通 createFunction/updateFunctionCode 默认不要先压缩 zip，优先使用 functionRootPath。",
+        ),
         handler: z.string().optional().describe("函数入口"),
         timeout: z.number().optional().describe("配置更新时的超时时间"),
         envVariables: z.record(z.string()).optional().describe("配置更新时要合并的环境变量"),

--- a/scripts/demo/js/scenarios.js
+++ b/scripts/demo/js/scenarios.js
@@ -107,15 +107,15 @@ const SCENARIO_CONFIG = {
     buttonText: '使用 AI 分析并修复错误',
     buttonPosition: '函数详情页，日志标签页内，错误日志条目旁',
     pagePath: '/scf/detail',
-    mcpTools: ['getFunctionLogs', 'getFunctionLogDetail', 'updateFunctionCode'],
+    mcpTools: ['queryFunctions', 'manageFunctions'],
     capabilityDocs: ['cloudbase-platform', 'cloud-functions'],
     promptTemplate: `我的云函数出现了错误，需要你的帮助分析和修复：
 
 1. **获取错误日志**：
    - 函数名称：[系统自动填充或用户填写]
    - 错误时间：[系统自动填充]
-   - 使用 CloudBase MCP 工具 \`getFunctionLogs\` 获取日志列表
-   - 使用 \`getFunctionLogDetail\` 获取详细错误信息
+   - 使用 CloudBase MCP 工具 \`queryFunctions(action="listFunctionLogs")\` 获取日志列表
+   - 使用 \`queryFunctions(action="getFunctionLogDetail")\` 获取详细错误信息
 
 2. **分析错误原因**：
    - 分析错误堆栈和错误消息
@@ -124,7 +124,8 @@ const SCENARIO_CONFIG = {
 
 3. **提供修复方案**：
    - 提供具体的代码修改建议
-   - 使用 \`updateFunctionCode\` 更新函数代码
+   - 使用 \`manageFunctions(action="updateFunctionCode")\` 更新函数代码
+   - 普通代码修复优先传 \`functionRootPath\`，不要默认先压缩 zip
    - 验证修复结果
 
 请帮我分析和修复这个函数错误。`

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -916,7 +916,7 @@
           },
           "functionRootPath": {
             "type": "string",
-            "description": "函数根目录（父目录绝对路径）"
+            "description": "创建或更新函数代码时默认推荐的本地目录方式。函数根目录（父目录绝对路径）。本地应按 cloudfunctions/<functionName>/index.js 布局，此参数传 cloudfunctions 目录的绝对路径（如 /abs/path/cloudfunctions），不要传到函数名子目录。SDK 会自动拼接函数名子目录，无需预先压缩 zip 或 base64 编码。"
           },
           "force": {
             "type": "boolean",

--- a/tests/function-layer-tools.test.js
+++ b/tests/function-layer-tools.test.js
@@ -180,6 +180,8 @@ describe("Function and gateway tool schemas", () => {
     expect(properties.layerVersion).toBeDefined();
     expect(properties.confirm).toBeDefined();
     expect(properties.path).toBeUndefined();
+    expect(properties.functionRootPath.description).toMatch(/默认推荐|无需预先压缩 zip/);
+    expect(properties.zipFile.description).toMatch(/仅兼容特殊场景|优先使用 functionRootPath/);
     expect(tool.annotations.readOnlyHint).toBe(false);
     expect(tool.annotations.destructiveHint).toBe(true);
     expect(tool.annotations.category).toBe("functions");


### PR DESCRIPTION
## Summary
- make `manageFunctions` steer normal code updates toward `functionRootPath` instead of defaulting to zip/base64 mental models
- add a fast-fail message when `updateFunctionCode` is called without either `functionRootPath` or `zipFile`
- update demo prompts, generated tool metadata, docs, and schema assertions to reinforce the default path

## Validation
- `cd mcp && npm run build`
- `node scripts/generate-tools-json.mjs`
- `node scripts/generate-tools-doc.mjs`
- `cd mcp && ./node_modules/.bin/vitest run --config vitest.config.js ../tests/function-layer-tools.test.js`