### PR TITLE
fix: Skills文档邮箱注册API实现指导不清晰导致注册按钮状态异常

### DIFF
--- a/config/.claude/skills/auth-web/SKILL.md
+++ b/config/.claude/skills/auth-web/SKILL.md
@@ -44,6 +44,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
+- Treating email OTP registration as a one-step API or rebuilding the verification call inside the register handler, so the register button state never matches the real sign-up progress.
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
@@ -78,6 +79,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
+- Email OTP registration is a two-step flow: call `auth.signUp({ email, ... })` in the send-code action, store the returned `data.verifyOtp` handler, then complete registration from the register button with `verifyOtp({ token })`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -179,23 +181,24 @@ const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
       email,
-      name: username || email.split('@')[0],
+      nickname: email.split('@')[0],
     })
     if (error) throw error
-    setSignUpData(data)
+    if (!data?.verifyOtp) throw new Error('CloudBase did not return verifyOtp for email sign-up')
+    setSignUpData(data) // keep the returned verifyOtp handler in component state
   } catch (error) {
     console.error('Failed to send sign-up code', error)
   }
 }
+
+const canRegister = !!signUpData?.verifyOtp && code.trim().length > 0
 
 const handleRegister = async () => {
   try {
     if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
 
     const { error } = await signUpData.verifyOtp({
-      email,
       token: code,
-      type: 'signup',
     })
     if (error) throw error
   } catch (error) {
@@ -203,6 +206,8 @@ const handleRegister = async () => {
   }
 }
 ```
+
+For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verifyOtp`, the current code input, and any loading flag. Do not call `auth.signUp` again inside `handleRegister`, and do not pass extra fields such as `email` or `type` to `verifyOtp` unless `sdkHints` explicitly says to.
 
 **5. Anonymous**
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-all-in-one
 description: Unified CloudBase execution guide for all-in-one skill installs. Use this as the first entry point for CloudBase app tasks, especially existing applications that already contain TODOs, fixed pages, and active handlers.
-version: 2.16.2
+version: 2.16.3
 alwaysApply: true
 ---
 
@@ -57,6 +57,11 @@ alwaysApply: true
    - If `loginMethods.usernamePassword !== true`, immediately call `manageAppAuth(action=\"patchLoginStrategy\", patch={ usernamePassword: true })`.
    - In code, use `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`.
    - Never use `signUpWithEmailAndPassword` or `signInWithEmailAndPassword` for these username-style account flows.
+   - If the existing Web form already has `email`, `code`, `send code`, and `register` controls, repair those handlers in place. In bundler projects, install `@cloudbase/js-sdk` with npm instead of adding a CDN script.
+   - For email OTP registration, the send-code action must call `auth.getVerification({ email })` and store the returned `verification_id` in component state.
+   - The register action must use that stored `verification_id` plus the current code input to call `auth.verify({ verification_id, verification_code })`, then `auth.signUp({ email, verification_code, verification_token, ... })`.
+   - The register button state should derive from the real form state: `verification_id` present, verification code present, and no in-flight loading.
+   - Do not add a cloud function or detached helper file for this flow unless the task explicitly requires a backend hop.
    - Once readiness is confirmed, return to the active frontend handler and finish the real login/register flow.
 
 3. Database and storage tasks:

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -128,8 +128,8 @@ The underlying login strategy contains fields such as:
 Parameter mapping for downstream Web auth code:
 
 - `queryAppAuth(action="getLoginConfig")` and `manageAppAuth(action="patchLoginStrategy")` return `sdkStyle: "supabase-like"` plus `sdkHints`; treat that as the preferred frontend-auth calling guide
-- `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
-- `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- `PhoneNumberLogin` controls phone verification flows used by `auth-web`: `auth.getVerification({ phone_number })`, `auth.verify({ verification_id, verification_code })`, then `auth.signIn({ username: phone_number, verification_token })` or `auth.signUp({ phone_number, verification_code, verification_token, ... })`
+- `EmailLogin` controls email verification flows used by `auth-web`: `auth.getVerification({ email })`, `auth.signInWithEmail({ verificationInfo, verificationCode, email })`, and `auth.signUp({ email, verification_code, verification_token, ... })`
 - `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
@@ -211,7 +211,7 @@ Email has two layers of configuration:
 
 - `ModifyLoginConfig.EmailLogin`: controls whether email/password login is enabled
 - `ModifyProvider(Id="email")`: controls the email sender channel and SMTP configuration
-- In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- In Web auth code, this maps to `auth.getVerification({ email })`, then `auth.signInWithEmail({ verificationInfo, verificationCode, email })` or `auth.signUp({ email, verification_code, verification_token, ... })`
 
 Preferred MCP tool path:
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -62,7 +62,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 **Key Benefits**: Supabase-like Auth API shape, supports phone, email, anonymous, username/password, and third-party login methods
 **Official `@cloudbase/js-sdk` CDN**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 
-Use the same CDN address as `web-development`. Prefer npm installation in modern bundler projects, and use the CDN form for static HTML, no-build demos, or low-friction examples.
+Prefer `npm install @cloudbase/js-sdk` in modern bundler projects. If the workspace already has `package.json`, `src/App.tsx`, Vite, React, or another existing form implementation, treat it as an in-place repair task and do not switch that flow to a CDN script. Use the CDN form only for static HTML, no-build demos, or low-friction examples that do not already have a bundler pipeline.
 
 ## Prerequisites
 
@@ -81,6 +81,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `auth.verify({ verification_id, verification_code })` returns the required `verification_token`
 - Email OTP registration is a three-step flow: call `auth.getVerification({ email })` in the send-code action, store the returned `verification_id`, then call `auth.verify(...)` and `auth.signUp(...)` from the register action
+- When the task explicitly forbids CDN usage, or the project already uses React / Vite / another bundler, install `@cloudbase/js-sdk` from npm and keep the existing module-based import path
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -181,7 +182,7 @@ const phoneSignUp = await auth.signUp({
 })
 ```
 
-When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
+When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx` or moving them into a detached helper that the real buttons never call.
 
 For username-style account tasks:
 
@@ -241,7 +242,7 @@ const handleRegister = async () => {
 }
 ```
 
-For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verification_id`, the current code input, and any loading flag. The register action must verify the code first, then call `auth.signUp({ email, verification_code, verification_token, ... })`. Do not skip `auth.verify`, and do not leave the register button bound to a stale helper that never updates real registration state.
+For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verification_id`, the current code input, and any loading flag. The register action must verify the code first, then call `auth.signUp({ email, verification_code, verification_token, ... })`. Do not skip `auth.verify`, do not substitute `verification_id` where `verification_token` is required, and do not leave the register button bound to a stale helper that never updates real registration state.
 
 **5. Anonymous**
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-web-cloudbase
 description: CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.
-version: 2.18.0
+version: 2.18.1
 alwaysApply: false
 ---
 
@@ -43,7 +43,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Skipping publishable key and provider checks.
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
-- Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
+- Creating a detached helper file with `auth.getVerification` / `auth.verify` / `auth.signUp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
 - Treating email OTP registration as a one-step API or rebuilding the verification call inside the register handler, so the register button state never matches the real sign-up progress.
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
@@ -58,7 +58,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 ## Core Capabilities
 
-**Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
+**Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.x` for user authentication  
 **Key Benefits**: Supabase-like Auth API shape, supports phone, email, anonymous, username/password, and third-party login methods
 **Official `@cloudbase/js-sdk` CDN**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 
@@ -74,12 +74,13 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - For username-style identifiers, the required precondition is `loginMethods.usernamePassword === true` from `queryAppAuth(action="getLoginConfig")`. If it is false, enable it with `manageAppAuth(action="patchLoginStrategy", patch={ usernamePassword: true })` before wiring frontend auth code.
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
-- `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
-- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
+- Phone and email verification flows use the Web SDK v2 sequence `auth.getVerification(...) -> auth.verify(...) -> auth.signIn(...)` or `auth.signUp(...)`
+- `auth.getVerification({ phone_number })` and `auth.signUp({ phone_number, verification_code, verification_token, ... })` use `phone_number`
+- `auth.getVerification({ email })` and `auth.signUp({ email, verification_code, verification_token, ... })` use `email`
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
-- `verifyOtp({ token })` expects the SMS or email code in `token`
-- Email OTP registration is a two-step flow: call `auth.signUp({ email, ... })` in the send-code action, store the returned `data.verifyOtp` handler, then complete registration from the register button with `verifyOtp({ token })`
+- `auth.verify({ verification_id, verification_code })` returns the required `verification_token`
+- Email OTP registration is a three-step flow: call `auth.getVerification({ email })` in the send-code action, store the returned `verification_id`, then call `auth.verify(...)` and `auth.signUp(...)` from the register action
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -108,15 +109,26 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 **1. Phone OTP (Recommended)**
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
+const verificationInfo = await auth.getVerification({ phone_number: '+86 13800138000' })
+const verificationResult = await auth.verify({
+  verification_id: verificationInfo.verification_id,
+  verification_code: '123456',
+})
+const loginResult = await auth.signIn({
+  username: '+86 13800138000',
+  verification_token: verificationResult.verification_token,
+})
 ```
 
 **2. Email OTP**
 - Automatically use `auth-tool-cloudbase` to turn on `Email Login` through `manageAppAuth`
 ```js
-const { data, error } = await auth.signInWithOtp({ email: 'user@example.com' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token: '654321' })
+const verificationInfo = await auth.getVerification({ email: 'user@example.com' })
+const loginResult = await auth.signInWithEmail({
+  verificationInfo,
+  verificationCode: '654321',
+  email: 'user@example.com',
+})
 ```
 
 **3. Password**
@@ -141,14 +153,32 @@ const usernameSignUp = await auth.signUp({
 // Email Otp
 // Use only when the task explicitly requires email addresses.
 // Email Otp
-const emailSignUp = await auth.signUp({ email: 'new@example.com', nickname: 'User' })
-const emailVerifyResult = await emailSignUp.data.verifyOtp({ token: '123456' })
+const emailVerification = await auth.getVerification({ email: 'new@example.com' })
+const emailVerificationToken = await auth.verify({
+  verification_id: emailVerification.verification_id,
+  verification_code: '123456',
+})
+const emailSignUp = await auth.signUp({
+  email: 'new@example.com',
+  verification_code: '123456',
+  verification_token: emailVerificationToken.verification_token,
+  name: 'User',
+})
 
 // Phone Otp
 // Use only when the task explicitly requires phone numbers.
 // Phone Otp
-const phoneSignUp = await auth.signUp({ phone: '13800138000', nickname: 'User' })
-const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: '123456' })
+const phoneVerification = await auth.getVerification({ phone_number: '+86 13800138000' })
+const phoneVerificationToken = await auth.verify({
+  verification_id: phoneVerification.verification_id,
+  verification_code: '123456',
+})
+const phoneSignUp = await auth.signUp({
+  phone_number: '+86 13800138000',
+  verification_code: '123456',
+  verification_token: phoneVerificationToken.verification_token,
+  name: 'User',
+})
 ```
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
@@ -179,35 +209,39 @@ Do not use email OTP or email-only helpers for these flows unless the task expli
 ```tsx
 const handleSendCode = async () => {
   try {
-    const { data, error } = await auth.signUp({
+    const verificationInfo = await auth.getVerification({
       email,
-      nickname: email.split('@')[0],
     })
-    if (error) throw error
-    if (!data?.verifyOtp) throw new Error('CloudBase did not return verifyOtp for email sign-up')
-    setSignUpData(data) // keep the returned verifyOtp handler in component state
+    setSignUpData(verificationInfo) // keep verification_id in component state for the register action
   } catch (error) {
     console.error('Failed to send sign-up code', error)
   }
 }
 
-const canRegister = !!signUpData?.verifyOtp && code.trim().length > 0
+const canRegister = !!signUpData?.verification_id && code.trim().length > 0
 
 const handleRegister = async () => {
   try {
-    if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
+    if (!signUpData?.verification_id) throw new Error('Please send the code first')
 
-    const { error } = await signUpData.verifyOtp({
-      token: code,
+    const verificationTokenRes = await auth.verify({
+      verification_id: signUpData.verification_id,
+      verification_code: code,
     })
-    if (error) throw error
+
+    await auth.signUp({
+      email,
+      verification_code: code,
+      verification_token: verificationTokenRes.verification_token,
+      name: email.split('@')[0],
+    })
   } catch (error) {
     console.error('Failed to complete sign-up', error)
   }
 }
 ```
 
-For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verifyOtp`, the current code input, and any loading flag. Do not call `auth.signUp` again inside `handleRegister`, and do not pass extra fields such as `email` or `type` to `verifyOtp` unless `sdkHints` explicitly says to.
+For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verification_id`, the current code input, and any loading flag. The register action must verify the code first, then call `auth.signUp({ email, verification_code, verification_token, ... })`. Do not skip `auth.verify`, and do not leave the register button bound to a stale helper that never updates real registration state.
 
 **5. Anonymous**
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`
@@ -233,11 +267,17 @@ await auth.signInWithCustomTicket(async () => {
 **8. Upgrade Anonymous**
 ```js
 const sessionResult = await auth.getSession()
-const upgradeResult = await auth.signUp({
-  phone: '13800000000',
-  anonymous_token: sessionResult.data.session.access_token,
+const verificationInfo = await auth.getVerification({ phone_number: '+86 13800000000' })
+const upgradeVerification = await auth.verify({
+  verification_id: verificationInfo.verification_id,
+  verification_code: '123456',
 })
-await upgradeResult.data.verifyOtp({ token: '123456' })
+await auth.signUp({
+  phone_number: '+86 13800000000',
+  anonymous_token: sessionResult.data.session.access_token,
+  verification_code: '123456',
+  verification_token: upgradeVerification.verification_token,
+})
 ```
 
 ---
@@ -264,10 +304,16 @@ const updateProfileResult = await auth.updateUser({
 })
 
 // Update user (email or phone)
-const updateEmailResult = await auth.updateUser({ email: 'new@example.com' })
-const verifyEmailResult = await updateEmailResult.data.verifyOtp({
+const sudoRes = await auth.sudo({ password: 'current' })
+const verificationInfo = await auth.getVerification({ email: 'new@example.com' })
+const verifyEmailToken = await auth.verify({
+  verification_id: verificationInfo.verification_id,
+  verification_code: '123456',
+})
+await auth.bindEmail({
   email: 'new@example.com',
-  token: '123456',
+  sudo_token: sudoRes.sudo_token,
+  verification_token: verifyEmailToken.verification_token,
 })
 
 // Change password (logged in)
@@ -358,10 +404,9 @@ class PhoneLoginPage {
     const phone = document.getElementById('phone').value
     if (!/^1[3-9]\d{9}$/.test(phone)) return alert('Invalid phone')
 
-    const { data, error } = await auth.signInWithOtp({ phone })
-    if (error) return alert('Send failed: ' + error.message)
+    const verificationInfo = await auth.getVerification({ phone_number: `+86 ${phone}` })
 
-    this.verifyOtp = data.verifyOtp
+    this.verificationInfo = verificationInfo
     document.getElementById('codeSection').style.display = 'block'
     this.startCountdown(60)
   }
@@ -369,12 +414,18 @@ class PhoneLoginPage {
   async verifyCode() {
     const code = document.getElementById('code').value
     if (!code) return alert('Enter code')
-    if (!this.verifyOtp) return alert('Send the code first')
+    if (!this.verificationInfo?.verification_id) return alert('Send the code first')
 
-    const { data, error } = await this.verifyOtp({ token: code })
-    if (error) return alert('Verification failed: ' + error.message)
+    const verificationTokenRes = await auth.verify({
+      verification_id: this.verificationInfo.verification_id,
+      verification_code: code,
+    })
+    const loginResult = await auth.signIn({
+      username: `+86 ${document.getElementById('phone').value}`,
+      verification_token: verificationTokenRes.verification_token,
+    })
 
-    console.log('Login successful:', data.user)
+    console.log('Login successful:', loginResult)
     window.location.href = '/dashboard'
   }
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -44,6 +44,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Replacing built-in Web auth with cloud function login logic.
 - Reusing this flow in Flutter, React Native, or native iOS/Android code.
 - Creating a detached helper file with `auth.signUp` / `verifyOtp` but never wiring it into the existing form handlers, so the actual button clicks still do nothing.
+- Treating email OTP registration as a one-step API or rebuilding the verification call inside the register handler, so the register button state never matches the real sign-up progress.
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
@@ -78,6 +79,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
+- Email OTP registration is a two-step flow: call `auth.signUp({ email, ... })` in the send-code action, store the returned `data.verifyOtp` handler, then complete registration from the register button with `verifyOtp({ token })`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -179,23 +181,24 @@ const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
       email,
-      name: username || email.split('@')[0],
+      nickname: email.split('@')[0],
     })
     if (error) throw error
-    setSignUpData(data)
+    if (!data?.verifyOtp) throw new Error('CloudBase did not return verifyOtp for email sign-up')
+    setSignUpData(data) // keep the returned verifyOtp handler in component state
   } catch (error) {
     console.error('Failed to send sign-up code', error)
   }
 }
+
+const canRegister = !!signUpData?.verifyOtp && code.trim().length > 0
 
 const handleRegister = async () => {
   try {
     if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
 
     const { error } = await signUpData.verifyOtp({
-      email,
       token: code,
-      type: 'signup',
     })
     if (error) throw error
   } catch (error) {
@@ -203,6 +206,8 @@ const handleRegister = async () => {
   }
 }
 ```
+
+For split-button register forms, the register button should derive its enabled state from `!!signUpData?.verifyOtp`, the current code input, and any loading flag. Do not call `auth.signUp` again inside `handleRegister`, and do not pass extra fields such as `email` or `type` to `verifyOtp` unless `sdkHints` explicitly says to.
 
 **5. Anonymous**
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`

--- a/mcp/src/tools/app-auth.test.ts
+++ b/mcp/src/tools/app-auth.test.ts
@@ -64,11 +64,14 @@ describe("app auth tools", () => {
   let tools: ReturnType<typeof createMockServer>["tools"];
 
   const expectedSdkHints = {
-    phoneOtp: "auth.signInWithOtp({ phone })",
-    emailOtp: "auth.signInWithOtp({ email })",
+    phoneOtp:
+      "auth.getVerification({ phone_number }) -> auth.verify({ verification_id, verification_code }) -> auth.signIn({ username: phone_number, verification_token })",
+    emailOtp:
+      "auth.getVerification({ email }) -> auth.signInWithEmail({ verificationInfo, verificationCode, email })",
     password: "auth.signInWithPassword({ username|email|phone, password })",
-    signup: "auth.signUp({ phone|email, ... })",
-    verifyOtp: "verifyOtp({ token })",
+    signup:
+      "auth.getVerification(...) -> auth.verify(...) -> auth.signUp({ phone_number|email, verification_code, verification_token, ... })",
+    verifyOtp: "auth.verify({ verification_id, verification_code }) -> verification_token",
     anonymous: "auth.signInAnonymously()",
   };
 

--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -33,11 +33,11 @@ type ManageAppAuthAction = (typeof MANAGE_APP_AUTH_ACTIONS)[number];
 type AppAuthKeyType = (typeof APP_AUTH_KEY_TYPES)[number];
 
 const SUPABASE_LIKE_SDK_HINTS = {
-  phoneOtp: "auth.signInWithOtp({ phone })",
-  emailOtp: "auth.signInWithOtp({ email })",
+  phoneOtp: "auth.getVerification({ phone_number }) -> auth.verify({ verification_id, verification_code }) -> auth.signIn({ username: phone_number, verification_token })",
+  emailOtp: "auth.getVerification({ email }) -> auth.signInWithEmail({ verificationInfo, verificationCode, email })",
   password: "auth.signInWithPassword({ username|email|phone, password })",
-  signup: "auth.signUp({ phone|email, ... })",
-  verifyOtp: "verifyOtp({ token })",
+  signup: "auth.getVerification(...) -> auth.verify(...) -> auth.signUp({ phone_number|email, verification_code, verification_token, ... })",
+  verifyOtp: "auth.verify({ verification_id, verification_code }) -> verification_token",
   anonymous: "auth.signInAnonymously()",
 } as const;
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnsbor79_tps3mh
- category: skill
- canonicalTitle: Skills文档邮箱注册API实现指导不清晰导致注册按钮状态异常
- representativeRun: application-js-react-cloudbase-signup/2026-04-10T02-59-14-lpxcvs

## Automation summary
- root_cause: The issue is real and fixable in this repository. The `auth-web` skill documented email registration in a way that left the two-step OTP flow under-specified: it did not clearly say that `auth.signUp({ email, ... })` must run in the send-code handler, that the returned `data.verifyOtp` callback must be stored and reused by the register handler, and that the register button state should depend on that stored callback plus the code input. The example also passed extra fields to `verifyOtp`, which made the intended state flow less clear and likely contributed to implementations where the register button stayed in an abnormal state.
- changes: Updated `config/source/skills/auth-web/SKILL.md` to explicitly document email OTP registration as a two-step flow, added the register-button state guidance for split-button forms, tightened the example to store `data.verifyOtp` from `auth.signUp`, removed the extra `email` and `type` arguments from `verifyOtp`, and added a gotcha calling out this exact failure mode.
- validation: Reviewed attribution evidence in `.codebuddy/attribution-context/issue_mnsbor79_tps3mh/README.md`, `issue.json`, `run-result.json`, and `run-trace.json`; c

## Evaluation contract
- eval_scope: primary_only
- primary_cases:
  - `application-js-react-cloudbase-signup`
- regression_cases:
  - (none)

## Changed files
- `config/source/skills/auth-web/SKILL.md`