### PR TITLE
fix: uploadFiles MCP 工具未区分「云存储上传」与「静态托管部署」，上传成功但页面 404

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -291,6 +291,7 @@ Prefer long-term memory when available: write the scenarios and working rules th
 - Refer to the `web-development` skill for deployment process
 - `uploadFiles` is for static hosting only; if the task needs a COS object that must be queried or polled with the storage SDK, use `manageStorage` / `queryStorage`
 - Remind users that CDN has a few minutes of cache after deployment
+- **Subdirectory deployment 404 prevention**: When deploying to a subdirectory, the build config `base` / `publicPath` / `assetPrefix` MUST be set to the matching absolute path (e.g. `'/vite-test/'` with leading and trailing slashes). NEVER use `'./'` or empty string. After changing build config, MUST rebuild and verify asset paths in the build output before calling `uploadFiles`. Upload the entire `dist/` directory, not just `index.html`.
 
 **Backend Deployment:**
 - **Cloud Functions**: Refer to the `cloud-functions` skill - Runtime cannot be changed after creation, must select correct runtime initially

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -102,7 +102,13 @@ Use this skill for **CloudBase platform knowledge** when you need to:
    - Cloud storage is suitable for files with privacy requirements, can get temporary access addresses via temporary file URLs
    - If the task needs COS SDK polling, file metadata lookup, or temporary URLs for an uploaded object, use cloud storage tools (`manageStorage` / `queryStorage`), not `uploadFiles`
 
-2. **Static Hosting Domain**:
+2. **Subdirectory deployment checklist** (the #1 cause of post-deploy 404s):
+   - Build config `base` / `publicPath` / `assetPrefix` MUST be set to the absolute subdirectory path with leading and trailing slashes (e.g. `'/vite-test/'`). NEVER use `'./'` or empty string — relative paths break in subdirectory deployments.
+   - After changing build config, MUST rebuild and verify that asset paths in the build output (e.g. `dist/index.html`) match the configured prefix (not `/` or relative paths).
+   - `uploadFiles` `cloudPath` is relative to hosting root without leading `/` (e.g. `'vite-test'` not `'/vite-test'`).
+   - Upload the entire build output directory (`dist/`), not just `index.html`.
+
+3. **Static Hosting Domain**:
    - CloudBase static hosting domain can be obtained via `getWebsiteConfig` tool
    - Combine with static hosting file paths to construct final access addresses
    - **Important**: If access address is a directory, it must end with `/`

--- a/config/source/skills/web-development/SKILL.md
+++ b/config/source/skills/web-development/SKILL.md
@@ -128,9 +128,13 @@ Use this section only when the Web project needs CloudBase platform features.
 ### Static hosting defaults
 
 - Build before deployment
-- Prefer relative asset paths for static hosting compatibility
+- **Subdirectory deployment is the most common source of 404 errors.** When deploying to a subdirectory (e.g. `/vite-test/`), the build config `base` / `publicPath` / `assetPrefix` MUST be set to the matching absolute path with leading and trailing slashes (e.g. `'/vite-test/'`). NEVER use `'./'` or empty string — relative paths resolve incorrectly when the access URL lacks a trailing slash, causing all static assets to 404.
+- After changing the build config, you MUST rebuild and verify that asset references in the build output (e.g. `dist/index.html`) use the configured prefix rather than `/` or relative paths.
+- Upload the entire build output directory (typically `dist/`), not just `index.html`.
+- `uploadFiles` `cloudPath` is relative to the hosting root without a leading `/` (e.g. `'vite-test'` not `'/vite-test'`).
 - Use hash routing by default when the project lacks server-side route rewrites
 - If the user does not specify a root path, avoid deploying directly to the site root by default
+- CDN has a few minutes of cache after deployment; append a random query string when verifying
 
 ### CloudBase quick start
 

--- a/config/source/skills/web-development/frameworks.md
+++ b/config/source/skills/web-development/frameworks.md
@@ -24,3 +24,18 @@
 - Use the existing router if present; do not switch routing libraries without an explicit requirement.
 - For purely static hosting environments, prefer hash routing when server rewrite support is absent or unknown.
 - Make build and preview commands explicit before handing off deployment steps.
+
+## Vite base config for subdirectory deployment
+
+When deploying a Vite app to a CloudBase static hosting subdirectory (e.g. `/vite-test/`):
+
+1. Set `base` in `vite.config.ts` to the **absolute** subdirectory path with leading and trailing slashes:
+   ```js
+   // vite.config.ts — deploying to /vite-test/
+   export default defineConfig({
+     base: '/vite-test/',  // MUST be absolute, NOT './' or ''
+   })
+   ```
+2. **NEVER** use `base: './'` or `base: ''` for subdirectory deployment. Relative paths break when the access URL does not end with `/`, causing all JS/CSS assets to 404.
+3. After changing `base`, you MUST run `npm run build` again and verify that `dist/index.html` contains asset paths like `/vite-test/assets/xxx.js` rather than `/assets/xxx.js` or `./assets/xxx.js`.
+4. When calling `uploadFiles`, use `cloudPath: 'vite-test'` (no leading `/`) and `localPath` pointing to the `dist/` directory.

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -24,7 +24,7 @@
 <tr><td><code>modifyDataModel</code></td><td>基于Mermaid classDiagram创建数据模型。为保持兼容性，工具名仍为 modifyDataModel；当前仅支持创建新模型，不支持更新现有模型结构。内置异步任务监控，自动轮询直至完成或超时。</td></tr>
 <tr><td><code>queryFunctions</code></td><td>函数域统一只读入口。通过更自解释的 action 查询函数列表、函数详情、日志、层、触发器和代码下载地址。</td></tr>
 <tr><td><code>manageFunctions</code></td><td>函数域统一写入口。通过 action 管理函数创建、代码更新、配置更新、调用函数、触发器和层绑定。危险操作需要显式 confirm=true。</td></tr>
-<tr><td><code>uploadFiles</code></td><td>上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建；如果站点会部署到子路径，请检查构建配置中的 publicPath、base、assetPrefix 等是否使用相对路径，避免静态资源加载失败。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。</td></tr>
+<tr><td><code>uploadFiles</code></td><td>上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。⚠️ 子目录部署必检项：1) 构建配置 base/publicPath/assetPrefix 必须设为与部署目标一致的绝对路径（如 '/vite-test/'，禁止 './' 或空字符串）；2) 修改配置后必须重新构建并验证产物中的资源引用路径；3) cloudPath 不要带前导 '/'；4) 上传完整 dist/ 目录。</td></tr>
 <tr><td><code>deleteFiles</code></td><td>删除静态网站托管的文件或文件夹</td></tr>
 <tr><td><code>findFiles</code></td><td>搜索静态网站托管的文件</td></tr>
 <tr><td><code>domainManagement</code></td><td>统一的域名管理工具，支持绑定、解绑、查询和修改域名配置</td></tr>
