### PR TITLE
fix: auth-web-cloudbase Skill 邮箱注册 API 流程说明不清晰

### DIFF
--- a/config/.claude/skills/auth-tool/SKILL.md
+++ b/config/.claude/skills/auth-tool/SKILL.md
@@ -130,6 +130,7 @@ Parameter mapping for downstream Web auth code:
 - `queryAppAuth(action="getLoginConfig")` and `manageAppAuth(action="patchLoginStrategy")` return `sdkStyle: "supabase-like"` plus `sdkHints`; treat that as the preferred frontend-auth calling guide
 - `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
 - `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- Email and phone signup complete through OTP verification. After `auth.signUp({ email|phone, ... })`, continue with the returned `verifyOtp({ token })`
 - `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
@@ -212,6 +213,7 @@ Email has two layers of configuration:
 - `ModifyLoginConfig.EmailLogin`: controls whether email/password login is enabled
 - `ModifyProvider(Id="email")`: controls the email sender channel and SMTP configuration
 - In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- `auth.signUp({ email })` is an email OTP registration step, not an `email + password` signup payload; finish the flow with `verifyOtp({ token })`
 
 Preferred MCP tool path:
 

--- a/config/.claude/skills/auth-web/SKILL.md
+++ b/config/.claude/skills/auth-web/SKILL.md
@@ -74,8 +74,11 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
-- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
+- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
+- Email and phone registration are OTP flows: `auth.signUp({ email|phone, ... })` is only the first step that sends the verification code; registration completes only after the returned `data.verifyOtp({ token })` succeeds
+- For email signup, the canonical sequence is: `auth.signUp({ email, ... })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code to finish account creation
+- Do not describe email registration as `auth.signUp({ email, password })`; for email-based password login, use `auth.signInWithPassword({ email, password })` after the account already exists
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
@@ -85,16 +88,16 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 ## Quick Start
 
 ```js
-import cloudbase from '@cloudbase/js-sdk'
+import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
   env: `env`, // CloudBase environment ID
-  region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
-  accessKey: 'publishable key', // required, get from auth-tool-cloudbase
+  region: `region`, // CloudBase environment Region, default 'ap-shanghai'
+  accessKey: "publishable key", // required, get from auth-tool-cloudbase
   auth: { detectSessionInUrl: true }, // required
-})
+});
 
-const auth = app.auth({ persistence: 'local' })
+const auth = app.auth({ persistence: "local" });
 ```
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
@@ -104,49 +107,88 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 ## Login Methods
 
 **1. Phone OTP (Recommended)**
+
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
+const { data, error } = await auth.signInWithOtp({ phone: "13800138000" });
+const { data: loginData, error: loginError } = await data.verifyOtp({
+  token: "123456",
+});
 ```
 
-**2. Email OTP**
+**2. Email OTP Login**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Email Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOtp({ email: 'user@example.com' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token: '654321' })
+const { data, error } = await auth.signInWithOtp({ email: "user@example.com" });
+const { data: loginData, error: loginError } = await data.verifyOtp({
+  token: "654321",
+});
 ```
 
 **3. Password**
+
 ```js
-const usernameLogin = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
-const emailLogin = await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
-const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+const usernameLogin = await auth.signInWithPassword({
+  username: "test_user",
+  password: "pass123",
+});
+const emailLogin = await auth.signInWithPassword({
+  email: "user@example.com",
+  password: "pass123",
+});
+const phoneLogin = await auth.signInWithPassword({
+  phone: "13800138000",
+  password: "pass123",
+});
 ```
 
 **4. Registration**
+
 - For username-style account systems, use username/password registration directly
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
+- Email and phone signup are always two-step OTP flows: first call `auth.signUp({ email|phone, ... })` to send the code, then keep the returned `data` object and call `data.verifyOtp({ token })` to finish registration
+- The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. In the second step, send only the verification code as `verifyOtp({ token })`; do not rebuild the signup payload
+- In split UI handlers, `auth.signUp({ email, ... })` is the "send code" step and `signupHandle.verifyOtp({ token })` is the "complete registration" step
+- Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow for an existing account, not the signup payload shown here
+- If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
+
+Email signup sequence at a glance:
+
+1. Call `auth.signUp({ email, nickname })` to send the email code.
+2. Persist the returned `data` signup handle from step 1.
+3. Call `signupHandle.verifyOtp({ token })` with only the code from the email.
+4. Treat the account as created only after step 3 succeeds.
+
 ```js
 // Username + Password
 const usernameSignUp = await auth.signUp({
-  username: 'newuser',
-  password: 'pass123',
-  nickname: 'User',
-})
+  username: "newuser",
+  password: "pass123",
+  nickname: "User",
+});
 
-// Email Otp
+// Email OTP signup.
 // Use only when the task explicitly requires email addresses.
-// Email Otp
-const emailSignUp = await auth.signUp({ email: 'new@example.com', nickname: 'User' })
-const emailVerifyResult = await emailSignUp.data.verifyOtp({ token: '123456' })
+const emailSignUp = await auth.signUp({
+  email: "new@example.com",
+  nickname: "User",
+});
+const emailSignupHandle = emailSignUp.data; // Required for the follow-up verify step.
+const emailVerifyResult = await emailSignupHandle.verifyOtp({
+  token: "123456",
+});
 
-// Phone Otp
+// Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
-// Phone Otp
-const phoneSignUp = await auth.signUp({ phone: '13800138000', nickname: 'User' })
-const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: '123456' })
+const phoneSignUp = await auth.signUp({
+  phone: "13800138000",
+  nickname: "User",
+});
+const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: "123456" });
 ```
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
@@ -159,17 +201,17 @@ const handleRegister = async () => {
     username,
     password,
     nickname: username,
-  })
-  if (error) throw error
-}
+  });
+  if (error) throw error;
+};
 
 const handleLogin = async () => {
   const { error } = await auth.signInWithPassword({
     username,
     password,
-  })
-  if (error) throw error
-}
+  });
+  if (error) throw error;
+};
 ```
 
 Do not use email OTP or email-only helpers for these flows unless the task explicitly says the account identifier is an email address. The corresponding form field should stay `type="text"` rather than `type="email"` for username-style account identifiers.
@@ -179,60 +221,64 @@ const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
       email,
-      name: username || email.split('@')[0],
-    })
-    if (error) throw error
-    setSignUpData(data)
+      nickname: username || email.split("@")[0],
+    });
+    if (error) throw error;
+
+    // Keep the returned sign-up handle for the follow-up verifyOtp step.
+    setSignUpData(data);
   } catch (error) {
-    console.error('Failed to send sign-up code', error)
+    console.error("Failed to send sign-up code", error);
   }
-}
+};
 
 const handleRegister = async () => {
   try {
-    if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
+    if (!signUpData?.verifyOtp) throw new Error("Please send the code first");
 
-    const { error } = await signUpData.verifyOtp({
-      email,
-      token: code,
-      type: 'signup',
-    })
-    if (error) throw error
+    const { error } = await signUpData.verifyOtp({ token: code });
+    if (error) throw error;
   } catch (error) {
-    console.error('Failed to complete sign-up', error)
+    console.error("Failed to complete sign-up", error);
   }
-}
+};
 ```
 
 **5. Anonymous**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInAnonymously()
+const { data, error } = await auth.signInAnonymously();
 ```
 
 **6. OAuth (Google/WeChat)**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Google Login` or `WeChat Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOAuth({ provider: 'google' })
-window.location.href = data.url // Auto-complete after callback
+const { data, error } = await auth.signInWithOAuth({ provider: "google" });
+window.location.href = data.url; // Auto-complete after callback
 ```
 
 **7. Custom Ticket**
+
 ```js
 await auth.signInWithCustomTicket(async () => {
-  const res = await fetch('/api/ticket')
-  return (await res.json()).ticket
-})
+  const res = await fetch("/api/ticket");
+  return (await res.json()).ticket;
+});
 ```
 
 **8. Upgrade Anonymous**
+
 ```js
-const sessionResult = await auth.getSession()
+const sessionResult = await auth.getSession();
 const upgradeResult = await auth.signUp({
-  phone: '13800000000',
+  phone: "13800000000",
   anonymous_token: sessionResult.data.session.access_token,
-})
-await upgradeResult.data.verifyOtp({ token: '123456' })
+});
+await upgradeResult.data.verifyOtp({ token: "123456" });
 ```
 
 ---
