### PR TITLE
fix: allinone skill 缺少强制指令：执行 CloudBase 能力开发前必须先读取对应专项 skill

### DIFF
--- a/config/source/editor-config/guides/cloudbase-rules.mdc
+++ b/config/source/editor-config/guides/cloudbase-rules.mdc
@@ -23,7 +23,7 @@ When the workspace already contains an existing application with explicit TODO m
 
 ### Global must-read rules
 
-- Identify the scenario first. Do not start implementation before reading the matching rule file.
+- **You MUST identify the scenario first. Do NOT start implementation before reading the matching rule file.** The rule files contain essential API signatures, parameter maps, return-value destructuring, and pitfall lists that prevent common integration errors.
 - Login or registration request -> read `{auth-tool}` first, then the platform auth rule.
 - Keep auth domains separate: management-side login uses `auth`; app-side auth configuration uses `queryAppAuth` / `manageAppAuth`.
 - When writing MCP or tool results to a local file with a generic file-writing tool, pass text rather than raw objects. For JSON files, serialize first with `JSON.stringify(result, null, 2)` and write that string.

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -23,9 +23,35 @@ When a skill body references stable sibling ids such as `auth-tool`, `auth-web`,
 
 If a skill points to its own `references/...` files, keep following those relative paths from the current skill directory. If the environment does not support MCP directly, read `cloudbase` first and follow its mcporter / MCP setup guidance before using any platform-specific skill.
 
+### ⚠️ MANDATORY: Read sub-skill before implementation
+
+**You MUST read the corresponding `references/<skill-id>/SKILL.md` file before writing any CloudBase capability code.** Do NOT implement CloudBase features based solely on this overview file — the sub-skill files contain essential API signatures, parameter maps, return-value destructuring, and pitfall lists that prevent common integration errors.
+
+When this skill is deployed as an all-in-one bundle, sub-skills live under `references/`. Use the High-priority routing table below to determine which sub-skill to read first:
+
+| Capability area | MUST read before coding | Also read |
+|-----------------|------------------------|-----------|
+| Web login / registration / auth | `references/auth-tool/SKILL.md` | `references/auth-web/SKILL.md` |
+| Web SDK integration / hosting | `references/web-development/SKILL.md` | — |
+| Mini program development | `references/miniprogram-development/SKILL.md` | `references/auth-wechat/SKILL.md` |
+| Cloud functions | `references/cloud-functions/SKILL.md` | — |
+| CloudRun backend | `references/cloudrun-development/SKILL.md` | — |
+| NoSQL database (Web) | `references/no-sql-web-sdk/SKILL.md` | — |
+| NoSQL database (Mini Program) | `references/no-sql-wx-mp-sdk/SKILL.md` | — |
+| MySQL database | `references/relational-database-tool/SKILL.md` | `references/relational-database-web/SKILL.md` |
+| AI text/chat (Web) | `references/ai-model-web/SKILL.md` | — |
+| AI text/chat/image (Node.js) | `references/ai-model-nodejs/SKILL.md` | — |
+| AI text/chat (WeChat) | `references/ai-model-wechat/SKILL.md` | — |
+| Cloud storage (Web) | `references/cloud-storage-web/SKILL.md` | — |
+| UI design | `references/ui-design/SKILL.md` | — |
+| AI Agent | `references/cloudbase-agent/SKILL.md` | — |
+| Spec workflow | `references/spec-workflow/SKILL.md` | — |
+
+**If you skip reading the sub-skill and implement based on this file alone, you will likely use wrong API signatures, incorrect parameter names, or miss required setup steps (e.g. enabling auth providers before writing login code).**
+
 ### Global rules before action
 
-- Identify the scenario first, then read the matching source skill before writing code or calling CloudBase APIs.
+- You MUST identify the scenario first, then read the matching source skill before writing code or calling CloudBase APIs. This is not optional.
 - Prefer semantic sources when maintaining the toolkit, but express runtime routing in stable skill identifiers rather than repo-only paths. Do not treat generated, mirrored, or IDE-specific artifacts as the primary knowledge source.
 - Use MCP or mcporter first for CloudBase management tasks, and inspect tool schemas before execution.
 - If the task includes UI, read `ui-design` first and output the design specification before interface code.


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mod8736e_qrsax8
- category: skill
- canonicalTitle: allinone skill 缺少强制指令：执行 CloudBase 能力开发前必须先读取对应专项 skill
- representativeRun: application-js-react-cloudbase-phone-signin/2026-04-24T18-02-16-sp4e3g

## Automation summary
总结： - **根本原因**：allinone SKILL.md（源自 `config/source/guideline/cloudbase/SKILL.md`）缺少强制性指令，强制代理在实现任何 CloudBase 能力开发之前必须阅读相应的子技能（例如，Web 认证任务需阅读 `references/auth-web/SKILL.md` 和 `references/auth-tool/SKILL.md`）。现有的“全局规则”部分使用了软性措辞（“首先识别场景”），而非强制性措辞，导致代理跳过了子技能阅读，直接从概览文件进行实现——这导致使用了错误的 API 签名、不正确的参数名称，并遗漏了所需的设置步骤。 - **变更**： 1. `config/source/guideline/cloudbase/SKILL.md`：在“全局规则之前”之前添加了一个显著的“⚠️ 强制：实现前阅读子技能”部分，并使用强制性措辞（“你必须”、“不要”），包含一个将能力区域映射到 `references/<skill-id>/SKILL.md` 路径的路由表，以及关于跳过子技能后果的警告。同时加强了第一条全局规则，使其明确说明“你必须...这不是可选的”。 2. `config/source/editor-config/guides/cloudbase-rules.mdc`：将软性措辞“首先识别场景。在阅读匹配的规则文件之前，不要开始实现”加强为强制性措辞“**你必须首先识别场景。在阅读匹配的规则文件之前，不要开始实现。**规则文件包含必要的 API 签名……” - **验证**：所有 3 个回归测试套件通过（10/10 个测试），包括 `build-allinone-skill` 测试。在临时目录中构建 allinone 包确认强制性指令和路由表已正确包含在输出中。 - **后续行动**：无。

## Changed files
- `config/source/editor-config/guides/cloudbase-rules.mdc`
- `config/source/guideline/cloudbase/SKILL.md`