### PR TITLE
feat(spec): ✍️ add mcp task job paradigm spec

### DIFF
--- a/specs/mcp-task-job-paradigm/design.md
+++ b/specs/mcp-task-job-paradigm/design.md
@@ -1,0 +1,354 @@
+# 技术方案设计
+
+## 设计目标
+
+本方案目标不是再增加一批新的 tool 名字，而是在当前仓库约束下，建立一套可持续扩展的 `task/job-first` 范式：
+
+1. **保留域入口收敛**：继续沿用现有 `queryXxx` / `manageXxx` 主入口思路，不把新范式误解为别名工具膨胀。
+2. **让任务成为第一等对象**：为多阶段、高风险、可暂停、可重试、可回滚的操作提供统一生命周期。
+3. **让 skill 成为 workflow contract**：从知识说明升级为路由、前置约束、verify、rollback 与 guardrail 合同。
+4. **让投影与评测共享同一语义源**：源码、skill、文档、兼容产物与测试都围绕同一套任务化合同运转。
+5. **渐进式落地**：先以少量高价值域试点，验证形态后再扩展。
+
+## 非目标
+
+1. 不在本轮把所有现有工具全部迁移到任务模式。
+2. 不为每个任务化动作新增独立 tool 名称或 alias tool。
+3. 不在首期试点中引入复杂分布式调度系统或重型外部工作流引擎。
+4. 不把 skill 改造成新的执行器；真实副作用仍由 MCP 工具承担。
+5. 不把所有同步动作强制改造成异步任务。
+
+## 当前问题分析
+
+### 1. 工具层仍偏同步 RPC 心智
+
+当前工具设计已经开始强调主入口收敛，但很多高风险能力仍停留在“调用一个 action，等一个结果”的心智下。对于需要计划、审批、执行、验证和收尾的操作，这种模型天然不够。
+
+### 2. Skill 更像知识说明，不像可执行 workflow contract
+
+现有 skill 已能较好说明场景、工具和文档，但尚未系统化表达：
+
+- 哪些场景必须进入计划阶段；
+- 哪些动作需要 `verify`；
+- 哪些失败后需要 `rollback` / `cleanup`；
+- 哪些场景不应继续走直接同步调用。
+
+### 3. 缺少跨域统一的任务控制面
+
+即使某些域底层已经有异步任务或长流程，也缺少统一的任务句柄、状态查询和控制语义，导致 Agent 只能依赖各域私有实现和零散文档。
+
+### 4. 缺少任务化语义的统一投影
+
+当前仓库已有较成熟的语义源与兼容层体系，但对 `task/job-first` 范式还没有明确的单一合同，未来很容易在主 guideline、子 skill、docs、manifest、all-in-one 和测试里逐渐漂移。
+
+## 总体架构
+
+```mermaid
+graph TD
+    A[用户请求] --> B[主 guideline / skill 路由]
+    B --> C{是否为任务化场景}
+    C -- 否 --> D[原域 query/manage 直接执行]
+    C -- 是 --> E[原域 manage action 发起 task]
+    E --> F[统一 task handle]
+    F --> G[queryTasks / manageTasks 控制面]
+    G --> H[状态查询 / 审批 / 暂停 / 重试 / 回滚 / 清理]
+    H --> I[verify / cleanup / 最终结果]
+    B --> J[兼容层 / 文档 / 聚合产物]
+    I --> K[测试 / 评测 / 失败归因]
+```
+
+该架构分为四层。
+
+## 一、域工具层：继续作为能力发起入口
+
+### 设计原则
+
+1. **域入口不变**：高风险能力仍从原域 `manageXxx` 发起，例如 `manageSqlDatabase`、`manageFunctions`。
+2. **同步 / 任务双模式共存**：低风险动作保持同步；高风险动作返回任务句柄。
+3. **action 保持 canonical**：避免因为任务化而新增大量并列 tool 名字。
+
+### 发起模式
+
+建议域工具在发起任务化动作时统一返回如下 envelope：
+
+```ts
+type TaskHandle = {
+  executionMode: "task";
+  taskId: string;
+  domain: string;
+  action: string;
+  status: TaskStatus;
+  nextStep?: string;
+  approvalRequired?: boolean;
+};
+```
+
+同步动作则继续返回原有结果 envelope：
+
+```ts
+type DirectHandle = {
+  executionMode: "direct";
+  data: unknown;
+};
+```
+
+### 域内 action 形态
+
+推荐沿用“在统一入口下新增 action”的方式，而不是拆 tool。例如数据库域可以演进为：
+
+```ts
+type ManageSqlDatabaseAction =
+  | "runStatement"
+  | "initializeSchema"
+  | "planSchemaChange"
+  | "runSchemaChange"
+  | "verifySchemaChange";
+```
+
+其中：
+
+- `runStatement` 仍用于低风险直接操作；
+- `planSchemaChange` / `runSchemaChange` 用于高风险任务流；
+- `runSchemaChange` 返回 `TaskHandle`；
+- 任务控制与回滚不在 SQL 域内继续分裂，而由统一任务控制面承担。
+
+## 二、任务控制面：新增独立 `tasks` 资源域
+
+### 为什么这里允许新增新域
+
+仓库规则要求“新增 tool 必须先回答为什么不能并入现有入口”。
+
+这里新增 `tasks` 资源域是合理的，因为任务对象具备独立资源边界：
+
+- 它跨越多个业务域（数据库、函数、部署、存储等）；
+- 它承载统一生命周期与控制语义；
+- 它不是某个具体业务动作的别名，而是独立的运行态对象。
+
+因此建议新增两个主入口：
+
+- `queryTasks`
+- `manageTasks`
+
+这符合“一域一 query / 一域一 manage”的现有设计哲学。
+
+### `queryTasks`
+
+建议覆盖以下动作：
+
+```ts
+type QueryTasksAction =
+  | "getTaskDetail"
+  | "listTasks"
+  | "listTaskEvents"
+  | "getTaskResult";
+```
+
+用途：
+
+- 查询单任务状态
+- 按域、状态、资源过滤任务
+- 查看关键阶段事件
+- 查看最终结果、验证结论和收尾建议
+
+### `manageTasks`
+
+建议覆盖以下动作：
+
+```ts
+type ManageTasksAction =
+  | "approveTask"
+  | "pauseTask"
+  | "resumeTask"
+  | "cancelTask"
+  | "retryTask"
+  | "rollbackTask"
+  | "cleanupTask";
+```
+
+说明：
+
+- 具体任务支持哪些控制动作，由任务元数据声明；
+- 不支持的动作应返回明确错误，而不是静默忽略；
+- 危险动作继续要求 `confirm=true`。
+
+### 任务状态模型
+
+建议统一状态枚举：
+
+```ts
+type TaskStatus =
+  | "planned"
+  | "awaitingApproval"
+  | "queued"
+  | "running"
+  | "verifying"
+  | "succeeded"
+  | "failed"
+  | "rolledBack"
+  | "cancelled"
+  | "cleanupPending"
+  | "cleaned";
+```
+
+### 任务记录结构
+
+建议统一记录：
+
+- `taskId`
+- `domain`
+- `action`
+- `resourceRef`
+- `status`
+- `supports`（pause/resume/retry/rollback/cleanup）
+- `approvalRequired`
+- `summary`
+- `events[]`
+- `verification`
+- `result`
+- `cleanupRecommendation`
+
+## 三、Skill 层：从知识说明升级为 workflow contract
+
+### 主 guideline 职责
+
+建议在 `config/source/guideline/cloudbase/SKILL.md` 中新增或强化以下结构：
+
+1. **什么时候必须进入任务流**
+2. **哪些域支持任务化动作**
+3. **进入任务流前的最小检查**
+4. **哪些场景不要直接走同步动作**
+5. **何时需要 verify / rollback / cleanup**
+
+### 子 skill 顶部合同模板
+
+对支持任务化动作的高价值 skill，统一增加以下区块：
+
+- `Use this first when...`
+- `Before action...`
+- `Prefer direct mode for...`
+- `Prefer task mode for...`
+- `Verify after...`
+- `Rollback / cleanup if...`
+- `Do NOT use for...`
+
+这样 skill 承担的是：
+
+- 路由
+- 前置检查
+- 风险分级
+- 收尾规范
+
+而不是把具体副作用逻辑写进 skill。
+
+### 结构化语义源
+
+为保持语义源可测试，建议新增一份结构化合同文件，例如：
+
+- `config/source/guideline/cloudbase/task-flows.yaml`
+
+建议字段包括：
+
+- `scenarioId`
+- `signals`
+- `primarySkill`
+- `thenRead`
+- `initiatingTool`
+- `initiatingAction`
+- `mode` (`direct` / `task` / `conditional`)
+- `beforeAction`
+- `verifyAfter`
+- `rollbackIf`
+- `doNotUse`
+- `priority`
+
+这份文件用于驱动：
+
+- 主 guideline 路由表
+- 兼容层投影
+- 测试 fixture
+- 后续评测合同
+
+## 四、兼容层、文档与测试投影
+
+### 语义源
+
+首要语义源建议为：
+
+- `mcp/src/tools/**/*.ts`：能力定义与 canonical action
+- `config/source/guideline/cloudbase/SKILL.md`：主路由合同
+- `config/source/guideline/cloudbase/task-flows.yaml`：结构化任务流映射
+- `config/source/skills/*/SKILL.md`：子 skill 的 workflow contract
+
+### 投影面
+
+需同步检查的面包括：
+
+- `doc/mcp-tools.md`
+- `doc/connection-modes.mdx`
+- `config/source/editor-config/` 兼容规则
+- `config/.claude/skills/` 兼容镜像（由脚本自动生成）
+- `.generated/compat-config/`
+- 对外 skills 仓库模板与 all-in-one 产物
+
+### 测试策略
+
+建议新增或扩展三类测试：
+
+#### 1. 任务控制面测试
+
+覆盖：
+
+- 任务创建返回 `TaskHandle`
+- 状态迁移合法性
+- 控制动作权限与 `confirm=true`
+- 结果查询与收尾建议
+
+#### 2. Skill / 路由合同测试
+
+覆盖：
+
+- 哪些场景应该进入任务流
+- 哪些场景仍应使用直接模式
+- 高风险场景是否定义 `beforeAction`、`verifyAfter`、`doNotUse`
+- skill 与结构化语义源是否一致
+
+#### 3. 投影一致性测试
+
+覆盖：
+
+- 主 guideline、子 skill、兼容规则、文档和生成产物中的 canonical 名称一致
+- 关键任务语义在 all-in-one 与兼容层中不丢失
+
+## 首期试点建议
+
+为了控制范围，建议首期只覆盖最值得任务化的三个方向：
+
+1. **SQL schema change**
+   - 最适合体现 `plan -> run -> verify -> rollback`
+2. **NoSQL backfill / collection migration**
+   - 适合体现长流程与幂等任务
+3. **函数或部署发布流程**
+   - 适合体现审批、发布、验证和清理
+
+这些场景有共同特征：
+
+- 高风险
+- 多阶段
+- 需要 verify
+- 容易误用同步心智
+
+## 风险与取舍
+
+1. **任务控制面会引入新域**：这是新增复杂度，但其资源边界独立，能避免每个域重复造轮子。
+2. **同步与任务双模式并存**：短期会增加文档与路由复杂度，但这是渐进式演进的必要代价。
+3. **skill 需要更强合同化**：会增加维护要求，但能显著提升 Agent 的稳定性与可评测性。
+4. **结构化语义源需要维护**：新增 `task-flows.yaml` 会带来同步成本，因此必须配套测试避免漂移。
+
+## 成功标准
+
+如果本方案成功，仓库应呈现以下变化：
+
+1. 维护者不再倾向于为每个复杂动作新增单独 tool，而是优先考虑是否进入任务流。
+2. Agent 在高风险场景下能先命中正确 skill，再走 `plan / run / verify / rollback` 路径。
+3. 文档、兼容层和测试都能明确区分直接动作与任务化动作。
+4. 首期试点域能以统一的任务句柄、状态模型和收尾语义对外提供能力。

