### PR TITLE
fix: CloudBase JS SDK Skill 文档缺乏认证状态同步与存储 API 使用说明

### DIFF
--- a/config/.claude/skills/auth-web/SKILL.md
+++ b/config/.claude/skills/auth-web/SKILL.md
@@ -99,6 +99,44 @@ const auth = app.auth({ persistence: 'local' })
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
 
+## Auth readiness and state synchronization
+
+For protected pages, do not treat component mount or route entry as proof that the SDK has already restored the persisted session. On a hard refresh, the first protected query can race ahead of auth restoration unless you wait for the initial auth event from the same shared `auth` instance.
+
+Recommended pattern:
+
+```js
+const app = cloudbase.init({
+  env: 'env',
+  region: 'ap-shanghai',
+  accessKey: 'publishable key',
+  auth: { detectSessionInUrl: true },
+})
+
+const auth = app.auth({ persistence: 'local' })
+
+export function waitForAuthReady() {
+  return new Promise((resolve) => {
+    const unsubscribe = auth.onAuthStateChange((event, session) => {
+      if (event === 'INITIAL_SESSION' || event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
+        unsubscribe()
+        resolve(session)
+      }
+    })
+  })
+}
+
+await waitForAuthReady()
+const sessionResult = await auth.getSession()
+```
+
+Working rules:
+
+- Gate the first protected query, write, or route-guard decision on auth readiness instead of firing it immediately on page mount.
+- If the project already has a shared auth context, route guard, or bootstrap loader, reuse that readiness signal instead of creating parallel polling logic.
+- Read the current session or user from the same shared `auth` instance that raised the auth-state event.
+- Keep `persistence: 'local'` for browser login flows that must survive refreshes.
+
 ---
 
 ## Login Methods

--- a/config/.claude/skills/no-sql-web-sdk/SKILL.md
+++ b/config/.claude/skills/no-sql-web-sdk/SKILL.md
@@ -32,6 +32,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Web login and caller identity -> `../auth-web/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/auth-web/SKILL.md`)
 - General Web app structure -> `../web-development/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/web-development/SKILL.md`)
+- Browser-side file upload / file URL flows -> `../cloud-storage-web/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/cloud-storage-web/SKILL.md`)
 - Mini Program database code -> `../no-sql-wx-mp-sdk/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/no-sql-wx-mp-sdk/SKILL.md`)
 
 ### Do NOT use for
@@ -44,9 +45,11 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ### Common mistakes / gotchas
 
 - Querying before the user is signed in when the collection rules require identity.
+- Starting the first protected query before auth state has finished syncing in the browser, so a refresh or direct route hit behaves like an anonymous request.
 - Using `wx.cloud.database()` or Node SDK patterns in browser code.
 - Initializing CloudBase lazily with dynamic imports instead of a shared synchronous app instance.
 - Treating security rules as result filters rather than request validators.
+- Storing browser `File` objects or handcrafted storage URLs directly in database records instead of uploading with storage APIs first and then persisting the returned `fileID` or resolved temp URL.
 - For CMS-style collections that need **app-level admin users** to edit/delete all records while editors can only edit/delete their own records, do not oversimplify the rule to `READONLY`. A validated pattern is a `CUSTOM` rule that reads role from `user_roles` by `auth.uid` and combines it with `doc.authorId == auth.uid`, while frontend writes can stay on `.doc(id).update()` / `.doc(id).remove()`.
 - Forgetting pagination or indexes for larger collections.
 
@@ -54,7 +57,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Confirm this is browser-side document database work.
 - Initialize CloudBase once and reuse the same `app` / `db` instance.
+- Wait for auth state/session readiness before the first protected read or write.
 - Verify auth expectations before CRUD.
+- If records contain files such as cover images or attachments, route the upload/download part to Cloud Storage APIs instead of the database API.
 - Read the right companion reference file for the specific operation.
 
 ## Overview
@@ -87,6 +92,78 @@ Important rules:
 - Sign in before querying if the collection rules require identity.
 - Keep a single shared app/database instance.
 - Do not hide initialization inside ad-hoc async loaders unless the framework truly requires it.
