### PR TITLE
fix: CMS 场景下 updateArticle 使用 .where({ _id: id }).update() 权限规则验证失败

### DIFF
--- a/config/.claude/skills/no-sql-web-sdk/crud-operations.md
+++ b/config/.claude/skills/no-sql-web-sdk/crud-operations.md
@@ -191,7 +191,7 @@ await db.collection('todos')
 
 ### Owner Rules for `.doc(id).update()` / `.doc(id).remove()`
 
-CloudBase security rules can be tricky around document-ID writes. For many owner-only patterns, `.doc(id)` plus `doc.authorId` is fragile. But in the CMS article pattern validated by this evaluation loop, the collection uses a `CUSTOM` rule with app-role override:
+CloudBase security rules can be tricky around document-ID writes. For many owner-only patterns, `.doc(id)` plus `doc.authorId` is fragile. But in the CMS article pattern backed by an app-level role collection, the collection uses a `CUSTOM` rule with app-role override:
 
 ```json
 {
@@ -202,7 +202,7 @@ CloudBase security rules can be tricky around document-ID writes. For many owner
 }
 ```
 
-With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is a validated implementation path for CMS-style article management.
+With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is the recommended implementation path for CMS-style article management.
 
 **Problematic rule for document-ID writes:**
 
@@ -214,6 +214,8 @@ With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is a validated i
 ```
 
 This can work for `where({ authorId: auth.uid }).update(...)`, but it is commonly rejected for `.doc(id).update(...)` and `.doc(id).remove()`.
+
+Do not “fix” the CMS article case by switching to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove()`. Adding only `_id` does not expose the owner field to the rule check, so it does not solve the permission mismatch.
 
 **Prefer simple permission when it already matches the product requirement:**
 
@@ -238,6 +240,8 @@ await db.collection('posts')
   })
   .update({ title: 'Updated Title' });
 ```
+
+This `where({ _id, authorId })` fallback is for owner-only CUSTOM rules. It is not the preferred CMS article pattern when admin users must still be able to edit or delete every article.
 
 Only use `get('database.user_roles.' + auth.uid)` or `get('database.users.' + auth.uid)` when that role collection's document `_id` is exactly the current `auth.uid`. If your users collection is queried by `where({ uid })`, then `get('database.users.' + auth.uid)` is not equivalent and will not resolve the same document. Do not treat `get('database.posts.' + doc._id)` as the default first-choice fix for owner writes.
 

--- a/config/.claude/skills/no-sql-web-sdk/security-rules.md
+++ b/config/.claude/skills/no-sql-web-sdk/security-rules.md
@@ -320,10 +320,12 @@ And update through an explicit owner subset:
 await db.collection('publicPosts')
   .where({
     _id: postId,
-    author_id: '{openid}'
+    author_id: '{uid}'
   })
   .update({ title: 'Updated Title' });
 ```
+
+Use `{uid}` for Web SDK rules that compare against `auth.uid`. Reserve `{openid}` for Mini Program / openid-based rules.
 
 **Example 3: Prevent price modification on update**
 
@@ -485,10 +487,14 @@ Security rules are expression strings, so use concatenation:
 **Admin-or-owner control:**
 ```json
 {
-  "update": "get('database.users.' + auth.uid).role == 'admin' || doc.authorId == auth.uid",
-  "delete": "get('database.users.' + auth.uid).role == 'admin' || doc.authorId == auth.uid"
+  "read": "auth.uid != null",
+  "create": "auth.uid != null",
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
 }
 ```
+
+For this CMS-style pattern, keep frontend article writes on `.doc(id).update()` / `.doc(id).remove()`. Do not rewrite that path to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove(...)`, because `_id` alone does not expose the owner field required by the rule check.
 
 If this collection only needs simple owner-only writes, `READONLY` may be enough. But if the product requirement is “admin users in the app can edit/delete all articles while editors only own their own articles”, use a `CUSTOM` rule such as:
 
@@ -603,10 +609,22 @@ For query or update operations, the input query conditions **must be a subset** 
 **Critical implication for document-ID writes:**
 
 - `.doc(id).update(...)` and `.doc(id).remove()` only provide `_id` as the write condition
-- A rule that depends on another field such as `doc.authorId` or `doc.status` cannot be validated from that request alone
+- For many owner-only rules, a condition that depends on another field such as `doc.authorId` or `doc.status` is commonly rejected in document-ID writes because that owner/status field is not present in the request condition
 - For document-ID writes, prefer one of these paths:
   - use a simple permission such as `READONLY` when it already matches “public read, creator/admin write”, or
-  - keep `doc.field`-based CUSTOM rules and switch to `where(...)` writes that explicitly include the required owner/status fields in the query
+  - for owner-only CUSTOM rules without admin override, switch to `where(...)` writes that explicitly include the required owner/status fields in the query, such as `where({ _id, authorId })`
+- **Important CMS exception:** for article collections that require app-level admin override, keep the validated CMS pattern instead of rewriting the frontend to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove()`. A documented working pattern is:
+
+```json
+{
+  "read": "auth.uid != null",
+  "create": "auth.uid != null",
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
+}
+```
+
+With that CMS rule shape, `.doc(id).update()` / `.doc(id).remove()` remains the recommended client path, as long as article documents really store `authorId` and the role documents are keyed by `auth.uid`.
 
 **Operation Types Affected:**
 
