### PR TITLE
fix: HTTP 云函数 Skill 缺少路径映射和网关路径处理的关键说明

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -50,6 +50,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
+- Assuming an HTTP Function automatically gets a browser/public URL path, or assuming that path is always `/{functionName}`.
+- Writing gateway prefixes such as `/api/httpDemo` into the function router itself. Public gateway path and in-function route path are different layers.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
@@ -198,6 +200,8 @@ server.listen(9000);
 - `queryGateway(action="getAccess")`
 - `manageGateway(action="createAccess")`
 - If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+
+When a user says they need browser/public access, do not assume creation already exposed the function. HTTP Function runtime routes still live inside the function, while gateway access adds an external path prefix separately.
 
 ## Related skills
 

--- a/config/.claude/skills/cloud-functions/references/http-functions.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions.md
@@ -143,6 +143,29 @@ manageGateway({
 });
 ```
 
+### Path mapping model
+
+Keep the public gateway path and the in-function router path as two different layers.
+
+- `manageGateway(..., path: "/api/hello")` creates the **external** access prefix.
+- Your HTTP Function still matches its own internal routes such as `/`, `/health`, `/users`.
+- Do **not** rewrite the function router to include the gateway prefix.
+
+Example mapping:
+
+| External URL | Route your HTTP Function should handle |
+| --- | --- |
+| `https://{domain}/api/hello` | `/` |
+| `https://{domain}/api/hello/health` | `/health` |
+| `https://{domain}/api/hello/users` | `/users` |
+
+For example, if you expose `path: "/api/httpDemo"`, the function code should normally keep handlers like `app.get("/")` and `app.get("/health")`. Do not change them to `app.get("/api/httpDemo")` or `app.get("/api/httpDemo/health")`.
+
+If the external caller reports a 404, verify these two layers separately:
+
+1. Use `queryGateway(action="getAccess")` to confirm which public path is actually exposed.
+2. Check the HTTP Function router to confirm it handles the internal path after the gateway prefix.
+
 Before enabling anonymous access, confirm both of these:
 
 1. The access path exists.

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -36,6 +36,9 @@ If a skill points to its own `references/...` files, keep following those relati
 
 - If the same implementation path fails 2-3 times, stop retrying and reroute. Re-check the selected platform skill, runtime, auth domain, permission model, and SDK boundary before editing more code.
 - Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment, implicit defaults, or copied local state.
+- For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write gateway prefixes such as `/api/httpDemo` into the function router itself.
+- Creating an HTTP Function does not guarantee a browser/public URL exists. If the task needs external access, create gateway access only when required and confirm the actual exposed path with `queryGateway(action="getAccess")` instead of assuming it is `/{functionName}`.
+- If an external HTTP invocation may be anonymous, or the caller reports `EXCEED_AUTHORITY`, inspect the function permission rule first and only widen access when the product requirement really needs anonymous callers.
 - Keep scenario-specific pitfall lists in the matching child skills instead of expanding this entry file.
 
 ### High-priority routing

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -38,6 +38,8 @@ If a skill points to its own `references/...` files, keep following those relati
 - Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment, implicit defaults, or copied local state.
 - For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write gateway prefixes such as `/api/httpDemo` into the function router itself.
 - Creating an HTTP Function does not guarantee a browser/public URL exists. If the task needs external access, create gateway access only when required and confirm the actual exposed path with `queryGateway(action="getAccess")` instead of assuming it is `/{functionName}`.
+- If the task explicitly says no HTTP access service is needed, do not create gateway access just to mirror the function name. Keep direct function invocation and gateway routing as separate delivery choices.
+- When a gateway path is created later, keep the path mapping separate: a public prefix such as `/api/httpDemo` should still map to in-function routes like `/`, `/health`, and `/users` instead of rewriting handlers to `/api/httpDemo/...`.
 - If an external HTTP invocation may be anonymous, or the caller reports `EXCEED_AUTHORITY`, inspect the function permission rule first and only widen access when the product requirement really needs anonymous callers.
 - Keep scenario-specific pitfall lists in the matching child skills instead of expanding this entry file.
 

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -31,6 +31,7 @@ alwaysApply: true
 - Web app execution -> `./web-development/SKILL.md`
 - Web auth provider readiness -> `./auth-tool/SKILL.md`
 - Web auth implementation -> `./auth-web/SKILL.md`
