### PR TITLE
fix(skill): add anonymous session pitfall to auth-web gotchas

### DIFF
--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -47,6 +47,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
+- **Treating `auth.getUser()` returning a user as proof of real login.** When the SDK is initialized with a `publishableKey` / `accessKey`, it may silently create an anonymous session. A route guard's `checkAuth()` must verify that the user actually signed in with username/password (e.g. check `session.loginType !== 'ANONYMOUS'` or that `user.user_metadata?.username` exists), not just that `getUser()` returns non-null. Otherwise unauthenticated visitors pass the guard, protected pages render without a real user, and role-based UI (edit / delete buttons gated on `currentUser.role`) breaks because `currentUser` has no role record.
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Add a new gotcha to `config/source/skills/auth-web/SKILL.md` warning about treating `auth.getUser()` returning a user as proof of real login
- When SDK is initialized with `publishableKey`, it may silently create an anonymous session — route guards must distinguish anonymous from real username/password sessions

## Root Cause
Discovered from cms-scaffold evaluation: agent wrote `checkAuth()` as `!getUser().error && !!user` without checking login type. This caused:
1. Auth guard passed for unauthenticated visitors (anonymous session)
2. Protected pages rendered without a real user
3. Role-gated UI (edit/delete buttons) broke because `currentUser` had no role record

## Test plan
- [ ] Verify `auth-web/SKILL.md` gotchas section renders correctly
- [ ] Re-run cms-scaffold evaluation with `--skillSourceRef` pointing to this branch
- [ ] Note: end-to-end effect depends on next `@cloudbase/cloudbase-mcp` npm release (see specs/attribution.md §6.2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)