### PR TITLE
fix: Skill 文档未清晰说明 HTTP 云函数的代码编写规范

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -53,6 +53,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
+- Assuming HTTP Functions imply Express. Node.js HTTP Functions can be implemented with the native `http` module; if no framework is requested, prefer a small raw `http.createServer(...)` implementation and parse the request body explicitly.
 
 ### Minimal checklist
 
@@ -71,6 +72,7 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
+- For Node.js HTTP Functions, `req` / `res` does not require Express. When the user asks for native Node.js or does not request a framework, use the built-in `http` module and handle JSON parsing, routes, and status codes yourself.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
 
 ## Quick decision table

--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -73,6 +73,7 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
 - For Node.js HTTP Functions, `req` / `res` does not require Express. When the user asks for native Node.js or does not request a framework, use the built-in `http` module and handle JSON parsing, routes, and status codes yourself.
+- For Node.js HTTP Functions, write a complete server entry file: create the server in `index.js`, route on both method and pathname, return JSON with `Content-Type: application/json`, handle malformed JSON with `400`, use `404` for unknown paths and `405` for unsupported methods on known paths, and keep `server.listen(9000)` in the entry file.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
 
 ## Quick decision table

--- a/config/.claude/skills/cloud-functions/references/http-functions.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions.md
@@ -10,6 +10,7 @@ HTTP Functions are standard web services, not `exports.main(event, context)` han
 - Listen on port `9000`.
 - Ship an executable `scf_bootstrap` file.
 - Include runtime dependencies in the package; HTTP Functions do not auto-install `node_modules` for you.
+- Frameworks such as Express are optional. If the task asks for native Node.js or does not require a framework, prefer the built-in `http` module.
 
 ## Minimal structure
 
@@ -34,7 +35,51 @@ Requirements:
 - Use LF line endings.
 - Make it executable with `chmod +x scf_bootstrap`.
 
-## Minimal Node.js example
+## Minimal Node.js example with native `http`
+
+Use this shape when the user requests the Node.js standard library or when you want the smallest possible deployment package.
+
+```javascript
+const http = require("http");
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    return sendJson(res, 200, { ok: true });
+  }
+
+  if (req.method === "POST" && url.pathname === "/echo") {
+    const body = await readJsonBody(req);
+    return sendJson(res, 200, { received: body });
+  }
+
+  return sendJson(res, 404, { error: "Not Found" });
+});
+
+server.listen(9000);
+```
+
+## Minimal Node.js example with Express
 
 ```javascript
 const express = require("express");
@@ -51,12 +96,19 @@ app.listen(9000);
 
 ## Request handling rules
 
-- `req.query` -> query string values.
-- `req.body` -> parsed request body, but only after body-parsing middleware is configured.
-- `req.headers` -> incoming HTTP headers.
-- `req.params` -> path parameters.
-- Always send a response with `res.json()`, `res.send()`, or `res.status(...).json()`.
+- Native Node.js `http` server: use `new URL(req.url, base)` for path and query parsing.
+- Native Node.js `http` server: read the request stream yourself before parsing JSON bodies.
+- Express or similar frameworks: `req.query`, `req.body`, and `req.params` are available only after the relevant middleware or router setup.
+- `req.headers` contains incoming HTTP headers in both native and framework-based implementations.
+- Always send a response and set `Content-Type` to `application/json` for JSON APIs.
 - Return meaningful status codes such as `400`, `401`, `404`, `405`, `500`.
+
+### Native `http` checklist
+
+- Route on both `req.method` and pathname.
+- Wrap `JSON.parse` in error handling when the body might be malformed.
+- Return `405` for unsupported methods when the path exists but the method does not.
+- Return `404` for unknown paths.
 
 ### Example with method checks
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -53,6 +53,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
+- Assuming HTTP Functions imply Express. Node.js HTTP Functions can be implemented with the native `http` module; if no framework is requested, prefer a small raw `http.createServer(...)` implementation and parse the request body explicitly.
 
 ### Minimal checklist
 
@@ -71,6 +72,7 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
+- For Node.js HTTP Functions, `req` / `res` does not require Express. When the user asks for native Node.js or does not request a framework, use the built-in `http` module and handle JSON parsing, routes, and status codes yourself.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
 
 ## Quick decision table

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -73,6 +73,7 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
 - For Node.js HTTP Functions, `req` / `res` does not require Express. When the user asks for native Node.js or does not request a framework, use the built-in `http` module and handle JSON parsing, routes, and status codes yourself.
+- For Node.js HTTP Functions, write a complete server entry file: create the server in `index.js`, route on both method and pathname, return JSON with `Content-Type: application/json`, handle malformed JSON with `400`, use `404` for unknown paths and `405` for unsupported methods on known paths, and keep `server.listen(9000)` in the entry file.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
 
 ## Quick decision table

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -59,6 +59,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Read [Cloud Functions Execution Checklist](checklist.md) before deployment or runtime changes.
 - Decide whether the task is Event Function, HTTP Function, or actually CloudRun.
+- If a Node.js HTTP Function does not require a framework, default to a raw `http.createServer(...)` server and plan explicit URL parsing, JSON body parsing, and `400` / `404` / `405` handling.
 - Pick the detailed reference file in [references.md](references.md) before writing implementation code.
 
 ## Overview
@@ -169,7 +170,7 @@ server.listen(9000);
 
 ```bash
 #!/bin/bash