@@ -241,68 +287,70 @@ await upgradeResult.data.verifyOtp({ token: '123456' })
 
 ```js
 // Sign out
-const signOutResult = await auth.signOut()
+const signOutResult = await auth.signOut();
 
 // Get user
-const userResult = await auth.getUser()
+const userResult = await auth.getUser();
 console.log(
   userResult.data.user.email,
   userResult.data.user.phone,
   userResult.data.user.user_metadata?.nickName,
-)
+);
 
 // Update user (except email, phone)
 const updateProfileResult = await auth.updateUser({
-  nickname: 'New Name',
-  gender: 'MALE',
-  avatar_url: 'url',
-})
+  nickname: "New Name",
+  gender: "MALE",
+  avatar_url: "url",
+});
 
 // Update user (email or phone)
-const updateEmailResult = await auth.updateUser({ email: 'new@example.com' })
+const updateEmailResult = await auth.updateUser({ email: "new@example.com" });
 const verifyEmailResult = await updateEmailResult.data.verifyOtp({
-  email: 'new@example.com',
-  token: '123456',
-})
+  email: "new@example.com",
+  token: "123456",
+});
 
 // Change password (logged in)
 const resetPasswordResult = await auth.resetPasswordForOld({
-  old_password: 'old',
-  new_password: 'new',
-})
+  old_password: "old",
+  new_password: "new",
+});
 
 // Reset password (forgot)
-const reauthResult = await auth.reauthenticate()
+const reauthResult = await auth.reauthenticate();
 const forgotPasswordResult = await reauthResult.data.updateUser({
-  nonce: '123456',
-  password: 'new',
-})
+  nonce: "123456",
+  password: "new",
+});
 
 // Link third-party
-const linkIdentityResult = await auth.linkIdentity({ provider: 'google' })
+const linkIdentityResult = await auth.linkIdentity({ provider: "google" });
 
 // View/Unlink identities
-const identitiesResult = await auth.getUserIdentities()
+const identitiesResult = await auth.getUserIdentities();
 const unlinkIdentityResult = await auth.unlinkIdentity({
   provider: identitiesResult.data.identities[0].id,
-})
+});
 
 // Delete account
-const deleteMeResult = await auth.deleteMe({ password: 'current' })
+const deleteMeResult = await auth.deleteMe({ password: "current" });
 
 // Listen to state changes
 const authStateSubscription = auth.onAuthStateChange((event, session, info) => {
   // INITIAL_SESSION, SIGNED_IN, SIGNED_OUT, TOKEN_REFRESHED, USER_UPDATED, PASSWORD_RECOVERY, BIND_IDENTITY
-})
+});
 
 // Get access token
-const sessionResult = await auth.getSession()
-await fetch('/api/protected', {
-  headers: { Authorization: `Bearer ${sessionResult.data.session?.access_token}` },
-})
+const sessionResult = await auth.getSession();
+await fetch("/api/protected", {
+  headers: {
+    Authorization: `Bearer ${sessionResult.data.session?.access_token}`,
+  },
+});
 
 // Refresh user
-const refreshUserResult = await auth.refreshUser()
+const refreshUserResult = await auth.refreshUser();
 ```
 
 ---
@@ -311,36 +359,36 @@ const refreshUserResult = await auth.refreshUser()
 
 ```ts
 declare type User = {
-  id: any
-  aud: string
-  role: string[]
-  email: any
-  email_confirmed_at: string
-  phone: any
-  phone_confirmed_at: string
-  confirmed_at: string
-  last_sign_in_at: string
+  id: any;
+  aud: string;
+  role: string[];
+  email: any;
+  email_confirmed_at: string;
+  phone: any;
+  phone_confirmed_at: string;
+  confirmed_at: string;
+  last_sign_in_at: string;
   app_metadata: {
-    provider: any
-    providers: any[]
-  }
+    provider: any;
+    providers: any[];
+  };
   user_metadata: {
-    name: any
-    picture: any
-    username: any
-    gender: any
-    locale: any
-    uid: any
-    nickName: any
-    avatarUrl: any
-    location: any
-    hasPassword: any
-  }
-  identities: any
-  created_at: string
-  updated_at: string
-  is_anonymous: boolean
-}
+    name: any;
+    picture: any;
+    username: any;
+    gender: any;
+    locale: any;
+    uid: any;
+    nickName: any;
+    avatarUrl: any;
+    location: any;
+    hasPassword: any;
+  };
+  identities: any;
+  created_at: string;
+  updated_at: string;
+  is_anonymous: boolean;
+};
 ```
 
 ---
@@ -350,43 +398,43 @@ declare type User = {
 ```js
 class PhoneLoginPage {
   async sendCode() {
-    const phone = document.getElementById('phone').value
-    if (!/^1[3-9]\d{9}$/.test(phone)) return alert('Invalid phone')
+    const phone = document.getElementById("phone").value;
+    if (!/^1[3-9]\d{9}$/.test(phone)) return alert("Invalid phone");
 
-    const { data, error } = await auth.signInWithOtp({ phone })
-    if (error) return alert('Send failed: ' + error.message)
+    const { data, error } = await auth.signInWithOtp({ phone });
+    if (error) return alert("Send failed: " + error.message);
 
-    this.verifyOtp = data.verifyOtp
-    document.getElementById('codeSection').style.display = 'block'
-    this.startCountdown(60)
+    this.verifyOtp = data.verifyOtp;
+    document.getElementById("codeSection").style.display = "block";
+    this.startCountdown(60);
   }
 
   async verifyCode() {
-    const code = document.getElementById('code').value
-    if (!code) return alert('Enter code')
-    if (!this.verifyOtp) return alert('Send the code first')
+    const code = document.getElementById("code").value;
+    if (!code) return alert("Enter code");
+    if (!this.verifyOtp) return alert("Send the code first");
 
-    const { data, error } = await this.verifyOtp({ token: code })
-    if (error) return alert('Verification failed: ' + error.message)
+    const { data, error } = await this.verifyOtp({ token: code });
+    if (error) return alert("Verification failed: " + error.message);
 
-    console.log('Login successful:', data.user)
-    window.location.href = '/dashboard'
+    console.log("Login successful:", data.user);
+    window.location.href = "/dashboard";
   }
 
   startCountdown(seconds) {
-    let countdown = seconds
-    const btn = document.getElementById('resendBtn')
-    btn.disabled = true
+    let countdown = seconds;
+    const btn = document.getElementById("resendBtn");
+    btn.disabled = true;
 
     const timer = setInterval(() => {
-      countdown--
-      btn.innerText = `Resend in ${countdown}s`
+      countdown--;
+      btn.innerText = `Resend in ${countdown}s`;
       if (countdown <= 0) {
-        clearInterval(timer)
-        btn.disabled = false
-        btn.innerText = 'Resend'
+        clearInterval(timer);
+        btn.disabled = false;
+        btn.innerText = "Resend";
       }
-    }, 1000)
+    }, 1000);
   }
 }
 ```

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -55,7 +55,8 @@ alwaysApply: true
    - If the account identifier is a plain username such as `admin`, `editor`, or another string without `@`, treat `usernamePassword` login as a blocking prerequisite.
    - First call `queryAppAuth(action=\"getLoginConfig\")`.
    - If `loginMethods.usernamePassword !== true`, immediately call `manageAppAuth(action=\"patchLoginStrategy\", patch={ usernamePassword: true })`.
-   - In code, use `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`.
+   - In code, use `auth.signInWithPassword({ username, password })` for username-style login.
+   - If self-service registration is required, confirm the documented email/phone verification signup flow that binds `username`, or use an explicit admin-side provisioning path.
    - Never use `signUpWithEmailAndPassword` or `signInWithEmailAndPassword` for these username-style account flows.
    - Once readiness is confirmed, return to the active frontend handler and finish the real login/register flow.
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -129,8 +129,8 @@ Parameter mapping for downstream Web auth code:
 
 - `queryAppAuth(action="getLoginConfig")` and `manageAppAuth(action="patchLoginStrategy")` return `sdkStyle: "supabase-like"` plus `sdkHints`; treat that as the preferred frontend-auth calling guide
 - `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
-- `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
-- Email and phone signup complete through OTP verification. After `auth.signUp({ email|phone, ... })`, continue with the returned `verifyOtp({ token })`
+- `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })`
+- Email and phone signup complete through OTP verification. After `auth.signUp({ email|phone, ... })`, continue with the returned `verifyOtp({ token })`; if the email account should later support password login, include `password` in the initial `auth.signUp(...)` payload
 - `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
@@ -212,8 +212,8 @@ Email has two layers of configuration:
 
 - `ModifyLoginConfig.EmailLogin`: controls whether email/password login is enabled
 - `ModifyProvider(Id="email")`: controls the email sender channel and SMTP configuration
-- In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
-- `auth.signUp({ email })` is an email OTP registration step, not an `email + password` signup payload; finish the flow with `verifyOtp({ token })`
+- In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })`
+- `auth.signUp({ email, password?, username?, ... })` is still a two-step email OTP registration flow; finish it with the returned `verifyOtp({ token })`
 
 Preferred MCP tool path:
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -130,6 +130,7 @@ Parameter mapping for downstream Web auth code:
 - `queryAppAuth(action="getLoginConfig")` and `manageAppAuth(action="patchLoginStrategy")` return `sdkStyle: "supabase-like"` plus `sdkHints`; treat that as the preferred frontend-auth calling guide
 - `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
 - `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- Email and phone signup complete through OTP verification. After `auth.signUp({ email|phone, ... })`, continue with the returned `verifyOtp({ token })`
 - `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
@@ -212,6 +213,7 @@ Email has two layers of configuration:
 - `ModifyLoginConfig.EmailLogin`: controls whether email/password login is enabled
 - `ModifyProvider(Id="email")`: controls the email sender channel and SMTP configuration
 - In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email })`
+- `auth.signUp({ email })` is an email OTP registration step, not an `email + password` signup payload; finish the flow with `verifyOtp({ token })`
 
 Preferred MCP tool path:
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -130,7 +130,7 @@ Parameter mapping for downstream Web auth code:
 - `queryAppAuth(action="getLoginConfig")` and `manageAppAuth(action="patchLoginStrategy")` return `sdkStyle: "supabase-like"` plus `sdkHints`; treat that as the preferred frontend-auth calling guide
 - `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
 - `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })`
-- Email and phone signup complete through OTP verification. After `auth.signUp({ email|phone, ... })`, continue with the returned `verifyOtp({ token })`; if the email account should later support password login, include `password` in the initial `auth.signUp(...)` payload
+- Email and phone signup require a verification-code step. The exact completion shape depends on the installed Web SDK surface, so follow the current Web SDK `authentication` docs instead of assuming one callback contract everywhere.
 - `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