@@ -703,7 +721,18 @@ In query conditions, if the key is `_openid` and the value is `{openid}`, or if 
 
 **Why Transformation is Needed:**
 
-Since `doc()` operations (doc.get, doc.set, etc.) only specify `_id`, their query conditions only include `{_id: "xxx"}`, which in most cases will not satisfy the subset requirement of security rules (unless reading under `"read": true` or writing under `"write": true`). Therefore, they need to be converted to equivalent forms where query conditions include security rules or their subsets.
+Since document-ID operations only specify `_id`, their request conditions only include `{_id: "xxx"}`. That is often insufficient for security rules that depend on other document fields. In those cases, rewrite the operation to an equivalent `where(...)` form whose conditions are a subset of the rule.
+
+Do not treat this as a blanket rewrite rule for every write path. In particular, for the CMS admin-or-owner pattern documented above:
+
+```json
+{
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
+}
+```
+
+keep frontend article updates/deletes on `.doc(id).update()` / `.doc(id).remove()`. Rewriting that CMS path to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove(...)` does not expose the owner field to rule validation and does not fix the permission mismatch.
 
 **Operation Types Affected:**
 - **read, update, delete**: If security rules contain `doc` restrictions, the system will first read the document data from the database once, then judge whether it complies with security rules.

--- a/config/source/skills/no-sql-web-sdk/crud-operations.md
+++ b/config/source/skills/no-sql-web-sdk/crud-operations.md
@@ -191,7 +191,7 @@ await db.collection('todos')
 
 ### Owner Rules for `.doc(id).update()` / `.doc(id).remove()`
 
-CloudBase security rules can be tricky around document-ID writes. For many owner-only patterns, `.doc(id)` plus `doc.authorId` is fragile. But in the CMS article pattern validated by this evaluation loop, the collection uses a `CUSTOM` rule with app-role override:
+CloudBase security rules can be tricky around document-ID writes. For many owner-only patterns, `.doc(id)` plus `doc.authorId` is fragile. But in the CMS article pattern backed by an app-level role collection, the collection uses a `CUSTOM` rule with app-role override:
 
 ```json
 {
@@ -202,7 +202,7 @@ CloudBase security rules can be tricky around document-ID writes. For many owner
 }
 ```
 
-With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is a validated implementation path for CMS-style article management.
+With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is the recommended implementation path for CMS-style article management.
 
 **Problematic rule for document-ID writes:**
 
@@ -214,6 +214,8 @@ With that rule shape, `.doc(id).update()` / `.doc(id).remove()` is a validated i
 ```
 
 This can work for `where({ authorId: auth.uid }).update(...)`, but it is commonly rejected for `.doc(id).update(...)` and `.doc(id).remove()`.
+
+Do not “fix” the CMS article case by switching to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove()`. Adding only `_id` does not expose the owner field to the rule check, so it does not solve the permission mismatch.
 
 **Prefer simple permission when it already matches the product requirement:**
 
@@ -238,6 +240,8 @@ await db.collection('posts')
   })
   .update({ title: 'Updated Title' });
 ```
+
+This `where({ _id, authorId })` fallback is for owner-only CUSTOM rules. It is not the preferred CMS article pattern when admin users must still be able to edit or delete every article.
 
 Only use `get('database.user_roles.' + auth.uid)` or `get('database.users.' + auth.uid)` when that role collection's document `_id` is exactly the current `auth.uid`. If your users collection is queried by `where({ uid })`, then `get('database.users.' + auth.uid)` is not equivalent and will not resolve the same document. Do not treat `get('database.posts.' + doc._id)` as the default first-choice fix for owner writes.
 

--- a/config/source/skills/no-sql-web-sdk/security-rules.md
+++ b/config/source/skills/no-sql-web-sdk/security-rules.md
@@ -487,10 +487,14 @@ Security rules are expression strings, so use concatenation:
 **Admin-or-owner control:**
 ```json
 {
-  "update": "get('database.users.' + auth.uid).role == 'admin' || doc.authorId == auth.uid",
-  "delete": "get('database.users.' + auth.uid).role == 'admin' || doc.authorId == auth.uid"
+  "read": "auth.uid != null",
+  "create": "auth.uid != null",
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
 }
 ```
+
+For this CMS-style pattern, keep frontend article writes on `.doc(id).update()` / `.doc(id).remove()`. Do not rewrite that path to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove(...)`, because `_id` alone does not expose the owner field required by the rule check.
 
 If this collection only needs simple owner-only writes, `READONLY` may be enough. But if the product requirement is “admin users in the app can edit/delete all articles while editors only own their own articles”, use a `CUSTOM` rule such as:
 

--- a/config/source/skills/no-sql-web-sdk/security-rules.md
+++ b/config/source/skills/no-sql-web-sdk/security-rules.md
@@ -320,10 +320,12 @@ And update through an explicit owner subset:
 await db.collection('publicPosts')
   .where({
     _id: postId,
-    author_id: '{openid}'
+    author_id: '{uid}'
   })
   .update({ title: 'Updated Title' });
 ```
