### PR TITLE
fix: MCP 工具：MySQL 开通 READY 后 SQL 操作仍超时 - 缺乏数据库就绪检测

### DIFF
--- a/config/source/skills/relational-database-tool/SKILL.md
+++ b/config/source/skills/relational-database-tool/SKILL.md
@@ -37,6 +37,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 - Initializing SDKs in an MCP management flow.
 - Running write SQL or DDL before checking whether MySQL is provisioned and ready.
+- Calling `runStatement` immediately after `describeCreateResult` returns `READY` without understanding that the data plane may still be warming up — use `initializeSchema` instead, which blocks until the database is actually accepting queries.
+- Manually retrying SQL when receiving `MYSQL_NOT_READY` — the tools automatically poll and wait for the data plane; just call the tool again after a short pause.
 - Treating document database tasks as MySQL management tasks.
 - Skipping `_openid` and permissions review after creating new SQL tables.
 - Destroying MySQL without explicit confirmation or without checking whether the environment still needs the instance.
@@ -121,6 +123,8 @@ Before calling this tool, **confirm**:
 - The target tables and conditions are correct.
 - You have run a corresponding read-only query when appropriate.
 
+**Data-plane warm-up:** After `describeCreateResult` returns `READY`, the SQL endpoint may need a few more seconds before it accepts queries. Both `runStatement` and `initializeSchema` automatically handle this warm-up gap by polling `SELECT 1` internally. If you encounter `MYSQL_NOT_READY`, wait a few seconds and retry — do not loop aggressively.
+
 When destroying MySQL, confirm:
 
 - The current environment really should lose the SQL instance.
@@ -154,15 +158,20 @@ When destroying MySQL, confirm:
 
 ## Recommended lifecycle flow
 
-### Scenario 1: MySQL is not provisioned yet
+### Scenario 1: MySQL is not provisioned yet ("from none to usable" flow)
 
-1. Call `querySqlDatabase(action="getInstanceInfo")`.
+This is the most common end-to-end flow. Follow every step in order — skipping the polling loop causes SQL timeouts.
+
+1. Call `querySqlDatabase(action="getInstanceInfo")` to check if MySQL already exists.
 2. If no instance exists, call `manageSqlDatabase(action="provisionMySQL", confirm=true)`.
-3. Poll provisioning status with:
-   - `querySqlDatabase(action="describeCreateResult")`
-   - `querySqlDatabase(action="describeTaskStatus")`
-4. Only continue when the returned lifecycle status is `READY`.
-5. For MySQL provisioning, prefer `describeCreateResult`; reserve `describeTaskStatus` for destroy flows whose task response carries `TaskName`.
+3. **Poll `querySqlDatabase(action="describeCreateResult")` in a loop** until the returned `status` is `READY`.
+   - Do **not** proceed to SQL execution after a single `describeCreateResult` call that returns `PENDING` or `RUNNING`.
+   - Prefer `describeCreateResult` for provisioning checks; reserve `describeTaskStatus` for destroy flows.
+4. Once `status` is `READY`, the **control plane** reports the instance is ready, but the **data plane** (SQL endpoint) may still be warming up for a short period.
+5. **Prefer `initializeSchema` over `runStatement`** for post-provisioning DDL — `initializeSchema` automatically waits for the data plane to become available before executing statements.
+   - Call `manageSqlDatabase(action="initializeSchema", statements=[...])` with your ordered DDL.
+   - If you must use `runStatement` instead, the tool will automatically retry with a short warm-up wait on transient errors; do **not** manually retry in a tight loop.
+6. If `runStatement` or `runQuery` returns `MYSQL_NOT_READY`, the tool has already exhausted its internal polling. Wait briefly (a few seconds) and try the same call once more — the data plane should be available by then.
 
 ### Scenario 2: Safely inspect data in a table
 
@@ -172,9 +181,9 @@ When destroying MySQL, confirm:
 
 ### Scenario 3: Apply schema initialization after provisioning
 
