### PR TITLE
fix: MCP工具错误提示不清晰导致云函数创建失败

### DIFF
--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -401,6 +401,30 @@ export function buildFunctionOperationErrorMessage(
     );
   }
 
+  // Handle 400 invalid parameter value errors from CloudBase API
+  if (/400.*invalid.*parameter|invalid.*parameter.*value/i.test(baseMessage)) {
+    suggestions.push(
+      "云 API 返回参数错误，请检查以下常见问题：",
+    );
+    suggestions.push(
+      "1. 函数名只能包含字母、数字、下划线和连字符，且不能以数字开头，长度不超过60个字符",
+    );
+    suggestions.push(
+      "2. Runtime 必须为支持的版本（如 Nodejs20.19、Nodejs18.15、Python3.9 等）",
+    );
+    suggestions.push(
+      "3. Handler 格式必须正确（对于 Node.js，格式为 文件名.导出函数名，如 index.main）",
+    );
+    suggestions.push(
+      "4. Timeout 值必须在 1-300 秒之间",
+    );
+    if (operation === "createFunction") {
+      suggestions.push(
+        `当前传入的参数：函数名=${functionName}，请核对以上格式要求后重试。`,
+      );
+    }
+  }
+
   if (suggestions.length === 0) {
     suggestions.push("请检查函数名、目录结构和环境中的函数状态后重试。");
   }


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8z05x3_aa5gtw
- category: tool
- canonicalTitle: MCP工具错误提示不清晰导致云函数创建失败
- representativeRun: atomic-js-cloudbase-mock-jinguyuan-dumpling-mcp/2026-04-21T18-40-58-elqzbn

## Automation summary
- root_cause: When the CloudBase API returns "400 invalid parameter value" error, the MCP tool's error message was too generic and didn't provide actionable guidance about what parameter was invalid or how to fix it.
- changes: Added error handling for "400 invalid parameter value" errors in `mcp/src/tools/functions.ts` (lines 404-426). When this error occurs, the function now provides specific suggestions about:
1. Function name format requirements (alphanumeric, underscore, hyphen; max 60 chars)
2. Runtime must be a supported version (e.g., Nodejs20.19, Nodejs18.15, Python3.9)
3. Handler format requirements (for Node.js: filename.exportFunctionName like index.main)
4. Timeout value must be between 1-300 seconds
- validation:
- All 9 existing unit tests in `functions.test.ts` pass
- All 3 skill/doc regression tests pass (build-skills-repo.test.js, build-compat-config.test.js, skill-quality-standards.test.js)
- follow_up: None. The fix is complete and addresses the attribution issue about unclear MCP tool error messages causing cloud function creation failures.

## Changed files
- `mcp/src/tools/functions.ts`