--- a/specs/mcp-task-job-paradigm/requirements.md
+++ b/specs/mcp-task-job-paradigm/requirements.md
@@ -1,0 +1,97 @@
+# 需求文档
+
+## 介绍
+
+当前仓库在工具与知识层已经具备两条重要基础：
+
+1. **MCP 工具收敛**：同一逻辑域优先复用 `queryXxx` / `manageXxx` 主入口，而不是继续拆出大量细粒度 tool；
+2. **Skill 单一语义源**：对外 skill 以 `config/source/skills/` 和 `config/source/guideline/` 为语义源，再投影到兼容层与生成产物。
+
+但从更复杂、更生产级的场景看，现有体系仍偏向“单次调用 -> 立即返回”的工具心智，存在以下问题：
+
+- 长流程、高风险、需要审批或回滚的操作，还没有统一的 `task / job` 一等对象；
+- skill 仍主要承担知识说明，尚未系统化承载 `workflow / policy / guardrail / verify / rollback`；
+- 同一能力在源码、skill、文档、兼容产物和评测中，还没有一套可测试的任务化合同；
+- 当需求进入“计划 -> 执行 -> 验证 -> 回滚 / 清理”的阶段时，Agent 仍容易退化成一次性同步调用思维。
+
+本需求希望为当前仓库建立一套新的 `MCP + skill` 范式：
+
+- **Tool / MCP** 负责提供稳定的能力面与状态面；
+- **Skill** 负责路由、SOP、风险边界与验收约束；
+- **Task / Job** 负责承载长流程、高风险、可暂停、可重试、可回滚、可审计的执行生命周期。
+
+本次 spec 聚焦仓库内的能力形态与落地路径，不要求一次性把所有域都任务化，而是先定义统一模式，再选高价值域试点。
+
+## 需求
+
+### 需求 1 - 高风险或长流程能力必须任务化
+
+**用户故事：** 作为仓库维护者，我希望高风险、长流程、需要确认或回滚的能力不再伪装成一次性 tool call，而是进入明确的 `task / job` 生命周期，这样 Agent 才能以生产级心智使用这些能力。
+
+#### 验收标准
+
+1. When 某个动作需要多阶段执行、人工确认、长时间运行、重试、验证或回滚时, the CloudBase AI Toolkit shall 将该动作建模为 `task / job`，而不是只返回一次性的同步结果。
+2. While 同一逻辑域已有 `queryXxx` / `manageXxx` 主入口时, the CloudBase AI Toolkit shall 继续使用原域入口发起任务，而不是为每个任务化动作继续新增 alias tool。
+3. When 某个动作被任务化后, the CloudBase AI Toolkit shall 返回稳定的任务句柄，至少包含 `taskId`、`domain`、`action`、`status` 与下一步建议。
+4. When 某个动作属于低风险、短耗时、无后续阶段的直接操作时, the CloudBase AI Toolkit may 保持同步执行模式，而不是强制所有动作都任务化。
+5. While 新增任务化能力时, the CloudBase AI Toolkit shall 明确说明为什么该能力不能继续作为纯同步动作处理。
+
+### 需求 2 - 任务生命周期必须成为独立且可观测的控制面
+
+**用户故事：** 作为 AI 调用方，我希望一旦进入任务化流程，就能查询状态、暂停、继续、取消、重试、回滚和查看结果，而不是只能等待一次性返回。
+
+#### 验收标准
+
+1. When 任务被创建后, the CloudBase AI Toolkit shall 提供统一的任务状态模型，至少覆盖 `planned`、`awaitingApproval`、`queued`、`running`、`verifying`、`succeeded`、`failed`、`rolledBack`、`cancelled` 等核心状态。
+2. When AI 需要查看任务进度或结果时, the CloudBase AI Toolkit shall 提供统一的任务查询入口，而不是要求 AI 回到各个原始域自行猜测状态查询方式。
+3. When 任务支持控制动作时, the CloudBase AI Toolkit shall 提供统一的控制语义，例如 `approve`、`pause`、`resume`、`cancel`、`retry`、`rollback`、`cleanup`。
+4. While 某个任务仍处于执行中或等待验证阶段时, the CloudBase AI Toolkit shall 返回结构化状态、最近事件和推荐下一步，而不是只返回无结构日志。
+5. When 任务结束后, the CloudBase AI Toolkit shall 支持查询结果摘要、验证结论和后续清理建议，便于 Agent 正确收尾。
+
+### 需求 3 - Skill 必须从知识说明升级为工作流合同
+
+**用户故事：** 作为 Agent 和 skill 维护者，我希望 skill 不只是“介绍工具能做什么”，而是明确告诉 Agent 在什么场景下该走哪条流程、先读什么、不要做什么、如何验证和回滚。
+
+#### 验收标准
+
+1. When 用户请求命中任务化或高风险场景时, the CloudBase AI Toolkit shall 通过主 guideline 或相关 skill 明确引导 Agent 进入 `plan -> run -> verify -> rollback / cleanup` 的工作流，而不是直接执行。
+2. When 某个 skill 对应的域支持任务化动作时, the CloudBase AI Toolkit shall 在该 skill 中明确说明 `Use this first when`、`Before action`、`Do not use`、`Verify after`、`Rollback / cleanup if needed` 等合同信息。
+3. While 维护 skill 内容时, the CloudBase AI Toolkit shall 优先把 workflow、guardrail、边界和常见误用前置，而不是继续堆叠冗长背景说明。
+4. When 多个 skill 同时可能命中同一请求时, the CloudBase AI Toolkit shall 明确主路由顺序和第二参考，而不是让多个 skill 并列竞争。
+5. When Agent 尚未完成最小必要的前置检查时, the CloudBase AI Toolkit shall 通过 skill 合同阻止直接进入危险动作。
+
+### 需求 4 - 语义源与兼容投影必须共享同一套任务化合同
+
+**用户故事：** 作为维护者，我希望源码、语义源、兼容层、文档和聚合产物对“哪些动作会返回任务、任务如何收尾、哪些 skill 负责路由”保持一致，这样不会在不同入口中产生语义漂移。
+
+#### 验收标准
+
+1. When 定义任务化范式时, the CloudBase AI Toolkit shall 明确语义源位置，至少覆盖域入口定义、skill 合同和任务化场景映射。
+2. When 兼容层、IDE 规则、skills 仓库或 all-in-one 产物被生成时, the CloudBase AI Toolkit shall 保留与语义源一致的任务化路由、前置约束与收尾语义。
+3. While 文档、prompt 或 manifest 描述任务化能力时, the CloudBase AI Toolkit shall 使用与源码一致的 canonical 名称，而不是引入新的近义别名。
+4. When 兼容产物与语义源出现冲突时, the CloudBase AI Toolkit shall 以语义源为准，并能让维护者识别漂移来源。
+5. When 某个任务化场景新增或调整时, the CloudBase AI Toolkit shall 说明需要联动的文档、生成脚本、测试与下游产物。
+
+### 需求 5 - 评测与验证必须覆盖任务流而不是只覆盖同步调用
+
+**用户故事：** 作为评测与质量维护者，我希望后续测试能覆盖“有没有正确进入任务流、有没有正确 verify / rollback”，而不是只覆盖工具能不能被注册。
+
+#### 验收标准
+
+1. When 新增任务化能力时, the CloudBase AI Toolkit shall 增加测试覆盖任务创建、状态迁移、控制动作和结果查询。
+2. When 维护相关 skill 与 guideline 时, the CloudBase AI Toolkit shall 增加 should-trigger、should-route、should-read、should-not-use 等验证思路，确保 Agent 会进入正确流程。
+3. While 文档与兼容产物被更新时, the CloudBase AI Toolkit shall 验证关键任务语义不会在聚合或同步链路中丢失。
+4. When 某个场景仍保留同步模式时, the CloudBase AI Toolkit shall 在测试与文档中明确其为什么不任务化，以避免未来语义混乱。
+5. When 复盘失败案例时, the CloudBase AI Toolkit shall 支持区分“能力缺失”“没有进入任务流”“进入了错误 skill / 错误入口”“缺少 verify / rollback”这几类根因。
+
+### 需求 6 - 首期实施必须以少量高价值域试点而不是全量改造
+
+**用户故事：** 作为仓库维护者，我希望新范式先在最值得的域试点，验证有效后再扩展，而不是一次性重写整个仓库导致范围失控。
+
+#### 验收标准
+
+1. When 启动首期实施时, the CloudBase AI Toolkit shall 先选择少量高价值、高风险、最适合任务化的域进行试点，例如 SQL schema change、NoSQL backfill / collection migration、函数或部署发布流程。
+2. While 首期试点尚未稳定时, the CloudBase AI Toolkit shall 不要求所有域同步迁移到任务模式。
+3. When 首期试点完成并验证通过后, the CloudBase AI Toolkit shall 能够复用统一的任务状态模型、skill 合同模板和评测方法扩展到其他域。
+4. While 试点域仍与旧同步能力并存时, the CloudBase AI Toolkit shall 明确区分推荐路径与过渡路径，避免 Agent 混用。
+5. When 维护者评估首期试点价值时, the CloudBase AI Toolkit shall 给出是否继续推广的判断依据，例如风险降低、调用正确率提升、收尾质量提升或评测表现改善。