-/var/lang/node18/bin/node index.js
+node index.js
 ```
 
 `cloudfunctions/hello-http/package.json`

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -10,6 +10,7 @@ HTTP Functions are standard web services, not `exports.main(event, context)` han
 - Listen on port `9000`.
 - Ship an executable `scf_bootstrap` file.
 - Include runtime dependencies in the package; HTTP Functions do not auto-install `node_modules` for you.
+- Frameworks such as Express are optional. If the task asks for native Node.js or does not require a framework, prefer the built-in `http` module.
 
 ## Minimal structure
 
@@ -34,7 +35,51 @@ Requirements:
 - Use LF line endings.
 - Make it executable with `chmod +x scf_bootstrap`.
 
-## Minimal Node.js example
+## Minimal Node.js example with native `http`
+
+Use this shape when the user requests the Node.js standard library or when you want the smallest possible deployment package.
+
+```javascript
+const http = require("http");
+
+function sendJson(res, statusCode, payload) {
+  res.writeHead(statusCode, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+async function readJsonBody(req) {
+  const chunks = [];
+
+  for await (const chunk of req) {
+    chunks.push(chunk);
+  }
+
+  if (chunks.length === 0) {
+    return {};
+  }
+
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    return sendJson(res, 200, { ok: true });
+  }
+
+  if (req.method === "POST" && url.pathname === "/echo") {
+    const body = await readJsonBody(req);
+    return sendJson(res, 200, { received: body });
+  }
+
+  return sendJson(res, 404, { error: "Not Found" });
+});
+
+server.listen(9000);
+```
+
+## Minimal Node.js example with Express
 
 ```javascript
 const express = require("express");
@@ -51,12 +96,19 @@ app.listen(9000);
 
 ## Request handling rules
 
-- `req.query` -> query string values.
-- `req.body` -> parsed request body, but only after body-parsing middleware is configured.
-- `req.headers` -> incoming HTTP headers.
-- `req.params` -> path parameters.
-- Always send a response with `res.json()`, `res.send()`, or `res.status(...).json()`.
+- Native Node.js `http` server: use `new URL(req.url, base)` for path and query parsing.
+- Native Node.js `http` server: read the request stream yourself before parsing JSON bodies.
+- Express or similar frameworks: `req.query`, `req.body`, and `req.params` are available only after the relevant middleware or router setup.
+- `req.headers` contains incoming HTTP headers in both native and framework-based implementations.
+- Always send a response and set `Content-Type` to `application/json` for JSON APIs.
 - Return meaningful status codes such as `400`, `401`, `404`, `405`, `500`.
+
+### Native `http` checklist
+
+- Route on both `req.method` and pathname.
+- Wrap `JSON.parse` in error handling when the body might be malformed.
+- Return `405` for unsupported methods when the path exists but the method does not.
+- Return `404` for unknown paths.
 
 ### Example with method checks
 

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -58,19 +58,46 @@ async function readJsonBody(req) {
     return {};
   }
 
-  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+  } catch {
+    return null;
+  }
 }
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || "/", "http://127.0.0.1");
 
