### PR TITLE
fix: Express 5 wildcard HTTP function reference

### DIFF
--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -76,12 +76,14 @@ app.post("/users", (req, res) => {
   return res.status(201).json({ name, email });
 });
 
-app.all("*", (req, res) => {
+app.all("/{*splat}", (req, res) => {
   res.status(405).json({ error: "Method Not Allowed" });
 });
 
 app.listen(9000);
 ```
+
+Express 5 note: do not use bare `*` or `/*` here. Express 5 uses `path-to-regexp` with named wildcards, so `app.all("/{*splat}", ...)` is the safe catch-all form when you also need to match the root path `/`.
 
 ## Deployment flow
 

--- a/tests/skill-quality-standards.test.js
+++ b/tests/skill-quality-standards.test.js
@@ -65,6 +65,23 @@ describe('skill quality standards', () => {
     expect(raw).toMatch(/cost/i);
   });
 
+  test('cloud-functions http reference stays compatible with Express 5 wildcard syntax', () => {
+    const raw = readFile(
+      'config',
+      'source',
+      'skills',
+      'cloud-functions',
+      'references',
+      'http-functions.md',
+    );
+
+    expect(raw).not.toContain('app.all("*")');
+    expect(raw).not.toContain("app.all('/*')");
+    expect(raw).toContain('app.all("/{*splat}", (req, res) => {');
+    expect(raw).toMatch(/Express 5 note:/);
+    expect(raw).toMatch(/path-to-regexp/);
+  });
+
   test('cloudbase-agent does not force global activation by default', () => {
     const raw = readSourceSkill('cloudbase-agent');
 


### PR DESCRIPTION
## Summary
- replace the Express HTTP function catch-all example with Express 5 compatible wildcard syntax
- add an explicit note about the `path-to-regexp` / named wildcard footgun
- add a regression test for the cloud-functions HTTP reference

## Attribution
- issue_mnz4k870_b68lnj
- representative run: atomic-js-cloudbase-http-function-basic/2026-04-14T21-15-32-8owufj
- related issue: #529

## Validation
- npx --yes vitest run tests/skill-quality-standards.test.js