@@ -213,7 +213,7 @@ Email has two layers of configuration:
 - `ModifyLoginConfig.EmailLogin`: controls whether email/password login is enabled
 - `ModifyProvider(Id="email")`: controls the email sender channel and SMTP configuration
 - In Web auth code, this maps to `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })`
-- `auth.signUp({ email, password?, username?, ... })` is still a two-step email OTP registration flow; finish it with the returned `verifyOtp({ token })`
+- `auth.signUp({ email, password?, username?, ... })` still starts an email verification-based registration flow. Finish it with the officially documented completion step for the installed Web SDK version.
 
 Preferred MCP tool path:
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -131,7 +131,8 @@ Parameter mapping for downstream Web auth code:
 - `PhoneNumberLogin` controls phone OTP flows used by `auth-web` `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })`
 - `EmailLogin` controls email OTP flows used by `auth-web` `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })`
 - Email and phone signup require a verification-code step. The exact completion shape depends on the installed Web SDK surface, so follow the current Web SDK `authentication` docs instead of assuming one callback contract everywhere.
-- `UserNameLogin` controls username/password Web auth flows used by `auth-web` `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })`
+- `UserNameLogin` controls username/password Web auth login used by `auth-web` `auth.signInWithPassword({ username, password })`
+- `UserNameLogin` does not create users by itself. Public Web signup still follows the documented email or phone verification flow, and `username` is bound during that verified signup when needed.
 - If the account identifier is a plain username string, do not route it through email-only helpers such as `signInWithEmailAndPassword`
 - `UserNameLogin` also enables the broader password-login surface exposed by `auth.signInWithPassword({ username|email|phone, password })`
 - `SmsVerificationConfig.Type = "apis"` requires both `Name` and `Method`

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -75,7 +75,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
-- `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
+- `auth.signInWithPassword({ username, password })` is the canonical username/password login path after the user has already been created and bound to a username during an email or phone verification signup flow
 - Email and phone registration are verification-code flows. The exact request and completion shape varies by SDK surface and version, so always verify the current Web SDK `authentication` docs before hard-coding the handler shape.
 - For email signup, collect the address, password, and optional username up front, then follow the official `auth.signUp(...)` example for the installed SDK version instead of assuming a custom callback contract.
 - If the email account should support later password login, include `password` in the initial sign-up payload before finishing the verification flow.
@@ -147,9 +147,10 @@ const phoneLogin = await auth.signInWithPassword({
 
 **4. Registration**
 
-- For username-style account systems, use username/password registration directly
-- Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
-- When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
+- Username/password is a login method, not a standalone self-service signup shortcut
+- For username-style account systems, first verify how the user record will be created. CloudBase public Web signup still requires an email or phone verification flow, and `username` is bound during that verified signup.
+- Do not promise a browser-only `auth.signUp({ username, password })` registration path unless the installed SDK version and official docs for that exact version explicitly document it
+- When the task uses plain usernames such as `admin`, `editor`, or `user01`, keep the login input as plain text and use `auth.signInWithPassword({ username, password })` for login after the account has been provisioned or bound through the documented signup flow
 - Email and phone signup require a verification-code step, but the completion API depends on the installed Web SDK surface. Follow the current `authentication` docs for your version instead of assuming every project exposes the same `verifyOtp` callback shape.
 - For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login.
 - If the UI splits "send code" and "complete registration" into different handlers, persist the verification context returned by step 1 exactly as shown in the official example for the installed SDK version.
@@ -162,13 +163,6 @@ Email signup sequence at a glance:
 4. Treat the account as created only after the verification step succeeds.
 
 ```js
-// Username + Password
-const usernameSignUp = await auth.signUp({
-  username: "newuser",
-  password: "pass123",
-  nickname: "User",
-});
-
 // Email signup.
 // Use only when the task explicitly requires email addresses.
 // Follow the exact completion flow from the current Web SDK authentication docs.
@@ -191,18 +185,9 @@ const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: "123456" });
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
 
-For username-style account tasks:
+For username-style account tasks where the required test users already exist:
 
 ```tsx
-const handleRegister = async () => {
-  const { error } = await auth.signUp({
-    username,
-    password,
-    nickname: username,
-  });
-  if (error) throw error;
-};
-
 const handleLogin = async () => {
   const { error } = await auth.signInWithPassword({
     username,
@@ -211,6 +196,11 @@ const handleLogin = async () => {
   if (error) throw error;
 };
 ```
+
+If the task also requires a self-service registration UI for username-style accounts, do not fabricate a direct `auth.signUp({ username, password })` path. Instead, stop and confirm the actual provisioning approach for this repo, for example:
+
+- email or phone verification signup that binds `username` during the verified registration flow
+- admin-side provisioning through documented management capabilities such as environment user creation APIs or existing backend/admin setup
 
 Do not use email OTP or email-only helpers for these flows unless the task explicitly says the account identifier is an email address. The corresponding form field should stay `type="text"` rather than `type="email"` for username-style account identifiers.
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -74,11 +74,11 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
-- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
+- `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
 - Email and phone registration are OTP flows: `auth.signUp({ email|phone, ... })` is only the first step that sends the verification code; registration completes only after the returned `data.verifyOtp({ token })` succeeds
-- For email signup, the canonical sequence is: `auth.signUp({ email, ... })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code to finish account creation
-- Do not describe email registration as `auth.signUp({ email, password })`; for email-based password login, use `auth.signInWithPassword({ email, password })` after the account already exists
+- For email signup, the canonical sequence is: `auth.signUp({ email, password, username? })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code to finish account creation
+- If the email account should support later password login, include `password` in the initial `auth.signUp(...)` payload before calling `verifyOtp`
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
@@ -151,14 +151,14 @@ const phoneLogin = await auth.signInWithPassword({
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
 - Email and phone signup are always two-step OTP flows: first call `auth.signUp({ email|phone, ... })` to send the code, then keep the returned `data` object and call `data.verifyOtp({ token })` to finish registration
+- For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login
 - The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. In the second step, send only the verification code as `verifyOtp({ token })`; do not rebuild the signup payload
 - In split UI handlers, `auth.signUp({ email, ... })` is the "send code" step and `signupHandle.verifyOtp({ token })` is the "complete registration" step
-- Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow for an existing account, not the signup payload shown here
 - If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
 
 Email signup sequence at a glance:
 
-1. Call `auth.signUp({ email, nickname })` to send the email code.
+1. Call `auth.signUp({ email, password, username? })` to send the email code.
 2. Persist the returned `data` signup handle from step 1.
 3. Call `signupHandle.verifyOtp({ token })` with only the code from the email.
 4. Treat the account as created only after step 3 succeeds.
@@ -175,7 +175,8 @@ const usernameSignUp = await auth.signUp({
 // Use only when the task explicitly requires email addresses.
 const emailSignUp = await auth.signUp({
   email: "new@example.com",
-  nickname: "User",
+  password: "pass123",
+  username: "newuser",
 });
 const emailSignupHandle = emailSignUp.data; // Required for the follow-up verify step.
 const emailVerifyResult = await emailSignupHandle.verifyOtp({
@@ -221,7 +222,8 @@ const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
       email,
-      nickname: username || email.split("@")[0],
+      password,
+      username: username || email.split("@")[0],
     });
     if (error) throw error;
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -73,14 +73,14 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - For username-style identifiers, the required precondition is `loginMethods.usernamePassword === true` from `queryAppAuth(action="getLoginConfig")`. If it is false, enable it with `manageAppAuth(action="patchLoginStrategy", patch={ usernamePassword: true })` before wiring frontend auth code.
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
-- `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
-- `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
+- `auth.getVerification({ phone_number })` and `auth.getVerification({ email })` start the documented public verification flow used by signup and verification-token login
+- For the documented signup flow, call `auth.verify({ verification_id, verification_code })` first, then call `auth.signUp({ phone_number|email, verification_code, verification_token, password?, username?, ... })`
 - `auth.signInWithPassword({ username, password })` is the canonical username/password login path after the user has already been created and bound to a username during an email or phone verification signup flow
-- Email and phone registration are verification-code flows. The exact request and completion shape varies by SDK surface and version, so always verify the current Web SDK `authentication` docs before hard-coding the handler shape.
-- For email signup, collect the address, password, and optional username up front, then follow the official `auth.signUp(...)` example for the installed SDK version instead of assuming a custom callback contract.
+- Email and phone registration are verification-code flows. When the installed SDK version exposes additional convenience helpers, verify that exact version's docs before replacing the documented `getVerification -> verify -> signUp` sequence.
+- For email signup, collect the address, password, and optional username up front, then pass `email`, `verification_code`, `verification_token`, and optional profile fields to `auth.signUp(...)`.
 - If the email account should support later password login, include `password` in the initial sign-up payload before finishing the verification flow.
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
-- `verifyOtp({ token })` expects the SMS or email code in `token`
+- `auth.verify({ verification_id, verification_code })` returns `verification_token`, which is then passed to `auth.signUp(...)` or verification-token login flows
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -149,38 +149,53 @@ const phoneLogin = await auth.signInWithPassword({
 
 - Username/password is a login method, not a standalone self-service signup shortcut
 - For username-style account systems, first verify how the user record will be created. CloudBase public Web signup still requires an email or phone verification flow, and `username` is bound during that verified signup.
-- Do not promise a browser-only `auth.signUp({ username, password })` registration path unless the installed SDK version and official docs for that exact version explicitly document it
+- Do not promise a browser-only `auth.signUp({ username, password })` registration path. The documented public Web flow is `auth.getVerification(...) -> auth.verify(...) -> auth.signUp(...)`.
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, keep the login input as plain text and use `auth.signInWithPassword({ username, password })` for login after the account has been provisioned or bound through the documented signup flow
-- Email and phone signup require a verification-code step, but the completion API depends on the installed Web SDK surface. Follow the current `authentication` docs for your version instead of assuming every project exposes the same `verifyOtp` callback shape.
-- For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login.
-- If the UI splits "send code" and "complete registration" into different handlers, persist the verification context returned by step 1 exactly as shown in the official example for the installed SDK version.
+- For email signup, put `password` and optional `username` on the final `auth.signUp(...)` call when the new account should later use password login.
+- If the UI splits "send code" and "complete registration" into different handlers, persist the `verification_id` returned by `auth.getVerification(...)`, then call `auth.verify(...)` and `auth.signUp(...)` in the completion handler.
 
 Email signup sequence at a glance:
 
-1. Call `auth.signUp({ email, password, username? })` using the current Web SDK shape.
-2. Persist the verification context returned by step 1 if the SDK example requires it.
-3. Complete the verification step exactly as documented for that SDK version.
-4. Treat the account as created only after the verification step succeeds.
+1. Call `auth.getVerification({ email })`.
+2. Call `auth.verify({ verification_id, verification_code })` to obtain `verification_token`.
+3. Call `auth.signUp({ email, verification_code, verification_token, password?, username? })`.
+4. Treat the account as created only after `auth.signUp(...)` succeeds. The documented flow auto-signs the user in on success.
 
 ```js
 // Email signup.
 // Use only when the task explicitly requires email addresses.