-1. Confirm MySQL is ready.
-2. Prepare ordered DDL statements.
-3. Run them through `manageSqlDatabase(action="initializeSchema")`.
+1. Confirm MySQL control-plane status is `READY` (via `describeCreateResult` or `getInstanceInfo`).
+2. Prepare ordered DDL statements (each `CREATE TABLE` must include `_openid VARCHAR(64) DEFAULT '' NOT NULL`).
+3. Run them through `manageSqlDatabase(action="initializeSchema", statements=[...])` — this action **blocks until the data plane is confirmed ready** before executing DDL, so it is safe to call immediately after provisioning.
 4. After creating tables, verify permissions with `queryPermissions` or `managePermissions`.
 
 ### Scenario 4: Execute a targeted write or DDL change

--- a/mcp/src/tools/databaseSQL.test.ts
+++ b/mcp/src/tools/databaseSQL.test.ts
@@ -220,6 +220,126 @@ describe("SQL database tools", () => {
     });
   });
 
+  it("querySqlDatabase(runQuery) waits for SQL endpoint after control plane reports ready", async () => {
+    let runSqlAttempt = 0;
+    mockCommonServiceCall.mockImplementation(async ({ Action, Param }: { Action: string; Param: any }) => {
+      if (Action === "RunSql") {
+        runSqlAttempt += 1;
+        if (runSqlAttempt === 1) {
+          throw Object.assign(new Error("connect ETIMEDOUT"), {
+            code: "ETIMEDOUT",
+          });
+        }
+
+        return {
+          RequestId: `req-run-${runSqlAttempt}`,
+          RowsAffected: 0,
+          Items: ['{"ready":true}'],
+          Infos: ['{"Field":"ready"}'],
+        };
+      }
+
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+          Data: {
+            Status: "success",
+          },
+        };
+      }
+
+      if (Action === "DescribeMySQLClusterDetail") {
+        return {
+          RequestId: "req-cluster",
+          Data: {
+            DbInfo: {
+              ClusterStatus: "running",
+            },
+          },
+        };
+      }
+
+      throw new Error(`unexpected action: ${Action}`);
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.querySqlDatabase.handler({
+      action: "runQuery",
+      sql: "SELECT * FROM demo",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        rows: [{ ready: true }],
+      },
+    });
+    expect(runSqlAttempt).toBe(3);
+  });
+
+  it("manageSqlDatabase(runStatement) returns MYSQL_NOT_READY when SQL endpoint never warms up", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "RunSql") {
+        throw Object.assign(new Error("connect ETIMEDOUT"), {
+          code: "ETIMEDOUT",
+        });
+      }
+
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+          Data: {
+            Status: "success",
+          },
+        };
+      }
+
+      if (Action === "DescribeMySQLClusterDetail") {
+        return {
+          RequestId: "req-cluster",
+          Data: {
+            DbInfo: {
+              ClusterStatus: "running",
+            },
+          },
+        };
+      }
+
+      throw new Error(`unexpected action: ${Action}`);
+    });
+
+    const originalNow = Date.now;
+    let now = 0;
+    const dateNowSpy = vi.spyOn(Date, "now").mockImplementation(() => now);
+    const setTimeoutSpy = vi
+      .spyOn(globalThis, "setTimeout")
+      .mockImplementation(((fn: (...args: any[]) => void, ms?: number, ...args: any[]) => {
+        now += typeof ms === "number" ? ms : 0;
+        fn(...args);
+        return 0 as any;
+      }) as typeof setTimeout);
+
+    const { tools } = createMockServer();
+    const result = await tools.manageSqlDatabase.handler({
+      action: "runStatement",
+      sql: "CREATE TABLE demo(id INT)",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: false,
+      errorCode: "MYSQL_NOT_READY",
+      data: {
+        probeSql: "SELECT 1",
+      },
+    });
+
+    setTimeoutSpy.mockRestore();
+    dateNowSpy.mockRestore();
+    Date.now = originalNow;
+  });
+
   it("querySqlDatabase(describeTaskStatus) maps success to READY", async () => {
     mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
       if (Action === "DescribeMySQLTaskStatus") {

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -14,6 +14,9 @@ const MANAGE_SQL_DATABASE = "manageSqlDatabase";
 const QUERY_PERMISSIONS = "queryPermissions";
 const MANAGE_PERMISSIONS = "managePermissions";
 
+const SQL_READY_TIMEOUT_MS = 30000;
+const SQL_READY_POLL_INTERVAL_MS = 1000;
+
 const QUERY_ACTIONS = [
   "runQuery",
   "describeCreateResult",
@@ -114,6 +117,16 @@ type InitializationReadiness =
       payload: ToolResult;
     };
 
+type SqlExecutionOutcome =
+  | {
+      result: TcbServiceResult;
+      payload?: never;
+    }
+  | {
+      result?: never;
+      payload: ToolResult;
+    };
+
 function buildNextAction(
   tool: string,
   action: string,
@@ -131,6 +144,10 @@ function buildNextAction(
 
 function buildSqlToolResult(payload: SqlToolPayload) {
   return buildJsonToolResult(payload);
+}
+
+function delay(ms: number) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 function stripLeadingSqlComments(sql: string) {
@@ -279,6 +296,31 @@ function extractErrorCode(error: unknown) {
   return typeof maybeCode === "string" ? maybeCode : undefined;
 }
 
+function extractErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return String(error ?? "");
+}
+
+function isRetryableSqlReadinessError(error: unknown) {
+  const errorCode = extractErrorCode(error);
+  const message = extractErrorMessage(error);
+
+  if (errorCode === "FailedOperation.DataSourceNotExist") {
+    return true;
+  }
+
+  return /ETIMEDOUT|ECONNRESET|ECONNREFUSED|ENOTFOUND|socket hang up|timeout|timed out|deadline exceeded|not ready/i.test(
+    message,
+  );
+}
+
 function normalizeCreateResultStatus(rawStatus: unknown): SqlLifecycleStatus {
   if (typeof rawStatus !== "string" || rawStatus.trim().length === 0) {
     return "PENDING";
@@ -388,6 +430,176 @@ async function callSqlControlPlane(
     Action: action,
     Param: param,
   }) as Promise<TcbServiceResult>;
+}
+
+async function waitForSqlDataPlaneReady(
+  context: QueryManageContext,
+  options?: {
+    dbInstance?: DbInstanceInput;
+    rawStatus?: unknown;
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  },
+): Promise<ToolResult | null> {
+  const timeoutMs = options?.timeoutMs ?? SQL_READY_TIMEOUT_MS;
+  const pollIntervalMs = options?.pollIntervalMs ?? SQL_READY_POLL_INTERVAL_MS;
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutMs;
+  const cloudbase = await context.getManager();
+  const dbContext = await resolveSqlDbContext(
+    context.getManager,
+    context.cloudBaseOptions,
+    options?.dbInstance,
+  );
+  let lastError: unknown;
+
+  while (Date.now() <= deadline) {
+    try {
+      const result = await callSqlControlPlane(cloudbase, "RunSql", {
+        EnvId: dbContext.envId,
+        Sql: "SELECT 1",
+        ReadOnly: true,
+        DbInstance: {
+          EnvId: dbContext.envId,
+          InstanceId: dbContext.instanceId,
+          Schema: dbContext.schema,
+        },
+      });
+      logCloudBaseResult(context.server.logger, result);
+      return null;
+    } catch (error) {
+      if (!isRetryableSqlReadinessError(error)) {
+        throw error;
+      }
+
+      lastError = error;
+    }
+
+    if (Date.now() + pollIntervalMs > deadline) {
+      break;
+    }
+
+    await delay(pollIntervalMs);
+  }
+
+  return buildSqlToolResult({
+    success: false,
+    errorCode: "MYSQL_NOT_READY",
+    message: `MySQL control plane reports ready, but the SQL endpoint is still not responding after ${timeoutMs}ms. Retry after the database finishes warming up.`,
+    data: {
+      status: "READY",
+      rawStatus: options?.rawStatus,
+      waitedMs: Date.now() - startedAt,
+      probeSql: "SELECT 1",
+      lastError: lastError ? extractErrorMessage(lastError) : undefined,
+    },
+    nextActions: [
+      buildNextAction(
+        QUERY_SQL_DATABASE,
+        "getInstanceInfo",
+        "Check the current MySQL instance state before retrying the SQL operation.",
+      ),
+    ],
+  });
+}
+
+async function executeSqlWithRecovery(
+  context: QueryManageContext,
+  options: {
+    sql: string;
+    readOnly?: boolean;
+    dbInstance?: DbInstanceInput;
+    notCreatedMessage: string;
+    notCreatedReason: string;
+    notReadyMessage: string;
+    notReadyReason: string;
+  },
+): Promise<SqlExecutionOutcome> {
+  const cloudbase = await context.getManager();
+  const dbContext = await resolveSqlDbContext(
+    context.getManager,
+    context.cloudBaseOptions,
+    options.dbInstance,
+  );
+
+  const runSql = async () => {
+    const result = await callSqlControlPlane(cloudbase, "RunSql", {
+      EnvId: dbContext.envId,
+      Sql: options.sql,
+      ...(options.readOnly ? { ReadOnly: true } : {}),
+      DbInstance: {
+        EnvId: dbContext.envId,
+        InstanceId: dbContext.instanceId,
+        Schema: dbContext.schema,
+      },
+    });
+    logCloudBaseResult(context.server.logger, result);
+    return result;
+  };
+
+  try {
+    return {
+      result: await runSql(),
+    };
+  } catch (error) {
+    if (!isRetryableSqlReadinessError(error)) {
+      throw error;
+    }
+
+    const instanceInfo = await getSqlInstanceInfo(context);
+    if (!instanceInfo.exists) {
+      return {
+        payload: buildSqlToolResult({
+          success: false,
+          errorCode: "MYSQL_NOT_CREATED",
+          message: options.notCreatedMessage,
+          nextActions: [
+            buildNextAction(
+              MANAGE_SQL_DATABASE,
+              "provisionMySQL",
+              options.notCreatedReason,
+              { action: "provisionMySQL", confirm: true },
+            ),
+          ],
+        }),
+      };
+    }
+
+    if (instanceInfo.status !== "READY") {
+      return {
+        payload: buildSqlToolResult({
+          success: false,
+          errorCode: "MYSQL_NOT_READY",
+          message: `${options.notReadyMessage} (current status: ${instanceInfo.status}).`,
+          data: {
+            status: instanceInfo.status,
+            rawStatus: instanceInfo.rawStatus,
+          },
+          nextActions: [
+            buildNextAction(
+              QUERY_SQL_DATABASE,
+              "getInstanceInfo",
+              options.notReadyReason,
+            ),
+          ],
+        }),
+      };
+    }
+
+    const readinessPayload = await waitForSqlDataPlaneReady(context, {
+      dbInstance: options.dbInstance,
+      rawStatus: instanceInfo.rawStatus,
+    });
+    if (readinessPayload) {
+      return {
+        payload: readinessPayload,
+      };
+    }
+
+    return {
+      result: await runSql(),
+    };
+  }
 }
 
 async function getSqlInstanceInfo({
@@ -600,47 +812,21 @@ async function handleRunQuery(
       ],
     });
   }
-
-  const cloudbase = await context.getManager();
-  const dbContext = await resolveSqlDbContext(
-    context.getManager,
-    context.cloudBaseOptions,
-    args.dbInstance,
-  );
-  let result;
-  try {
-    result = await callSqlControlPlane(cloudbase, "RunSql", {
-      EnvId: dbContext.envId,
-      Sql: args.sql,
-      ReadOnly: true,
-      DbInstance: {
-        EnvId: dbContext.envId,
-        InstanceId: dbContext.instanceId,
-        Schema: dbContext.schema,
-      },
-    });
-    logCloudBaseResult(context.server.logger, result);
-  } catch (error: any) {
-    const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-    if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
-      return buildSqlToolResult({
-        success: false,
-        errorCode: "MYSQL_NOT_CREATED",
-        message: "MySQL is not provisioned yet or not found. Please provision MySQL before running queries.",
-        nextActions: [
-          buildNextAction(
-            MANAGE_SQL_DATABASE,
-            "provisionMySQL",
-            "Provision MySQL before querying data.",
-            { action: "provisionMySQL", confirm: true },
-          ),
-        ],
-      });
-    }
-    throw error;
+  const execution = await executeSqlWithRecovery(context, {
+    sql: args.sql,
+    readOnly: true,
+    dbInstance: args.dbInstance,
+    notCreatedMessage:
+      "MySQL is not provisioned yet or not found. Please provision MySQL before running queries.",
+    notCreatedReason: "Provision MySQL before querying data.",
+    notReadyMessage: "MySQL is not ready yet for read-only SQL execution",
+    notReadyReason: "Check current instance status before retrying the query.",
+  });
+  if (execution.payload) {
+    return execution.payload;
   }
 
-  const normalized = normalizeRunSqlResult(result);
+  const normalized = normalizeRunSqlResult(execution.result);
   return buildSqlToolResult({
     success: true,
     data: {
@@ -970,47 +1156,21 @@ async function handleRunStatement(
       ],
     });
   }
-
-  const cloudbase = await context.getManager();
-  const dbContext = await resolveSqlDbContext(
-    context.getManager,
-    context.cloudBaseOptions,
-    args.dbInstance,
-  );
-  let result;
-  try {
-    result = await callSqlControlPlane(cloudbase, "RunSql", {
-      EnvId: dbContext.envId,
-      Sql: args.sql,
-      DbInstance: {
-        EnvId: dbContext.envId,
-        InstanceId: dbContext.instanceId,
-        Schema: dbContext.schema,
-      },
-    });
-    logCloudBaseResult(context.server.logger, result);
-  } catch (error: any) {
-    const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-    if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
-      return buildSqlToolResult({
-        success: false,
-        errorCode: "MYSQL_NOT_CREATED",
-        message: "MySQL is not provisioned yet or not found. Please provision MySQL before running statements.",
-        nextActions: [
-          buildNextAction(
-            MANAGE_SQL_DATABASE,
-            "provisionMySQL",
-            "Provision MySQL before executing statements.",
-            { action: "provisionMySQL", confirm: true },
-          ),
-        ],
-      });
-    }
-    throw error;
+  const execution = await executeSqlWithRecovery(context, {
+    sql: args.sql,
+    dbInstance: args.dbInstance,
+    notCreatedMessage:
+      "MySQL is not provisioned yet or not found. Please provision MySQL before running statements.",
+    notCreatedReason: "Provision MySQL before executing statements.",
+    notReadyMessage: "MySQL is not ready yet for SQL execution",
+    notReadyReason: "Check current instance status before retrying the statement.",
+  });
+  if (execution.payload) {
+    return execution.payload;
   }
 
   const statementType = getSqlVerb(args.sql) || "UNKNOWN";
-  const normalized = normalizeRunSqlResult(result);
+  const normalized = normalizeRunSqlResult(execution.result);
   return buildSqlToolResult({
     success: true,
     data: {
@@ -1104,6 +1264,17 @@ async function resolveInitializationReadiness(
     };
   }
 
+  const readinessPayload = await waitForSqlDataPlaneReady(context, {
+    dbInstance: args.dbInstance,
+    rawStatus,
+  });
+  if (readinessPayload) {
+    return {
+      ready: false,
+      payload: readinessPayload,
+    };
+  }
+
   return {
     ready: true,
     instanceInfo,
@@ -1142,38 +1313,20 @@ async function handleInitializeSchema(
 
   for (const statement of args.statements) {
     try {
-      let result;
-      try {
-        result = await callSqlControlPlane(cloudbase, "RunSql", {
-          EnvId: dbContext.envId,
-          Sql: statement,
-          DbInstance: {
-            EnvId: dbContext.envId,
-            InstanceId: dbContext.instanceId,
-            Schema: dbContext.schema,
-          },
-        });
-        logCloudBaseResult(context.server.logger, result);
-      } catch (error: any) {
-        const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-        if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
-          return buildSqlToolResult({
-            success: false,
-            errorCode: "MYSQL_NOT_CREATED",
-            message: "MySQL is not provisioned yet or not found. Please provision MySQL before initializing schema.",
-            nextActions: [
-              buildNextAction(
-                MANAGE_SQL_DATABASE,
-                "provisionMySQL",
-                "Provision MySQL before executing statements.",
-                { action: "provisionMySQL", confirm: true },
-              ),
-            ],
-          });
-        }
-        throw error;
+      const execution = await executeSqlWithRecovery(context, {
+        sql: statement,
+        dbInstance: args.dbInstance,
+        notCreatedMessage:
+          "MySQL is not provisioned yet or not found. Please provision MySQL before initializing schema.",
+        notCreatedReason: "Provision MySQL before executing schema initialization statements.",
+        notReadyMessage: "MySQL is not ready yet for schema initialization",
+        notReadyReason: "Check current instance status before retrying schema initialization.",
+      });
+      if (execution.payload) {
+        return execution.payload;
       }
-      const normalized = normalizeRunSqlResult(result);
+
+      const normalized = normalizeRunSqlResult(execution.result);
       if (typeof normalized.requestId === "string") {
         requestIdList.push(normalized.requestId);
       }

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -1432,7 +1432,7 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
     {
       title: "Manage SQL database lifecycle or execute write SQL",
       description:
-        "Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, and schema initialization. IMPORTANT: MySQL must be provisioned first (action=provisionMySQL with confirm=true) before any runStatement or initializeSchema call. If MySQL is not yet provisioned, the tool will return MYSQL_NOT_CREATED with a nextAction to provision first.",
+        "Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, write SQL/DDL execution, and schema initialization. IMPORTANT: MySQL must be provisioned first (action=provisionMySQL with confirm=true) before any runStatement or initializeSchema call. If MySQL is not yet provisioned, the tool will return MYSQL_NOT_CREATED with a nextAction to provision first. After provisioning, poll querySqlDatabase(action=describeCreateResult) until status=READY, then use initializeSchema (preferred) or runStatement — both automatically wait for the data plane to warm up before executing SQL.",
       inputSchema: {
         action: z
           .enum(MANAGE_ACTIONS)

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -689,14 +689,21 @@ async function getSqlInstanceInfo({
       throw error;
     }
 
+    const clusterDetailLaggingAfterProvision = createStatus === "READY";
+
     return {
-      exists: createStatus === "PENDING" || createStatus === "RUNNING",
+      // The cluster-detail API can lag behind a successful create result.
+      // Treat that window as an existing instance that is still warming up.
+      exists:
+        clusterDetailLaggingAfterProvision ||
+        createStatus === "PENDING" ||
+        createStatus === "RUNNING",
       envId,
       instanceId: "default",
       schema: envId,
       rawStatus:
         typeof createRawStatus === "string" ? createRawStatus : null,
-      status: createStatus,
+      status: clusterDetailLaggingAfterProvision ? "PENDING" : createStatus,
       createResult: createData ?? createResult,
     };
   }


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnry7ddi_rn8emg
- category: tool
- canonicalTitle: MCP 工具：MySQL 开通 READY 后 SQL 操作仍超时 - 缺乏数据库就绪检测
- representativeRun: atomic-js-none-chain-mysql-from-none-to-usable/2026-04-09T20-42-08-rzsikc

## Automation summary
README.md tencent-cloud

## Changed files
- `mcp/src/tools/databaseSQL.test.ts`
- `mcp/src/tools/databaseSQL.ts`