### PR TITLE
fix: MCP工具命名与发现性不足导致云函数创建任务未执行

### DIFF
--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -125,6 +125,29 @@ Examples:
 
 - `0 0 2 1 * * *` -> 2:00 AM on the first day of every month
 - `0 30 9 * * * *` -> 9:30 AM every day
+- `0 */5 * * * * *` -> every 5 minutes
+
+#### Create function with timer trigger
+
+```javascript
+manageFunctions({
+  action: "createFunction",
+  func: {
+    name: "timerHello",
+    type: "Event",
+    runtime: "Nodejs18.15",
+    timeout: 30,
+    triggers: [
+      {
+        name: "myTimer",
+        type: "timer",
+        config: "0 */5 * * * * *"  // every 5 minutes
+      }
+    ]
+  },
+  functionRootPath: "/absolute/path/to/cloudfunctions"
+});
+```
 
 ### VPC access
 

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -266,7 +266,10 @@ const CREATE_FUNCTION_SCHEMA = z.object({
         `  Java: ${RECOMMENDED_RUNTIMES.java}\n` +
         `  Go: ${RECOMMENDED_RUNTIMES.golang}`,
     ),
-  triggers: z.array(TRIGGER_SCHEMA).optional().describe("触发器配置数组"),
+  triggers: z.array(TRIGGER_SCHEMA).optional().describe(
+    "触发器配置数组。支持定时触发器(timer)，使用 7 段 cron 格式：秒 分 时 日 月 星期 年。" +
+    "示例：[{ name: 'myTimer', type: 'timer', config: '0 */5 * * * * *' }] 创建每5分钟执行一次的定时触发器"
+  ),
   handler: z.string().optional().describe("函数入口"),
   ignore: z.union([z.string(), z.array(z.string())]).optional().describe("忽略文件"),
   isWaitInstall: z.boolean().optional().describe("是否等待依赖安装"),
@@ -1444,7 +1447,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
     {
       title: "管理云函数域资源",
       description:
-        "函数域统一写入口。通过 action 管理函数创建、代码更新、配置更新、调用函数、触发器和层绑定。危险操作需要显式 confirm=true。",
+        "函数域统一写入口。通过 action 管理函数创建、代码更新、配置更新、调用函数、定时触发器和层绑定。危险操作需要显式 confirm=true。定时触发器示例：func.triggers = [{ name: 'myTimer', type: 'timer', config: '0 */5 * * * * *' }]，其中 config 使用 7 段 cron 格式（秒 分 时 日 月 星期 年），例如 '0 */5 * * * * *' 表示每5分钟执行一次。",
       inputSchema: {
         action: z
           .enum(MANAGE_FUNCTION_ACTIONS)


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z633l_qhka36
- category: tool
- canonicalTitle: MCP工具命名与发现性不足导致云函数创建任务未执行
- representativeRun: atomic-js-cloudbase-timer-trigger/2026-04-21T18-45-20-2tpbig

## Automation summary
- **root_cause**: The MCP tool `manageFunctions` description didn't explicitly mention timer triggers, making it hard for agents to discover how to create timer trigger cloud functions. The description mentioned "触发器" (triggers) but not "定时触发器" (timer triggers) or provide examples.
- **changes**:
1. Updated `mcp/src/tools/functions.ts`:
- Enhanced `manageFunctions` tool description to explicitly mention "定时触发器" (timer triggers) with a concrete example showing how to use `func.triggers` to create a timer trigger
- Enhanced `CREATE_FUNCTION_SCHEMA.triggers` field description to mention timer triggers with an example
2. Updated `config/source/skills/cloud-functions/references/operations-and-config.md`:
- Added a complete code example showing how to create a function with a timer trigger using `manageFunctions`
- **validation**:
- TypeScript compilation passes (`npx tsc --noEmit`)
- All skill tests pass (10/10 tests in build-skills-repo.test.js, build-compat-config.test.js, skill-quality-standards.test.js)
- **follow_up**: None - the fix addresses the discoverability issue by making timer triggers more explicit in both the MCP tool descriptions and skill documentation.

## Changed files
- `config/source/skills/cloud-functions/references/operations-and-config.md`
- `mcp/src/tools/functions.ts`