### PR TITLE
fix: MCP 工具与任务描述能力不匹配导致批量云函数操作失败

### DIFF
--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -161,6 +161,14 @@ Use CLI only when MCP tools are unavailable.
 - `tcb fn deploy <name>` -> Event Function
 - `tcb fn deploy <name> --httpFn` -> HTTP Function
 - `tcb fn deploy <name> --httpFn --ws` -> HTTP Function with WebSocket
-- `tcb fn deploy --all` -> Deploy all functions
+- `tcb fn deploy --all` -> Deploy all functions (⚠️ only for deploy, NOT for config update)
+
+> **Important**: `--all` flag only works for `tcb fn deploy`. It does NOT work for `tcb fn config update`. If you need to batch update function configurations (timeout, memorySize, etc.), you must update each function individually:
+> ```bash
+> tcb fn config update batch-func-1
+> tcb fn config update batch-func-2
+> tcb fn config update batch-func-3
+> ```
+> Or use MCP tool `manageFunctions(action="updateFunctionConfig")` with each function name.
 
 In non-interactive agent runs, do not default to CLI login or interactive setup flows.

--- a/config/source/skills/cloudbase-cli/references/functions.md
+++ b/config/source/skills/cloudbase-cli/references/functions.md
@@ -24,7 +24,7 @@ Covers both Event Functions (普通云函数) and HTTP Functions (HTTP 云函数
 |------|---------|
 | List all functions (列出函数) | `tcb fn list` |
 | Function detail (查看详情) | `tcb fn detail <name>` |
-| Deploy all functions | `tcb fn deploy --all` |
+| Deploy all functions | `tcb fn deploy --all` (⚠️ only for deploy, NOT for config update) |
 | Deploy single Event Function | `tcb fn deploy <name>` |
 | Deploy HTTP Function | `tcb fn deploy <name> --httpFn` |
 | Deploy HTTP + WebSocket | `tcb fn deploy <name> --httpFn --ws` |
@@ -54,6 +54,12 @@ Covers both Event Functions (普通云函数) and HTTP Functions (HTTP 云函数
 ```bash
 # Reads cloudbaserc.json → deploys every function listed
 tcb fn deploy --all
+
+# ⚠️ NOTE: --all only works for deploy, NOT for config update
+# To batch update config, you must update each function individually:
+# tcb fn config update func-a
+# tcb fn config update func-b
+
 # Verify
 tcb fn list
 ```


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z9e9x_xk2ijf
- category: tool
- canonicalTitle: MCP 工具与任务描述能力不匹配导致批量云函数操作失败
- representativeRun: atomic-js-cloudfunction-batch-update/2026-04-21T18-48-08-9cr134

## Automation summary
**
- **root_cause**: The task required batch updating function configs (timeout=30, memorySize=512) for 3 cloud functions, but neither CLI nor MCP tool supports `--all` for `config update` - it only works for `deploy`. The skill documentation was misleading by mentioning `--all` without clarifying its limitation, causing the agent to attempt batch config update which failed with "400 invalid parameter value".
- **changes**:
1. Updated `config/source/skills/cloud-functions/references/operations-and-config.md` - Added clarification that `--all` only works for deploy, not config update, and provided guidance to update functions individually
2. Updated `config/source/skills/cloudbase-cli/references/functions.md` - Added same clarification in the CLI command reference table and Deploy All section
- **validation**:
- Ran skill quality tests: `vitest run ../tests/build-skills-repo.test.js ../tests/build-compat-config.test.js ../tests/skill-quality-standards.test.js` - all 10 tests passed
- Verified TypeScript compilation: no errors
- Cross-file consistency check: all occurrences of `--all` in skill docs now include the clarification
- **follow_up**: The fix is complete. The skill docs now

## Changed files
- `config/source/skills/cloud-functions/references/operations-and-config.md`
- `config/source/skills/cloudbase-cli/references/functions.md`