+- Cloud Functions, including HTTP Functions and browser-facing endpoints -> `./cloud-functions/SKILL.md`
 - Browser-side document database CRUD -> `./no-sql-web-sdk/SKILL.md`
 - Browser-side file upload -> `./cloud-storage-web/SKILL.md`
 - Platform overview only when capability selection is still unclear -> `./cloudbase-platform/SKILL.md`
@@ -39,6 +40,7 @@ alwaysApply: true
 
 - If the same path fails 2-3 times, stop retrying and reroute. Check platform skill, auth domain, runtime, and permission model before editing more code.
 - Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment or implicit defaults.
+- For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write prefixes such as `/api/httpDemo` into the router itself; create gateway access separately when the task actually needs an external path, then verify function permissions before treating the URL as usable.
 
 ### Do NOT use this as
 

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -40,7 +40,10 @@ alwaysApply: true
 
 - If the same path fails 2-3 times, stop retrying and reroute. Check platform skill, auth domain, runtime, and permission model before editing more code.
 - Always specify `EnvId` explicitly in code, configuration, and command examples when initializing CloudBase clients or manager operations. Do not rely on the current CLI-selected environment or implicit defaults.
-- For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write prefixes such as `/api/httpDemo` into the router itself; create gateway access separately when the task actually needs an external path, then verify function permissions before treating the URL as usable.
+- For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write prefixes such as `/api/httpDemo` into the router itself; create gateway access separately only when the task actually needs an external path, and verify function permissions before treating the URL as usable.
+- HTTP Function path mapping rule: if the public gateway path is `/api/httpDemo`, the function router should still handle `/`, `/health`, `/users` inside the service. Do not rewrite those handlers to `/api/httpDemo`, `/api/httpDemo/health`, or other gateway-prefixed paths.
+- HTTP Function delivery rule: creating the function does not guarantee a browser/public URL exists. Confirm the actual exposed path with `queryGateway(action="getAccess")` after creating access, and if the task explicitly says no HTTP access service is needed, do not create gateway access just to mirror the function name.
+- HTTP Function permission rule: when the caller may be anonymous, or when external invocation reports `EXCEED_AUTHORITY`, inspect the function rule first and only widen access when the product requirement really needs anonymous callers.
 
 ### Do NOT use this as
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -52,9 +52,12 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
 - Assuming an HTTP Function automatically gets a browser/public URL path, or assuming that path is always `/{functionName}`.
 - Writing gateway prefixes such as `/api/httpDemo` into the function router itself. Public gateway path and in-function route path are different layers.
+- Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
+- Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Use `managePermissions(action="updateResourcePermission", resourceType="function")` to allow public access.
+- Mismatching the `scf_bootstrap` Node.js binary path with the function runtime (e.g. using `/var/lang/node18/bin/node` but setting `runtime: "Nodejs16.13"`).
 
 ### Minimal checklist
 
