### PR TITLE
fix(skill): add signInWithPassword return format and checkAuth guidance

### DIFF
--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -141,11 +141,15 @@ const uid = data.user.id
 
 **Checking login state (for route guards / auth checks):**
 ```js
-// Use auth.getLoginState() — returns the current session if logged in, null/undefined if not.
-// Do NOT use auth.getUser() alone — it may return an anonymous user when the SDK
-// is initialized with a publishableKey.
+// Use auth.getLoginState() to get the current session.
+// IMPORTANT: uid alone is NOT enough — when the SDK is initialized with a
+// publishableKey it may create an anonymous session that also has a uid.
+// Route guards must reject anonymous sessions explicitly.
 const loginState = await auth.getLoginState()
-const isLoggedIn = !!loginState && !!loginState.uid
+const isRealLogin = !!loginState
+  && !!loginState.uid
+  && loginState.loginType !== 'ANONYMOUS'
+// Use isRealLogin (not just !!uid) to gate protected routes.
 ```
 
 **4. Registration**

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -121,10 +121,31 @@ const { data: loginData, error: loginError } = await data.verifyOtp({ token: '65
 ```
 
 **3. Password**
+
+All auth methods return `{ data, error }`. Always check `error` first:
 ```js
-const usernameLogin = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
-const emailLogin = await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
-const phoneLogin = await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+// Login — returns { data: { user, session }, error: null } on success
+const { data, error } = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
+if (error) {
+  // Handle login failure (wrong password, user not found, provider not enabled)
+  console.error('Login failed:', error.message)
+  return false
+}
+// data.user.id is the uid; data.session contains the active session
+const uid = data.user.id
+
+// Also works with email or phone:
+// await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
+// await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+```
+
+**Checking login state (for route guards / auth checks):**
+```js
+// Use auth.getLoginState() — returns the current session if logged in, null/undefined if not.
+// Do NOT use auth.getUser() alone — it may return an anonymous user when the SDK
+// is initialized with a publishableKey.
+const loginState = await auth.getLoginState()
+const isLoggedIn = !!loginState && !!loginState.uid
 ```
 
 **4. Registration**
@@ -167,11 +188,13 @@ const handleRegister = async () => {
 }
 
 const handleLogin = async () => {
-  const { error } = await auth.signInWithPassword({
+  const { data, error } = await auth.signInWithPassword({
     username,
     password,
   })
   if (error) throw error
+  // Login succeeded — data.user.id is the uid
+  return true
 }
 ```
 


### PR DESCRIPTION
## Summary
- Replace bare `signInWithPassword` one-liners with full `{ data, error }` destructuring showing success path (`data.user.id`) and error handling
- Add "Checking login state" section: recommend `getLoginState()` over `getUser()` for route guards, explain anonymous session pitfall
- Update `handleLogin` example to destructure `{ data, error }` consistently

## Root Cause
From cms-scaffold evaluation: agents produce **different return-value handling each run** because the skill only showed the call signature, not the response shape:
- Run A: `const result = await auth.signInWithPassword(...)` then `result.error` → works ✅
- Run B: `const result: any = ...` then `result.uid` → fails ❌ (uid is not top-level)
- Run C: `const { error } = ...` then success path never uses `data` → no uid available

## Depends on
- PR #588 (anonymous session pitfall) — already merged

## Test plan
- [ ] Verify auth-web/SKILL.md renders correctly
- [ ] Run cms-scaffold with `--skillSourceRef fix/auth-web-signin-return-format` to verify agent uses correct return format
- [ ] Note: end-to-end effect depends on next npm release (specs/attribution.md §6.2.2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)