-// Follow the exact completion flow from the current Web SDK authentication docs.
-const emailSignUp = await auth.signUp({
+const emailVerification = await auth.getVerification({
   email: "new@example.com",
+});
+const emailVerificationCode = "123456";
+const emailVerificationTokenRes = await auth.verify({
+  verification_id: emailVerification.verification_id,
+  verification_code: emailVerificationCode,
+});
+await auth.signUp({
+  email: "new@example.com",
+  verification_code: emailVerificationCode,
+  verification_token: emailVerificationTokenRes.verification_token,
   password: "pass123",
   username: "newuser",
 });
-const emailVerificationContext = emailSignUp.data;
-// Complete the verification step with the official SDK example for your installed version.
 
 // Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
-const phoneSignUp = await auth.signUp({
-  phone: "13800138000",
+const phoneVerification = await auth.getVerification({
+  phone_number: "+86 13800138000",
+});
+const phoneVerificationCode = "123456";
+const phoneVerificationTokenRes = await auth.verify({
+  verification_id: phoneVerification.verification_id,
+  verification_code: phoneVerificationCode,
+});
+await auth.signUp({
+  phone_number: "+86 13800138000",
+  verification_code: phoneVerificationCode,
+  verification_token: phoneVerificationTokenRes.verification_token,
   nickname: "User",
 });
-const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: "123456" });
 ```
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
@@ -207,15 +222,12 @@ Do not use email OTP or email-only helpers for these flows unless the task expli
 ```tsx
 const handleSendCode = async () => {
   try {
-    const { data, error } = await auth.signUp({
+    const verification = await auth.getVerification({
       email,
-      password,
-      username: username || email.split("@")[0],
     });
-    if (error) throw error;
 
-    // Keep the returned verification context for the follow-up completion step.
-    setSignUpData(data);
+    // Keep the verification ID for the follow-up completion step.
+    setVerificationId(verification.verification_id);
   } catch (error) {
     console.error("Failed to send sign-up code", error);
   }
@@ -223,10 +235,20 @@ const handleSendCode = async () => {
 
 const handleRegister = async () => {
   try {
-    if (!signUpData) throw new Error("Please send the code first");
+    if (!verificationId) throw new Error("Please send the code first");
 
-    // Complete the verification step with the official SDK example for the installed version.
-    const { error } = await signUpData.verifyOtp({ token: code });
+    const verificationTokenRes = await auth.verify({
+      verification_id: verificationId,
+      verification_code: code,
+    });
+
+    const { error } = await auth.signUp({
+      email,
+      verification_code: code,
+      verification_token: verificationTokenRes.verification_token,
+      password,
+      username: username || email.split("@")[0],
+    });
     if (error) throw error;
   } catch (error) {
     console.error("Failed to complete sign-up", error);

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -77,6 +77,7 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
 - Email and phone registration are OTP flows: call `auth.signUp({ email|phone, ... })`, then complete the signup with the returned `data.verifyOtp({ token })`
+- For email signup, the canonical sequence is: `auth.signUp({ email, ... })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code
 - Do not describe email registration as `auth.signUp({ email, password })`; for email-based password login, use `auth.signInWithPassword({ email, password })` after the account already exists
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
@@ -151,6 +152,7 @@ const phoneLogin = await auth.signInWithPassword({
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
 - Email and phone signup are always two-step OTP flows: first call `auth.signUp({ email|phone, ... })` to send the code, then keep the returned `data` object and call `data.verifyOtp({ token })` to finish registration
 - The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. In the second step, send only the verification code as `verifyOtp({ token })`; do not rebuild the signup payload
+- In split UI handlers, `auth.signUp({ email, ... })` is the "send code" step and `signupHandle.verifyOtp({ token })` is the "complete registration" step
 - Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow for an existing account, not the signup payload shown here
 - If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
 
@@ -168,7 +170,7 @@ const emailSignUp = await auth.signUp({
   email: "new@example.com",
   nickname: "User",
 });
-const emailSignupHandle = emailSignUp.data;
+const emailSignupHandle = emailSignUp.data; // Required for the follow-up verify step.
 const emailVerifyResult = await emailSignupHandle.verifyOtp({
   token: "123456",
 });

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -74,10 +74,10 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
-- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
+- `auth.signInWithOtp({ email })` and `auth.signUp({ email })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
-- Email and phone registration are OTP flows: call `auth.signUp({ email|phone, ... })`, then complete the signup with the returned `data.verifyOtp({ token })`
-- For email signup, the canonical sequence is: `auth.signUp({ email, ... })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code
+- Email and phone registration are OTP flows: `auth.signUp({ email|phone, ... })` is only the first step that sends the verification code; registration completes only after the returned `data.verifyOtp({ token })` succeeds
+- For email signup, the canonical sequence is: `auth.signUp({ email, ... })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code to finish account creation
 - Do not describe email registration as `auth.signUp({ email, password })`; for email-based password login, use `auth.signInWithPassword({ email, password })` after the account already exists
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
@@ -117,7 +117,7 @@ const { data: loginData, error: loginError } = await data.verifyOtp({
 });
 ```
 
-**2. Email OTP**
+**2. Email OTP Login**
 
 - Automatically use `auth-tool-cloudbase` to turn on `Email Login` through `manageAppAuth`
 
@@ -155,6 +155,13 @@ const phoneLogin = await auth.signInWithPassword({
 - In split UI handlers, `auth.signUp({ email, ... })` is the "send code" step and `signupHandle.verifyOtp({ token })` is the "complete registration" step
 - Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow for an existing account, not the signup payload shown here
 - If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
+
+Email signup sequence at a glance:
+
+1. Call `auth.signUp({ email, nickname })` to send the email code.
+2. Persist the returned `data` signup handle from step 1.
+3. Call `signupHandle.verifyOtp({ token })` with only the code from the email.
+4. Treat the account as created only after step 3 succeeds.
 
 ```js
 // Username + Password

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -87,16 +87,16 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 ## Quick Start
 
 ```js
-import cloudbase from '@cloudbase/js-sdk'
+import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
   env: `env`, // CloudBase environment ID
-  region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
-  accessKey: 'publishable key', // required, get from auth-tool-cloudbase
+  region: `region`, // CloudBase environment Region, default 'ap-shanghai'
+  accessKey: "publishable key", // required, get from auth-tool-cloudbase
   auth: { detectSessionInUrl: true }, // required
-})
+});
 
-const auth = app.auth({ persistence: 'local' })
+const auth = app.auth({ persistence: "local" });
 ```
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
@@ -106,50 +106,80 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 ## Login Methods
 
 **1. Phone OTP (Recommended)**
+
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
+const { data, error } = await auth.signInWithOtp({ phone: "13800138000" });
+const { data: loginData, error: loginError } = await data.verifyOtp({
+  token: "123456",
+});
 ```
 
 **2. Email OTP**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Email Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOtp({ email: 'user@example.com' })
-const { data: loginData, error: loginError } = await data.verifyOtp({ token: '654321' })
+const { data, error } = await auth.signInWithOtp({ email: "user@example.com" });
+const { data: loginData, error: loginError } = await data.verifyOtp({
+  token: "654321",
+});
 ```
 
 **3. Password**
+
 ```js
-const usernameLogin = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
-const emailLogin = await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
-const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+const usernameLogin = await auth.signInWithPassword({
+  username: "test_user",
+  password: "pass123",
+});
+const emailLogin = await auth.signInWithPassword({
+  email: "user@example.com",
+  password: "pass123",
+});
+const phoneLogin = await auth.signInWithPassword({
+  phone: "13800138000",
+  password: "pass123",
+});
 ```
 
 **4. Registration**
+
 - For username-style account systems, use username/password registration directly
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
-- Email and phone signup are verification-code flows. Send the code with `auth.signUp(...)`, then call the returned `verifyOtp({ token })` to finish registration
-- The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. For the follow-up step, send only the verification code as `verifyOtp({ token })`
-- Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow, not the signup payload shown here
+- Email and phone signup are always two-step OTP flows: first call `auth.signUp({ email|phone, ... })` to send the code, then keep the returned `data` object and call `data.verifyOtp({ token })` to finish registration
+- The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. In the second step, send only the verification code as `verifyOtp({ token })`; do not rebuild the signup payload
+- Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow for an existing account, not the signup payload shown here
+- If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
+
 ```js
 // Username + Password
 const usernameSignUp = await auth.signUp({
-  username: 'newuser',
-  password: 'pass123',
-  nickname: 'User',
-})
+  username: "newuser",
+  password: "pass123",
+  nickname: "User",
+});
 
 // Email OTP signup.
 // Use only when the task explicitly requires email addresses.
-const emailSignUp = await auth.signUp({ email: 'new@example.com', nickname: 'User' })
-const emailVerifyResult = await emailSignUp.data.verifyOtp({ token: '123456' })
+const emailSignUp = await auth.signUp({
+  email: "new@example.com",
+  nickname: "User",
+});
+const emailSignupHandle = emailSignUp.data;
+const emailVerifyResult = await emailSignupHandle.verifyOtp({
+  token: "123456",
+});
 
 // Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
-const phoneSignUp = await auth.signUp({ phone: '13800138000', nickname: 'User' })
-const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: '123456' })
+const phoneSignUp = await auth.signUp({
+  phone: "13800138000",
+  nickname: "User",
+});
+const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: "123456" });
 ```
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
@@ -162,17 +192,17 @@ const handleRegister = async () => {
     username,
     password,
     nickname: username,
-  })
-  if (error) throw error
-}
+  });
+  if (error) throw error;
+};
 
 const handleLogin = async () => {
   const { error } = await auth.signInWithPassword({
     username,
     password,
-  })
-  if (error) throw error
-}
+  });
+  if (error) throw error;
+};
 ```
 
 Do not use email OTP or email-only helpers for these flows unless the task explicitly says the account identifier is an email address. The corresponding form field should stay `type="text"` rather than `type="email"` for username-style account identifiers.
@@ -182,56 +212,64 @@ const handleSendCode = async () => {
   try {
     const { data, error } = await auth.signUp({
       email,
-      name: username || email.split('@')[0],
-    })
-    if (error) throw error
-    setSignUpData(data)
+      nickname: username || email.split("@")[0],
+    });
+    if (error) throw error;
+
+    // Keep the returned sign-up handle for the follow-up verifyOtp step.
+    setSignUpData(data);
   } catch (error) {
-    console.error('Failed to send sign-up code', error)
+    console.error("Failed to send sign-up code", error);
   }
-}
+};
 
 const handleRegister = async () => {
   try {
-    if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
+    if (!signUpData?.verifyOtp) throw new Error("Please send the code first");
 
-    const { error } = await signUpData.verifyOtp({ token: code })
-    if (error) throw error
+    const { error } = await signUpData.verifyOtp({ token: code });
+    if (error) throw error;
   } catch (error) {
-    console.error('Failed to complete sign-up', error)
+    console.error("Failed to complete sign-up", error);
   }
-}
+};
 ```
 
 **5. Anonymous**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Anonymous Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInAnonymously()
