### PR TITLE
fix: HTTP 云函数 Skill 缺少路径映射和网关路径处理的关键说明

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.18.0
+version: 2.18.1
 alwaysApply: false
 ---
 
@@ -50,6 +50,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
+- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default, so exposing `/api/http-demo` or the default `/${targetName}` changes the path your handler must match unless you normalize the prefix yourself.
 - Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.

--- a/config/.claude/skills/cloud-functions/references/http-functions.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions.md
@@ -150,6 +150,52 @@ Before enabling anonymous access, confirm both of these:
 
 If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function")` before widening access.
 
+### Gateway path mapping for HTTP Functions
+
+`manageGateway(action="createAccess")` creates a public access path, but it does **not** rewrite that path to `/` before the request reaches your HTTP Function.
+
+- Public access path `/api/http-demo` + request `GET /api/http-demo` -> your server normally receives pathname `/api/http-demo`
+- Public access path `/api/http-demo` + request `GET /api/http-demo/health` -> your server normally receives pathname `/api/http-demo/health`
+- If you omit `path`, `createAccess` defaults to `/${targetName}`, so a handler that only matches `/` will not automatically match the default public URL
+
+When your implementation wants internal routes like `/` and `/health`, use one of these approaches:
+
+1. Match the public path directly in your handler.
+2. Strip a known public base path in code before routing.
+
+Example with Node.js built-in `http` module:
+
+```javascript
+const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+
+function normalizePath(pathname) {
+  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") {
+    return pathname;
+  }
+
+  if (pathname === PUBLIC_BASE_PATH) {
+    return "/";
+  }
+
+  if (pathname.startsWith(`${PUBLIC_BASE_PATH}/`)) {
+    return pathname.slice(PUBLIC_BASE_PATH.length);
+  }
+
+  return pathname;
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, "http://127.0.0.1");
+  const pathname = normalizePath(url.pathname);
+
+  if (req.method === "GET" && pathname === "/") {
+    // Handle public /api/http-demo as internal /
+  }
+});
+```
+
+Do not assume `createAccess` gives you gateway rewrite behavior. If you need separate route-rewrite semantics, treat that as an explicit gateway-routing requirement and confirm the route capability first instead of guessing.
+
 ## SSE and WebSocket notes
 
 ### SSE

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -31,6 +31,7 @@ alwaysApply: true
 - Web app execution -> `./web-development/SKILL.md`
 - Web auth provider readiness -> `./auth-tool/SKILL.md`
 - Web auth implementation -> `./auth-web/SKILL.md`
+- Cloud Functions or HTTP Functions -> `./cloud-functions/SKILL.md`
 - Browser-side document database CRUD -> `./no-sql-web-sdk/SKILL.md`
 - Browser-side file upload -> `./cloud-storage-web/SKILL.md`
 - Platform overview only when capability selection is still unclear -> `./cloudbase-platform/SKILL.md`
@@ -69,3 +70,9 @@ alwaysApply: true
    - Functional closure beats exploration.
    - Avoid broad repo sweeps, UI redesign, and detached demo code.
    - Keep file discovery narrow. Prefer direct reads of the known active files over `Glob` / broad search across the whole project.
+
+5. HTTP Cloud Functions:
+   - Before writing or deploying an HTTP Function, read `./cloud-functions/SKILL.md` and then `./cloud-functions/references/http-functions.md`.
+   - Keep the runtime model straight: HTTP Functions are web servers on port `9000` with `req` / `res`, plus `scf_bootstrap`.
+   - If the function will be exposed through `manageGateway(action="createAccess")`, do not assume the public path is rewritten to `/` before it reaches your server.
+   - The default gateway path is `/${targetName}` when `path` is omitted, so handlers that only match `/` or `/health` may miss external requests unless you either match the public prefix directly or strip a known base path before routing.

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -50,7 +50,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
-- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default, so exposing `/api/http-demo` or the default `/${targetName}` changes the path your handler must match unless you normalize the prefix yourself.
+- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default — the full public path reaches your handler unchanged. Exposing `/api/http-demo` or the default `/${targetName}` means your code must match that prefix or normalize it before routing. See the gateway path mapping section in `./references/http-functions.md`.
 - Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
@@ -91,6 +91,7 @@ Use these rules whenever you are writing the function code itself:
 - With the native `http` module, parse `req.url` yourself with `new URL(...)`, collect the request body from the stream, and only then call `JSON.parse`. Empty bodies should be handled explicitly instead of assuming JSON is always present.
 - Return responses explicitly with `res.writeHead(...)` and `res.end(...)`, including `Content-Type` such as `application/json; charset=utf-8` for JSON APIs.
 - Keep routing and method handling explicit. Unknown paths should return `404`, and known paths with unsupported methods should normally return `405`.
+- When your HTTP Function is accessed through a gateway path, the full public path (including the prefix) reaches your handler unchanged — the gateway does **not** strip or rewrite it. If you create gateway access with `path: "/api/hello"` or rely on the default `/${targetName}`, a handler that only matches `/` will not match the actual request path. Either set `path: "/"` in `createAccess`, or normalize the base path in your code before routing. See the gateway path mapping section in `./references/http-functions.md` for a complete example.
 - Keep gateway setup and security-rule changes separate from the runtime code. They affect access, not the HTTP Function programming model.
 - Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; anonymous or public invocation requirements should be handled through the function security rule workflow.
 