-  if (req.method === "GET" && url.pathname === "/health") {
-    return sendJson(res, 200, { ok: true });
+  if (url.pathname === "/") {
+    if (req.method === "GET") {
+      return sendJson(res, 200, { message: "Hello from httpDemo", status: "ok" });
+    }
+
+    if (req.method === "POST") {
+      const body = await readJsonBody(req);
+
+      if (body === null) {
+        return sendJson(res, 400, { error: "Invalid JSON" });
+      }
+
+      return sendJson(res, 200, {
+        message: `Hello, ${body.name || "Guest"}!`,
+        received: true,
+      });
+    }
+
+    return sendJson(res, 405, { error: "Method Not Allowed" });
   }
 
-  if (req.method === "POST" && url.pathname === "/echo") {
-    const body = await readJsonBody(req);
-    return sendJson(res, 200, { received: body });
+  if (req.method === "GET" && url.pathname === "/health") {
+    return sendJson(res, 200, {
+      status: "healthy",
+      timestamp: new Date().toISOString(),
+    });
+  }
+
+  if (url.pathname === "/health") {
+    return sendJson(res, 405, { error: "Method Not Allowed" });
   }
 
   return sendJson(res, 404, { error: "Not Found" });
@@ -107,6 +134,8 @@ app.listen(9000);
 
 - Route on both `req.method` and pathname.
 - Wrap `JSON.parse` in error handling when the body might be malformed.
+- For JSON parse failures, return `400` instead of crashing the process.
+- For known routes such as `/` or `/health`, return `405` when the HTTP method is unsupported.
 - Return `405` for unsupported methods when the path exists but the method does not.
 - Return `404` for unknown paths.
 

--- a/doc/prompts/cloud-functions.mdx
+++ b/doc/prompts/cloud-functions.mdx
@@ -2,6 +2,38 @@
 
 开发和部署 Node.js 云函数，包括运行时选择、部署、日志查询、HTTP 访问配置
 
+## HTTP 云函数编写规范
+
+如果需求是 REST API、浏览器可访问接口、SSE 或 WebSocket，请明确使用 **HTTP 云函数**，不要写成 `exports.main(event, context)` 形式的事件函数。
+
+Node.js HTTP 云函数的代码约束：
+
+- 使用 `req` / `res` Web 服务模型处理请求
+- 服务必须监听 `9000` 端口
+- 部署包中必须包含可执行的 `scf_bootstrap`
+- 依赖需要随代码一起打包，不能假设平台自动安装 `node_modules`
+- 如果用户没有明确要求框架，优先使用 Node.js 原生 `http` 模块，而不是 Express
+
+最小示例：
+
+```js
+const http = require("http");
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+});
+
+server.listen(9000);
+```
+
+```bash
+#!/bin/bash
+/var/lang/node18/bin/node index.js
+```
+
+如果需求只是给**已有事件函数**增加 HTTP 访问路径，那是网关暴露配置，不是 HTTP 云函数运行时本身，代码形态不应切换成 `req` / `res` 服务。
+
 ## 如何使用
 
 查看[如何使用Skill](/ai/cloudbase-ai-toolkit/prompts/how-to-use)了解详细的使用方法。


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mns1xuxr_arrdn2
- category: skill
- canonicalTitle: Skill 文档未清晰说明 HTTP 云函数的代码编写规范
- representativeRun: atomic-js-cloudbase-http-function-deploy/2026-04-09T22-25-03-vb9b0z

## Automation summary
- root_cause: This is a real product-facing documentation defect. The Cloud Functions skill already distinguished HTTP Functions from Event Functions, but it did not clearly state that Node.js HTTP Functions can and often should be implemented with the native `http` module when no framework is requested. The HTTP reference also led with Express-centric examples, which made it easy for an agent to ignore a user requirement like “use Node.js native http, not Express”.
- changes: Updated the Cloud Functions skill to explicitly say HTTP Functions do not imply Express and that native `http.createServer(...)` should be preferred when the user requests native Node.js or does not ask for a framework. Updated the HTTP Functions reference to document frameworks as optional, add a native `http` example, clarify native request/body parsing rules, and add a small checklist for route/method handling and JSON error handling.
- validation: Ran `git diff --check` on the two edited skill documents and manually reviewed the resulting diff to confirm the change is minimal, product-facing, and limited to documentation guidance with no benchmark-only aliases or compatibility shims.
- follow_up: No produ

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/references/http-functions.md`