+const { data, error } = await auth.signInAnonymously();
 ```
 
 **6. OAuth (Google/WeChat)**
+
 - Automatically use `auth-tool-cloudbase` to turn on `Google Login` or `WeChat Login` through `manageAppAuth`
+
 ```js
-const { data, error } = await auth.signInWithOAuth({ provider: 'google' })
-window.location.href = data.url // Auto-complete after callback
+const { data, error } = await auth.signInWithOAuth({ provider: "google" });
+window.location.href = data.url; // Auto-complete after callback
 ```
 
 **7. Custom Ticket**
+
 ```js
 await auth.signInWithCustomTicket(async () => {
-  const res = await fetch('/api/ticket')
-  return (await res.json()).ticket
-})
+  const res = await fetch("/api/ticket");
+  return (await res.json()).ticket;
+});
 ```
 
 **8. Upgrade Anonymous**
+
 ```js
-const sessionResult = await auth.getSession()
+const sessionResult = await auth.getSession();
 const upgradeResult = await auth.signUp({
-  phone: '13800000000',
+  phone: "13800000000",
   anonymous_token: sessionResult.data.session.access_token,
-})
-await upgradeResult.data.verifyOtp({ token: '123456' })
+});
+await upgradeResult.data.verifyOtp({ token: "123456" });
 ```
 
 ---
@@ -240,68 +278,70 @@ await upgradeResult.data.verifyOtp({ token: '123456' })
 
 ```js
 // Sign out
-const signOutResult = await auth.signOut()
+const signOutResult = await auth.signOut();
 
 // Get user
-const userResult = await auth.getUser()
+const userResult = await auth.getUser();
 console.log(
   userResult.data.user.email,
   userResult.data.user.phone,
   userResult.data.user.user_metadata?.nickName,
-)
+);
 
 // Update user (except email, phone)
 const updateProfileResult = await auth.updateUser({
-  nickname: 'New Name',
-  gender: 'MALE',
-  avatar_url: 'url',
-})
+  nickname: "New Name",
+  gender: "MALE",
+  avatar_url: "url",
+});
 
 // Update user (email or phone)
-const updateEmailResult = await auth.updateUser({ email: 'new@example.com' })
+const updateEmailResult = await auth.updateUser({ email: "new@example.com" });
 const verifyEmailResult = await updateEmailResult.data.verifyOtp({
-  email: 'new@example.com',
-  token: '123456',
-})
+  email: "new@example.com",
+  token: "123456",
+});
 
 // Change password (logged in)
 const resetPasswordResult = await auth.resetPasswordForOld({
-  old_password: 'old',
-  new_password: 'new',
-})
+  old_password: "old",
+  new_password: "new",
+});
 
 // Reset password (forgot)
-const reauthResult = await auth.reauthenticate()
+const reauthResult = await auth.reauthenticate();
 const forgotPasswordResult = await reauthResult.data.updateUser({
-  nonce: '123456',
-  password: 'new',
-})
+  nonce: "123456",
+  password: "new",
+});
 
 // Link third-party
-const linkIdentityResult = await auth.linkIdentity({ provider: 'google' })
+const linkIdentityResult = await auth.linkIdentity({ provider: "google" });
 
 // View/Unlink identities
-const identitiesResult = await auth.getUserIdentities()
+const identitiesResult = await auth.getUserIdentities();
 const unlinkIdentityResult = await auth.unlinkIdentity({
   provider: identitiesResult.data.identities[0].id,
-})
+});
 
 // Delete account
-const deleteMeResult = await auth.deleteMe({ password: 'current' })
+const deleteMeResult = await auth.deleteMe({ password: "current" });
 
 // Listen to state changes
 const authStateSubscription = auth.onAuthStateChange((event, session, info) => {
   // INITIAL_SESSION, SIGNED_IN, SIGNED_OUT, TOKEN_REFRESHED, USER_UPDATED, PASSWORD_RECOVERY, BIND_IDENTITY
-})
+});
 
 // Get access token
-const sessionResult = await auth.getSession()
-await fetch('/api/protected', {
-  headers: { Authorization: `Bearer ${sessionResult.data.session?.access_token}` },
-})
+const sessionResult = await auth.getSession();
+await fetch("/api/protected", {
+  headers: {
+    Authorization: `Bearer ${sessionResult.data.session?.access_token}`,
+  },
+});
 
 // Refresh user