@@ -182,6 +183,19 @@ exports.main = async (event, context) => {
 const http = require("http");
 const { URL } = require("url");
 
+// Gateway path prefix — the gateway does NOT rewrite the path before it reaches
+// your handler. If the public URL is /hello-http, requests arrive with
+// pathname /hello-http, not /.  Strip a known prefix so internal routes
+// (like / and /health) match regardless of the access path.
+const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+
+function normalizePath(pathname) {
+  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
+  if (pathname === PUBLIC_BASE_PATH) return "/";
+  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  return pathname;
+}
+
 function sendJson(res, statusCode, data) {
   res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(data));
@@ -189,8 +203,9 @@ function sendJson(res, statusCode, data) {
 
 const server = http.createServer((req, res) => {
   const url = new URL(req.url || "/", "http://127.0.0.1");
+  const pathname = normalizePath(url.pathname);
 
-  if (req.method === "GET" && url.pathname === "/") {
+  if (req.method === "GET" && pathname === "/") {
     sendJson(res, 200, { ok: true, message: "hello from http function" });
   } else {
     sendJson(res, 404, { error: "Not Found" });

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -50,7 +50,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
-- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default — the full public path reaches your handler unchanged. Exposing `/api/http-demo` or the default `/${targetName}` means your code must match that prefix or normalize it before routing. See the gateway path mapping section in `./references/http-functions.md`.
+- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default — the full public path reaches your handler unchanged. Exposing `/api/http-demo` or the default `/${targetName}` means your code must match that prefix or normalize it before routing. **Never use `process.env.PUBLIC_BASE_PATH || ""`** — this env var is not set by the CloudBase runtime and defaults to empty string, making path normalization a no-op. Hard-code the function name as the base path instead. See the gateway path mapping section in `./references/http-functions.md`.
 - Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
@@ -91,9 +91,12 @@ Use these rules whenever you are writing the function code itself:
 - With the native `http` module, parse `req.url` yourself with `new URL(...)`, collect the request body from the stream, and only then call `JSON.parse`. Empty bodies should be handled explicitly instead of assuming JSON is always present.
 - Return responses explicitly with `res.writeHead(...)` and `res.end(...)`, including `Content-Type` such as `application/json; charset=utf-8` for JSON APIs.
 - Keep routing and method handling explicit. Unknown paths should return `404`, and known paths with unsupported methods should normally return `405`.
-- When your HTTP Function is accessed through a gateway path, the full public path (including the prefix) reaches your handler unchanged — the gateway does **not** strip or rewrite it. If you create gateway access with `path: "/api/hello"` or rely on the default `/${targetName}`, a handler that only matches `/` will not match the actual request path. Either set `path: "/"` in `createAccess`, or normalize the base path in your code before routing. See the gateway path mapping section in `./references/http-functions.md` for a complete example.
+- When your HTTP Function is accessed through a gateway path, the full public path (including the prefix) reaches your handler unchanged — the gateway does **not** strip or rewrite it. If you create gateway access with `path: "/api/hello"` or rely on the default `/${targetName}`, a handler that only matches `/` will not match the actual request path. **You must handle this in one of two ways:**
+  1. Call `manageGateway(action="createAccess", path="/")` to expose the function at `/` — then no path normalization is needed in code.
+  2. Hard-code `const BASE_PATH = "/<functionName>"` in your function code and strip it before routing. **Do NOT use `process.env.PUBLIC_BASE_PATH || ""`** — this env var is not set by the CloudBase runtime, so it defaults to empty string and the normalization becomes a no-op. Always hard-code the actual function name as the base path.
+  See the gateway path mapping section in `./references/http-functions.md` for a complete example.
 - Keep gateway setup and security-rule changes separate from the runtime code. They affect access, not the HTTP Function programming model.
-- Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; anonymous or public invocation requirements should be handled through the function security rule workflow.
+- Do not add custom HTTP access service configuration when the task is only to create an HTTP Function itself — but note that if the function needs to be reachable from browsers, you should call `manageGateway(action="createAccess", path="/")` to expose it at the root path. Without this, the default gateway path is `/${functionName}`, which means your handler must strip that prefix before routing (see the gateway path mapping section). Anonymous or public invocation requirements should be handled through the function security rule workflow.
 
 ## Quick decision table
 
@@ -184,15 +187,16 @@ const http = require("http");
 const { URL } = require("url");
 
 // Gateway path prefix — the gateway does NOT rewrite the path before it reaches
-// your handler. If the public URL is /hello-http, requests arrive with
-// pathname /hello-http, not /.  Strip a known prefix so internal routes
-// (like / and /health) match regardless of the access path.
-const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+// your handler. The default public path is /<functionName>, so requests to
+// /hello-http arrive with pathname /hello-http, not /.
+// ALWAYS hard-code the function name as BASE_PATH. Do NOT use an env var
+// that defaults to "" — it will be empty and the normalization will be a no-op.
+const BASE_PATH = "/hello-http";
 
 function normalizePath(pathname) {
-  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
-  if (pathname === PUBLIC_BASE_PATH) return "/";
-  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  if (!BASE_PATH || BASE_PATH === "/") return pathname;
+  if (pathname === BASE_PATH) return "/";
+  if (pathname.startsWith(BASE_PATH + "/")) return pathname.slice(BASE_PATH.length);
   return pathname;
 }
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.18.0
+version: 2.18.1
 alwaysApply: false
 ---
 
@@ -50,6 +50,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
+- Assuming the access path created by `manageGateway(action="createAccess")` is stripped before the request reaches an HTTP Function. It is not rewritten by default, so exposing `/api/http-demo` or the default `/${targetName}` changes the path your handler must match unless you normalize the prefix yourself.
 - Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -55,6 +55,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
+- Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Use `managePermissions(action="updateResourcePermission", resourceType="function")` to allow public access.
+- Mismatching the `scf_bootstrap` Node.js binary path with the function runtime (e.g. using `/var/lang/node18/bin/node` but setting `runtime: "Nodejs16.13"`).
 
 ### Minimal checklist
 
@@ -73,7 +75,24 @@ Use this skill when developing, deploying, and operating CloudBase cloud functio
 
 - If the request is for SDK calls, timers, or event-driven workflows, write an **Event Function** with `exports.main = async (event, context) => {}`.
 - If the request is for REST APIs, browser-facing endpoints, SSE, or WebSocket, write an **HTTP Function** with `req` / `res` on port `9000`.
+- For Node.js HTTP Functions, default to the native `http` module unless the user explicitly asks for Express, Koa, NestJS, or another framework.
 - If the user mentions HTTP access for an existing Event Function, keep the Event Function code shape and add gateway access separately.
+
+## HTTP Function authoring contract
+
+Use these rules whenever you are writing the function code itself:
+
+- Do not write an HTTP Function as `exports.main(event, context)`. That is the Event Function contract.
+- Treat the function as a standard web server process that must listen on port `9000`.
+- With Node.js, prefer `http.createServer((req, res) => { ... })` by default so the runtime contract stays explicit.
+- With the Node.js native `http` module, do not assume Express-style helpers exist. `req.body`, `req.query`, and `req.params` are not provided for you.
+- For Node.js HTTP Functions, choose one module system up front and keep it consistent. Default to CommonJS for simple functions (`require(...)`, no `"type": "module"` in `package.json`) unless you explicitly want ES Modules.
+- If you do choose ES Modules (`"type": "module"` + `import ...`), do not mix in CommonJS-only globals or APIs such as `require(...)`, `module.exports`, or bare `__dirname`. In ESM, derive file paths from `import.meta.url` with `fileURLToPath(...)` only when needed.
+- With the native `http` module, parse `req.url` yourself with `new URL(...)`, collect the request body from the stream, and only then call `JSON.parse`. Empty bodies should be handled explicitly instead of assuming JSON is always present.
+- Return responses explicitly with `res.writeHead(...)` and `res.end(...)`, including `Content-Type` such as `application/json; charset=utf-8` for JSON APIs.
+- Keep routing and method handling explicit. Unknown paths should return `404`, and known paths with unsupported methods should normally return `405`.
+- Keep gateway setup and security-rule changes separate from the runtime code. They affect access, not the HTTP Function programming model.
+- Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; anonymous or public invocation requirements should be handled through the function security rule workflow.
 
 ## Quick decision table
 
@@ -161,10 +180,21 @@ exports.main = async (event, context) => {
 
 ```js
 const http = require("http");
+const { URL } = require("url");
+
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
 
 const server = http.createServer((req, res) => {
-  res.writeHead(200, { "Content-Type": "application/json" });
-  res.end(JSON.stringify({ ok: true, message: "hello from http function" }));
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/") {
+    sendJson(res, 200, { ok: true, message: "hello from http function" });
+  } else {
+    sendJson(res, 404, { error: "Not Found" });
+  }
 });
 
 server.listen(9000);
@@ -176,6 +206,8 @@ server.listen(9000);
 #!/bin/bash
 /var/lang/node18/bin/node index.js
 ```
+
+The `scf_bootstrap` binary path must match the runtime — see the full mapping table in `./references/http-functions.md`.
 
 `cloudfunctions/hello-http/package.json`
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -8,15 +8,18 @@ Use this checklist before creating or updating a CloudBase function.
    - Event Function: `exports.main(event, context)`, SDK/timer driven
    - HTTP Function: `req` / `res`, listens on port `9000`
 2. Pick the runtime before creation and state it explicitly.
-3. For HTTP Functions, confirm `scf_bootstrap` exists and the service listens on port `9000`.
+3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
 4. Confirm the function root path points to the parent directory, not the function directory itself.
-5. If the request is really for a long-running container service, reroute to `cloudrun-development`.
+5. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
+6. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
 
 - Choosing the wrong function type and compensating later.
 - Mixing Event Function and HTTP Function handler shapes in the same implementation.
 - Forgetting that runtime cannot be changed after creation.
+- Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
+- Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Treating Cloud Functions as the default answer for Web authentication.
 
 ## Done criteria

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -11,7 +11,7 @@ Use this checklist before creating or updating a CloudBase function.
 3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
 4. Confirm the function root path points to the parent directory, not the function directory itself.
 5. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
-6. For HTTP Functions, verify that route handlers account for the gateway path prefix. The gateway does **not** strip the public path before forwarding requests to your function. If the gateway access path is `/api/demo` or the default `/${targetName}`, the handler receives that full prefix — routes that only match `/` will not match. Either set `path: "/"` when calling `manageGateway(action="createAccess")`, or normalize the prefix in code before routing (see `./references/http-functions.md` gateway path mapping).
+6. For HTTP Functions, verify that route handlers account for the gateway path prefix. The gateway does **not** strip the public path before forwarding requests to your function. If the gateway access path is `/api/demo` or the default `/${targetName}`, the handler receives that full prefix — routes that only match `/` will not match. **Do NOT use `process.env.PUBLIC_BASE_PATH || ""`** — this env var is not set by the CloudBase runtime and defaults to empty string, making normalization a no-op. Either: (a) call `manageGateway(action="createAccess", path="/")` to expose at `/`, or (b) hard-code `const BASE_PATH = "/<functionName>"` in your function code and strip it before routing (see `./references/http-functions.md` gateway path mapping).
 7. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
@@ -22,11 +22,12 @@ Use this checklist before creating or updating a CloudBase function.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
 - Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Writing HTTP Function routes that only match `/` and `/health` but ignoring that the gateway forwards the full public path (e.g. `/myFunction` or `/api/demo`). This causes every route to return 404 when accessed through the gateway.
+- Using `process.env.PUBLIC_BASE_PATH || ""` for path normalization — this env var is not set by the CloudBase runtime, so it defaults to empty string and normalization is a no-op. Always hard-code the function name as the base path (e.g. `const BASE_PATH = "/httpDemo"`).
 - Treating Cloud Functions as the default answer for Web authentication.
 
 ## Done criteria
 
 - Function type and runtime are explicit.
 - Packaging constraints are checked.
-- Gateway path prefix is handled — the handler either normalizes the prefix or the gateway access is configured with `path: "/"` so internal routes match directly.
+- Gateway path prefix is handled — the handler either normalizes the prefix with a hard-coded `BASE_PATH = "/<functionName>"`, or the gateway access is configured with `path: "/"` so internal routes match directly. **No `process.env.PUBLIC_BASE_PATH || ""`** — it defaults to empty and does nothing.
 - The task is confirmed to be a function workflow rather than CloudRun.

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -11,7 +11,8 @@ Use this checklist before creating or updating a CloudBase function.
 3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
 4. Confirm the function root path points to the parent directory, not the function directory itself.
 5. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
-6. If the request is really for a long-running container service, reroute to `cloudrun-development`.
+6. For HTTP Functions, verify that route handlers account for the gateway path prefix. The gateway does **not** strip the public path before forwarding requests to your function. If the gateway access path is `/api/demo` or the default `/${targetName}`, the handler receives that full prefix — routes that only match `/` will not match. Either set `path: "/"` when calling `manageGateway(action="createAccess")`, or normalize the prefix in code before routing (see `./references/http-functions.md` gateway path mapping).
+7. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
 
@@ -20,10 +21,12 @@ Use this checklist before creating or updating a CloudBase function.
 - Forgetting that runtime cannot be changed after creation.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
 - Forgetting to configure function security rules for HTTP Functions that need anonymous access.
+- Writing HTTP Function routes that only match `/` and `/health` but ignoring that the gateway forwards the full public path (e.g. `/myFunction` or `/api/demo`). This causes every route to return 404 when accessed through the gateway.
 - Treating Cloud Functions as the default answer for Web authentication.
 
 ## Done criteria
 
 - Function type and runtime are explicit.
 - Packaging constraints are checked.
+- Gateway path prefix is handled — the handler either normalizes the prefix or the gateway access is configured with `path: "/"` so internal routes match directly.
 - The task is confirmed to be a function workflow rather than CloudRun.

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -51,6 +51,17 @@ If the user specifies "Node.js 18", use runtime `Nodejs18.15` and the path `/var
 const http = require("http");
 const { URL } = require("url");
 
+// Strip gateway path prefix — the gateway does NOT rewrite paths.
+// See "Gateway path mapping for HTTP Functions" below for details.
+const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+
+function normalizePath(pathname) {
+  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
+  if (pathname === PUBLIC_BASE_PATH) return "/";
+  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  return pathname;
+}
+
 function sendJson(res, statusCode, data) {
   res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(data));
@@ -83,13 +94,14 @@ function readJsonBody(req) {
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || "/", "http://127.0.0.1");
+  const pathname = normalizePath(url.pathname);
 
-  if (req.method === "GET" && url.pathname === "/health") {
+  if (req.method === "GET" && pathname === "/health") {
     sendJson(res, 200, { ok: true });
     return;
   }
 
-  if (req.method === "POST" && url.pathname === "/echo") {
+  if (req.method === "POST" && pathname === "/echo") {
     try {
       const body = await readJsonBody(req);
       sendJson(res, 200, { received: body });
@@ -114,6 +126,7 @@ server.listen(9000);
 - Treat routing, method checks, and body parsing as part of the function code. With the native `http` module, parse `req.url` yourself and read the request body from the stream before calling `JSON.parse`.
 - Return JSON responses explicitly and set `Content-Type` yourself, for example `application/json; charset=utf-8`.
 - Keep unsupported routes and methods explicit. Return `404` for unknown paths, and return `405` when the path exists but the HTTP method is not allowed.
+- Always normalize the gateway path prefix before routing. The gateway forwards the full public path (e.g. `/myFunction` or `/api/demo`) unchanged — it does **not** rewrite it to `/`. Either set `path: "/"` in `manageGateway(action="createAccess")`, or strip a known base path in code. See the **Gateway path mapping** section below for details.
 - Keep `scf_bootstrap`, `index.js`, `package.json`, and any bundled dependencies in the function directory that will be uploaded.
 
 ### Module system note
@@ -140,6 +153,15 @@ That combination avoids the common ESM pitfall where `__dirname` is not defined.
 const http = require("http");
 const { URL } = require("url");
 
+const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+
+function normalizePath(pathname) {
+  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
+  if (pathname === PUBLIC_BASE_PATH) return "/";
+  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  return pathname;
+}
+
 function sendJson(res, statusCode, data) {
   res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
   res.end(JSON.stringify(data));
@@ -172,8 +194,9 @@ function readJsonBody(req) {
 
 const server = http.createServer(async (req, res) => {
   const url = new URL(req.url || "/", "http://127.0.0.1");
+  const pathname = normalizePath(url.pathname);
 
-  if (url.pathname === "/users" && req.method === "POST") {
+  if (pathname === "/users" && req.method === "POST") {
     try {
       const { name, email } = await readJsonBody(req);
 
@@ -190,7 +213,7 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
-  if (url.pathname === "/users") {
+  if (pathname === "/users") {
     sendJson(res, 405, { error: "Method Not Allowed" });
     return;
   }

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -10,6 +10,7 @@ HTTP Functions are standard web services, not `exports.main(event, context)` han
 - Listen on port `9000`.
 - Ship an executable `scf_bootstrap` file.
 - Include runtime dependencies in the package; HTTP Functions do not auto-install `node_modules` for you.
+- For simple HTTP APIs, prefer the Node.js native `http` module so the function shape stays explicit and dependency-light. Only introduce Express, Koa, NestJS, or similar frameworks when the user explicitly asks for one or the service complexity justifies it.
 
 ## Minimal structure
 
@@ -25,7 +26,7 @@ my-http-function/
 
 ```bash
 #!/bin/bash
-node index.js
+/var/lang/node18/bin/node index.js
 ```
 
 Requirements:
@@ -34,56 +35,192 @@ Requirements:
 - Use LF line endings.
 - Make it executable with `chmod +x scf_bootstrap`.
 
+The `scf_bootstrap` Node.js binary path must match the function runtime. Use this mapping:
+
+| Runtime value | `scf_bootstrap` binary path |
+| --- | --- |
+| `Nodejs20.19` | `/var/lang/node20/bin/node` |
+| `Nodejs18.15` | `/var/lang/node18/bin/node` |
+| `Nodejs16.13` | `/var/lang/node16/bin/node` |
+
+If the user specifies "Node.js 18", use runtime `Nodejs18.15` and the path `/var/lang/node18/bin/node`.
+
 ## Minimal Node.js example
 
 ```javascript
-const express = require("express");
-const app = express();
+const http = require("http");
+const { URL } = require("url");
 
-app.use(express.json());
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
 
-app.get("/health", (req, res) => {
-  res.json({ ok: true });
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+
+    req.on("end", () => {
+      if (!raw) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (req.method === "GET" && url.pathname === "/health") {
+    sendJson(res, 200, { ok: true });
+    return;
+  }
+
+  if (req.method === "POST" && url.pathname === "/echo") {
+    try {
+      const body = await readJsonBody(req);
+      sendJson(res, 200, { received: body });
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+    }
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
 });
 
-app.listen(9000);
+server.listen(9000);
 ```
+
+## Code-writing rules
+
+- Do not write HTTP Functions as `exports.main = async (event, context) => {}`. That is the Event Function contract.
+- Start an HTTP server explicitly with `http.createServer(...)` or a framework app, and always bind to port `9000`.
+- Choose one Node.js module system and keep it consistent. For simple HTTP Functions, CommonJS is the safest default: use `require(...)` and leave `"type": "module"` out of `package.json`.
+- If you intentionally use ES Modules, use `import ...` consistently and do not rely on CommonJS-only globals such as bare `__dirname`, `require(...)`, or `module.exports`. When you need the current file path in ESM, derive it from `import.meta.url`.
+- Treat routing, method checks, and body parsing as part of the function code. With the native `http` module, parse `req.url` yourself and read the request body from the stream before calling `JSON.parse`.
+- Return JSON responses explicitly and set `Content-Type` yourself, for example `application/json; charset=utf-8`.
+- Keep unsupported routes and methods explicit. Return `404` for unknown paths, and return `405` when the path exists but the HTTP method is not allowed.
+- Keep `scf_bootstrap`, `index.js`, `package.json`, and any bundled dependencies in the function directory that will be uploaded.
+
+### Module system note
+
+The minimal examples in this document use CommonJS:
+
+- `const http = require("http")`
+- no `"type": "module"` in `package.json`
+
+That combination avoids the common ESM pitfall where `__dirname` is not defined. If you switch to ES Modules, switch the whole function to `import` syntax and update any file-path logic accordingly.
 
 ## Request handling rules
 
-- `req.query` -> query string values.
-- `req.body` -> parsed request body, but only after body-parsing middleware is configured.
+- With Node native `http`, use `new URL(req.url, "http://127.0.0.1")` and read `url.searchParams` for query values.
+- With Node native `http`, `req.body` does not exist. Read the body stream manually, then parse JSON yourself.
 - `req.headers` -> incoming HTTP headers.
-- `req.params` -> path parameters.
-- Always send a response with `res.json()`, `res.send()`, or `res.status(...).json()`.
+- Path parameters are framework-level conveniences. With the native `http` module, match `url.pathname` yourself.
+- Always send a response explicitly. With Node native `http`, use `res.writeHead(...)` and `res.end(...)`.
 - Return meaningful status codes such as `400`, `401`, `404`, `405`, `500`.
 
 ### Example with method checks
 
 ```javascript
-const express = require("express");
-const app = express();
+const http = require("http");
+const { URL } = require("url");
 
-app.use(express.json());
+function sendJson(res, statusCode, data) {
+  res.writeHead(statusCode, { "Content-Type": "application/json; charset=utf-8" });
+  res.end(JSON.stringify(data));
+}
 
-app.post("/users", (req, res) => {
-  const { name, email } = req.body;
+function readJsonBody(req) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
 
-  if (!name || !email) {
-    return res.status(400).json({ error: "name and email are required" });
+    req.on("data", (chunk) => {
+      raw += chunk;
+    });
+
+    req.on("end", () => {
+      if (!raw) {
+        resolve({});
+        return;
+      }
+
+      try {
+        resolve(JSON.parse(raw));
+      } catch (error) {
+        reject(new Error("Invalid JSON body"));
+      }
+    });
+
+    req.on("error", reject);
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  const url = new URL(req.url || "/", "http://127.0.0.1");
+
+  if (url.pathname === "/users" && req.method === "POST") {
+    try {
+      const { name, email } = await readJsonBody(req);
+
+      if (!name || !email) {
+        sendJson(res, 400, { error: "name and email are required" });
+        return;
+      }
+
+      sendJson(res, 201, { name, email });
+    } catch (error) {
+      sendJson(res, 400, { error: error.message });
+    }
+
+    return;
   }
 
-  return res.status(201).json({ name, email });
+  if (url.pathname === "/users") {
+    sendJson(res, 405, { error: "Method Not Allowed" });
+    return;
+  }
+
+  sendJson(res, 404, { error: "Not Found" });
 });
 
+server.listen(9000);
+```
+
+### Express 5 catch-all note
+
+If the user explicitly asks for Express, keep in mind that Express 5 uses `path-to-regexp` semantics for wildcards. Do not use bare `*` or `/*` as the catch-all route.
+
+```javascript
 app.all("/{*splat}", (req, res) => {
   res.status(405).json({ error: "Method Not Allowed" });
 });
-
-app.listen(9000);
 ```
 
-Express 5 note: do not use bare `*` or `/*` here. Express 5 uses `path-to-regexp` with named wildcards, so `app.all("/{*splat}", ...)` is the safe catch-all form when you also need to match the root path `/`.
+Express 5 note: `app.all("/{*splat}", (req, res) => {` is the safe catch-all form when you also need to match the root path `/`, because the router is based on `path-to-regexp` rather than the older Express 4 wildcard behavior.
+
+## End-to-end deployment lifecycle
+
+Follow these steps in order when creating an HTTP Function:
+
+1. **Write the function code** — create the directory with `index.js`, `scf_bootstrap`, and `package.json`.
+2. **Deploy with `manageFunctions`** — set `type: "HTTP"`, `protocolType: "HTTP"`, and `runtime` explicitly.
+3. **Configure security rules** — HTTP Functions default to a restrictive security rule. If the function should be publicly accessible (anonymous access), call `managePermissions(action="updateResourcePermission")` with `resourceType="function"`.
+4. **Verify** — call the function URL and confirm it returns the expected response. If you get `EXCEED_AUTHORITY`, the security rule needs to be updated (step 3).
 
 ## Deployment flow
 
@@ -96,11 +233,42 @@ manageFunctions({
     name: "myHttpFunction",
     type: "HTTP",
     protocolType: "HTTP",
+    runtime: "Nodejs18.15",
     timeout: 60
   },
   functionRootPath: "/absolute/path/to/cloudfunctions"
 });
 ```
+
+**Important parameters:**
+
+- `type: "HTTP"` — marks the function as an HTTP Function (not an Event Function).
+- `protocolType: "HTTP"` — the wire protocol. Use `"WS"` for WebSocket.
+- `runtime` — the execution runtime. Must match the `scf_bootstrap` binary path. Default is `"Nodejs18.15"` if omitted, but always set it explicitly to avoid ambiguity.
+- `functionRootPath` — the parent directory of the function folder (e.g. `/path/to/cloudfunctions` if the code lives in `/path/to/cloudfunctions/myHttpFunction/`).
+
+### Security rule configuration
+
+After creating an HTTP Function, it will reject anonymous callers with `EXCEED_AUTHORITY` by default. If the function should be publicly accessible:
+
+```javascript
+managePermissions({
+  action: "updateResourcePermission",
+  resourceType: "function",
+  resourceId: "myHttpFunction",
+  permission: {
+    aclTag: "CUSTOM",
+    rule: "true"
+  }
+});
+```
+
+- `aclTag: "CUSTOM"` with `rule: "true"` allows all callers (anonymous access).
+- Do NOT use `readSecurityRule` / `writeSecurityRule` — those are removed. Use `queryPermissions` / `managePermissions` instead.
+- Security rule semantics for `resourceType="function"` differ from NoSQL database rules. Do not reuse `doc._openid` or `auth.openid` expressions from NoSQL security rules.
+- Official reference: `https://docs.cloudbase.net/cloud-function/security-rules`
+
+If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function", resourceId="myHttpFunction")` before widening access.
 
 ### WebSocket
 
@@ -146,9 +314,7 @@ manageGateway({
 Before enabling anonymous access, confirm both of these:
 
 1. The access path exists.
-2. The function security rule allows the intended caller identity.
-
-If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function")` before widening access.
+2. The function security rule allows the intended caller identity (see Security rule configuration above).
 
 ### Gateway path mapping for HTTP Functions
 

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -150,6 +150,52 @@ Before enabling anonymous access, confirm both of these:
 
 If an external caller reports `EXCEED_AUTHORITY`, inspect the function permission first with `queryPermissions(action="getResourcePermission", resourceType="function")` before widening access.
 
+### Gateway path mapping for HTTP Functions
+
+`manageGateway(action="createAccess")` creates a public access path, but it does **not** rewrite that path to `/` before the request reaches your HTTP Function.
+
+- Public access path `/api/http-demo` + request `GET /api/http-demo` -> your server normally receives pathname `/api/http-demo`
+- Public access path `/api/http-demo` + request `GET /api/http-demo/health` -> your server normally receives pathname `/api/http-demo/health`
+- If you omit `path`, `createAccess` defaults to `/${targetName}`, so a handler that only matches `/` will not automatically match the default public URL
+
+When your implementation wants internal routes like `/` and `/health`, use one of these approaches:
+
+1. Match the public path directly in your handler.
+2. Strip a known public base path in code before routing.
+
+Example with Node.js built-in `http` module:
+
+```javascript
+const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+
+function normalizePath(pathname) {
+  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") {
+    return pathname;
+  }
+
+  if (pathname === PUBLIC_BASE_PATH) {
+    return "/";
+  }
+
+  if (pathname.startsWith(`${PUBLIC_BASE_PATH}/`)) {
+    return pathname.slice(PUBLIC_BASE_PATH.length);
+  }
+
+  return pathname;
+}
+
+const server = http.createServer((req, res) => {
+  const url = new URL(req.url, "http://127.0.0.1");
+  const pathname = normalizePath(url.pathname);
+
+  if (req.method === "GET" && pathname === "/") {
+    // Handle public /api/http-demo as internal /
+  }
+});
+```
+
+Do not assume `createAccess` gives you gateway rewrite behavior. If you need separate route-rewrite semantics, treat that as an explicit gateway-routing requirement and confirm the route capability first instead of guessing.
+
 ## SSE and WebSocket notes
 
 ### SSE

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -52,13 +52,17 @@ const http = require("http");
 const { URL } = require("url");
 
 // Strip gateway path prefix — the gateway does NOT rewrite paths.
-// See "Gateway path mapping for HTTP Functions" below for details.
-const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+// The default public path is /<functionName>. Hard-code the function name
+// as BASE_PATH. Do NOT use process.env.PUBLIC_BASE_PATH || "" — that
+// env var is not set by the CloudBase runtime, so it defaults to empty
+// string and normalization becomes a no-op.
+// Change this value to match YOUR function name:
+const BASE_PATH = "/my-http-function";
 
 function normalizePath(pathname) {
-  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
-  if (pathname === PUBLIC_BASE_PATH) return "/";
-  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  if (!BASE_PATH || BASE_PATH === "/") return pathname;
+  if (pathname === BASE_PATH) return "/";
+  if (pathname.startsWith(BASE_PATH + "/")) return pathname.slice(BASE_PATH.length);
   return pathname;
 }
 
@@ -126,7 +130,10 @@ server.listen(9000);
 - Treat routing, method checks, and body parsing as part of the function code. With the native `http` module, parse `req.url` yourself and read the request body from the stream before calling `JSON.parse`.
 - Return JSON responses explicitly and set `Content-Type` yourself, for example `application/json; charset=utf-8`.
 - Keep unsupported routes and methods explicit. Return `404` for unknown paths, and return `405` when the path exists but the HTTP method is not allowed.
-- Always normalize the gateway path prefix before routing. The gateway forwards the full public path (e.g. `/myFunction` or `/api/demo`) unchanged — it does **not** rewrite it to `/`. Either set `path: "/"` in `manageGateway(action="createAccess")`, or strip a known base path in code. See the **Gateway path mapping** section below for details.
+- Always normalize the gateway path prefix before routing. The gateway forwards the full public path (e.g. `/myFunction` or `/api/demo`) unchanged — it does **not** rewrite it to `/`. **You must handle this in one of two ways:**
+  1. Call `manageGateway(action="createAccess", path="/")` to expose the function at `/` — then no path normalization is needed in code.
+  2. Hard-code `const BASE_PATH = "/<functionName>"` in your function code and strip it before routing. **Do NOT use `process.env.PUBLIC_BASE_PATH || ""`** — this env var is not set by the CloudBase runtime, so it defaults to empty string and the normalization becomes a no-op. Always hard-code the actual function name as the base path.
+  See the **Gateway path mapping** section below for details.
 - Keep `scf_bootstrap`, `index.js`, `package.json`, and any bundled dependencies in the function directory that will be uploaded.
 
 ### Module system note
@@ -153,12 +160,12 @@ That combination avoids the common ESM pitfall where `__dirname` is not defined.
 const http = require("http");
 const { URL } = require("url");
 
-const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+const BASE_PATH = "/my-users-function";
 
 function normalizePath(pathname) {
-  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") return pathname;
-  if (pathname === PUBLIC_BASE_PATH) return "/";
-  if (pathname.startsWith(PUBLIC_BASE_PATH + "/")) return pathname.slice(PUBLIC_BASE_PATH.length);
+  if (!BASE_PATH || BASE_PATH === "/") return pathname;
+  if (pathname === BASE_PATH) return "/";
+  if (pathname.startsWith(BASE_PATH + "/")) return pathname.slice(BASE_PATH.length);
   return pathname;
 }
 
@@ -349,25 +356,38 @@ Before enabling anonymous access, confirm both of these:
 
 When your implementation wants internal routes like `/` and `/health`, use one of these approaches:
 
-1. Match the public path directly in your handler.
-2. Strip a known public base path in code before routing.
+1. **Recommended**: Call `manageGateway(action="createAccess", path="/")` to expose the function at `/` — then no path normalization is needed in code. This is the simplest approach.
+2. Match the public path directly in your handler (e.g. check for `/myFunction` instead of `/`).
+3. Hard-code the function name as `BASE_PATH` in code and strip it before routing.
+
+**Critical**: Do NOT use `process.env.PUBLIC_BASE_PATH || ""` for the base path. This environment variable is **not set** by the CloudBase runtime. Defaulting to empty string means no normalization happens and all routes return 404 when accessed through the gateway. Always hard-code the actual function name:
+
+```javascript
+// Correct — hard-code the function name
+const BASE_PATH = "/myFunction";
+
+// WRONG — env var is never set, defaults to "", normalization is a no-op
+// const BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+```
 
 Example with Node.js built-in `http` module:
 
 ```javascript
-const PUBLIC_BASE_PATH = process.env.PUBLIC_BASE_PATH || "";
+// Hard-code the function name as BASE_PATH — the default gateway path
+// is /<functionName>. Change this to match YOUR function name.
+const BASE_PATH = "/myFunction";
 
 function normalizePath(pathname) {
-  if (!PUBLIC_BASE_PATH || PUBLIC_BASE_PATH === "/") {
+  if (!BASE_PATH || BASE_PATH === "/") {
     return pathname;
   }
 
-  if (pathname === PUBLIC_BASE_PATH) {
+  if (pathname === BASE_PATH) {
     return "/";
   }
 
-  if (pathname.startsWith(`${PUBLIC_BASE_PATH}/`)) {
-    return pathname.slice(PUBLIC_BASE_PATH.length);
+  if (pathname.startsWith(`${BASE_PATH}/`)) {
+    return pathname.slice(BASE_PATH.length);
   }
 
   return pathname;
@@ -378,7 +398,7 @@ const server = http.createServer((req, res) => {
   const pathname = normalizePath(url.pathname);
 
   if (req.method === "GET" && pathname === "/") {
-    // Handle public /api/http-demo as internal /
+    // Handle public /myFunction as internal /
   }
 });
 ```

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -151,6 +151,8 @@ describe("functions tool helpers", () => {
     });
     expect(mockCreateAccess).not.toHaveBeenCalled();
     expect(payload.message).toContain("manageGateway(action=\"createAccess\")");
+    expect(payload.message).toContain("默认使用 /httpDemo");
+    expect(payload.message).toContain("不会自动把公网路径重写成 /");
     expect(payload.message).toContain("匿名身份访问");
     expect(payload.message).toContain("EXCEED_AUTHORITY");
     expect(payload.nextActions).toEqual(

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -946,7 +946,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           tool: "manageGateway",
           action: "createAccess",
           reason:
-            "如果需要通过 URL 访问 HTTP 函数，请按实际路径和鉴权需求显式创建访问入口，不要默认假设 /函数名 已存在",
+            "如果需要通过 URL 访问 HTTP 函数，请按实际路径和鉴权需求显式创建访问入口，不要默认假设 /函数名 已存在，也不要默认假设网关会把该路径重写成 / 再转发给函数",
         });
         nextActions.push({
           tool: "queryGateway",
@@ -969,7 +969,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
 
       const message =
         func.type === "HTTP"
-          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createAccess") 按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
+          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createAccess") 按实际路径和鉴权需求创建访问入口。注意：createAccess 默认使用 /${functionName}，且不会自动把公网路径重写成 / 再转发给 HTTP 函数；如果你的代码只匹配 / 或 /health，请同步处理该前缀或显式按公网路径设计路由。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
           : `已创建函数 ${functionName}`;
 
       return buildEnvelope(

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -149,6 +149,7 @@ describe("gateway tools", () => {
     expect(schema.action.description).toContain("默认域名访问入口");
     expect(schema.targetName.description).toContain("填写函数名");
     expect(schema.path.description).toContain("/api/hello");
+    expect(schema.path.description).toContain("不会把 /api/hello 重写成 /");
     expect(schema.type.description).toContain("已创建的 HTTP 云函数时传 HTTP");
     expect(schema.auth.description).toContain("通常设为 false");
   });

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -573,7 +573,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "管理网关域资源",
       description:
-        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。",
+        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限，也不会把访问路径自动重写成 / 后再转发给 HTTP 云函数。",
       inputSchema: {
         action: z
           .enum(MANAGE_GATEWAY_ACTIONS)
@@ -589,7 +589,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         path: z
           .string()
           .optional()
-          .describe("访问路径，默认 /{targetName}。例如为 HTTP 函数暴露 /api/hello 时传 /api/hello。该参数只创建网关入口，不会自动放开函数资源权限。"),
+          .describe("访问路径，默认 /{targetName}。例如为 HTTP 函数暴露 /api/hello 时传 /api/hello。该参数只创建网关入口，不会自动放开函数资源权限，也不会把 /api/hello 重写成 / 再转发给 HTTP 云函数；如果函数内部只匹配 / 或 /health，请在代码里处理该前缀或显式按公网路径设计路由。"),
         type: z
           .enum(["Event", "HTTP"])
           .optional()


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo1hkx69_frhv2z
- category: skill
- canonicalTitle: HTTP 云函数 Skill 缺少路径映射和网关路径处理的关键说明
- representativeRun: atomic-js-cloudbase-http-function-deploy/2026-04-19T19-06-49-f9d639

## Automation summary
在 iOS 应用中使用 CloudBase HTTP API 实现数据库操作 更新 CloudBase 云函数的环境变量 在 CloudBase 云托管中创建一个支持多语言的后端服务 README.md tencent-cloud

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/references/http-functions.md`