--- a/specs/mcp-task-job-paradigm/tasks.md
+++ b/specs/mcp-task-job-paradigm/tasks.md
@@ -1,0 +1,43 @@
+# 实施计划
+
+- [ ] 1. 定义统一任务控制面合同
+  - 明确哪些动作保留直接模式，哪些动作必须任务化。
+  - 设计统一的 `TaskHandle`、`TaskStatus`、任务结果与事件结构。
+  - 明确 `queryTasks` / `manageTasks` 作为独立资源域的边界与 canonical action。
+  - _需求: 需求1, 需求2_
+
+- [ ] 2. 为首期试点域补齐任务化 action 设计
+  - 在试点域的 `queryXxx` / `manageXxx` 主入口中新增 `plan / run / verify` 类 action。
+  - 设计从域入口发起任务、再转入统一任务控制面的交互方式。
+  - 明确高风险动作的 `confirm`、审批与回滚支持策略。
+  - _需求: 需求1, 需求2, 需求6_
+
+- [ ] 3. 建立任务化场景的结构化语义源
+  - 新增 `config/source/guideline/cloudbase/task-flows.yaml` 或等价结构化文件。
+  - 为高价值场景定义 `primarySkill`、`initiatingTool`、`mode`、`beforeAction`、`verifyAfter`、`rollbackIf` 与 `doNotUse`。
+  - 用该语义源约束主 guideline、子 skill 与下游投影。
+  - _需求: 需求3, 需求4, 需求6_
+
+- [ ] 4. 升级主 guideline 与高价值 skill 为 workflow contract
+  - 更新 `config/source/guideline/cloudbase/SKILL.md`，明确哪些场景必须进入任务流。
+  - 为试点域相关 skill 增加 `Before action`、`Prefer task mode`、`Verify after`、`Rollback / cleanup if` 等区块。
+  - 明确直接模式、任务模式和不推荐路径之间的边界。
+  - _需求: 需求3, 需求4_
+
+- [ ] 5. 对齐文档、兼容规则与聚合产物
+  - 更新 `doc/mcp-tools.md`、`doc/connection-modes.mdx`、IDE 兼容规则和对外 skills 入口，使其表达一致的任务化语义。
+  - 检查 all-in-one、兼容镜像和生成产物是否保留 canonical 名称与关键 workflow 合同。
+  - 明确语义源与兼容投影的同步流程。
+  - _需求: 需求4, 需求5_
+
+- [ ] 6. 增加任务流测试与评测合同
+  - 为任务控制面增加创建、状态迁移、控制动作、结果查询测试。
+  - 为 skill 路由增加 should-trigger、should-route、should-read、should-not-use 测试。
+  - 为兼容投影增加一致性测试，防止关键任务语义在生成链路中丢失。
+  - _需求: 需求5_
+
+- [ ] 7. 完成首期试点与推广评估
+  - 在 SQL schema change、NoSQL migration 或发布流程中至少选择一个域进行完整试点。
+  - 记录试点中的调用正确率、收尾质量、失败归因与维护成本。
+  - 基于试点结果决定后续是否扩展到更多域，并形成推广标准。
+  - _需求: 需求6_


### PR DESCRIPTION
## Summary
- add initial spec for the MCP + skill + task/job-first paradigm
- define requirements, design, and implementation tasks under `specs/mcp-task-job-paradigm/`
- frame the evolution around converged domain tools, workflow-oriented skills, and first-class task control plane

## Scope
- spec only, no runtime implementation yet
- intended as a WIP discussion draft for architecture alignment

## Notes
- this PR focuses on how current `queryXxx` / `manageXxx` entrypoints can evolve toward task/job-first workflows
- it also proposes `queryTasks` / `manageTasks` as the cross-domain task control surface
