### PR TITLE
fix(workflow): 设置 CodeBuddy 默认模型为 hy3-preview-ioa

### DIFF
--- a/.github/workflows/issue-auto-processor-simple.yml
+++ b/.github/workflows/issue-auto-processor-simple.yml
@@ -416,7 +416,7 @@ jobs:
               build_bug_prompt
 
               set +e
-              raw_output=$(timeout 1200s codebuddy -p "$(cat /tmp/codebuddy-prompt.txt)" -y --output-format json --permission-mode acceptEdits 2>&1)
+              raw_output=$(timeout 1200s codebuddy -p "$(cat /tmp/codebuddy-prompt.txt)" -y --output-format json --permission-mode acceptEdits --model hy3-preview-ioa 2>&1)
               exit_code=$?
               set -e
 
@@ -516,7 +516,7 @@ jobs:
             build_analysis_prompt
 
             set +e
-            raw_output=$(timeout 1200s codebuddy -p "$(cat /tmp/codebuddy-prompt.txt)" -y --output-format json --permission-mode acceptEdits </dev/null 2>&1)
+            raw_output=$(timeout 1200s codebuddy -p "$(cat /tmp/codebuddy-prompt.txt)" -y --output-format json --permission-mode acceptEdits --model hy3-preview-ioa </dev/null 2>&1)
             exit_code=$?
             set -e
 


### PR DESCRIPTION
## 修改内容

在 `.github/workflows/issue-auto-processor-simple.yml` 的两处 `codebuddy` CLI 调用中添加 `--model hy3-preview-ioa` 参数。

## 修改位置

1. Bug fix 流程（第 419 行）
2. Analysis 流程（第 519 行）

确保 issue-auto-processor 工作流使用指定的模型。