### PR TITLE
fix: MCP 云函数配置工具参数错误提示不清晰，缺乏正确调用示例

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -56,6 +56,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
 - Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Use `managePermissions(action="updateResourcePermission", resourceType="function")` to allow public access.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime (e.g. using `/var/lang/node18/bin/node` but setting `runtime: "Nodejs16.13"`).
+- Accessing the wrong field path for environment variables. Current variables are in `functionDetail.Environment.Variables` (array of `{Key, Value}` objects), not `functionDetail.EnvVariables`. See `./references/operations-and-config.md` for the correct update pattern.
 
 ### Minimal checklist
 

--- a/config/.claude/skills/cloud-functions/checklist.md
+++ b/config/.claude/skills/cloud-functions/checklist.md
@@ -21,6 +21,8 @@ Use this checklist before creating or updating a CloudBase function.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
 - Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Treating Cloud Functions as the default answer for Web authentication.
+- When updating environment variables, accessing the wrong field path. Use `functionDetail.Environment.Variables` (array format), not `functionDetail.EnvVariables`.
+- Manually merging environment variables when using `manageFunctions(action="updateFunctionConfig")`. The tool already handles merging internally - just pass the new/modified variables.
 
 ## Done criteria
 

--- a/config/.claude/skills/cloud-functions/references/operations-and-config.md
+++ b/config/.claude/skills/cloud-functions/references/operations-and-config.md
@@ -86,31 +86,59 @@ Key parameters:
 
 ## Environment variable updates
 
-Do not overwrite function environment variables blindly.
+### Important: Automatic merge behavior
 
-### Safe pattern
+The `manageFunctions(action="updateFunctionConfig")` tool automatically merges environment variables internally. You only need to provide the new or updated variables - existing variables will be preserved.
 
-1. Read current config with `queryFunctions(action="getFunctionDetail")`.
-2. Merge existing variables with the new variables.
-3. Update with `manageFunctions(action="updateFunctionConfig")`.
+### Correct usage pattern
 
 ```javascript
-const current = await queryFunctions({
-  action: "getFunctionDetail",
-  functionName: "functionName"
-});
-
-const mergedEnvVariables = {
-  ...current.EnvVariables,
-  ...newEnvVariables
-};
-
+// Only pass the variables you want to add or update
+// Existing variables will be preserved automatically
 await manageFunctions({
   action: "updateFunctionConfig",
-  functionName: "functionName",
-  envVariables: mergedEnvVariables
+  functionName: "my-function",
+  envVariables: {
+    NEW_VAR: "new-value",
+    EXISTING_VAR: "updated-value"  // This will update the existing variable
+  }
 });
 ```
+
+### Complete example: Read, modify, and update
+
+If you need to read existing variables first, access them through `Environment.Variables` (array format) and then update:
+
+```javascript
+// Step 1: Get current configuration
+const result = await queryFunctions({
+  action: "getFunctionDetail",
+  functionName: "my-function"
+});
+
+// Step 2: Current env variables are in Environment.Variables as an array
+// [{ Key: "EXISTING_VAR", Value: "old-value" }, ...]
+const currentVars = result.functionDetail.Environment?.Variables || [];
+console.log("Current variables:", currentVars);
+
+// Step 3: Update with new/modified variables (tool handles merging)
+await manageFunctions({
+  action: "updateFunctionConfig",
+  functionName: "my-function",
+  envVariables: {
+    NEW_VAR: "new-value",          // Will be added
+    EXISTING_VAR: "updated-value"  // Will be updated
+    // Other existing variables are preserved automatically
+  }
+});
+```
+
+### Key points
+
+- **Field location**: Environment variables are in `functionDetail.Environment.Variables` (array of `{Key, Value}` objects), not `functionDetail.EnvVariables`
+- **Merge behavior**: The tool automatically merges new variables with existing ones - you don't need to manually merge
+- **Value type**: All values must be strings; numbers and booleans should be converted to strings
+- **Preservation**: Variables not included in the update are preserved automatically
 
 ## Trigger and VPC notes
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -56,6 +56,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
 - Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Use `managePermissions(action="updateResourcePermission", resourceType="function")` to allow public access.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime (e.g. using `/var/lang/node18/bin/node` but setting `runtime: "Nodejs16.13"`).
+- Accessing the wrong field path for environment variables. Current variables are in `functionDetail.Environment.Variables` (array of `{Key, Value}` objects), not `functionDetail.EnvVariables`. See `./references/operations-and-config.md` for the correct update pattern.
 
 ### Minimal checklist
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -21,6 +21,8 @@ Use this checklist before creating or updating a CloudBase function.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
 - Forgetting to configure function security rules for HTTP Functions that need anonymous access.
 - Treating Cloud Functions as the default answer for Web authentication.
