### PR TITLE
fix: manageGateway 工具参数设计不清晰导致 HTTP 函数配置不完整

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -141,6 +141,18 @@ describe("gateway tools", () => {
     ({ tools } = createMockServer());
   });
 
+  it("manageGateway schema should explain how to expose an existing HTTP function", () => {
+    const schema = tools.manageGateway.meta.inputSchema;
+
+    expect(tools.manageGateway.meta.description).toContain("HTTP 云函数补默认域名访问");
+    expect(schema.action.description).toContain("createAccess");
+    expect(schema.action.description).toContain("默认域名访问入口");
+    expect(schema.targetName.description).toContain("填写函数名");
+    expect(schema.path.description).toContain("/api/hello");
+    expect(schema.type.description).toContain("已创建的 HTTP 云函数时传 HTTP");
+    expect(schema.auth.description).toContain("通常设为 false");
+  });
+
   it("manageGateway(action=createAccess) should normalize path and return structured payload", async () => {
     const result = await tools.manageGateway.handler({
       action: "createAccess",

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -162,7 +162,7 @@ describe("gateway tools", () => {
     expect(payload).toMatchObject({
       success: true,
       message:
-        "已为目标 helloFn 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。",
+        "已为目标 helloFn 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开函数安全规则；若需要匿名或浏览器直接访问，请继续检查函数资源权限。",
       data: {
         action: "createAccess",
         targetType: "function",
@@ -174,6 +174,17 @@ describe("gateway tools", () => {
           tool: "queryGateway",
           action: "getAccess",
           reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
+        }),
+        expect.objectContaining({
+          tool: "queryPermissions",
+          action: "getResourcePermission",
+          reason:
+            "确认函数安全规则是否允许预期访问方；网关 auth=false 不等于函数已允许匿名访问",
+        }),
+        expect.objectContaining({
+          tool: "managePermissions",
+          action: "updateResourcePermission",
+          reason: "只有在确认需要匿名或浏览器直连访问时，才按实际安全要求更新函数权限",
         }),
       ],
     });

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -358,12 +358,22 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           path: accessPath,
           raw: result,
         },
-        `已为目标 ${input.targetName} 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。`,
+        `已为目标 ${input.targetName} 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开函数安全规则；若需要匿名或浏览器直接访问，请继续检查函数资源权限。`,
         [
           {
             tool: "queryGateway",
             action: "getAccess",
             reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
+          },
+          {
+            tool: "queryPermissions",
+            action: "getResourcePermission",
+            reason: "确认函数安全规则是否允许预期访问方；网关 auth=false 不等于函数已允许匿名访问",
+          },
+          {
+            tool: "managePermissions",
+            action: "updateResourcePermission",
+            reason: "只有在确认需要匿名或浏览器直连访问时，才按实际安全要求更新函数权限",
           },
         ],
       );
@@ -563,7 +573,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "管理网关域资源",
       description:
-        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。",
+        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。",
       inputSchema: {
         action: z.enum(MANAGE_GATEWAY_ACTIONS).describe("写操作类型，例如 createAccess"),
         targetType: z
@@ -571,9 +581,18 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           .optional()
           .describe("目标资源类型。当前支持 function，后续可扩展"),
         targetName: z.string().optional().describe("目标资源名称"),
-        path: z.string().optional().describe("访问路径，默认 /{targetName}"),
-        type: z.enum(["Event", "HTTP"]).optional().describe("目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。"),
-        auth: z.boolean().optional().describe("是否开启鉴权"),
+        path: z
+          .string()
+          .optional()
+          .describe("访问路径，默认 /{targetName}。该参数只创建网关入口，不会自动放开函数资源权限。"),
+        type: z
+          .enum(["Event", "HTTP"])
+          .optional()
+          .describe("目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。"),
+        auth: z
+          .boolean()
+          .optional()
+          .describe("是否开启网关路径鉴权。该开关仅控制网关入口本身，不会修改函数资源权限；若需匿名或浏览器直连访问，还需检查并按需调整函数安全规则。"),
         route: z
           .object({
             routeId: z.string().optional(),

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -573,26 +573,31 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "管理网关域资源",
       description:
-        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。",
+        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。",
       inputSchema: {
-        action: z.enum(MANAGE_GATEWAY_ACTIONS).describe("写操作类型，例如 createAccess"),
+        action: z
+          .enum(MANAGE_GATEWAY_ACTIONS)
+          .describe("写操作类型，例如 createAccess。为已有函数补默认域名访问入口时使用 createAccess"),
         targetType: z
           .enum(["function"])
           .optional()
           .describe("目标资源类型。当前支持 function，后续可扩展"),
-        targetName: z.string().optional().describe("目标资源名称"),
+        targetName: z
+          .string()
+          .optional()
+          .describe("目标资源名称。createAccess 到云函数时填写函数名"),
         path: z
           .string()
           .optional()
-          .describe("访问路径，默认 /{targetName}。该参数只创建网关入口，不会自动放开函数资源权限。"),
+          .describe("访问路径，默认 /{targetName}。例如为 HTTP 函数暴露 /api/hello 时传 /api/hello。该参数只创建网关入口，不会自动放开函数资源权限。"),
         type: z
           .enum(["Event", "HTTP"])
           .optional()
-          .describe("目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。"),
+          .describe("目标函数的运行时类型，不是接入协议。createAccess 到已创建的 HTTP 云函数时传 HTTP；给 Event 函数补网关访问时传 Event 或省略。"),
         auth: z
           .boolean()
           .optional()
-          .describe("是否开启网关路径鉴权。该开关仅控制网关入口本身，不会修改函数资源权限；若需匿名或浏览器直连访问，还需检查并按需调整函数安全规则。"),
+          .describe("是否开启网关路径鉴权。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限，仍需检查并按需调整函数安全规则。"),
         route: z
           .object({
             routeId: z.string().optional(),


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mns2ckez_z9rdxw
- category: tool
- canonicalTitle: manageGateway 工具参数设计不清晰导致 HTTP 函数配置不完整
- representativeRun: atomic-js-cloudbase-http-service-config/2026-04-09T22-42-10-dvs6vv

## Automation summary
model-context-protocol Web Development AI-native tools for modern development workflows full-stack README.md tencent-cloud

## Changed files
- `mcp/src/tools/gateway.test.ts`
- `mcp/src/tools/gateway.ts`