### PR TITLE
fix: MCP工具在多步串联操作场景下可发现性不足，模型未发起任何实际MCP调用

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -52,6 +52,7 @@ If a skill points to its own `references/...` files, keep following those relati
 | AI Agent (智能体开发) | `cloudbase-agent` |  domain skill as needed | `cloud-functions`,`cloudrun-development`, | AG-UI protocol, scf_bootstrap, SSE streaming |
 | UI generation | `ui-design` | platform skill | backend-only skills | Design specification first |
 | Spec workflow / architecture design | `spec-workflow` | `cloudbase` and platform skill | direct implementation skills | Requirements, design, tasks confirmed |
+| NoSQL direct MCP operations (check / create / insert / query without writing SDK code) | `cloudbase-platform` | `no-sql-web-sdk` or `no-sql-wx-mp-sdk` (for SDK code only) | `auth-web`, `http-api` | Collection must exist before data operations; use `checkCollection` → `createCollection` → insert → query sequence |
 | Resource health inspection / troubleshooting / 巡检 / 诊断 | `ops-inspector` | `cloud-functions`, `cloudrun-development` | `ui-design`, `spec-workflow` | CLS enabled, time range for logs |
 
 ### Routing reminders
@@ -59,6 +60,7 @@ If a skill points to its own `references/...` files, keep following those relati
 - Web auth failures are usually caused by skipping provider configuration, not by missing frontend code snippets.
 - Native App failures are usually caused by reading Web SDK paths, not by missing HTTP API knowledge.
 - Mini program failures are usually caused by treating `wx.cloud` like Web auth or Web SDK.
+- NoSQL MCP operation failures are usually caused by the model generating SDK code (`db.collection(...)`) instead of calling the MCP tools (`readNoSqlDatabaseStructure`, `writeNoSqlDatabaseStructure`, `readNoSqlDatabaseContent`, `writeNoSqlDatabaseContent`) directly. When the task says to operate on a collection via MCP, call the tools — do not write JavaScript.
 
 ### Web SDK quick reminder
 
@@ -283,6 +285,15 @@ Prefer long-term memory when available: write the scenarios and working rules th
 **Mini Program Projects:**
 - NoSQL Database: Refer to the `no-sql-wx-mp-sdk` skill
 - MySQL Relational Database: Refer to the `relational-database-tool` skill (via tools)
+
+**Direct MCP Tool Operations (no SDK code):**
+- When the task requires operating NoSQL collections directly via MCP tools (not writing browser/mini-program code), use these 4 tools:
+  - `readNoSqlDatabaseStructure` — check/list/describe collections and indexes
+  - `writeNoSqlDatabaseStructure` — create/update/delete collections and indexes
+  - `readNoSqlDatabaseContent` — query documents from a collection
+  - `writeNoSqlDatabaseContent` — insert/update/delete documents
+- Read the `cloudbase-platform` skill for the full multi-step workflow and call examples
+- **Do NOT** generate `db.collection(...)` SDK code when the task expects direct MCP tool calls
 
 ### 3. Deployment
 

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -195,6 +195,82 @@ Compatibility note:
    - If involving cloud functions, while ensuring security, can minimize the number of cloud functions as much as possible
    - For example: implement one cloud function for client-side requests, implement one cloud function for data initialization
 