-const refreshUserResult = await auth.refreshUser()
+const refreshUserResult = await auth.refreshUser();
 ```
 
 ---
@@ -310,36 +350,36 @@ const refreshUserResult = await auth.refreshUser()
 
 ```ts
 declare type User = {
-  id: any
-  aud: string
-  role: string[]
-  email: any
-  email_confirmed_at: string
-  phone: any
-  phone_confirmed_at: string
-  confirmed_at: string
-  last_sign_in_at: string
+  id: any;
+  aud: string;
+  role: string[];
+  email: any;
+  email_confirmed_at: string;
+  phone: any;
+  phone_confirmed_at: string;
+  confirmed_at: string;
+  last_sign_in_at: string;
   app_metadata: {
-    provider: any
-    providers: any[]
-  }
+    provider: any;
+    providers: any[];
+  };
   user_metadata: {
-    name: any
-    picture: any
-    username: any
-    gender: any
-    locale: any
-    uid: any
-    nickName: any
-    avatarUrl: any
-    location: any
-    hasPassword: any
-  }
-  identities: any
-  created_at: string
-  updated_at: string
-  is_anonymous: boolean
-}
+    name: any;
+    picture: any;
+    username: any;
+    gender: any;
+    locale: any;
+    uid: any;
+    nickName: any;
+    avatarUrl: any;
+    location: any;
+    hasPassword: any;
+  };
+  identities: any;
+  created_at: string;
+  updated_at: string;
+  is_anonymous: boolean;
+};
 ```
 
 ---
@@ -349,43 +389,43 @@ declare type User = {
 ```js
 class PhoneLoginPage {
   async sendCode() {
-    const phone = document.getElementById('phone').value
-    if (!/^1[3-9]\d{9}$/.test(phone)) return alert('Invalid phone')
+    const phone = document.getElementById("phone").value;
+    if (!/^1[3-9]\d{9}$/.test(phone)) return alert("Invalid phone");
 
-    const { data, error } = await auth.signInWithOtp({ phone })
-    if (error) return alert('Send failed: ' + error.message)
+    const { data, error } = await auth.signInWithOtp({ phone });
+    if (error) return alert("Send failed: " + error.message);
 
-    this.verifyOtp = data.verifyOtp
-    document.getElementById('codeSection').style.display = 'block'
-    this.startCountdown(60)
+    this.verifyOtp = data.verifyOtp;
+    document.getElementById("codeSection").style.display = "block";
+    this.startCountdown(60);
   }
 
   async verifyCode() {
-    const code = document.getElementById('code').value
-    if (!code) return alert('Enter code')
-    if (!this.verifyOtp) return alert('Send the code first')
+    const code = document.getElementById("code").value;
+    if (!code) return alert("Enter code");
+    if (!this.verifyOtp) return alert("Send the code first");
 
-    const { data, error } = await this.verifyOtp({ token: code })
-    if (error) return alert('Verification failed: ' + error.message)
+    const { data, error } = await this.verifyOtp({ token: code });
+    if (error) return alert("Verification failed: " + error.message);
 
-    console.log('Login successful:', data.user)
-    window.location.href = '/dashboard'
+    console.log("Login successful:", data.user);
+    window.location.href = "/dashboard";
   }
 
   startCountdown(seconds) {
-    let countdown = seconds
-    const btn = document.getElementById('resendBtn')
-    btn.disabled = true
+    let countdown = seconds;
+    const btn = document.getElementById("resendBtn");
+    btn.disabled = true;
 
     const timer = setInterval(() => {
-      countdown--
-      btn.innerText = `Resend in ${countdown}s`
+      countdown--;
+      btn.innerText = `Resend in ${countdown}s`;
       if (countdown <= 0) {
-        clearInterval(timer)
-        btn.disabled = false
-        btn.innerText = 'Resend'
+        clearInterval(timer);
+        btn.disabled = false;
+        btn.innerText = "Resend";
       }
-    }, 1000)
+    }, 1000);
   }
 }
 ```

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -76,9 +76,9 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email, ... })` both use the `email` field, but they serve different purposes: `signInWithOtp` starts email login, while `signUp` starts email registration
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
-- Email and phone registration are OTP flows: `auth.signUp({ email|phone, ... })` is only the first step that sends the verification code; registration completes only after the returned `data.verifyOtp({ token })` succeeds
-- For email signup, the canonical sequence is: `auth.signUp({ email, password, username? })` to send the code, persist the returned `data` signup handle, then call `signupHandle.verifyOtp({ token })` with only the verification code to finish account creation
-- If the email account should support later password login, include `password` in the initial `auth.signUp(...)` payload before calling `verifyOtp`
+- Email and phone registration are verification-code flows. The exact request and completion shape varies by SDK surface and version, so always verify the current Web SDK `authentication` docs before hard-coding the handler shape.
+- For email signup, collect the address, password, and optional username up front, then follow the official `auth.signUp(...)` example for the installed SDK version instead of assuming a custom callback contract.
+- If the email account should support later password login, include `password` in the initial sign-up payload before finishing the verification flow.
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
@@ -150,18 +150,16 @@ const phoneLogin = await auth.signInWithPassword({
 - For username-style account systems, use username/password registration directly
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
-- Email and phone signup are always two-step OTP flows: first call `auth.signUp({ email|phone, ... })` to send the code, then keep the returned `data` object and call `data.verifyOtp({ token })` to finish registration
-- For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login
-- The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. In the second step, send only the verification code as `verifyOtp({ token })`; do not rebuild the signup payload
-- In split UI handlers, `auth.signUp({ email, ... })` is the "send code" step and `signupHandle.verifyOtp({ token })` is the "complete registration" step
-- If the UI splits "send code" and "complete registration" into different handlers, persist the returned sign-up handle from step 1 and reuse it in step 2
+- Email and phone signup require a verification-code step, but the completion API depends on the installed Web SDK surface. Follow the current `authentication` docs for your version instead of assuming every project exposes the same `verifyOtp` callback shape.
+- For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login.
+- If the UI splits "send code" and "complete registration" into different handlers, persist the verification context returned by step 1 exactly as shown in the official example for the installed SDK version.
 
 Email signup sequence at a glance:
 
-1. Call `auth.signUp({ email, password, username? })` to send the email code.
-2. Persist the returned `data` signup handle from step 1.
-3. Call `signupHandle.verifyOtp({ token })` with only the code from the email.
-4. Treat the account as created only after step 3 succeeds.
+1. Call `auth.signUp({ email, password, username? })` using the current Web SDK shape.
+2. Persist the verification context returned by step 1 if the SDK example requires it.
+3. Complete the verification step exactly as documented for that SDK version.
+4. Treat the account as created only after the verification step succeeds.
 
 ```js
 // Username + Password
@@ -171,17 +169,16 @@ const usernameSignUp = await auth.signUp({
   nickname: "User",
 });
 
-// Email OTP signup.
+// Email signup.
 // Use only when the task explicitly requires email addresses.
+// Follow the exact completion flow from the current Web SDK authentication docs.
 const emailSignUp = await auth.signUp({
   email: "new@example.com",
   password: "pass123",
   username: "newuser",
 });
-const emailSignupHandle = emailSignUp.data; // Required for the follow-up verify step.
-const emailVerifyResult = await emailSignupHandle.verifyOtp({
-  token: "123456",
-});
+const emailVerificationContext = emailSignUp.data;
+// Complete the verification step with the official SDK example for your installed version.
 
 // Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
@@ -227,7 +224,7 @@ const handleSendCode = async () => {
     });
     if (error) throw error;
 
-    // Keep the returned sign-up handle for the follow-up verifyOtp step.
+    // Keep the returned verification context for the follow-up completion step.
     setSignUpData(data);
   } catch (error) {
     console.error("Failed to send sign-up code", error);
@@ -236,8 +233,9 @@ const handleSendCode = async () => {
 
 const handleRegister = async () => {
   try {
-    if (!signUpData?.verifyOtp) throw new Error("Please send the code first");
+    if (!signUpData) throw new Error("Please send the code first");
 
+    // Complete the verification step with the official SDK example for the installed version.
     const { error } = await signUpData.verifyOtp({ token: code });
     if (error) throw error;
   } catch (error) {

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -76,6 +76,8 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - `auth.signInWithOtp({ phone })` and `auth.signUp({ phone })` use the phone number in a `phone` field, not `phone_number`
 - `auth.signInWithOtp({ email })` and `auth.signUp({ email })` use `email`
 - `auth.signUp({ username, password })` and `auth.signInWithPassword({ username, password })` are the canonical username/password Web auth path
+- Email and phone registration are OTP flows: call `auth.signUp({ email|phone, ... })`, then complete the signup with the returned `data.verifyOtp({ token })`
+- Do not describe email registration as `auth.signUp({ email, password })`; for email-based password login, use `auth.signInWithPassword({ email, password })` after the account already exists
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `verifyOtp({ token })` expects the SMS or email code in `token`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
@@ -128,6 +130,8 @@ const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', passwor
 - For username-style account systems, use username/password registration directly
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
+- Email and phone signup are verification-code flows. Send the code with `auth.signUp(...)`, then call the returned `verifyOtp({ token })` to finish registration
+- Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow, not the signup payload shown here
 ```js
 // Username + Password
 const usernameSignUp = await auth.signUp({
@@ -136,15 +140,13 @@ const usernameSignUp = await auth.signUp({
   nickname: 'User',
 })
 
-// Email Otp
+// Email OTP signup.
 // Use only when the task explicitly requires email addresses.
-// Email Otp
 const emailSignUp = await auth.signUp({ email: 'new@example.com', nickname: 'User' })
 const emailVerifyResult = await emailSignUp.data.verifyOtp({ token: '123456' })
 
-// Phone Otp
+// Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
-// Phone Otp
 const phoneSignUp = await auth.signUp({ phone: '13800138000', nickname: 'User' })
 const phoneVerifyResult = await phoneSignUp.data.verifyOtp({ token: '123456' })
 ```

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -73,14 +73,13 @@ Use the same CDN address as `web-development`. Prefer npm installation in modern
 - For username-style identifiers, the required precondition is `loginMethods.usernamePassword === true` from `queryAppAuth(action="getLoginConfig")`. If it is false, enable it with `manageAppAuth(action="patchLoginStrategy", patch={ usernamePassword: true })` before wiring frontend auth code.
 - Treat CloudBase Web Auth as **Supabase-like**, not “every `supabase-js` auth example is valid unchanged”
 - When `queryAppAuth` / `manageAppAuth` returns `sdkStyle: "supabase-like"` and `sdkHints`, follow those method and parameter hints first
-- `auth.getVerification({ phone_number })` and `auth.getVerification({ email })` start the documented public verification flow used by signup and verification-token login
-- For the documented signup flow, call `auth.verify({ verification_id, verification_code })` first, then call `auth.signUp({ phone_number|email, verification_code, verification_token, password?, username?, ... })`
+- `auth.signUp({ email|phone, password, username?, ... })` starts the documented public signup flow for email or phone registration and returns a `verifyOtp({ token })` callback in `data`
 - `auth.signInWithPassword({ username, password })` is the canonical username/password login path after the user has already been created and bound to a username during an email or phone verification signup flow
-- Email and phone registration are verification-code flows. When the installed SDK version exposes additional convenience helpers, verify that exact version's docs before replacing the documented `getVerification -> verify -> signUp` sequence.
-- For email signup, collect the address, password, and optional username up front, then pass `email`, `verification_code`, `verification_token`, and optional profile fields to `auth.signUp(...)`.
+- Email and phone registration are verification-code flows. Follow the installed Web SDK docs and complete the flow through the returned `data.verifyOtp({ token })` callback unless that SDK version documents a different surface.
+- For email signup, collect the address, password, and optional username up front, then pass them to `auth.signUp(...)` before asking the user for the verification code.
 - If the email account should support later password login, include `password` in the initial sign-up payload before finishing the verification flow.
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
-- `auth.verify({ verification_id, verification_code })` returns `verification_token`, which is then passed to `auth.signUp(...)` or verification-token login flows
+- The `verifyOtp({ token })` callback returned by `auth.signUp(...)` completes the signup after the user enters the received verification code
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
@@ -149,53 +148,47 @@ const phoneLogin = await auth.signInWithPassword({
 
 - Username/password is a login method, not a standalone self-service signup shortcut
 - For username-style account systems, first verify how the user record will be created. CloudBase public Web signup still requires an email or phone verification flow, and `username` is bound during that verified signup.
-- Do not promise a browser-only `auth.signUp({ username, password })` registration path. The documented public Web flow is `auth.getVerification(...) -> auth.verify(...) -> auth.signUp(...)`.
+- Do not promise a browser-only `auth.signUp({ username, password })` registration path. The documented public Web flow is `auth.signUp({ email|phone, password, username?, ... }) -> data.verifyOtp({ token })`.
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, keep the login input as plain text and use `auth.signInWithPassword({ username, password })` for login after the account has been provisioned or bound through the documented signup flow
-- For email signup, put `password` and optional `username` on the final `auth.signUp(...)` call when the new account should later use password login.
-- If the UI splits "send code" and "complete registration" into different handlers, persist the `verification_id` returned by `auth.getVerification(...)`, then call `auth.verify(...)` and `auth.signUp(...)` in the completion handler.
+- Do not switch to email OTP or phone OTP unless the task explicitly requires email addresses or phone numbers for the account identifier.
+- For email signup, put `password` and optional `username` on the initial `auth.signUp(...)` call when the new account should later use password login.
+- If the UI splits "send code" and "complete registration" into different handlers, persist the `verifyOtp` callback returned by `auth.signUp(...)`, then call it from the completion handler with the user-entered code.
 
 Email signup sequence at a glance:
 
-1. Call `auth.getVerification({ email })`.
-2. Call `auth.verify({ verification_id, verification_code })` to obtain `verification_token`.
-3. Call `auth.signUp({ email, verification_code, verification_token, password?, username? })`.
-4. Treat the account as created only after `auth.signUp(...)` succeeds. The documented flow auto-signs the user in on success.
+1. Call `auth.signUp({ email, password, username? })`.
+2. Store the returned `data.verifyOtp` callback.
+3. Call `data.verifyOtp({ token })` after the user receives and enters the verification code.
+4. Treat the account as created only after `verifyOtp(...)` succeeds. The documented flow auto-signs the user in on success.
 
 ```js
 // Email signup.
 // Use only when the task explicitly requires email addresses.
-const emailVerification = await auth.getVerification({
+const { data: emailSignUpData, error: emailSignUpError } = await auth.signUp({
   email: "new@example.com",
-});
-const emailVerificationCode = "123456";
-const emailVerificationTokenRes = await auth.verify({
-  verification_id: emailVerification.verification_id,
-  verification_code: emailVerificationCode,
-});
-await auth.signUp({
-  email: "new@example.com",
-  verification_code: emailVerificationCode,
-  verification_token: emailVerificationTokenRes.verification_token,
   password: "pass123",
   username: "newuser",
 });
+if (emailSignUpError) throw emailSignUpError;
+const emailVerificationCode = "123456";
+const { error: emailVerifyError } = await emailSignUpData.verifyOtp({
+  token: emailVerificationCode,
+});
+if (emailVerifyError) throw emailVerifyError;
 
 // Phone OTP signup.
 // Use only when the task explicitly requires phone numbers.
-const phoneVerification = await auth.getVerification({
-  phone_number: "+86 13800138000",
+const { data: phoneSignUpData, error: phoneSignUpError } = await auth.signUp({
+  phone: "13800138000",
+  password: "pass123",
+  username: "phone_user",
 });
+if (phoneSignUpError) throw phoneSignUpError;
 const phoneVerificationCode = "123456";
-const phoneVerificationTokenRes = await auth.verify({
-  verification_id: phoneVerification.verification_id,
-  verification_code: phoneVerificationCode,
+const { error: phoneVerifyError } = await phoneSignUpData.verifyOtp({
+  token: phoneVerificationCode,
 });
-await auth.signUp({
-  phone_number: "+86 13800138000",
-  verification_code: phoneVerificationCode,
-  verification_token: phoneVerificationTokenRes.verification_token,
-  nickname: "User",
-});
+if (phoneVerifyError) throw phoneVerifyError;
 ```
 
 When the project already has `handleSendCode` / `handleRegister` or similar UI handlers, wire the SDK calls there directly instead of leaving them commented out in `App.tsx`.
@@ -212,9 +205,8 @@ const handleLogin = async () => {
 };
 ```
 
-If the task also requires a self-service registration UI for username-style accounts, do not fabricate a direct `auth.signUp({ username, password })` path. Instead, stop and confirm the actual provisioning approach for this repo, for example:
+If the task also requires a self-service registration UI for username-style accounts, do not fabricate a direct `auth.signUp({ username, password })` path. Instead, confirm that the repo accepts an email or phone signup that binds `username`, then wire the documented `signUp(...)->verifyOtp(...)` flow into the active handlers.
 
-- email or phone verification signup that binds `username` during the verified registration flow
 - admin-side provisioning through documented management capabilities such as environment user creation APIs or existing backend/admin setup
 
 Do not use email OTP or email-only helpers for these flows unless the task explicitly says the account identifier is an email address. The corresponding form field should stay `type="text"` rather than `type="email"` for username-style account identifiers.
@@ -222,12 +214,15 @@ Do not use email OTP or email-only helpers for these flows unless the task expli
 ```tsx
 const handleSendCode = async () => {
   try {
-    const verification = await auth.getVerification({
+    const { data, error } = await auth.signUp({
       email,
+      password,
+      username: username || email.split("@")[0],
     });
+    if (error) throw error;
 
-    // Keep the verification ID for the follow-up completion step.
-    setVerificationId(verification.verification_id);
+    // Keep the callback for the follow-up completion step.
+    setVerifyOtpCallback(() => data.verifyOtp);
   } catch (error) {
     console.error("Failed to send sign-up code", error);
   }
@@ -235,20 +230,9 @@ const handleSendCode = async () => {
 
 const handleRegister = async () => {
   try {
-    if (!verificationId) throw new Error("Please send the code first");
+    if (!verifyOtpCallback) throw new Error("Please send the code first");
 
-    const verificationTokenRes = await auth.verify({
-      verification_id: verificationId,
-      verification_code: code,
-    });
-
-    const { error } = await auth.signUp({
-      email,
-      verification_code: code,
-      verification_token: verificationTokenRes.verification_token,
-      password,
-      username: username || email.split("@")[0],
-    });
+    const { error } = await verifyOtpCallback({ token: code });
     if (error) throw error;
   } catch (error) {
     console.error("Failed to complete sign-up", error);

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -131,6 +131,7 @@ const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', passwor
 - Do not switch to email OTP or phone OTP unless the task explicitly says the account identifier is an email address or phone number
 - When the task uses plain usernames such as `admin`, `editor`, or `user01`, the canonical form code is `auth.signUp({ username, password })`
 - Email and phone signup are verification-code flows. Send the code with `auth.signUp(...)`, then call the returned `verifyOtp({ token })` to finish registration
+- The `verifyOtp` callback returned from `auth.signUp({ email|phone, ... })` already carries the signup context. For the follow-up step, send only the verification code as `verifyOtp({ token })`
 - Do not write email registration as `auth.signUp({ email, password })`; email/password is a sign-in flow, not the signup payload shown here
 ```js
 // Username + Password
@@ -194,11 +195,7 @@ const handleRegister = async () => {
   try {
     if (!signUpData?.verifyOtp) throw new Error('Please send the code first')
 
-    const { error } = await signUpData.verifyOtp({
-      email,
-      token: code,
-      type: 'signup',
-    })
+    const { error } = await signUpData.verifyOtp({ token: code })
     if (error) throw error
   } catch (error) {
     console.error('Failed to complete sign-up', error)

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -40,7 +40,7 @@
 <tr><td><code>queryAppAuth</code></td><td>应用侧认证配置只读入口。用于查询登录方式、provider、publishable key、API key、client 配置和静态域名等认证准备状态。若业务要接受普通用户名样式标识符，先查询 action=getLoginConfig；若 usernamePassword=false，下一步应立即调用 manageAppAuth(action=patchLoginStrategy, patch=&#123; usernamePassword: true &#125;)，不要直接写 email 登录 API。</td></tr>
 <tr><td><code>manageAppAuth</code></td><td>应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch=&#123; usernamePassword: true &#125;，再实现对应前端登录逻辑。</td></tr>
 <tr><td><code>queryPermissions</code></td><td>权限域统一只读入口。支持查询资源权限、角色列表/详情、应用用户列表/详情。</td></tr>
-<tr><td><code>managePermissions</code></td><td>权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp(&#123; username, password &#125;)`，登录应使用 `auth.signInWithPassword(&#123; username, password &#125;)`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。</td></tr>
+<tr><td><code>managePermissions</code></td><td>权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的公开注册表单；前端用户名样式账号登录应使用 `auth.signInWithPassword(&#123; username, password &#125;)`，自助注册应遵循官方邮箱/手机号验证 `auth.signUp(...)` 流程并在注册时绑定 `username`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。</td></tr>
 <tr><td><code>queryLogs</code></td><td>日志域统一只读入口。支持检查日志服务状态并搜索 CLS 日志。</td></tr>
 <tr><td><code>queryAgents</code></td><td>Agent 域统一只读入口。支持列表、详情与日志查询。</td></tr>
 <tr><td><code>manageAgents</code></td><td>Agent 域统一写入口。支持创建、更新和删除远端 Agent。</td></tr>
@@ -774,7 +774,7 @@ classDiagram
 ---
 
 ### `managePermissions`
-权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp(&#123; username, password &#125;)`，登录应使用 `auth.signInWithPassword(&#123; username, password &#125;)`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。
+权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的公开注册表单；前端用户名样式账号登录应使用 `auth.signInWithPassword(&#123; username, password &#125;)`，自助注册应遵循官方邮箱/手机号验证 `auth.signUp(...)` 流程并在注册时绑定 `username`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。
 
 #### 参数
 

--- a/mcp/src/tools/app-auth.test.ts
+++ b/mcp/src/tools/app-auth.test.ts
@@ -67,8 +67,8 @@ describe("app auth tools", () => {
     phoneOtp: "auth.signInWithOtp({ phone })",
     emailOtp: "auth.signInWithOtp({ email })",
     password: "auth.signInWithPassword({ username|email|phone, password })",
-    signup: "auth.signUp({ username, password }) or auth.signUp({ phone|email, ... })",
-    verifyOtp: "verifyOtp({ token }) for phone/email OTP signup or login",
+    signup: "auth.signUp({ phone|email, password?, username?, ... })",
+    verifyOtp: "verifyOtp({ token }) to complete phone/email OTP signup or login",
     anonymous: "auth.signInAnonymously()",
   };
 
@@ -205,7 +205,8 @@ describe("app auth tools", () => {
       },
       webSdkHint: {
         blocked: false,
-        register: "auth.signUp({ username, password })",
+        register:
+          "Use the documented email/phone verification signup flow and bind username there if needed",
         login: "auth.signInWithPassword({ username, password })",
         accountInputType: "text",
         avoidEmailHelpers: true,
@@ -260,7 +261,8 @@ describe("app auth tools", () => {
       },
       webSdkHint: {
         blocked: false,
-        register: "auth.signUp({ username, password })",
+        register:
+          "Use the documented email/phone verification signup flow and bind username there if needed",
         login: "auth.signInWithPassword({ username, password })",
         accountInputType: "text",
         avoidEmailHelpers: true,

--- a/mcp/src/tools/app-auth.test.ts
+++ b/mcp/src/tools/app-auth.test.ts
@@ -67,8 +67,8 @@ describe("app auth tools", () => {
     phoneOtp: "auth.signInWithOtp({ phone })",
     emailOtp: "auth.signInWithOtp({ email })",
     password: "auth.signInWithPassword({ username|email|phone, password })",
-    signup: "auth.signUp({ phone|email, ... })",
-    verifyOtp: "verifyOtp({ token })",
+    signup: "auth.signUp({ username, password }) or auth.signUp({ phone|email, ... })",
+    verifyOtp: "verifyOtp({ token }) for phone/email OTP signup or login",
     anonymous: "auth.signInAnonymously()",
   };
 

--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -36,8 +36,8 @@ const SUPABASE_LIKE_SDK_HINTS = {
   phoneOtp: "auth.signInWithOtp({ phone })",
   emailOtp: "auth.signInWithOtp({ email })",
   password: "auth.signInWithPassword({ username|email|phone, password })",
-  signup: "auth.signUp({ phone|email, ... })",
-  verifyOtp: "verifyOtp({ token })",
+  signup: "auth.signUp({ username, password }) or auth.signUp({ phone|email, ... })",
+  verifyOtp: "verifyOtp({ token }) for phone/email OTP signup or login",
   anonymous: "auth.signInAnonymously()",
 } as const;
 

--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -36,8 +36,8 @@ const SUPABASE_LIKE_SDK_HINTS = {
   phoneOtp: "auth.signInWithOtp({ phone })",
   emailOtp: "auth.signInWithOtp({ email })",
   password: "auth.signInWithPassword({ username|email|phone, password })",
-  signup: "auth.signUp({ username, password }) or auth.signUp({ phone|email, ... })",
-  verifyOtp: "verifyOtp({ token }) for phone/email OTP signup or login",
+  signup: "auth.signUp({ phone|email, password?, username?, ... })",
+  verifyOtp: "verifyOtp({ token }) to complete phone/email OTP signup or login",
   anonymous: "auth.signInAnonymously()",
 } as const;
 
@@ -171,7 +171,8 @@ function buildWebSdkHint(loginMethods: ReturnType<typeof buildLoginMethods>) {
 
   return {
     blocked: false,
-    register: "auth.signUp({ username, password })",
+    register:
+      "Use the documented email/phone verification signup flow and bind username there if needed",
     login: "auth.signInWithPassword({ username, password })",
     accountInputType: "text",
     avoidEmailHelpers: true,

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -531,7 +531,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
     {
       title: "管理权限与用户配置",
       description:
-        "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
+        "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的公开注册表单；前端用户名样式账号登录应使用 `auth.signInWithPassword({ username, password })`，自助注册应遵循官方邮箱/手机号验证 `auth.signUp(...)` 流程并在注册时绑定 `username`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
       inputSchema: {
         action: z.enum(MANAGE_PERMISSION_ACTIONS),
         resourceType: z

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2186,7 +2186,7 @@
     },
     {
       "name": "managePermissions",
-      "description": "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
+      "description": "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的公开注册表单；前端用户名样式账号登录应使用 `auth.signInWithPassword({ username, password })`，自助注册应遵循官方邮箱/手机号验证 `auth.signUp(...)` 流程并在注册时绑定 `username`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnouau2z_bk9am7
- category: skill
- canonicalTitle: auth-web-cloudbase Skill 邮箱注册 API 流程说明不清晰
- representativeRun: application-js-react-cloudbase-cms-scaffold/2026-04-09T15-31-32-zotzhj

## Automation summary
README.md tencent-cloud

## Changed files
- `config/source/skills/auth-tool/SKILL.md`
- `config/source/skills/auth-web/SKILL.md`
- `mcp/src/tools/app-auth.test.ts`
- `mcp/src/tools/app-auth.ts`