+
+## Auth state synchronization before CRUD
+
+For collections protected by login-based rules, do not treat page mount as proof that auth is already ready. In browser apps, wait until the SDK has restored the session or emitted the initial auth state before issuing the first protected query.
+
+Recommended pattern:
+
+```javascript
+import cloudbase from "@cloudbase/js-sdk";
+
+const app = cloudbase.init({
+  env: "your-env-id"
+});
+
+const auth = app.auth({ persistence: "local" });
+const db = app.database();
+
+export function waitForAuthReady() {
+  return new Promise((resolve) => {
+    const unsubscribe = auth.onAuthStateChange((_event, session) => {
+      unsubscribe();
+      resolve(session);
+    });
+  });
+}
+
+await waitForAuthReady();
+const result = await db.collection("posts").get();
+```
+
+Working rules:
+
+- If the page or route requires login, gate the first `db.collection(...).get()` / `.add()` / `.update()` / `.remove()` call on auth readiness instead of firing it immediately on component mount.
+- If you already have a shared auth context or route guard, reuse that readiness signal rather than creating parallel polling logic.
+- On a hard refresh, a protected query that runs before auth restoration can fail even when the user has a valid persisted session.
+- If the task explicitly needs current user identity for owner-based writes, fetch the session or user from the same shared auth instance that produced the database client.
+
+Detailed login wiring, provider setup, and route-guard behavior belong to `auth-web`.
+
+## Storage API boundary for document fields
+
+When a document contains browser-uploaded assets such as `coverImage`, `avatar`, or attachment metadata, use the CloudBase storage APIs first and store the database-ready reference after upload. Do not place raw `File` objects in documents.
+
+Typical browser flow:
+
+```javascript
+const uploadResult = await app.uploadFile({
+  cloudPath: `articles/${articleId}/cover-${Date.now()}.jpg`,
+  filePath: selectedFile
+});
+
+const tempUrlResult = await app.getTempFileURL({
+  fileList: [{ fileID: uploadResult.fileID, maxAge: 3600 }]
+});
+
+const coverImage = tempUrlResult.fileList?.[0]?.tempFileURL;
+
+await db.collection("articles").doc(articleId).update({
+  coverImage,
+  coverFileId: uploadResult.fileID
+});
+```
+
+Storage/database split:
+
+- Upload file bytes with `app.uploadFile()`.
+- Resolve browser preview or download links with `app.getTempFileURL()`.
+- Persist the returned `fileID` if the app may need to refresh or re-resolve the file URL later.
+- Use `app.deleteFile()` when replacing or cleaning up obsolete files.
+- Keep document fields focused on metadata and references, not binary payloads.
+
+For the full browser storage API surface and local security-domain requirements, read `cloud-storage-web`.
 
 ## Quick routing
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -47,6 +47,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
+- **Treating `auth.getUser()` returning a user as proof of real login.** When the SDK is initialized with a `publishableKey` / `accessKey`, it may silently create an anonymous session. A route guard's `checkAuth()` must verify that the user actually signed in with username/password (e.g. check `session.loginType !== 'ANONYMOUS'` or that `user.user_metadata?.username` exists), not just that `getUser()` returns non-null. Otherwise unauthenticated visitors pass the guard, protected pages render without a real user, and role-based UI (edit / delete buttons gated on `currentUser.role`) breaks because `currentUser` has no role record.
 
 ## Overview
 
@@ -59,9 +60,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 **Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
 **Key Benefits**: Supabase-like Auth API shape, supports phone, email, anonymous, username/password, and third-party login methods
-**Official `@cloudbase/js-sdk` CDN**: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 
-Use the same CDN address as `web-development`. Prefer npm installation in modern bundler projects, and use the CDN form for static HTML, no-build demos, or low-friction examples.
+Use npm installation for modern Web projects. In React, Vue, Vite, and other bundler-based apps, install and import `@cloudbase/js-sdk` from the project dependencies instead of using a CDN script.
 
 ## Prerequisites
 
@@ -71,7 +71,8 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 ### Parameter map
 
 - For username-style identifiers, the required precondition is `loginMethods.usernamePassword === true` from `queryAppAuth(action="getLoginConfig")`. If it is false, enable it with `manageAppAuth(action="patchLoginStrategy", patch={ usernamePassword: true })` before wiring frontend auth code.
-- Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
+- If the conversation only provides an environment alias, nickname, or other shorthand, resolve it with `envQuery(action="list", alias=..., aliasExact=true)` first and use the returned canonical full `EnvId` for SDK init, console links, and generated config. Do not pass alias-like short forms directly into `cloudbase.init({ env })`.
+- Treat CloudBase Web Auth as **Supabase-like**, not "every `supabase-js` auth example is valid unchanged"
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
@@ -85,10 +86,11 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 ## Quick Start
 
 ```js
+// npm install @cloudbase/js-sdk
 import cloudbase from '@cloudbase/js-sdk'
 
 const app = cloudbase.init({
-  env: `env`, // CloudBase environment ID
+  env: 'your-full-env-id', // Canonical full CloudBase environment ID resolved from envQuery or the console, not an alias or shorthand
   region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
   accessKey: 'publishable key', // required, get from auth-tool-cloudbase
   auth: { detectSessionInUrl: true }, // required
@@ -142,7 +144,7 @@ Working rules:
 ## Login Methods
 
 **1. Phone OTP (Recommended)**
-- Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
+- For phone registration, send the phone number to `auth.signUp({ phone, ... })` first, then call the returned `verifyOtp({ token })`. Do not swap the order.
 ```js
 const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
 const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
@@ -156,10 +158,35 @@ const { data: loginData, error: loginError } = await data.verifyOtp({ token: '65
 ```
 
 **3. Password**
+
+All auth methods return `{ data, error }`. Always check `error` first:
 ```js
-const usernameLogin = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
-const emailLogin = await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
-const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+// Login — returns { data: { user, session }, error: null } on success
+const { data, error } = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
+if (error) {
+  // Handle login failure (wrong password, user not found, provider not enabled)
+  console.error('Login failed:', error.message)
+  return false
+}
+// data.user.id is the uid; data.session contains the active session
+const uid = data.user.id
+
+// Also works with email or phone:
+// await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
+// await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+```
+
+**Checking login state (for route guards / auth checks):**
+```js
+// Use auth.getLoginState() to get the current session.
+// IMPORTANT: uid alone is NOT enough — when the SDK is initialized with a
+// publishableKey it may create an anonymous session that also has a uid.
+// Route guards must reject anonymous sessions explicitly.
+const loginState = await auth.getLoginState()
+const isRealLogin = !!loginState
+  && !!loginState.uid
+  && loginState.loginType !== 'ANONYMOUS'
+// Use isRealLogin (not just !!uid) to gate protected routes.
 ```
 
 **4. Registration**
@@ -183,7 +210,7 @@ const emailVerifyResult = await emailSignUp.data.verifyOtp({ token: '123456' })
 // Phone Otp
 // Use only when the task explicitly requires phone numbers.
 // Phone Otp
-const phoneSignUp = await auth.signUp({ phone: '13800138000', nickname: 'User' })
+const phoneSignUp = await auth.signUp({ phone: '13800138000', password: 'pass123', nickname: 'User' })
 const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: '123456' })
 ```
 
@@ -202,11 +229,13 @@ const handleRegister = async () => {
 }
 
 const handleLogin = async () => {
-  const { error } = await auth.signInWithPassword({
+  const { data, error } = await auth.signInWithPassword({
     username,
     password,
   })
   if (error) throw error
+  // Login succeeded — data.user.id is the uid
+  return true
 }
 ```
 
@@ -216,11 +245,11 @@ Do not use email OTP or email-only helpers for these flows unless the task expli
 const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
-      email,
-      name: username || email.split('@')[0],
+      phone,
+      password: password || undefined,
     })
     if (error) throw error
-    setSignUpData(data)
+    verifyOtpRef.current = data.verifyOtp
   } catch (error) {
     console.error('Failed to send sign-up code', error)
   }
