### PR TITLE
fix: MCP CloudBase 数据库工具命名/描述缺乏关键词匹配，导致无法通过自然语言搜索发现

### DIFF
--- a/mcp/src/tools/dataModel.ts
+++ b/mcp/src/tools/dataModel.ts
@@ -625,9 +625,9 @@ export function registerDataModelTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "manageDataModel",
     {
-      title: "数据模型管理",
+      title: "数据模型管理（model / schema / collection 设计）",
       description:
-        "数据模型查询工具，支持查询和列表数据模型（只读操作）。通过 action 参数区分操作类型：list=获取模型列表（不含Schema，可选 names 参数过滤），get=查询单个模型详情（含Schema字段列表、格式、关联关系等，需要提供 name 参数），docs=生成SDK使用文档（需要提供 name 参数）",
+        "CloudBase 数据模型（data model）与 schema 设计查询工具，支持查询和列表模型定义（只读操作）。适用于查看模型 schema、字段结构、关联关系、collection 设计与 SDK 文档。通过 action 参数区分操作类型：list=获取模型列表（不含Schema，可选 names 参数过滤），get=查询单个模型详情（含Schema字段列表、格式、关联关系等，需要提供 name 参数），docs=生成SDK使用文档（需要提供 name 参数）",
       inputSchema: {
         action: z
           .enum(["get", "list", "docs"])
@@ -991,9 +991,9 @@ export function registerDataModelTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "modifyDataModel",
     {
-      title: "修改数据模型（当前仅支持创建）",
+      title: "修改数据模型（当前仅支持创建 model / schema）",
       description:
-        "基于Mermaid classDiagram创建数据模型。为保持兼容性，工具名仍为 modifyDataModel；当前仅支持创建新模型，不支持更新现有模型结构。内置异步任务监控，自动轮询直至完成或超时。",
+        "基于 Mermaid classDiagram 创建 CloudBase 数据模型（data model）与 schema。为保持兼容性，工具名仍为 modifyDataModel；当前仅支持创建新模型，不支持更新现有模型结构。适用于通过自然语言设计 collection/model schema 后落地创建。内置异步任务监控，自动轮询直至完成或超时。",
       inputSchema: {
         mermaidDiagram: z.string()
           .describe(`Mermaid classDiagram代码，描述数据模型结构。

--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -310,9 +310,9 @@ export function registerDatabaseTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "readNoSqlDatabaseStructure",
     {
-      title: "读取 NoSQL 数据库结构",
+      title: "读取 NoSQL 数据库结构（集合 / collection / 索引 / index）",
       description:
-        "读取 NoSQL 数据库集合与索引结构，支持列出集合、查看集合详情、列出索引以及检查索引是否存在。",
+        "读取 CloudBase NoSQL 云数据库的结构信息，支持集合（collection）与索引（index）发现，包括列出集合、查看集合详情、列出索引以及检查索引是否存在。适用于数据库表结构、集合结构、索引结构、schema 概览等只读查询。",
       inputSchema: {
         action: z.enum([
           "listCollections",
@@ -498,9 +498,9 @@ checkIndex: 检查指定索引是否存在`),
   server.registerTool?.(
     "writeNoSqlDatabaseStructure",
     {
-      title: "修改 NoSQL 数据库结构",
+      title: "修改 NoSQL 数据库结构（集合 / collection / 索引 / index）",
       description:
-        "修改 NoSQL 数据库结构，支持创建/删除集合，以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。",
+        "修改 CloudBase NoSQL 云数据库结构，支持创建/删除集合（collection），以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。适用于数据库建表、集合初始化、索引配置、schema 调整等写操作。",
       inputSchema: {
         action: z.enum([
           "createCollection",
@@ -669,8 +669,9 @@ deleteCollection: 删除集合`),
   server.registerTool?.(
     "readNoSqlDatabaseContent",
     {
-      title: "查询并获取 NoSQL 数据库数据记录",
-      description: "查询并获取 NoSQL 数据库数据记录",
+      title: "查询 NoSQL 数据库文档 / 记录 / document / record",
+      description:
+        "查询 CloudBase NoSQL 云数据库中的文档（document）/ 记录（record）/ 数据行，支持按集合（collection）读取、过滤、排序、分页与字段投影。适用于查数据、读表内容、查询 collection 文档列表、按条件搜索记录等只读场景。",
       inputSchema: {
         collectionName: z.string().describe("集合名称"),
         instanceId: z
@@ -771,9 +772,9 @@ deleteCollection: 删除集合`),
   server.registerTool?.(
     "writeNoSqlDatabaseContent",
     {
-      title: "修改 NoSQL 数据库数据记录",
+      title: "修改 NoSQL 数据库文档 / 记录 / document / record",
       description:
-        "修改 NoSQL 数据库数据记录。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传“字段到值的普通对象”这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径，例如把 `address.city` 设为 `shenzhen`；如果把整个 `address` 对象作为 `$set` 的值传入，则整个 `address` 对象会被替换，同级其他字段将丢失。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
+        "修改 CloudBase NoSQL 云数据库中的文档（document）/ 记录（record）数据，支持 insert、update、delete。适用于新增数据、更新 collection 文档、删除记录、写入表内容等场景。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传“字段到值的普通对象”这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径，例如把 `address.city` 设为 `shenzhen`；如果把整个 `address` 对象作为 `$set` 的值传入，则整个 `address` 对象会被替换，同级其他字段将丢失。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
       inputSchema: {
         action: z
           .enum(["insert", "update", "delete"])

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -1220,9 +1220,9 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     QUERY_SQL_DATABASE,
     {
-      title: "Query SQL database state or execute read-only SQL",
+      title: "Query SQL database / MySQL tables / schema / read-only SQL",
       description:
-        "Query SQL database information. Supports read-only SQL execution, MySQL provisioning result lookup, MySQL task status lookup, and current instance context discovery.",
+        "Query CloudBase SQL database and MySQL state. Supports read-only SQL execution, table/schema inspection, query result lookup, MySQL provisioning result lookup, MySQL task status lookup, and current instance context discovery. Use this for database query, SQL select, table data inspection, schema context lookup, and read-only database troubleshooting.",
       inputSchema: {
         action: z
           .enum(QUERY_ACTIONS)
@@ -1270,9 +1270,9 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     MANAGE_SQL_DATABASE,
     {
-      title: "Manage SQL database lifecycle or execute write SQL",
+      title: "Manage SQL database / MySQL lifecycle / schema / write SQL",
       description:
-        "Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, and schema initialization. IMPORTANT: MySQL must be provisioned first (action=provisionMySQL with confirm=true) before any runStatement or initializeSchema call. If MySQL is not yet provisioned, the tool will return MYSQL_NOT_CREATED with a nextAction to provision first.",
+        "Manage CloudBase SQL database and MySQL resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, table creation, schema initialization, and database lifecycle operations. Use this for creating tables, altering schema, executing insert/update/delete statements, and provisioning or destroying MySQL. IMPORTANT: MySQL must be provisioned first (action=provisionMySQL with confirm=true) before any runStatement or initializeSchema call. If MySQL is not yet provisioned, the tool will return MYSQL_NOT_CREATED with a nextAction to provision first.",
       inputSchema: {
         action: z
           .enum(MANAGE_ACTIONS)


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo0sca3h_xwm3t7
- category: tool
- canonicalTitle: MCP CloudBase 数据库工具命名/描述缺乏关键词匹配，导致无法通过自然语言搜索发现
- representativeRun: application-js-react-supabase-realtime-battle-scaffold/2026-04-16T01-02-59-bqfe9j

## Automation summary
操作类型：get=查询单个模型（含Schema字段列表、格式、关联关系，需要提供 name 参数），list=获取模型列表（不含Schema，可选 names 参数过滤），docs=生成SDK使用文档（需要提供 name 参数） 操作类型：get=查询单个模型（含Schema字段列表、格式、关联关系，需要提供 name 参数），list=获取模型列表（不含Schema，可选 names 参数过滤），docs=生成SDK使用文档（需要提供 name 参数） README.md tencent-cloud get_temp_credentials web hosting IsDefault action delete domains checkIndex action deleteCollection

## Evaluation contract
- eval_scope: primary_only
- primary_cases:
  - `application-js-react-supabase-realtime-battle-scaffold`
- regression_cases:
  - (none)

## Changed files
- `mcp/src/tools/dataModel.ts`
- `mcp/src/tools/databaseNoSQL.ts`
- `mcp/src/tools/databaseSQL.ts`