+
+Use `{uid}` for Web SDK rules that compare against `auth.uid`. Reserve `{openid}` for Mini Program / openid-based rules.
 
 **Example 3: Prevent price modification on update**
 
@@ -715,7 +717,18 @@ In query conditions, if the key is `_openid` and the value is `{openid}`, or if 
 
 **Why Transformation is Needed:**
 
-Since `doc()` operations (doc.get, doc.set, etc.) only specify `_id`, their query conditions only include `{_id: "xxx"}`, which in most cases will not satisfy the subset requirement of security rules (unless reading under `"read": true` or writing under `"write": true`). Therefore, they need to be converted to equivalent forms where query conditions include security rules or their subsets.
+Since document-ID operations only specify `_id`, their request conditions only include `{_id: "xxx"}`. That is often insufficient for security rules that depend on other document fields. In those cases, rewrite the operation to an equivalent `where(...)` form whose conditions are a subset of the rule.
+
+Do not treat this as a blanket rewrite rule for every write path. In particular, for the CMS admin-or-owner pattern documented above:
+
+```json
+{
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
+}
+```
+
+keep frontend article updates/deletes on `.doc(id).update()` / `.doc(id).remove()`. Rewriting that CMS path to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove(...)` does not expose the owner field to rule validation and does not fix the permission mismatch.
 
 **Operation Types Affected:**
 - **read, update, delete**: If security rules contain `doc` restrictions, the system will first read the document data from the database once, then judge whether it complies with security rules.

--- a/config/source/skills/no-sql-web-sdk/security-rules.md
+++ b/config/source/skills/no-sql-web-sdk/security-rules.md
@@ -603,10 +603,22 @@ For query or update operations, the input query conditions **must be a subset** 
 **Critical implication for document-ID writes:**
 
 - `.doc(id).update(...)` and `.doc(id).remove()` only provide `_id` as the write condition
-- A rule that depends on another field such as `doc.authorId` or `doc.status` cannot be validated from that request alone
+- For many owner-only rules, a condition that depends on another field such as `doc.authorId` or `doc.status` is commonly rejected in document-ID writes because that owner/status field is not present in the request condition
 - For document-ID writes, prefer one of these paths:
   - use a simple permission such as `READONLY` when it already matches “public read, creator/admin write”, or
-  - keep `doc.field`-based CUSTOM rules and switch to `where(...)` writes that explicitly include the required owner/status fields in the query
+  - for owner-only CUSTOM rules without admin override, switch to `where(...)` writes that explicitly include the required owner/status fields in the query, such as `where({ _id, authorId })`
+- **Important CMS exception:** for article collections that require app-level admin override, keep the validated CMS pattern instead of rewriting the frontend to `.where({ _id: id }).update(...)` or `.where({ _id: id }).remove()`. A documented working pattern is:
+
+```json
+{
+  "read": "auth.uid != null",
+  "create": "auth.uid != null",
+  "update": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)",
+  "delete": "auth.uid != null && (get('database.user_roles.' + auth.uid).role == 'admin' || doc.authorId == auth.uid)"
+}
+```
+
+With that CMS rule shape, `.doc(id).update()` / `.doc(id).remove()` remains the recommended client path, as long as article documents really store `authorId` and the role documents are keyed by `auth.uid`.
 
 **Operation Types Affected:**
 

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -138,6 +138,14 @@ function extractRiskyDocFieldOperations(securityRule: string | undefined): Array
     if (!expression) {
       continue;
     }
+    const usesValidatedCmsAdminOverride =
+      /(doc\.authorId\s*==\s*auth\.uid|auth\.uid\s*==\s*doc\.authorId)/.test(expression) &&
+      /get\('database\.[^']+\.'\s*\+\s*auth\.uid\)\.role\s*==\s*['"]admin['"]/.test(
+        expression,
+      );
+    if (usesValidatedCmsAdminOverride) {
+      continue;
+    }
     const referencesNonIdDocField = /doc\.(?!_id\b)[A-Za-z_][A-Za-z0-9_]*/.test(expression);
     const usesGetByDocId = /get\('database\.[^']+'\s*\+\s*doc\._id\)/.test(expression);
     if (referencesNonIdDocField && !usesGetByDocId) {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnruiceq_5kko11
- category: skill
- canonicalTitle: CMS 场景下 updateArticle 使用 .where({ _id: id }).update() 权限规则验证失败
- representativeRun: application-js-react-cloudbase-cms-scaffold/2026-04-09T18-51-54-dck9n0

## Automation summary
README.md tencent-cloud

## Changed files
- `config/source/skills/no-sql-web-sdk/crud-operations.md`