### PR TITLE
fix: MCP 查询云函数日志工具参数校验错误或提示不清晰

### DIFF
--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -493,6 +493,8 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
     }
   };
 
+  const TIME_FORMAT_REGEX = /^\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}:\d{2}$/;
+
   const validateLogRange = (
     startTime?: string,
     endTime?: string,
@@ -501,6 +503,17 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
   ) => {
     if ((offset || 0) + (limit || 0) > 10000) {
       throw new Error("offset+limit 不能大于 10000");
+    }
+
+    if (startTime && !TIME_FORMAT_REGEX.test(startTime)) {
+      throw new Error(
+        `startTime 格式错误: "${startTime}"。必须使用 YYYY-MM-DD HH:mm:ss 格式（如 2024-01-01 00:00:00）`,
+      );
+    }
+    if (endTime && !TIME_FORMAT_REGEX.test(endTime)) {
+      throw new Error(
+        `endTime 格式错误: "${endTime}"。必须使用 YYYY-MM-DD HH:mm:ss 格式（如 2024-01-01 23:59:59）`,
+      );
     }
 
     if (startTime && endTime) {
@@ -610,15 +623,30 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         input.limit,
       );
       const cloudbase = await getManager();
-      const result = await cloudbase.functions.getFunctionLogsV2({
-        name: input.functionName,
-        offset: input.offset,
-        limit: input.limit,
-        startTime: input.startTime,
-        endTime: input.endTime,
-        requestId: input.requestId,
-        qualifier: input.qualifier,
-      });
+      let result;
+      try {
+        result = await cloudbase.functions.getFunctionLogsV2({
+          name: input.functionName,
+          offset: input.offset,
+          limit: input.limit,
+          startTime: input.startTime,
+          endTime: input.endTime,
+          requestId: input.requestId,
+          qualifier: input.qualifier,
+        });
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        if (/invalid parameter/i.test(errMsg)) {
+          throw new Error(
+            `${errMsg}\n\n常见原因：\n` +
+            `1. startTime/endTime 格式错误，必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 00:00:00），不支持 ISO 8601 或时间戳\n` +
+            `2. startTime 和 endTime 间隔超过一天\n` +
+            `3. functionName 不存在或格式不正确\n` +
+            `建议：不传 startTime/endTime 时默认查询最近一天的日志。`,
+          );
+        }
+        throw error;
+      }
       logCloudBaseResult(server.logger, result);
       return buildEnvelope(
         {
@@ -644,11 +672,25 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       }
       validateLogRange(input.startTime, input.endTime);
       const cloudbase = await getManager();
-      const result = await cloudbase.functions.getFunctionLogDetail({
-        startTime: input.startTime,
-        endTime: input.endTime,
-        logRequestId: input.requestId,
-      });
+      let result;
+      try {
+        result = await cloudbase.functions.getFunctionLogDetail({
+          startTime: input.startTime,
+          endTime: input.endTime,
+          logRequestId: input.requestId,
+        });
+      } catch (error) {
+        const errMsg = error instanceof Error ? error.message : String(error);
+        if (/invalid parameter/i.test(errMsg)) {
+          throw new Error(
+            `${errMsg}\n\n常见原因：\n` +
+            `1. startTime/endTime 格式错误，必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 00:00:00），不支持 ISO 8601 或时间戳\n` +
+            `2. startTime 和 endTime 间隔超过一天\n` +
+            `建议：不传 startTime/endTime 时默认查询最近一天的日志。`,
+          );
+        }
+        throw error;
+      }
       logCloudBaseResult(server.logger, result);
       return buildEnvelope(
         {
@@ -1417,12 +1459,20 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         action: z
           .enum(QUERY_FUNCTION_ACTIONS)
           .describe("只读操作类型，例如 listFunctions、getFunctionDetail、listFunctionLogs"),
-        functionName: z.string().optional().describe("函数名称。函数相关 action 必填"),
+        functionName: z.string().optional().describe(
+          "函数名称。listFunctionLogs、getFunctionDetail、listFunctionLayers、listFunctionTriggers、getFunctionDownloadUrl 时必填",
+        ),
         limit: z.number().optional().describe("分页数量。列表类 action 可选"),
         offset: z.number().optional().describe("分页偏移。列表类 action 可选"),
         codeSecret: z.string().optional().describe("代码保护密钥"),
-        startTime: z.string().optional().describe("日志查询开始时间"),
-        endTime: z.string().optional().describe("日志查询结束时间"),
+        startTime: z.string().optional().describe(
+          "日志查询开始时间，格式必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 00:00:00）。" +
+          "与 endTime 间隔不能超过一天。不传时默认查询最近一天",
+        ),
+        endTime: z.string().optional().describe(
+          "日志查询结束时间，格式必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 23:59:59）。" +
+          "与 startTime 间隔不能超过一天。不传时默认为当前时间",
+        ),
         requestId: z.string().optional().describe("日志 requestId。获取日志详情时必填"),
         qualifier: z.string().optional().describe("函数版本，日志查询时可选"),
         runtime: z.string().optional().describe("层查询的运行时筛选"),


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z2h9t_o13t7d
- category: tool
- canonicalTitle: MCP 查询云函数日志工具参数校验错误或提示不清晰
- representativeRun: atomic-js-cloudbase-query-function-logs/2026-04-21T18-42-37-el95p1

## Automation summary
所有任务已完成。以下是摘要： 总结： - 根本原因：`queryFunctions` 工具的 `listFunctionLogs` 操作存在三个问题：(1) `startTime`/`endTime` 参数的描述未指定所需格式 (`YYYY-MM-DD HH:mm:ss`)，也未提及 24 小时范围限制，导致代理以错误格式（例如 ISO 8601）传递时间；(2) `functionName` 的描述过于模糊（“函数相关 action 必填”），未列出哪些操作实际需要它；(3) 当 CloudBase API 返回“400 invalid parameter value”时，错误直接传递，未提供任何可操作的指导，代理无法知道哪个参数错误或如何修复。 - 变更：`mcp/src/tools/functions.ts` 文件中的 4 项修改： 1. 增强了 `startTime`/`endTime` 参数描述，以指定 `YYYY-MM-DD HH:mm:ss` 格式，给出示例，声明 24 小时限制，并解释默认行为 2. 改进了 `functionName` 描述，明确列出需要它的操作（listFunctionLogs, getFunctionDetail, listFunctionLayers, listFunctionTriggers, getFunctionDownloadUrl） 3. 在 `validateLogRange` 中添加了 `TIME_FORMAT_REGEX` 验证，用于在调用 API 之前拒绝错误格式的时间字符串，并提供清晰的错误消息，显示预期格式 4. 在 `listFunctionLogs` 和 `getFunctionLogDetail` 处理程序中添加了 try/catch 块，拦截“invalid parameter value”API 错误，并附加常见原因（错误的时间格式、超出 24 小时限制、函数名问题）和可操作的建议（省略时间以使用默认的最后 24 小时） - 验证：TypeScript 编译 (`tsc --noEmit`) 通过，现有 9 个函数测试通过，3 个强制技能回归测试通过 - 后续：无

## Changed files
- `mcp/src/tools/functions.ts`