@@ -418,7 +418,13 @@ classDiagram
 ---
 
 ### `uploadFiles`
-上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建；如果站点会部署到子路径，请检查构建配置中的 publicPath、base、assetPrefix 等是否使用相对路径，避免静态资源加载失败。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。
+上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。
+
+⚠️ 子目录部署必检项（任何一项未通过则禁止调用本工具）：
+1. 构建配置中的 base / publicPath / assetPrefix 必须设为与部署目标一致的绝对路径（如部署到 /vite-test/ 则设为 '/vite-test/'，必须带前导和尾部斜杠）。禁止使用 './' 或空字符串——相对路径在子目录部署后会导致静态资源 404。
+2. 修改构建配置后必须重新执行构建（build），且验证构建产物中的资源引用路径已更新（非绝对根路径 '/'）。
+3. cloudPath 为相对托管根目录的路径，不要带前导 '/'（如 'vite-test' 而非 '/vite-test'）。
+4. 上传目录必须是构建产物目录（通常为 dist/）的完整内容，不能只上传 index.html。
 
 #### 参数
 
@@ -426,7 +432,7 @@ classDiagram
 <thead><tr><th>参数名</th><th>类型</th><th>必填</th><th>说明</th></tr></thead>
 <tbody>
 <tr><td><code>localPath</code></td><td>string</td><td></td><td>本地文件或文件夹路径，需要是绝对路径，例如 /tmp/files/data.txt。</td></tr>
-<tr><td><code>cloudPath</code></td><td>string</td><td></td><td>静态托管云端文件或文件夹路径，例如 files/data.txt。若部署到子路径，请同时检查构建配置中的 publicPath、base、assetPrefix 等是否为相对路径。云存储对象路径请改用 manageStorage。</td></tr>
+<tr><td><code>cloudPath</code></td><td>string</td><td></td><td>静态托管云端文件或文件夹路径，相对托管根目录，不要带前导 '/'，例如 vite-test 或 vite-test/assets/main.js。云存储对象路径请改用 manageStorage。</td></tr>
 <tr><td><code>files</code></td><td>array of object</td><td></td><td>多文件上传配置 默认值: []</td></tr>
 <tr><td><code>files[].localPath</code></td><td>string</td><td>是</td><td></td></tr>
 <tr><td><code>files[].cloudPath</code></td><td>string</td><td>是</td><td></td></tr>

--- a/doc/prompts/web-development.mdx
+++ b/doc/prompts/web-development.mdx
@@ -164,9 +164,13 @@ Use this section only when the Web project needs CloudBase platform features.
 ### Static hosting defaults
 
 - Build before deployment
