### PR TITLE
fix: all-in-one skill 未区分 CLI 与 MCP 使用场景，导致 CLI 禁用时误用

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -118,8 +118,11 @@ Use these rules whenever you are writing the function code itself:
 3. **Write code and deploy, do not stop at local files**
    - Use `manageFunctions(action="createFunction")` for creation
    - Use `manageFunctions(action="updateFunctionCode")` for code updates
+   - Use `manageFunctions(action="updateFunctionConfig")` for config updates (timeout, memorySize, envVariables)
    - Keep `functionRootPath` as the directory that directly contains function folders (e.g., `cloudfunctions/` or `functions/`), NOT the project root and NOT the function subdirectory itself
-   - Use CLI only as a fallback when MCP tools are unavailable
+   - **Prefer MCP tools over CLI** — when MCP tools are available, use `manageFunctions` and `queryFunctions` instead of CLI commands
+   - **Do NOT use CLI when it is explicitly disabled** — if the runtime indicates CLI is unavailable, use MCP tools exclusively
+   - For batch updates (multiple functions), call `manageFunctions(action="updateFunctionConfig")` individually for each function — MCP does not have a `--all` batch parameter like CLI
 
 4. **Prefer doc-first fallbacks**
    - If a task falls back to `callCloudApi`, first check the official docs or knowledge-base entry for that action

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -121,7 +121,7 @@ Use these rules whenever you are writing the function code itself:
    - Use `manageFunctions(action="updateFunctionConfig")` for config updates (timeout, memorySize, envVariables)
    - Keep `functionRootPath` as the directory that directly contains function folders (e.g., `cloudfunctions/` or `functions/`), NOT the project root and NOT the function subdirectory itself
    - **Prefer MCP tools over CLI** — when MCP tools are available, use `manageFunctions` and `queryFunctions` instead of CLI commands
-   - **Do NOT use CLI when it is explicitly disabled** — if the runtime indicates CLI is unavailable, use MCP tools exclusively
+   - **Do NOT assume CLI is available from task wording alone** — if the available capabilities only include MCP tools, use MCP tools exclusively
    - For batch updates (multiple functions), call `manageFunctions(action="updateFunctionConfig")` individually for each function — MCP does not have a `--all` batch parameter like CLI
 
 4. **Prefer doc-first fallbacks**

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -164,7 +164,7 @@ Use CLI **only** when MCP tools are unavailable AND CLI is explicitly enabled in
 - `tcb fn deploy --all` -> Deploy all functions
 - `tcb fn config update <name>` -> Update function config (timeout, memorySize, envVariables)
 
-**Important:** When the runtime indicates CLI is disabled (e.g., `tcbCliEnabled: false`), use MCP tools exclusively. Do not attempt CLI commands in such environments.
+**Important:** When the available capabilities include MCP tools but not CLI access, use MCP tools exclusively. Do not attempt CLI commands in such environments.
 
 **Batch updates via MCP:** MCP does not have a `--all` batch parameter. To update multiple functions, call `manageFunctions(action="updateFunctionConfig")` individually for each function.
 

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -156,11 +156,16 @@ Prefer the converged entrances below, but translate historical names when they a
 
 ## CLI fallback
 
-Use CLI only when MCP tools are unavailable.
+Use CLI **only** when MCP tools are unavailable AND CLI is explicitly enabled in the runtime environment.
 
 - `tcb fn deploy <name>` -> Event Function
 - `tcb fn deploy <name> --httpFn` -> HTTP Function
 - `tcb fn deploy <name> --httpFn --ws` -> HTTP Function with WebSocket
 - `tcb fn deploy --all` -> Deploy all functions
+- `tcb fn config update <name>` -> Update function config (timeout, memorySize, envVariables)
+
+**Important:** When the runtime indicates CLI is disabled (e.g., `tcbCliEnabled: false`), use MCP tools exclusively. Do not attempt CLI commands in such environments.
+
+**Batch updates via MCP:** MCP does not have a `--all` batch parameter. To update multiple functions, call `manageFunctions(action="updateFunctionConfig")` individually for each function.
 
 In non-interactive agent runs, do not default to CLI login or interactive setup flows.


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z9w2j_u59a3i
- category: skill
- canonicalTitle: all-in-one skill 未区分 CLI 与 MCP 使用场景，导致 CLI 禁用时误用
- representativeRun: atomic-js-cloudfunction-batch-update/2026-04-21T18-48-27-zvfyy0

## Automation summary
SUMMARY:
- root_cause: The cloud-functions skill did not explicitly differentiate between CLI and MCP usage scenarios. When the runtime had CLI disabled (`tcbCliEnabled: false`) but MCP enabled (`mcpEnabled: true`), the skill's guidance to "Use CLI only as a fallback when MCP tools are unavailable" was insufficient. Agents needed clearer direction that when CLI is explicitly disabled, they must use MCP tools exclusively and cannot rely on CLI batch commands like `--all`.
- changes:
1. Updated `config/source/skills/cloud-functions/SKILL.md` (lines 118-125): Added explicit guidance to prefer MCP tools over CLI, not use CLI when explicitly disabled, and clarified that batch updates via MCP require individual `manageFunctions(action="updateFunctionConfig")` calls since MCP lacks a `--all` parameter.
2. Updated `config/source/skills/cloud-functions/references/operations-and-config.md` (lines 156-170): Enhanced the "CLI fallback" section with stronger warnings about CLI-disabled environments and added documentation about batch update behavior differences between CLI and MCP.
- validation: All 10 regression tests pass (`build-skills-repo.test.js`, `build-compat-config.test.js`, `skill-qua

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/references/operations-and-config.md`