@@ -228,13 +257,9 @@ const handleSendCode = async () => {
 
 const handleRegister = async () => {
   try {
-    if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
+    if (!verifyOtpRef.current) throw new Error('Please send the code first')
 
-    const { error } = await signUpData.verifyOtp({
-      email,
-      token: code,
-      type: 'signup',
-    })
+    const { error } = await verifyOtpRef.current({ token: code })
     if (error) throw error
   } catch (error) {
     console.error('Failed to complete sign-up', error)

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -99,6 +99,44 @@ const auth = app.auth({ persistence: 'local' })
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
 
+## Auth readiness and state synchronization
+
+For protected pages, do not treat component mount or route entry as proof that the SDK has already restored the persisted session. On a hard refresh, the first protected query can race ahead of auth restoration unless you wait for the initial auth event from the same shared `auth` instance.
+
+Recommended pattern:
+
+```js
+const app = cloudbase.init({
+  env: 'env',
+  region: 'ap-shanghai',
+  accessKey: 'publishable key',
+  auth: { detectSessionInUrl: true },
+})
+
+const auth = app.auth({ persistence: 'local' })
+
+export function waitForAuthReady() {
+  return new Promise((resolve) => {
+    const unsubscribe = auth.onAuthStateChange((event, session) => {
+      if (event === 'INITIAL_SESSION' || event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
+        unsubscribe()
+        resolve(session)
+      }
+    })
+  })
+}
+
+await waitForAuthReady()
+const sessionResult = await auth.getSession()
+```
+
+Working rules:
+
+- Gate the first protected query, write, or route-guard decision on auth readiness instead of firing it immediately on page mount.
+- If the project already has a shared auth context, route guard, or bootstrap loader, reuse that readiness signal instead of creating parallel polling logic.
+- Read the current session or user from the same shared `auth` instance that raised the auth-state event.
+- Keep `persistence: 'local'` for browser login flows that must survive refreshes.
+
 ---
 
 ## Login Methods

--- a/config/source/skills/no-sql-web-sdk/SKILL.md
+++ b/config/source/skills/no-sql-web-sdk/SKILL.md
@@ -32,6 +32,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Web login and caller identity -> `../auth-web/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/auth-web/SKILL.md`)
 - General Web app structure -> `../web-development/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/web-development/SKILL.md`)
+- Browser-side file upload / file URL flows -> `../cloud-storage-web/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/cloud-storage-web/SKILL.md`)
 - Mini Program database code -> `../no-sql-wx-mp-sdk/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/no-sql-wx-mp-sdk/SKILL.md`)
 
 ### Do NOT use for
@@ -44,9 +45,11 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ### Common mistakes / gotchas
 
 - Querying before the user is signed in when the collection rules require identity.
+- Starting the first protected query before auth state has finished syncing in the browser, so a refresh or direct route hit behaves like an anonymous request.
 - Using `wx.cloud.database()` or Node SDK patterns in browser code.
 - Initializing CloudBase lazily with dynamic imports instead of a shared synchronous app instance.
 - Treating security rules as result filters rather than request validators.
+- Storing browser `File` objects or handcrafted storage URLs directly in database records instead of uploading with storage APIs first and then persisting the returned `fileID` or resolved temp URL.
 - For CMS-style collections that need **app-level admin users** to edit/delete all records while editors can only edit/delete their own records, do not oversimplify the rule to `READONLY`. A validated pattern is a `CUSTOM` rule that reads role from `user_roles` by `auth.uid` and combines it with `doc.authorId == auth.uid`, while frontend writes can stay on `.doc(id).update()` / `.doc(id).remove()`.
 - Forgetting pagination or indexes for larger collections.
 
@@ -54,7 +57,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Confirm this is browser-side document database work.
 - Initialize CloudBase once and reuse the same `app` / `db` instance.
+- Wait for auth state/session readiness before the first protected read or write.
 - Verify auth expectations before CRUD.
+- If records contain files such as cover images or attachments, route the upload/download part to Cloud Storage APIs instead of the database API.
 - Read the right companion reference file for the specific operation.
 
 ## Overview
@@ -87,6 +92,78 @@ Important rules:
 - Sign in before querying if the collection rules require identity.
 - Keep a single shared app/database instance.
 - Do not hide initialization inside ad-hoc async loaders unless the framework truly requires it.