+- When updating environment variables, accessing the wrong field path. Use `functionDetail.Environment.Variables` (array format), not `functionDetail.EnvVariables`.
+- Manually merging environment variables when using `manageFunctions(action="updateFunctionConfig")`. The tool already handles merging internally - just pass the new/modified variables.
 
 ## Done criteria
 

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -86,31 +86,59 @@ Key parameters:
 
 ## Environment variable updates
 
-Do not overwrite function environment variables blindly.
+### Important: Automatic merge behavior
 
-### Safe pattern
+The `manageFunctions(action="updateFunctionConfig")` tool automatically merges environment variables internally. You only need to provide the new or updated variables - existing variables will be preserved.
 
-1. Read current config with `queryFunctions(action="getFunctionDetail")`.
-2. Merge existing variables with the new variables.
-3. Update with `manageFunctions(action="updateFunctionConfig")`.
+### Correct usage pattern
 
 ```javascript
-const current = await queryFunctions({
-  action: "getFunctionDetail",
-  functionName: "functionName"
-});
-
-const mergedEnvVariables = {
-  ...current.EnvVariables,
-  ...newEnvVariables
-};
-
+// Only pass the variables you want to add or update
+// Existing variables will be preserved automatically
 await manageFunctions({
   action: "updateFunctionConfig",
-  functionName: "functionName",
-  envVariables: mergedEnvVariables
+  functionName: "my-function",
+  envVariables: {
+    NEW_VAR: "new-value",
+    EXISTING_VAR: "updated-value"  // This will update the existing variable
+  }
 });
 ```
+
+### Complete example: Read, modify, and update
+
+If you need to read existing variables first, access them through `Environment.Variables` (array format) and then update:
+
+```javascript
+// Step 1: Get current configuration
+const result = await queryFunctions({
+  action: "getFunctionDetail",
+  functionName: "my-function"
+});
+
+// Step 2: Current env variables are in Environment.Variables as an array
+// [{ Key: "EXISTING_VAR", Value: "old-value" }, ...]
+const currentVars = result.functionDetail.Environment?.Variables || [];
+console.log("Current variables:", currentVars);
+
+// Step 3: Update with new/modified variables (tool handles merging)
+await manageFunctions({
+  action: "updateFunctionConfig",
+  functionName: "my-function",
+  envVariables: {
+    NEW_VAR: "new-value",          // Will be added
+    EXISTING_VAR: "updated-value"  // Will be updated
+    // Other existing variables are preserved automatically
+  }
+});
+```
+
+### Key points
+
+- **Field location**: Environment variables are in `functionDetail.Environment.Variables` (array of `{Key, Value}` objects), not `functionDetail.EnvVariables`
+- **Merge behavior**: The tool automatically merges new variables with existing ones - you don't need to manually merge
+- **Value type**: All values must be strings; numbers and booleans should be converted to strings
+- **Preservation**: Variables not included in the update are preserved automatically
 
 ## Trigger and VPC notes
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z7fmc_00x4gf
- category: tool
- canonicalTitle: MCP 云函数配置工具参数错误提示不清晰，缺乏正确调用示例
- representativeRun: atomic-js-cloudfunction-env-merge-update/2026-04-21T18-52-10-4jfgkf

## Automation summary
- root_cause: The cloud-functions skill documentation contained an incorrect example for updating function environment variables. The example showed accessing `current.EnvVariables` which doesn't exist - the correct path is `functionDetail.Environment.Variables` (array of `{Key, Value}` objects). Additionally, the documentation didn't clarify that the `manageFunctions(action="updateFunctionConfig")` tool already handles automatic merging internally, making the manual merge pattern shown redundant and potentially confusing.
- changes:
1. Updated `config/source/skills/cloud-functions/references/operations-and-config.md` with clear guidance about the automatic merge behavior, correct field access pattern (`Environment.Variables`), and proper usage examples showing both simple updates and read-modify-update patterns.
2. Updated `config/source/skills/cloud-functions/checklist.md` to add common failure patterns about incorrect field access and unnecessary manual merging.
3. Updated `config/source/skills/cloud-functions/SKILL.md` to add a note about the correct field path.
4. Synced all changes to the `config/.claude/skills/` mirror as required by the project rules.
5. Ran `scripts/build-

## Changed files
- `config/.claude/skills/cloud-functions/SKILL.md`
- `config/.claude/skills/cloud-functions/checklist.md`
- `config/.claude/skills/cloud-functions/references/operations-and-config.md`
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/checklist.md`
- `config/source/skills/cloud-functions/references/operations-and-config.md`