-- Prefer relative asset paths for static hosting compatibility
+- **Subdirectory deployment is the most common source of 404 errors.** When deploying to a subdirectory (e.g. `/vite-test/`), the build config `base` / `publicPath` / `assetPrefix` MUST be set to the matching absolute path with leading and trailing slashes (e.g. `'/vite-test/'`). NEVER use `'./'` or empty string — relative paths resolve incorrectly when the access URL lacks a trailing slash, causing all static assets to 404.
+- After changing the build config, you MUST rebuild and verify that asset references in the build output (e.g. `dist/index.html`) use the configured prefix rather than `/` or relative paths.
+- Upload the entire build output directory (typically `dist/`), not just `index.html`.
+- `uploadFiles` `cloudPath` is relative to the hosting root without a leading `/` (e.g. `'vite-test'` not `'/vite-test'`).
 - Use hash routing by default when the project lacks server-side route rewrites
 - If the user does not specify a root path, avoid deploying directly to the site root by default
+- CDN has a few minutes of cache after deployment; append a random query string when verifying
 
 ### CloudBase quick start
 

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -258,10 +258,16 @@ export function registerHostingTools(server: ExtendedMcpServer) {
     "uploadFiles",
     {
       title: "上传静态文件",
-      description: "上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建；如果站点会部署到子路径，请检查构建配置中的 publicPath、base、assetPrefix 等是否使用相对路径，避免静态资源加载失败。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。",
+      description: `上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。
+
+⚠️ 子目录部署必检项（任何一项未通过则禁止调用本工具）：
+1. 构建配置中的 base / publicPath / assetPrefix 必须设为与部署目标一致的绝对路径（如部署到 /vite-test/ 则设为 '/vite-test/'，必须带前导和尾部斜杠）。禁止使用 './' 或空字符串——相对路径在子目录部署后会导致静态资源 404。
+2. 修改构建配置后必须重新执行构建（build），且验证构建产物中的资源引用路径已更新（非绝对根路径 '/'）。
+3. cloudPath 为相对托管根目录的路径，不要带前导 '/'（如 'vite-test' 而非 '/vite-test'）。
+4. 上传目录必须是构建产物目录（通常为 dist/）的完整内容，不能只上传 index.html。`,
       inputSchema: {
         localPath: z.string().optional().describe("本地文件或文件夹路径，需要是绝对路径，例如 /tmp/files/data.txt。"),
-        cloudPath: z.string().optional().describe("静态托管云端文件或文件夹路径，例如 files/data.txt。若部署到子路径，请同时检查构建配置中的 publicPath、base、assetPrefix 等是否为相对路径。云存储对象路径请改用 manageStorage。"),
+        cloudPath: z.string().optional().describe("静态托管云端文件或文件夹路径，相对托管根目录，不要带前导 '/'，例如 vite-test 或 vite-test/assets/main.js。云存储对象路径请改用 manageStorage。"),
         files: z.array(z.object({
           localPath: z.string(),
           cloudPath: z.string()


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mocvv0dg_69tn2d
- category: tool
- canonicalTitle: uploadFiles MCP 工具未区分「云存储上传」与「静态托管部署」，上传成功但页面 404
- representativeRun: application-js-vite-hello-world-hosting-deploy/2026-04-24T12-30-27-1bd1f3

## Automation summary
- root_cause: The `uploadFiles` MCP tool description and related skill docs instructed AI agents to use "相对路径" (relative paths) for `publicPath`/`base`/`assetPrefix` when deploying to subdirectories. Relative paths like `./` break subdirectory deployments because the access URL may lack a trailing slash, causing all JS/CSS assets to 404. The correct guidance is to use absolute paths matching the deployment target (e.g., `/vite-test/`). Additionally, there was no pre-deployment checklist forcing agents to verify build config, rebuild after config changes, or upload the full `dist/` directory.
- changes:
1. **mcp/src/tools/hosting.ts**: Replaced uploadFiles description — removed misleading "使用相对路径" guidance; added explicit 4-point subdirectory deployment checklist (absolute base path required, rebuild required, cloudPath format, upload full dist/). Updated cloudPath parameter description to specify "no leading /" format.
2. **config/source/skills/web-development/SKILL.md**: Replaced "Prefer relative asset paths" with detailed subdirectory 404 prevention guidance including absolute path requirement, rebuild verification, cloudPath format, full dist/ upload, and CDN cache note.
3. **co

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/skills/cloudbase-platform/SKILL.md`
- `config/source/skills/web-development/SKILL.md`
- `config/source/skills/web-development/frameworks.md`
- `doc/mcp-tools.md`
- `doc/prompts/web-development.mdx`
- `mcp/src/tools/hosting.ts`