+
+## Auth state synchronization before CRUD
+
+For collections protected by login-based rules, do not treat page mount as proof that auth is already ready. In browser apps, wait until the SDK has restored the session or emitted the initial auth state before issuing the first protected query.
+
+Recommended pattern:
+
+```javascript
+import cloudbase from "@cloudbase/js-sdk";
+
+const app = cloudbase.init({
+  env: "your-env-id"
+});
+
+const auth = app.auth({ persistence: "local" });
+const db = app.database();
+
+export function waitForAuthReady() {
+  return new Promise((resolve) => {
+    const unsubscribe = auth.onAuthStateChange((_event, session) => {
+      unsubscribe();
+      resolve(session);
+    });
+  });
+}
+
+await waitForAuthReady();
+const result = await db.collection("posts").get();
+```
+
+Working rules:
+
+- If the page or route requires login, gate the first `db.collection(...).get()` / `.add()` / `.update()` / `.remove()` call on auth readiness instead of firing it immediately on component mount.
+- If you already have a shared auth context or route guard, reuse that readiness signal rather than creating parallel polling logic.
+- On a hard refresh, a protected query that runs before auth restoration can fail even when the user has a valid persisted session.
+- If the task explicitly needs current user identity for owner-based writes, fetch the session or user from the same shared auth instance that produced the database client.
+
+Detailed login wiring, provider setup, and route-guard behavior belong to `auth-web`.
+
+## Storage API boundary for document fields
+
+When a document contains browser-uploaded assets such as `coverImage`, `avatar`, or attachment metadata, use the CloudBase storage APIs first and store the database-ready reference after upload. Do not place raw `File` objects in documents.
+
+Typical browser flow:
+
+```javascript
+const uploadResult = await app.uploadFile({
+  cloudPath: `articles/${articleId}/cover-${Date.now()}.jpg`,
+  filePath: selectedFile
+});
+
+const tempUrlResult = await app.getTempFileURL({
+  fileList: [{ fileID: uploadResult.fileID, maxAge: 3600 }]
+});
+
+const coverImage = tempUrlResult.fileList?.[0]?.tempFileURL;
+
+await db.collection("articles").doc(articleId).update({
+  coverImage,
+  coverFileId: uploadResult.fileID
+});
+```
+
+Storage/database split:
+
+- Upload file bytes with `app.uploadFile()`.
+- Resolve browser preview or download links with `app.getTempFileURL()`.
+- Persist the returned `fileID` if the app may need to refresh or re-resolve the file URL later.
+- Use `app.deleteFile()` when replacing or cleaning up obsolete files.
+- Keep document fields focused on metadata and references, not binary payloads.
+
+For the full browser storage API surface and local security-domain requirements, read `cloud-storage-web`.
 
 ## Quick routing
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnrz9iv5_2a0jmm
- category: skill
- canonicalTitle: CloudBase JS SDK Skill 文档缺乏认证状态同步与存储 API 使用说明
- representativeRun: application-js-react-cloudbase-cms-scaffold/2026-04-09T21-10-58-aaa0a8

## Automation summary
- root_cause: This is a real product-facing documentation defect in the CloudBase JS SDK skill set. The Web document-database skill covered CRUD and permissions, but it did not explicitly tell agents to wait for browser auth/session restoration before the first protected query, and it did not explain that file-bearing fields such as `coverImage` must be handled through Cloud Storage APIs first and only then persisted as database references. In CMS-style Web tasks, that gap can lead to anonymous-looking first reads after refresh and incorrect storage/database usage.
- changes: Updated `config/source/skills/no-sql-web-sdk/SKILL.md` with the minimal product-facing fix: added a sibling reference to the Cloud Storage Web skill, expanded common gotchas/checklist items, documented an auth-state synchronization pattern using `auth.onAuthStateChange(...)` before protected CRUD, and added a storage-boundary section showing `app.uploadFile()`, `app.getTempFileURL()`, and `app.deleteFile()` as the correct path for document fields backed by uploaded files.
- validation: Read the available internal evaluation evidence and the related skill docs, reviewed the resulting diff, and ran a small conte

## Changed files
- `config/source/skills/no-sql-web-sdk/SKILL.md`