### PR TITLE
fix: MCP Supabase 工具缺乏预置账号信息查询能力

### DIFF
--- a/mcp/src/tools/app-auth.test.ts
+++ b/mcp/src/tools/app-auth.test.ts
@@ -197,6 +197,10 @@ describe("app auth tools", () => {
       envId: "env-test",
       sdkStyle: "supabase-like",
       sdkHints: expectedSdkHints,
+      presetAccountHint: {
+        tool: "queryPermissions",
+        supportedActions: ["getUser", "listUsers"],
+      },
       loginMethods: {
         usernamePassword: true,
         email: true,
@@ -287,6 +291,10 @@ describe("app auth tools", () => {
         email: true,
         anonymous: true,
         phone: false,
+      },
+      presetAccountHint: {
+        tool: "queryPermissions",
+        supportedActions: ["getUser", "listUsers"],
       },
       next_step: {
         tool: "manageAppAuth",

--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -192,6 +192,19 @@ function buildLoginConfigNextStep(loginMethods: ReturnType<typeof buildLoginMeth
   };
 }
 
+function buildPresetAccountHint() {
+  return {
+    tool: "queryPermissions",
+    supportedActions: ["getUser", "listUsers"],
+    note:
+      "预置测试账号、管理员账号或评测账号属于环境侧应用用户，可按普通用户名字符串直接查询，不需要邮箱语义。",
+    examples: [
+      'queryPermissions({ action: "getUser", username: "admin" })',
+      'queryPermissions({ action: "listUsers", username: "editor" })',
+    ],
+  };
+}
+
 function extractProviders(value: unknown): Array<Record<string, unknown>> {
   const payload = normalizePlainObject(value, "providersResult");
   const providers = payload?.Providers ?? payload?.ProviderList ?? payload?.Data ?? [];
@@ -402,6 +415,7 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
               success: true,
               envId,
               loginMethods,
+              presetAccountHint: buildPresetAccountHint(),
               ...(nextStep ? { next_step: nextStep } : {}),
               ...(webSdkHint ? { webSdkHint } : {}),
             });


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo0rqcoj_m1yzp4
- category: tool
- canonicalTitle: MCP Supabase 工具缺乏预置账号信息查询能力
- representativeRun: application-js-react-supabase-cms-scaffold/2026-04-16T00-51-50-a6cb0g

## Automation summary
README.md tencent-cloud

## Evaluation contract
- eval_scope: primary_only
- primary_cases:
  - `application-js-react-supabase-cms-scaffold`
- regression_cases:
  - (none)

## Changed files
- `mcp/src/tools/app-auth.test.ts`
- `mcp/src/tools/app-auth.ts`