### PR TITLE
docs: 添加 iOS App 开发视频教程和 CloudBase 游戏开发文章

### DIFF
--- a/doc/components/TutorialsGrid.tsx
+++ b/doc/components/TutorialsGrid.tsx
@@ -25,6 +25,17 @@ const TERMINAL_ORDER = ['小程序', 'Web', '小游戏', '原生应用'];
 const tutorials: Tutorial[] = [
   // 文章
   {
+    id: 'article-cloudbase-ai-game-development',
+    title: '圆梦：借助云开发 CloudBase实现你的游戏开发梦想',
+    description: '努力的小雨',
+    category: '文章',
+    url: 'https://juejin.cn/post/7441617101999861812',
+    type: 'article',
+    terminalTags: ['Web', '小游戏'],
+    appTypeTags: ['游戏'],
+    devToolTags: ['CodeBuddy'],
+  },
+  {
     id: 'article-qiyi-ai-app-community',
     title: '不会代码，她靠AI开发了APP，要把10万用户的社区运营起来',
     description: '云开发团队',
@@ -388,6 +399,18 @@ const tutorials: Tutorial[] = [
     devToolTags: ['Cursor', 'Figma'],
   },
   // 视频
+  {
+    id: 'video-ios-codebuddy-three-frogs',
+    title: '我帮大家把路铺平了！联合腾讯工程师优化 CodeBuddy 后，零基础做个带后端的 iOS App 竟然这么简单？',
+    description: '经本正一',
+    category: '视频教程',
+    url: 'https://www.bilibili.com/video/BV1iUcszSEUG/',
+    type: 'video',
+    thumbnail: 'http://i0.hdslb.com/bfs/archive/b7a256280c48f357905e753dfce4d39607b1799a.jpg',
+    terminalTags: ['原生应用'],
+    appTypeTags: ['工具/效率'],
+    devToolTags: ['CodeBuddy'],
+  },
   {
     id: 'video-vibecoding-compare-coze-cloudbase',
     title: 'vibecoding托管平台对比 扣子 vs cloudbase',

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -679,18 +679,18 @@ classDiagram
 ---
 
 ### `manageGateway`
-网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。
+网关域统一写入口。createAccess 为云函数创建访问入口时，必须显式提供 type：HTTP 云函数传 HTTP，Event 函数传 Event；省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。
 
 #### 参数
 
 <table>
 <thead><tr><th>参数名</th><th>类型</th><th>必填</th><th>说明</th></tr></thead>
 <tbody>
-<tr><td><code>action</code></td><td>string</td><td>是</td><td>写操作类型，例如 createAccess 可填写的值: "createAccess", "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "deleteAccess", "updatePathAuth"</td></tr>
+<tr><td><code>action</code></td><td>string</td><td>是</td><td>写操作类型，例如 createAccess。若 action=createAccess 且 targetType=function，必须显式提供 type。 可填写的值: "createAccess", "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "deleteAccess", "updatePathAuth"</td></tr>
 <tr><td><code>targetType</code></td><td>string</td><td></td><td>目标资源类型。当前支持 function，后续可扩展 可填写的值: "function"</td></tr>
 <tr><td><code>targetName</code></td><td>string</td><td></td><td>目标资源名称</td></tr>
 <tr><td><code>path</code></td><td>string</td><td></td><td>访问路径，默认 /&#123;targetName&#125;</td></tr>
-<tr><td><code>type</code></td><td>string</td><td></td><td>目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。 可填写的值: "Event", "HTTP"</td></tr>
+<tr><td><code>type</code></td><td>string</td><td></td><td>目标函数的本身类型（非接入形式）。若 action=createAccess 且 targetType=function，此字段必须显式提供：HTTP 云函数传 HTTP，Event 函数传 Event。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。 可填写的值: "Event", "HTTP"</td></tr>
 <tr><td><code>auth</code></td><td>boolean</td><td></td><td>是否开启鉴权</td></tr>
 <tr><td><code>route</code></td><td>object</td><td></td><td>HTTP 路由配置对象</td></tr>
 <tr><td><code>route.routeId</code></td><td>string</td><td></td><td></td></tr>

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -151,6 +151,7 @@ describe("functions tool helpers", () => {
     });
     expect(mockCreateAccess).not.toHaveBeenCalled();
     expect(payload.message).toContain("manageGateway(action=\"createAccess\")");
+    expect(payload.message).toContain("type=\"HTTP\"");
     expect(payload.message).toContain("匿名身份访问");
     expect(payload.message).toContain("EXCEED_AUTHORITY");
     expect(payload.nextActions).toEqual(

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -946,7 +946,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           tool: "manageGateway",
           action: "createAccess",
           reason:
-            "如果需要通过 URL 访问 HTTP 函数，请按实际路径和鉴权需求显式创建访问入口，不要默认假设 /函数名 已存在",
+            "如果需要通过 URL 访问 HTTP 函数，请调用 manageGateway(action=\"createAccess\") 并显式传 type=\"HTTP\"，再按实际路径和鉴权需求创建访问入口，不要默认假设 /函数名 已存在",
         });
         nextActions.push({
           tool: "queryGateway",
@@ -969,7 +969,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
 
       const message =
         func.type === "HTTP"
-          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createAccess") 按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
+          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createAccess")，并把 type="HTTP" 一起传入，再按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
           : `已创建函数 ${functionName}`;
 
       return buildEnvelope(

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -206,6 +206,31 @@ describe("gateway tools", () => {
     });
   });
 
+  it("manageGateway metadata should warn that createAccess requires explicit type", () => {
+    expect(tools.manageGateway.meta.description).toContain("createAccess");
+    expect(tools.manageGateway.meta.description).toContain("type");
+    expect(tools.manageGateway.meta.inputSchema.action.description).toContain("显式");
+    expect(tools.manageGateway.meta.inputSchema.type.description).toContain("createAccess");
+    expect(tools.manageGateway.meta.inputSchema.type.description).toContain("省略会默认按 Event 路由处理");
+  });
+
+  it("manageGateway(action=createAccess) should reject missing type with a clear message", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "createAccess",
+      targetType: "function",
+      targetName: "helloFn",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCreateAccess).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      success: false,
+      message: expect.stringContaining("必须显式提供 type"),
+    });
+    expect(payload.message).toContain("FUNCTION_PARAM_INVALID");
+  });
+
   it("queryGateway(action=getAccess) should aggregate access urls from domains", async () => {
     const result = await tools.queryGateway.handler({
       action: "getAccess",

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -328,6 +328,11 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       if (!input.targetName || !input.targetType) {
         throw new Error("action=createAccess 时必须提供 targetType 和 targetName");
       }
+      if (!input.type) {
+        throw new Error(
+          "action=createAccess 且 targetType=function 时必须显式提供 type。HTTP 云函数传 HTTP；Event 函数传 Event。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。",
+        );
+      }
       const cloudbase = await getManager();
       const accessPath = normalizeAccessPath(input.path || `/${input.targetName}`);
       let result;
@@ -335,14 +340,14 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         result = await cloudbase.access.createAccess({
           name: input.targetName,
           path: accessPath,
-          type: ((input.type || "Event") === "HTTP" ? 6 : 1) as 1 | 2,
+          type: (input.type === "HTTP" ? 6 : 1) as 1 | 2,
           auth: input.auth,
         });
       } catch (err: any) {
         if (err.message && err.message.includes("An error has occurred")) {
           let hint = "为目标资源配置访问路由失败（后端内部错误）。请确保：1) 目标云函数已成功创建并处于 Active 状态；2) 环境默认 HTTP 域名已完成初始化；3) 该访问路径未被占用。";
           if (input.type === "HTTP") {
-            hint += "此外注意：如果目标函数最初是作为 Event 函数创建的，这里 type 必须依然传 Event（或省略），传 HTTP 会导致此错误。";
+            hint += "此外注意：如果目标函数最初是作为 Event 函数创建的，这里 type 仍必须传 Event；误传 HTTP 会导致此错误。";
           }
           throw new Error(`${hint} 原始错误：${err.message}`);
         }
@@ -563,16 +568,21 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "管理网关域资源",
       description:
-        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。",
+        "网关域统一写入口。createAccess 为云函数创建访问入口时，必须显式提供 type：HTTP 云函数传 HTTP，Event 函数传 Event；省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。",
       inputSchema: {
-        action: z.enum(MANAGE_GATEWAY_ACTIONS).describe("写操作类型，例如 createAccess"),
+        action: z
+          .enum(MANAGE_GATEWAY_ACTIONS)
+          .describe("写操作类型，例如 createAccess。若 action=createAccess 且 targetType=function，必须显式提供 type。"),
         targetType: z
           .enum(["function"])
           .optional()
           .describe("目标资源类型。当前支持 function，后续可扩展"),
         targetName: z.string().optional().describe("目标资源名称"),
         path: z.string().optional().describe("访问路径，默认 /{targetName}"),
-        type: z.enum(["Event", "HTTP"]).optional().describe("目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。"),
+        type: z
+          .enum(["Event", "HTTP"])
+          .optional()
+          .describe("目标函数的本身类型（非接入形式）。若 action=createAccess 且 targetType=function，此字段必须显式提供：HTTP 云函数传 HTTP，Event 函数传 Event。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。"),
         auth: z.boolean().optional().describe("是否开启鉴权"),
         route: z
           .object({

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1898,7 +1898,7 @@
     },
     {
       "name": "manageGateway",
-      "description": "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。",
+      "description": "网关域统一写入口。createAccess 为云函数创建访问入口时，必须显式提供 type：HTTP 云函数传 HTTP，Event 函数传 Event；省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1914,7 +1914,7 @@
               "deleteAccess",
               "updatePathAuth"
             ],
-            "description": "写操作类型，例如 createAccess"
+            "description": "写操作类型，例如 createAccess。若 action=createAccess 且 targetType=function，必须显式提供 type。"
           },
           "targetType": {
             "type": "string",
@@ -1937,7 +1937,7 @@
               "Event",
               "HTTP"
             ],
-            "description": "目标函数的本身类型（非接入形式）。如果被访问的函数是 Event 型（默认），此处必须传 Event；只有当被访问函数在创建时就是 HTTP 函数时才传 HTTP。"
+            "description": "目标函数的本身类型（非接入形式）。若 action=createAccess 且 targetType=function，此字段必须显式提供：HTTP 云函数传 HTTP，Event 函数传 Event。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。"
           },
           "auth": {
             "type": "boolean",


### PR DESCRIPTION
本次 PR 通过自动化流程发现并添加了以下教程资源：

## 新增视频教程
- 标题: 我帮大家把路铺平了！联合腾讯工程师优化 CodeBuddy 后，零基础做个带后端的 iOS App 竟然这么简单？
- 作者: 经本正一
- 平台: Bilibili
- 链接: https://www.bilibili.com/video/BV1iUcszSEUG/
- 标签: 原生应用, 工具/效率, CodeBuddy

## 新增文章教程
- 标题: 圆梦：借助云开发 CloudBase实现你的游戏开发梦想
- 作者: 努力的小雨
- 平台: Juejin
- 链接: https://juejin.cn/post/7441617101999861812
- 标签: Web/小游戏, 游戏, CodeBuddy

## 变更文件
- doc/components/TutorialsGrid.tsx