### PR TITLE
fix: queryPermissions 工具查询不存在 Bucket 时未返回错误

### DIFF
--- a/mcp/src/tools/permissions.test.ts
+++ b/mcp/src/tools/permissions.test.ts
@@ -106,6 +106,13 @@ describe("permission tools", () => {
       RequestId: "req-create-user",
     });
     mockGetCloudBaseManager.mockResolvedValue({
+      env: {
+        getEnvInfo: vi.fn().mockResolvedValue({
+          EnvInfo: {
+            Storages: [{ Bucket: "bucket-1" }],
+          },
+        }),
+      },
       permission: {
         describeResourcePermission: mockDescribeResourcePermission,
         describeRoleList: mockDescribeRoleList,
@@ -192,6 +199,56 @@ describe("permission tools", () => {
           "{\"create\":\"auth.uid != null\",\"update\":\"auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)\",\"delete\":\"auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)\"}",
       }),
     ]);
+  });
+
+  it("queryPermissions(action=getResourcePermission) should fail when storage bucket does not exist", async () => {
+    const result = await tools.queryPermissions.handler({
+      action: "getResourcePermission",
+      resourceType: "storage",
+      resourceId: "missing-bucket",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDescribeResourcePermission).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      success: false,
+      message: "存储 Bucket missing-bucket 不存在",
+    });
+  });
+
+  it("queryPermissions(action=getResourcePermission) should allow existing storage bucket", async () => {
+    mockDescribeResourcePermission.mockResolvedValueOnce({
+      Data: {
+        TotalCount: 1,
+        PermissionList: [
+          {
+            ResourceType: "storage",
+            Resource: "bucket-1",
+            Permission: "ADMINWRITE",
+          },
+        ],
+      },
+      RequestId: "req-storage-perm",
+    });
+
+    const result = await tools.queryPermissions.handler({
+      action: "getResourcePermission",
+      resourceType: "storage",
+      resourceId: "bucket-1",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDescribeResourcePermission).toHaveBeenCalledWith({
+      resourceType: "storage",
+      resources: ["bucket-1"],
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        resourceType: "storage",
+        resourceId: "bucket-1",
+      },
+    });
   });
 
   it("queryPermissions(action=listResourcePermissions) should include resource-level hints for risky custom rules", async () => {

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -301,6 +301,30 @@ function buildPermissionHints(securityRule: string | undefined, resourceId: stri
   ].filter(Boolean) as PermissionHint[];
 }
 
+async function ensureStorageBucketsExist(cloudbase: any, resourceIds: string[]) {
+  if (!resourceIds.length) {
+    return;
+  }
+
+  const envInfo = await cloudbase.env.getEnvInfo();
+  const existingBuckets = new Set(
+    (envInfo?.EnvInfo?.Storages ?? [])
+      .map((item: { Bucket?: string }) => item?.Bucket)
+      .filter((bucket: string | undefined): bucket is string => Boolean(bucket)),
+  );
+  const missingBuckets = resourceIds.filter((resourceId) => !existingBuckets.has(resourceId));
+
+  if (missingBuckets.length === 0) {
+    return;
+  }
+
+  if (missingBuckets.length === 1) {
+    throw new Error(`存储 Bucket ${missingBuckets[0]} 不存在`);
+  }
+
+  throw new Error(`以下存储 Bucket 不存在: ${missingBuckets.join(", ")}`);
+}
+
 export function registerPermissionTools(server: ExtendedMcpServer) {
   const cloudBaseOptions = server.cloudBaseOptions;
   const getManager = () => getCloudBaseManager({ cloudBaseOptions });
@@ -374,6 +398,9 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
             if (!resourceType || !resourceId) {
               throw new Error("action=getResourcePermission 时必须提供 resourceType 和 resourceId");
             }
+            if (resourceType === "storage") {
+              await ensureStorageBucketsExist(cloudbase, [resourceId]);
+            }
             const result = await cloudbase.permission.describeResourcePermission({
               resourceType: mapResourceType(resourceType),
               resources: [resourceId],
@@ -400,6 +427,9 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
           case "listResourcePermissions": {
             if (!resourceType) {
               throw new Error("action=listResourcePermissions 时必须提供 resourceType");
+            }
+            if (resourceType === "storage" && resourceIds?.length) {
+              await ensureStorageBucketsExist(cloudbase, resourceIds);
             }
             const result = await cloudbase.permission.describeResourcePermission({
               resourceType: mapResourceType(resourceType),


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mns3pyqp_xkjdhl
- category: tool
- canonicalTitle: queryPermissions 工具查询不存在 Bucket 时未返回错误
- representativeRun: atomic-js-none-describe-storage-acl-not-found/2026-04-09T23-20-45-6eizrm

## Automation summary
README.md tencent-cloud

## Changed files
- `mcp/src/tools/permissions.test.ts`
- `mcp/src/tools/permissions.ts`