### PR TITLE
fix: Skill 未说明云数据库集合需预先创建，导致 add() 调用失败

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -50,6 +50,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
+- Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
@@ -110,6 +111,12 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
    - Event Function details -> `./references/event-functions.md`
    - HTTP Function details -> `./references/http-functions.md`
    - Logs, gateway, env vars, and legacy mappings -> `./references/operations-and-config.md`
+
+## Database write reminder
+
+- If a function will write to CloudBase document database, create the target collection first through console or management tooling.
+- `db.collection("feedback").add(...)` only inserts into an existing collection; it does not auto-create `feedback` when absent.
+- If the product requirement says "create when missing", implement that as an explicit collection-management step before the first write instead of assuming the runtime write call will provision it.
 
 ## Function types comparison
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mns14m7u_p8w0jc
- category: skill
- canonicalTitle: Skill 未说明云数据库集合需预先创建，导致 add() 调用失败
- representativeRun: atomic-js-cloudbase-db-add-feedback/2026-04-09T22-07-03-lzf4sf

## Automation summary
- root_cause: The Cloud Functions skill did not state that CloudBase document database collections must be created before calling `db.collection(...).add()`. Internal evaluation evidence matched an actual product-facing docs gap, and the repo’s own integration test flow already assumes explicit collection creation before insert.
- changes: Updated `config/source/skills/cloud-functions/SKILL.md` with one new gotcha and one focused “Database write reminder” section that clarifies `add()` only writes to an existing collection and that “create when missing” must be handled as an explicit collection-management step.
- validation: Reviewed the relevant skill and evidence files, confirmed the existing integration test already creates collections before insert, and ran `git diff --check -- config/source/skills/cloud-functions/SKILL.md` successfully.
- follow_up: No code or API surface changes were needed. CloudBase MCP docs sync is disabled for this run, so any external published docs or generated mirrors were not updated here.
自动检查更新失败：Request timed out: GET https://mirrors.tencent.com/npm/@tencent%2Fcodex-internal。请手动执行 npm i -g @tencent/codex-internal --registry https://mirrors.tencent.

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`