+## NoSQL Database MCP Tool Operations
+
+When using CloudBase MCP tools directly (not writing browser/mini-program SDK code), use these 4 tools for NoSQL database operations:
+
+### Tool Overview
+
+| Tool | Purpose | Key actions |
+|------|---------|-------------|
+| `readNoSqlDatabaseStructure` | Read collection and index structure | `listCollections`, `describeCollection`, `checkCollection`, `listIndexes`, `checkIndex` |
+| `writeNoSqlDatabaseStructure` | Create, update, or delete collections and indexes | `createCollection`, `updateCollection`, `deleteCollection` |
+| `readNoSqlDatabaseContent` | Query documents from a collection | Query with filters, projection, sort, pagination |
+| `writeNoSqlDatabaseContent` | Insert, update, or delete documents | `insert`, `update`, `delete` |
+
+### Typical Multi-Step Workflow
+
+For common NoSQL operations that require chaining multiple tool calls, follow this sequence:
+
+```
+1. Check collection exists → readNoSqlDatabaseStructure(action="checkCollection", collectionName="...")
+2. If not exists, create collection → writeNoSqlDatabaseStructure(action="createCollection", collectionName="...")
+3. Verify/describe collection → readNoSqlDatabaseStructure(action="describeCollection", collectionName="...")
+4. Insert documents → writeNoSqlDatabaseContent(action="insert", collectionName="...", documents=[{...}])
+5. Query documents → readNoSqlDatabaseContent(collectionName="...", query={...})
+```
+
+**Important**: After `createCollection`, the tool internally waits for the collection to become ready before returning. You do NOT need to add a separate delay or retry loop.
+
+### Call Examples
+
+**Check if a collection exists:**
+```
+readNoSqlDatabaseStructure(action="checkCollection", collectionName="my_collection")
+```
+
+**Create a collection:**
+```
+writeNoSqlDatabaseStructure(action="createCollection", collectionName="my_collection")
+```
+
+**Describe a collection (includes index info):**
+```
+readNoSqlDatabaseStructure(action="describeCollection", collectionName="my_collection")
+```
+
+**List all collections:**
+```
+readNoSqlDatabaseStructure(action="listCollections")
+```
+
+**Insert a document:**
+```
+writeNoSqlDatabaseContent(action="insert", collectionName="my_collection", documents=[{"name":"test","status":"active"}])
+```
+
+**Query documents with a filter:**
+```
+readNoSqlDatabaseContent(collectionName="my_collection", query={"name":"test"})
+```
+
+**Update documents (use `$set` for partial updates):**
+```
+writeNoSqlDatabaseContent(action="update", collectionName="my_collection", query={"name":"test"}, update={"$set":{"status":"completed"}})
+```
+
+**Delete documents:**
+```
+writeNoSqlDatabaseContent(action="delete", collectionName="my_collection", query={"name":"test"})
+```
+
+### Common Mistakes
+
+- **Forgetting to create the collection first**: All content operations (`readNoSqlDatabaseContent`, `writeNoSqlDatabaseContent`) require the collection to already exist. Always check with `checkCollection` and create with `createCollection` if needed before doing data operations.
+- **Using `update` without `$set`**: When updating documents, passing a plain object like `{"status":"completed"}` will **replace the entire document**. Use `{"$set":{"status":"completed"}}` for partial updates.
+- **Mixing SDK code patterns with MCP tool calls**: When in pure MCP mode, do NOT generate JavaScript code using `db.collection(...)`. Call the MCP tools directly instead.
+- **Not chaining operations sequentially**: Multi-step operations (check → create → insert → query) must be done in order; each step may depend on the previous step's result.
+
 ## Data Models
 
 1. **Get Data Model Operation Object**:


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mocmz9tl_ss16ci
- category: tool
- canonicalTitle: MCP工具在多步串联操作场景下可发现性不足，模型未发起任何实际MCP调用
- representativeRun: atomic-js-none-chain-nosql-create-insert-query/2026-04-24T08-14-55-0p425r

## Automation summary
- **root_cause**: When a model is in pure MCP mode (no SDK code to write), it cannot discover the 4 NoSQL MCP tools (`readNoSqlDatabaseStructure`, `writeNoSqlDatabaseStructure`, `readNoSqlDatabaseContent`, `writeNoSqlDatabaseContent`) because neither the main `cloudbase` guideline nor the `cloudbase-platform` skill documents them. The existing `no-sql-web-sdk` and `no-sql-wx-mp-sdk` skills only cover browser/mini-program SDK code patterns (`db.collection(...)`), not direct MCP tool calls. The model created a TaskCreate but then stopped, saying "您的消息没有完整发送", and never initiated any MCP tool calls.
- **changes**: Two files modified (Layer 1 — skill text fix):
1. `config/source/skills/cloudbase-platform/SKILL.md` — Added a comprehensive "NoSQL Database MCP Tool Operations" section including: tool overview table mapping 4 MCP tools to their actions, typical multi-step workflow (checkCollection → createCollection → describeCollection → insert → query), 8 call examples with concrete parameters, and common mistakes (forgetting to create collection first, using update without `$set`, mixing SDK code with MCP calls, not chaining sequentially).
2. `config/source/guideline/cloudbase/SKILL.md`

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/skills/cloudbase-platform/SKILL.md`