@@ -73,7 +76,25 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
+- For Node.js HTTP Functions, default to the native `http` module unless the user explicitly asks for Express, Koa, NestJS, or another framework.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
+
+## HTTP Function authoring contract
+
+Use these rules whenever you are writing the function code itself:
+
+- Do not write an HTTP Function as `exports.main(event, context)`. That is the Event Function contract.
+- Treat the function as a standard web server process that must listen on port `9000`.
+- With Node.js, prefer `http.createServer((req, res) => { ... })` by default so the runtime contract stays explicit.
+- With the Node.js native `http` module, do not assume Express-style helpers exist. `req.body`, `req.query`, and `req.params` are not provided for you.
+- For Node.js HTTP Functions, choose one module system up front and keep it consistent. Default to CommonJS for simple functions (`require(...)`, no `"type": "module"` in `package.json`) unless you explicitly want ES Modules.
+- If you do choose ES Modules (`"type": "module"` + `import ...`), do not mix in CommonJS-only globals or APIs such as `require(...)`, `module.exports`, or bare `__dirname`. In ESM, derive file paths from `import.meta.url` with `fileURLToPath(...)` only when needed.
+- With the native `http` module, parse `req.url` yourself with `new URL(...)`, collect the request body from the stream, and only then call `JSON.parse`. Empty bodies should be handled explicitly instead of assuming JSON is always present.
+- Return responses explicitly with `res.writeHead(...)` and `res.end(...)`, including `Content-Type` such as `application/json; charset=utf-8` for JSON APIs.
+- Keep routing and method handling explicit. Unknown paths should return `404`, and known paths with unsupported methods should normally return `405`.
+- Keep gateway setup and security-rule changes separate from the runtime code. They affect access, not the HTTP Function programming model.
+- Keep the public gateway path and the in-function router path as separate layers. If the public path is `/api/httpDemo`, the function should usually still handle internal routes like `/` and `/health` rather than `/api/httpDemo` and `/api/httpDemo/health`.
+- Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; anonymous or public invocation requirements should be handled through the function security rule workflow.
 
 ## Quick decision table
 
@@ -100,7 +121,7 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 3. **Write code and deploy, do not stop at local files**
    - Use `manageFunctions(action="createFunction")` for creation
    - Use `manageFunctions(action="updateFunctionCode")` for code updates
-   - Keep `functionRootPath` as the parent directory of the function folder
+   - Keep `functionRootPath` as the directory that directly contains function folders (e.g., `cloudfunctions/` or `functions/`), NOT the project root and NOT the function subdirectory itself
    - Use CLI only as a fallback when MCP tools are unavailable
 
 4. **Prefer doc-first fallbacks**
@@ -112,6 +133,12 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
    - Event Function details -> `./references/event-functions.md`
    - HTTP Function details -> `./references/http-functions.md`
    - Logs, gateway, env vars, and legacy mappings -> `./references/operations-and-config.md`
+
+## Database write reminder
+
+- If a function will write to CloudBase document database, create the target collection first through console or management tooling.
+- `db.collection("feedback").add(...)` only inserts into an existing collection; it does not auto-create `feedback` when absent.
+- If the product requirement says "create when missing", implement that as an explicit collection-management step before the first write instead of assuming the runtime write call will provision it.
 
 ## Function types comparison
 
