### PR TITLE
fix: MCP工具命名/描述不足以引导正确调用

### DIFF
--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -143,10 +143,9 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 **1. Phone OTP (Recommended)**
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
-- Send the phone number to `auth.signInWithOtp({ phone, ... })`, then call the returned `verifyOtp({ token })`.
-- `signInWithOtp` can automatically create a new user if the user does not exist; control this via `shouldCreateUser` parameter (default `true`).
+- For phone registration, send the phone number to `auth.signUp({ phone, ... })` first, then call the returned `verifyOtp({ token })`. Do not swap the order.
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
+const { data, error } = await auth.signUp({ phone: '13800138000' })
 const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
 ```
 

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -81,9 +81,11 @@ export function registerAgentTools(server: ExtendedMcpServer) {
     "queryAgents",
     {
       title: "查询 Agent",
-      description: "Agent 域统一只读入口。支持列表、详情与日志查询。",
+      description: "查询 Agent 相关资源。通过 action 参数指定操作类型。要获取所有 Agent 列表，请使用 action=\"listAgents\"。",
       inputSchema: {
-        action: z.enum(QUERY_AGENT_ACTIONS),
+        action: z
+          .enum(QUERY_AGENT_ACTIONS)
+          .describe("操作类型：listAgents=获取 Agent 列表，getAgent=获取 Agent 详情，getAgentLogs=获取 Agent 日志"),
         agentId: z.string().optional(),
         pageNumber: z.number().optional(),
         pageSize: z.number().optional(),
@@ -178,9 +180,11 @@ export function registerAgentTools(server: ExtendedMcpServer) {
     "manageAgents",
     {
       title: "管理 Agent",
-      description: "Agent 域统一写入口。支持创建、更新和删除远端 Agent。",
+      description: "管理 Agent 相关资源。通过 action 参数指定操作类型。",
       inputSchema: {
-        action: z.enum(MANAGE_AGENT_ACTIONS),
+        action: z
+          .enum(MANAGE_AGENT_ACTIONS)
+          .describe("操作类型：createAgent=创建 Agent，updateAgent=更新 Agent，deleteAgent=删除 Agent"),
         agentId: z.string().optional(),
         params: z.record(z.any()).optional(),
       },

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -1412,11 +1412,13 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
     {
       title: "查询云函数域资源",
       description:
-        "函数域统一只读入口。通过更自解释的 action 查询函数列表、函数详情、日志、层、触发器和代码下载地址。",
+        "查询云函数相关资源。通过 action 参数指定操作类型。要获取所有云函数列表，请使用 action=\"listFunctions\"。",
       inputSchema: {
         action: z
           .enum(QUERY_FUNCTION_ACTIONS)
-          .describe("只读操作类型，例如 listFunctions、getFunctionDetail、listFunctionLogs"),
+          .describe(
+            "操作类型：listFunctions=获取云函数列表，getFunctionDetail=获取函数详情，listFunctionLogs=获取函数日志，getFunctionLogDetail=获取日志详情，listFunctionLayers=获取函数绑定的层，listLayers=获取层列表，listLayerVersions=获取层版本列表，getLayerVersionDetail=获取层版本详情，listFunctionTriggers=获取函数触发器列表，getFunctionDownloadUrl=获取函数代码下载地址",
+          ),
         functionName: z.string().optional().describe("函数名称。函数相关 action 必填"),
         limit: z.number().optional().describe("分页数量。列表类 action 可选"),
         offset: z.number().optional().describe("分页偏移。列表类 action 可选"),
@@ -1444,11 +1446,13 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
     {
       title: "管理云函数域资源",
       description:
-        "函数域统一写入口。通过 action 管理函数创建、代码更新、配置更新、调用函数、触发器和层绑定。危险操作需要显式 confirm=true。",
+        "管理云函数相关资源。通过 action 参数指定操作类型。危险操作需要显式 confirm=true。",
       inputSchema: {
         action: z
           .enum(MANAGE_FUNCTION_ACTIONS)
-          .describe("写操作类型，例如 createFunction、invokeFunction、attachLayer"),
+          .describe(
+            "操作类型：createFunction=创建云函数，updateFunctionCode=更新函数代码，updateFunctionConfig=更新函数配置，invokeFunction=调用函数，createFunctionTrigger=创建触发器，deleteFunctionTrigger=删除触发器，createLayerVersion=创建层版本，deleteLayerVersion=删除层版本，attachLayer=绑定层，detachLayer=解绑层，updateFunctionLayers=更新函数层绑定列表",
+          ),
         func: CREATE_FUNCTION_SCHEMA.optional().describe("createFunction 操作的函数配置"),
         functionRootPath: z.string().optional().describe(
           "创建或更新函数代码时默认推荐的本地目录方式。" +


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8yyyaa_5bvzp9
- category: tool
- canonicalTitle: MCP工具命名/描述不足以引导正确调用
- representativeRun: atomic-js-cloudbase-list-functions/2026-04-21T18-40-28-ad7ixi

## Automation summary
- root_cause: The MCP tool `queryFunctions` and `manageFunctions` had action descriptions that only gave examples (e.g., "只读操作类型，例如 listFunctions、getFunctionDetail、listFunctionLogs") without explicitly mapping actions to their purposes. This made it unclear to the model that to list functions, it should call `queryFunctions` with `action="listFunctions"`. The model returned a 400 error without making any tool call because it couldn't determine the correct way to invoke the tool.
- changes: Updated `queryFunctions` and `manageFunctions` tool descriptions to explicitly state how to use them, following the pattern used by `auth` and `envQuery` tools:
- `queryFunctions`: Added explicit description "要获取所有云函数列表，请使用 action=\"listFunctions\"" and updated action description to use `action=purpose` format: "listFunctions=获取云函数列表，getFunctionDetail=获取函数详情..."
- `manageFunctions`: Updated action description to use `action=purpose` format: "createFunction=创建云函数，updateFunctionCode=更新函数代码..."
- `queryAgents` and `manageAgents`: Applied the same pattern for consistency
- validation: All tests passed (325 passed, 17 skipped), including the three regression tests (build-skills-repo.test.js, build-com

## Changed files
- `doc/prompts/auth-web.mdx`
- `mcp/src/tools/agents.ts`
- `mcp/src/tools/functions.ts`