### PR TITLE
fix: MCP queryPermissions 返回字段与任务要求字段命名不一致

### DIFF
--- a/mcp/src/tools/permissions.test.ts
+++ b/mcp/src/tools/permissions.test.ts
@@ -155,6 +155,7 @@ describe("permission tools", () => {
         action: "getResourcePermission",
         resourceType: "noSqlDatabase",
         resourceId: "todos",
+        aclTag: "READONLY",
       },
     });
   });

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -380,9 +380,10 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
             });
             logCloudBaseResult(server.logger, result);
             const permissions = result.Data.PermissionList ?? [];
+            const matchedPermission =
+              permissions.find((item) => item.Resource === resourceId) ?? permissions[0];
             const securityRule =
-              permissions.find((item) => item.Resource === resourceId)?.SecurityRule ??
-              permissions[0]?.SecurityRule;
+              matchedPermission?.SecurityRule;
             const hints = buildPermissionHints(securityRule, resourceId);
             return buildEnvelope(
               {
@@ -390,6 +391,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
                 envId,
                 resourceType,
                 resourceId,
+                aclTag: matchedPermission?.Permission,
                 permissions,
                 hints,
                 raw: result,


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnoa2xj8_oz3hul
- category: tool
- canonicalTitle: MCP queryPermissions 返回字段与任务要求字段命名不一致
- representativeRun: atomic-js-none-describe-storage-acl/2026-04-07T07-07-19-5yd57w

## Automation summary
README.md tencent-cloud

## Evaluation contract
- eval_scope: primary_only
- primary_cases:
  - `atomic-js-none-describe-storage-acl`
- regression_cases:
  - (none)

## Changed files
- `mcp/src/tools/permissions.test.ts`
- `mcp/src/tools/permissions.ts`