@@ -155,14 +182,42 @@ exports.main = async (event, context) => {
 
 ```js
 const http = require("http");
+const { URL } = require("url");
 
-const server = http.createServer((req, res) => {
-  res.writeHead(200, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ ok: true, message: "hello from http function" }));
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
+
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    req.on("data", (chunk) => { raw += chunk; });
+    req.on("end", () => {
+      if (!raw) { resolve({}); return; }
+      try { resolve(JSON.parse(raw)); } catch { resolve({}); }
+    });
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/") {
+    sendJson(res, 200, { ok: true, message: "hello from http function" });
+  } else if (req.method === "POST" && url.pathname === "/") {
+    const body = await readJsonBody(req);
+    sendJson(res, 200, { received: body });
+  } else {
+    sendJson(res, 404, { error: "Not Found" });
+  }
 });
 
 server.listen(9000);
 ```
+
+For a more complete example with routing, method checks, and error handling, see `./references/http-functions.md`.
 
 `cloudfunctions/hello-http/scf_bootstrap`
 
@@ -170,6 +225,8 @@ server.listen(9000);
 #!/bin/bash
 /var/lang/node18/bin/node index.js
 ```
+
+The `scf_bootstrap` binary path must match the runtime — see the full mapping table in `./references/http-functions.md`.
 
 `cloudfunctions/hello-http/package.json`
 
@@ -191,9 +248,42 @@ server.listen(9000);
 
 ### Logs
 
-- `queryFunctions(action="listFunctionLogs")`
-- `queryFunctions(action="getFunctionLogDetail")`
-- If these are unavailable, read `./references/operations-and-config.md` before any `callCloudApi` fallback
+**Query function logs** — use the `queryFunctions` tool:
+
+- `queryFunctions(action="listFunctionLogs", functionName="xxx")` — list execution logs of a specific function
+- `queryFunctions(action="getFunctionLogDetail", requestId="xxx")` — fetch the detail of one log entry
+
+**`queryFunctions` vs `queryLogs`**:
+- `queryFunctions` queries execution logs of a single cloud function and requires `functionName`
+- `queryLogs` searches CLS (cross-service log aggregation) using CLS query syntax
+
+**Examples**:
+```javascript
+// List recent logs for cloud function "my-function"
+queryFunctions(action="listFunctionLogs", functionName="my-function", limit=10)
+
+// Inspect the log detail for a specific request id
+queryFunctions(action="getFunctionLogDetail", requestId="abc-123")
+
+// Cross-service error search via CLS
+queryLogs(action="searchLogs", queryString='(src:app OR src:system) AND log:"ERROR"', service="tcb")
+```
+
+`queryLogs` `queryString` follows CLS syntax (see https://cloud.tencent.com/document/api/876/128127). The examples below are starting points; adapt them to the concrete log content of your query:
+- Function logs: `(src:app OR src:system) AND log:"START RequestId"`
+- Aggregated function request status: `| select request_id, max(status_code) as status where ((request_id='xxxx' AND retry_num=0) AND retry_num=0) AND status_code!=202 group by request_id, retry_num`
+- Document database (NoSQL): `module:database`
+- Document database slow-query events: `module:database AND eventType:(MongoSlowQuery)` — `MongoSlowQuery` is the document-database slow-query event
+- Relational database (MySQL): `module:rdb`
+- Relational database (MySQL) events: `module:rdb AND eventType:(MysqlFreeze OR MysqlRecover OR MysqlSlowQuery)` — `MysqlFreeze` = freeze, `MysqlRecover` = recover, `MysqlSlowQuery` = slow query
+- Workflow (approval flow): `module:workflow`
+- Data model: `module:model`
+- User permissions: `module:auth`
+- LLM trace logs: `module:llm AND logType:llm-tracelog`
+- Gateway access logs: `logType:accesslog`
+- App publish / delete events: `module:app AND eventType:(AppProdPub OR AppProdDel)` — `AppProdPub` = app publish, `AppProdDel` = app delete
+
+If these are unavailable, read `./references/operations-and-config.md` before any `callCloudApi` fallback
 
 ### Gateway exposure
 
@@ -208,3 +298,4 @@ When a user says they need browser/public access, do not assume creation already
 - `cloudrun-development` -> container services, long-lived runtimes, Agent hosting
 - `http-api` -> raw CloudBase HTTP API invocation patterns
 - `cloudbase-platform` -> general CloudBase platform decisions
+- `ops-inspector` -> AIOps-style inspection and log search across services

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -50,6 +50,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
+- Assuming an HTTP Function automatically gets a browser/public URL path, or assuming that path is always `/{functionName}`.
+- Writing gateway prefixes such as `/api/httpDemo` into the function router itself. Public gateway path and in-function route path are different layers.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
@@ -198,6 +200,8 @@ server.listen(9000);
 - `queryGateway(action="getAccess")`
 - `manageGateway(action="createAccess")`
 - If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+
+When a user says they need browser/public access, do not assume creation already exposed the function. HTTP Function runtime routes still live inside the function, while gateway access adds an external path prefix separately.
 
 ## Related skills
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -8,15 +8,20 @@ Use this checklist before creating or updating a CloudBase function.
    - Event Function: `exports.main(event, context)`, SDK/timer driven
    - HTTP Function: `req` / `res`, listens on port `9000`
 2. Pick the runtime before creation and state it explicitly.
-3. For HTTP Functions, confirm `scf_bootstrap` exists and the service listens on port `9000`.
+3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
 4. Confirm the function root path points to the parent directory, not the function directory itself.
-5. If the request is really for a long-running container service, reroute to `cloudrun-development`.
+5. If the task needs browser/public access, keep the gateway path and the in-function router path separate. For example, an external path like `/api/httpDemo/health` should normally map to an internal function route like `/health`.
+6. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
+7. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
 
 - Choosing the wrong function type and compensating later.
 - Mixing Event Function and HTTP Function handler shapes in the same implementation.
 - Forgetting that runtime cannot be changed after creation.
+- Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
+- Writing the public gateway prefix into the HTTP Function router instead of handling the internal route after the prefix is stripped.
+- Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Treating Cloud Functions as the default answer for Web authentication.
 
 ## Done criteria

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -10,6 +10,7 @@ HTTP Functions are standard web services, not `exports.main(event, context)` han
 - Listen on port `9000`.
 - Ship an executable `scf_bootstrap` file.
 - Include runtime dependencies in the package; HTTP Functions do not auto-install `node_modules` for you.
+- For simple HTTP APIs, prefer the Node.js native `http` module so the function shape stays explicit and dependency-light. Only introduce Express, Koa, NestJS, or similar frameworks when the user explicitly asks for one or the service complexity justifies it.
 
 ## Minimal structure
 
@@ -25,7 +26,7 @@ my-http-function/
 
 ```bash
 #!/bin/bash
-node index.js
+/var/lang/node18/bin/node index.js
 ```
 
 Requirements:
@@ -34,56 +35,193 @@ Requirements:
 - Use LF line endings.
 - Make it executable with `chmod +x scf_bootstrap`.
 
+The `scf_bootstrap` Node.js binary path must match the function runtime. Use this mapping:
+
+| Runtime value | `scf_bootstrap` binary path |
+| --- | --- |
+| `Nodejs20.19` | `/var/lang/node20/bin/node` |
+| `Nodejs18.15` | `/var/lang/node18/bin/node` |
+| `Nodejs16.13` | `/var/lang/node16/bin/node` |
+
+If the user specifies "Node.js 18", use runtime `Nodejs18.15` and the path `/var/lang/node18/bin/node`.
+
 ## Minimal Node.js example
 
 ```javascript
-const express = require("express");
-const app = express();
+const http = require("http");
+const { URL } = require("url");
 
-app.use(express.json());
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
 
-app.get("/health", (req, res) => {
-  res.json({ ok: true });
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+
+    req.on("end", () => {
+      if (!raw) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/echo") {
+    try {
+      const body = await readJsonBody(req);
+      sendJson(res, 200, { received: body });
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+    }
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
 });
 
-app.listen(9000);
+server.listen(9000);
 ```
+
+## Code-writing rules
+
+- Do not write HTTP Functions as `exports.main = async (event, context) => {}`. That is the Event Function contract.
+- Start an HTTP server explicitly with `http.createServer(...)` or a framework app, and always bind to port `9000`.
+- Choose one Node.js module system and keep it consistent. For simple HTTP Functions, CommonJS is the safest default: use `require(...)` and leave `"type": "module"` out of `package.json`.
+- If you intentionally use ES Modules, use `import ...` consistently and do not rely on CommonJS-only globals such as bare `__dirname`, `require(...)`, or `module.exports`. When you need the current file path in ESM, derive it from `import.meta.url`.
+- Treat routing, method checks, and body parsing as part of the function code. With the native `http` module, parse `req.url` yourself and read the request body from the stream before calling `JSON.parse`.
+- Return JSON responses explicitly and set `Content-Type` yourself, for example `application/json; charset=utf-8`.
+- Keep unsupported routes and methods explicit. Return `404` for unknown paths, and return `405` when the path exists but the HTTP method is not allowed.
+- Keep the public gateway path and the in-function router path as separate layers. If the public path is `/api/httpDemo`, the function should still normally handle internal routes like `/` and `/health`.
+- Keep `scf_bootstrap`, `index.js`, `package.json`, and any bundled dependencies in the function directory that will be uploaded.
+
+### Module system note
+
+The minimal examples in this document use CommonJS:
+
+- `const http = require("http")`
+- no `"type": "module"` in `package.json`
+
+That combination avoids the common ESM pitfall where `__dirname` is not defined. If you switch to ES Modules, switch the whole function to `import` syntax and update any file-path logic accordingly.
 
 ## Request handling rules
 
-- `req.query` -> query string values.
-- `req.body` -> parsed request body, but only after body-parsing middleware is configured.
+- With Node native `http`, use `new URL(req.url, "http://127.0.0.1")` and read `url.searchParams` for query values.
+- With Node native `http`, `req.body` does not exist. Read the body stream manually, then parse JSON yourself.
 - `req.headers` -> incoming HTTP headers.
-- `req.params` -> path parameters.
-- Always send a response with `res.json()`, `res.send()`, or `res.status(...).json()`.
+- Path parameters are framework-level conveniences. With the native `http` module, match `url.pathname` yourself.
+- Always send a response explicitly. With Node native `http`, use `res.writeHead(...)` and `res.end(...)`.
 - Return meaningful status codes such as `400`, `401`, `404`, `405`, `500`.
 
 ### Example with method checks
 
 ```javascript
-const express = require("express");
-const app = express();
+const http = require("http");
+const { URL } = require("url");
 
-app.use(express.json());
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
 
-app.post("/users", (req, res) => {
-  const { name, email } = req.body;
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
 
-  if (!name || !email) {
-    return res.status(400).json({ error: "name and email are required" });
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+
+    req.on("end", () => {
+      if (!raw) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (url.pathname === "/users" && req.method === "POST") {
+    try {
+      const { name, email } = await readJsonBody(req);
+
+      if (!name || !email) {
+        sendJson(res, 400, { error: "name and email are required" });
+        return;
+      }
+
+      sendJson(res, 201, { name, email });
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+    }
+
+    return;
   }
 
-  return res.status(201).json({ name, email });
+  if (url.pathname === "/users") {
+    sendJson(res, 405, { error: "Method Not Allowed" });
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
 });
 
+server.listen(9000);
+```
+
+### Express 5 catch-all note
+
+If the user explicitly asks for Express, keep in mind that Express 5 uses `path-to-regexp` semantics for wildcards. Do not use bare `*` or `/*` as the catch-all route.
+
+```javascript
 app.all("/{*splat}", (req, res) => {
   res.status(405).json({ error: "Method Not Allowed" });
 });
-
-app.listen(9000);
 ```
 
-Express 5 note: do not use bare `*` or `/*` here. Express 5 uses `path-to-regexp` with named wildcards, so `app.all("/{*splat}", ...)` is the safe catch-all form when you also need to match the root path `/`.
+Express 5 note: `app.all("/{*splat}", (req, res) => {` is the safe catch-all form when you also need to match the root path `/`, because the router is based on `path-to-regexp` rather than the older Express 4 wildcard behavior.
+
+## End-to-end deployment lifecycle
+
+Follow these steps in order when creating an HTTP Function:
+
+1. **Write the function code** — create the directory with `index.js`, `scf_bootstrap`, and `package.json`.
+2. **Deploy with `manageFunctions`** — set `type: "HTTP"`, `protocolType: "HTTP"`, and `runtime` explicitly.
+3. **Configure security rules** — HTTP Functions default to a restrictive security rule. If the function should be publicly accessible (anonymous access), call `managePermissions(action="updateResourcePermission")` with `resourceType="function"`.
+4. **Verify** — call the function URL and confirm it returns the expected response. If you get `EXCEED_AUTHORITY`, the security rule needs to be updated (step 3). If you get a 404 on an exposed browser/public path, verify the gateway prefix and the internal function route separately.
 
 ## Deployment flow
 
@@ -96,11 +234,43 @@ manageFunctions({
     name: "myHttpFunction",
     type: "HTTP",
     protocolType: "HTTP",
+    runtime: "Nodejs18.15",
     timeout: 60
   },
   functionRootPath: "/absolute/path/to/cloudfunctions"
 });
 ```
+
+**Important parameters:**
+
+- `type: "HTTP"` — marks the function as an HTTP Function (not an Event Function).
+- `protocolType: "HTTP"` — the wire protocol. Use `"WS"` for WebSocket.
+- `runtime` — the execution runtime. Must match the `scf_bootstrap` binary path. Default is `"Nodejs18.15"` if omitted, but always set it explicitly to avoid ambiguity.
+- `functionRootPath` — the parent directory of the function folder (e.g. `/path/to/cloudfunctions` if the code lives in `/path/to/cloudfunctions/myHttpFunction/`).
+
+### Security rule configuration
+
+After creating an HTTP Function, it will reject anonymous callers with `EXCEED_AUTHORITY` by default. If the function should be publicly accessible:
+
+```javascript
+managePermissions({
+  action: "updateResourcePermission",
+  resourceType: "function",
+  resourceId: "myHttpFunction",
+  permission: {
+    aclTag: "CUSTOM",
+    rule: "true"
+  }
+});
+```
+
+- `aclTag: "CUSTOM"` with `rule: "true"` allows all callers (anonymous access).
+- Do NOT use `readSecurityRule` / `writeSecurityRule` — those are removed. Use `queryPermissions` / `managePermissions` instead.
+- Security rule semantics for `resourceType="function"` differ from NoSQL database rules. Do not reuse `doc._openid` or `auth.openid` expressions from NoSQL security rules.
+- Official reference: `https://docs.cloudbase.net/cloud-function/security-rules`
+
+If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function", resourceId="myHttpFunction")` before widening access.
+If an external caller reports a 404 on a browser/public path, inspect the gateway path mapping before changing the HTTP Function router.
 
 ### WebSocket
 
@@ -169,9 +339,7 @@ If the external caller reports a 404, verify these two layers separately:
 Before enabling anonymous access, confirm both of these:
 
 1. The access path exists.
-2. The function security rule allows the intended caller identity.
-
-If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function")` before widening access.
+2. The function security rule allows the intended caller identity (see Security rule configuration above).
 
 ## SSE and WebSocket notes
 

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -143,6 +143,29 @@ manageGateway({
 });
 ```
 
+### Path mapping model
+
+Keep the public gateway path and the in-function router path as two different layers.
+
+- `manageGateway(..., path: "/api/hello")` creates the **external** access prefix.
+- Your HTTP Function still matches its own internal routes such as `/`, `/health`, `/users`.
+- Do **not** rewrite the function router to include the gateway prefix.
+
+Example mapping:
+
+| External URL | Route your HTTP Function should handle |
+| --- | --- |
+| `https://{domain}/api/hello` | `/` |
+| `https://{domain}/api/hello/health` | `/health` |
+| `https://{domain}/api/hello/users` | `/users` |
+
+For example, if you expose `path: "/api/httpDemo"`, the function code should normally keep handlers like `app.get("/")` and `app.get("/health")`. Do not change them to `app.get("/api/httpDemo")` or `app.get("/api/httpDemo/health")`.
+
+If the external caller reports a 404, verify these two layers separately:
+
+1. Use `queryGateway(action="getAccess")` to confirm which public path is actually exposed.
+2. Check the HTTP Function router to confirm it handles the internal path after the gateway prefix.
+
 Before enabling anonymous access, confirm both of these:
 
 1. The access path exists.

--- a/scripts/skills-repo-template/cloudbase-guidelines/SKILL.md
+++ b/scripts/skills-repo-template/cloudbase-guidelines/SKILL.md
@@ -27,6 +27,11 @@ If a skill points to its own `references/...` files, keep following those relati
 - Use MCP or mcporter first for CloudBase management tasks, and inspect tool schemas before execution.
 - If the task includes UI, read `ui-design` first and output the design specification before interface code.
 - If the task includes login, registration, or auth configuration, read `auth-tool` first and enable required providers before frontend implementation.
+- For HTTP Functions, keep the public gateway path and the in-function router path as separate layers. Do not write gateway prefixes such as `/api/httpDemo` into the function router itself.
+- Creating an HTTP Function does not guarantee a browser/public URL exists. If the task needs external access, create gateway access only when required and confirm the actual exposed path with `queryGateway(action="getAccess")` instead of assuming it is `/{functionName}`.
+- If the task explicitly says no HTTP access service is needed, do not create gateway access just to mirror the function name. Keep direct function invocation and gateway routing as separate delivery choices.
+- When a gateway path is created later, keep the path mapping separate: a public prefix such as `/api/httpDemo` should still map to in-function routes like `/`, `/health`, and `/users` instead of rewriting handlers to `/api/httpDemo/...`.
+- If an external HTTP invocation may be anonymous, or the caller reports `EXCEED_AUTHORITY`, inspect the function permission rule first and only widen access when the product requirement really needs anonymous callers.
 
 ### High-priority routing
 

--- a/tests/build-allinone-skill.test.js
+++ b/tests/build-allinone-skill.test.js
@@ -92,6 +92,8 @@ test.skipIf(!hasNode24ViaNvm())(
     expect(mainSkill).toContain('references/auth-web/SKILL.md');
     expect(mainSkill).toContain('## Activation Contract');
     expect(mainSkill).toContain('Provider status and publishable key');
+    expect(mainSkill).toContain('do not create gateway access just to mirror the function name');
+    expect(mainSkill).toContain('should still map to in-function routes like `/`, `/health`, and `/users`');
   },
 );
 

--- a/tests/build-skills-repo.test.js
+++ b/tests/build-skills-repo.test.js
@@ -31,4 +31,11 @@ test('build-skills-repo publishes skills and guideline from minimal sources', ()
   const readme = fs.readFileSync(path.join(OUTPUT_DIR, 'README.md'), 'utf8');
   expect(readme).toContain('cloudbase-guidelines');
   expect(readme).toContain('auth-web');
+
+  const guideline = fs.readFileSync(
+    path.join(OUTPUT_DIR, 'skills', 'cloudbase-guidelines', 'SKILL.md'),
+    'utf8',
+  );
+  expect(guideline).toContain('do not create gateway access just to mirror the function name');
+  expect(guideline).toContain('should still map to in-function routes like `/`, `/health`, and `/users`');
 });


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo1hkx69_frhv2z
- category: skill
- canonicalTitle: HTTP 云函数 Skill 缺少路径映射和网关路径处理的关键说明
- representativeRun: atomic-js-cloudbase-http-function-deploy/2026-04-16T12-55-40-01e14c

## Automation summary
- root_cause: The main `cloud-functions` skill did not surface a key HTTP-function guardrail that already existed deeper in the references and MCP tool messaging: creating an HTTP function does not automatically create a browser/public gateway path, `/{functionName}` is not guaranteed, and gateway path prefixes are separate from the in-function router. In all-in-one usage, agents can stop at the top-level skill and miss that distinction, which is a real product-facing documentation defect.
- changes: Updated `config/source/skills/cloud-functions/SKILL.md` with two explicit HTTP-function gotchas and one gateway-exposure note. The skill now warns against assuming automatic public path mapping, warns against baking gateway prefixes like `/api/httpDemo` into the function router, and states that browser/public access requires separate gateway configuration layered on top of the HTTP function’s own routes.
- validation: Re-read the existing HTTP-function reference to confirm the new top-level guidance matches the established contract for gateway access and anonymous-access handling, then ran `git diff --check` to verify the edit is clean. No broader automated test run was necessary becau

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`