### PR TITLE
fix: CloudBase MCP 缺少云函数调用测试工具和可用日志，导致部署后无法验证功能正确性

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -225,6 +225,17 @@ The `scf_bootstrap` binary path must match the runtime — see the full mapping 
 - `manageFunctions(action="createFunction")`
 - `manageFunctions(action="updateFunctionCode")`
 - `manageFunctions(action="updateFunctionConfig")`
+- `manageFunctions(action="invokeFunction")`
+
+### Function invocation and verification
+
+After deploying or updating a function, always verify it works by invoking it and checking the result:
+
+1. **Invoke the function** — `manageFunctions(action="invokeFunction", functionName="...", params={...})` to call the function with test parameters and inspect the `invokeResult`.
+2. **Check logs on failure** — if the invocation returns an error or unexpected result, use `queryFunctions(action="listFunctionLogs", functionName="...")` to view recent execution logs, then `queryFunctions(action="getFunctionLogDetail", requestId="...")` for details.
+3. **Fix and redeploy** — update the function code and repeat verification.
+
+This deploy → invoke → check-logs loop is the primary way to confirm a function works correctly after deployment. Do not skip it.
 
 ### Logs
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -21,9 +21,12 @@ Use this checklist before creating or updating a CloudBase function.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
 - Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Treating Cloud Functions as the default answer for Web authentication.
+- Deploying a function without invoking it to verify it works.
 
 ## Done criteria
 
 - Function type and runtime are explicit.
 - Packaging constraints are checked.
 - The task is confirmed to be a function workflow rather than CloudRun.
+- The deployed function has been invoked with test parameters via `manageFunctions(action="invokeFunction")` and returns the expected result.
+- If invocation failed, logs were checked via `queryFunctions(action="listFunctionLogs")` and the issue was resolved.

--- a/config/source/skills/cloud-functions/references/event-functions.md
+++ b/config/source/skills/cloud-functions/references/event-functions.md
@@ -65,9 +65,43 @@ manageFunctions({
 - If runtime must change, recreate the function.
 - Prefer MCP management tools over CLI in agent flows.
 
-## Invocation patterns
+## Invocation and verification
 
-### Web
+### MCP-side invocation (for testing)
+
+After deploying an Event Function, use `manageFunctions(action="invokeFunction")` to call it directly and verify it works:
+
+```javascript
+manageFunctions({
+  action: "invokeFunction",
+  functionName: "myFunction",
+  params: { userId: "123" }
+});
+```
+
+The response contains `invokeResult` with the function's return value. If it errors or returns unexpected data, check the logs:
+
+```javascript
+queryFunctions({
+  action: "listFunctionLogs",
+  functionName: "myFunction"
+});
+```
+
+### Deployment verification loop
+
+After every `createFunction` or `updateFunctionCode`, follow this loop:
+
+1. **Invoke** — `manageFunctions(action="invokeFunction", functionName="myFunction", params={...})` with representative test parameters.
+2. **Inspect result** — check `invokeResult` for expected output or error messages.
+3. **Check logs on failure** — `queryFunctions(action="listFunctionLogs", functionName="myFunction")` then `queryFunctions(action="getFunctionLogDetail", requestId="...")` to diagnose.
+4. **Fix and redeploy** — update code and repeat.
+
+Do not assume deployment succeeded without invoking the function.
+
+### Client-side invocation (for production)
+
+#### Web
 
 ```javascript
 import cloudbase from "@cloudbase/js-sdk";
@@ -79,7 +113,7 @@ const result = await app.callFunction({
 });
 ```
 
-### Mini Program
+#### Mini Program
 
 ```javascript
 const result = await wx.cloud.callFunction({
@@ -88,7 +122,7 @@ const result = await wx.cloud.callFunction({
 });
 ```
 
-### Node.js backend
+#### Node.js backend
 
 ```javascript
 const tcb = require("@cloudbase/node-sdk");
@@ -100,7 +134,7 @@ const result = await app.callFunction({
 });
 ```
 
-### Raw HTTP API
+#### Raw HTTP API
 
 Use the CloudBase HTTP API only when the task is explicitly about raw API invocation.
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mnronexl_l8xq76
- category: tool
- canonicalTitle: CloudBase MCP 缺少云函数调用测试工具和可用日志，导致部署后无法验证功能正确性
- representativeRun: application-js-react-cloudbase-realtime-battle-scaffold/2026-04-09T16-02-40-udtqju

## Automation summary
`invokeFunction` 现已在所有三个云函数技能文件中提及。所有回归测试均已通过。 总结： - **根本原因**：云函数技能文档（`SKILL.md`、`event-functions.md`、`checklist.md`）完全没有提及 `manageFunctions(action="invokeFunction")`，这是用于调用/测试已部署函数的 MCP 工具操作。部署函数后，代理没有指导如何验证功能正确性——他们无法调用函数来测试它，也没有被告知在调用失败时检查日志。`invokeFunction` 操作自工具整合工作以来一直存在于 MCP 代码中，但该技能从未更新以记录它。 - **变更**（层1 - 技能文本修复）： 1. **SKILL.md**：将 `manageFunctions(action="invokeFunction")` 添加到“首选工具映射”→“函数管理”部分，并添加了一个新的“函数调用和验证”子部分，记录了部署→调用→检查日志的验证循环。 2. **event-functions.md**：重构“调用模式”为“调用和验证”，添加了 `manageFunctions(action="invokeFunction")` 作为 MCP 端测试方法，并添加了一个“部署验证循环”工作流。将客户端调用模式分组到“客户端调用（生产环境）”下。 3. **checklist.md**：添加了“部署函数而未调用它以验证其是否有效”作为常见的失败模式，并添加了两个完成标准：通过 `invokeFunction` 验证调用以及在失败时检查日志。 - **验证**：所有3个回归测试套件（`build-skills-repo`、`build-compat-config`、`skill-quality-standards`）均通过，共有10个测试。 - **后续行动**：无需进一步操作。修复在技能文档层面，这正是解决正确的问题——代理没有验证部署，因为技能从未告诉他们 `invokeFunction` 存在。

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/checklist.md`
- `config/source/skills/cloud-functions/references/event-functions.md`