### PR TITLE
fix: CloudBase all-in-one skill 缺少获取环境列表的清晰指引与示例

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -147,10 +147,49 @@ When your IDE does not support native MCP, use **mcporter** as the CLI to config
   `npx mcporter call cloudbase.auth action=status --output json`
 - Start device-flow login (future-friendly device-code login; no keys in config):
   `npx mcporter call cloudbase.auth action=start_auth authMode=device --output json`
-- If the user gives an environment alias / nickname / short form instead of the full `EnvId`, resolve it first:
-  `npx mcporter call cloudbase.envQuery action=list alias=demo aliasExact=true fields='["EnvId","Alias","Status","IsDefault"]' --output json`
 - Bind environment after login (envId from CloudBase console):
   `npx mcporter call cloudbase.auth action=set_env envId=<full-env-id> --output json`
+
+### Getting Environment List
+
+**Purpose:** Retrieve all CloudBase environments accessible to the current account, including EnvId, Alias, Status, and other metadata.
+
+**When to use:**
+- Before binding an environment to see available options
+- When the user provides an alias/nickname instead of a full EnvId
+- To display environment summary information
+
+**Method 1 - Direct MCP tool call (IDE with MCP):**
+```json
+{
+  "tool": "envQuery",
+  "action": "list",
+  "fields": ["EnvId", "Alias", "Status", "EnvType", "Region", "PackageName", "IsDefault"]
+}
+```
+
+**Method 2 - Using mcporter CLI:**
+```bash
+npx mcporter call cloudbase.envQuery action=list fields='["EnvId","Alias","Status","EnvType","Region","PackageName","IsDefault"]' --output json
+```
+
+**Method 3 - Filter by alias (when resolving a nickname):**
+```json
+{
+  "tool": "envQuery",
+  "action": "list",
+  "alias": "demo",
+  "aliasExact": true,
+  "fields": ["EnvId", "Alias", "Status"]
+}
+```
+
+**Important notes:**
+- `action=list` returns a concise summary with essential fields only
+- Available fields: EnvId, Alias, Status, EnvType, Region, PackageId, PackageName, IsDefault
+- Use `aliasExact=true` to avoid matching prefixes (e.g., "prod" won't match "production")
+- If the user gives an environment alias/nickname/short form instead of the full `EnvId`, always resolve it first with `envQuery(action=list, alias=..., aliasExact=true)` before using it in SDK init, `auth.set_env`, console URLs, or config files
+- For detailed environment information (including billing), use `action=info` instead
 - Query app-side login config:
   `npx mcporter call cloudbase.queryAppAuth action=getLoginConfig --output json`
 - Patch app-side login strategy:

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -109,9 +109,35 @@ Use this skill for **CloudBase platform knowledge** when you need to:
 
 ## Environment and Authentication
 
-1. **SDK Initialization**:
-   - CloudBase SDK initialization requires environment ID
-   - Can query environment ID via `envQuery` tool
+### Getting Environment List
+
+To retrieve all accessible CloudBase environments with their metadata (EnvId, Alias, Status, etc.):
+
+**Using MCP tool:**
+```json
+{
+  "tool": "envQuery",
+  "action": "list",
+  "fields": ["EnvId", "Alias", "Status", "EnvType", "Region", "PackageName", "IsDefault"]
+}
+```
+
+**Resolving an alias to full EnvId:**
+```json
+{
+  "tool": "envQuery",
+  "action": "list",
+  "alias": "your-alias",
+  "aliasExact": true,
+  "fields": ["EnvId", "Alias", "Status"]
+}
+```
+
+### SDK Initialization
+
+1. **Environment ID Required**:
+   - CloudBase SDK initialization requires the full environment ID (EnvId)
+   - Query the environment ID via `envQuery` tool as shown above
    - If the user only provides an environment alias, nickname, or other short form, resolve it with `envQuery(action="list", alias=..., aliasExact=true)` first and use the returned full `EnvId`
    - Do not pass alias-like short forms directly into SDK init, `auth.set_env`, console URLs, or generated config files
    - For Web, always initialize synchronously:


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8yn81w_xg27dg
- category: skill
- canonicalTitle: CloudBase all-in-one skill 缺少获取环境列表的清晰指引与示例
- representativeRun: atomic-js-cloudbase-describe-envs/2026-04-21T18-31-12-ilef91

## Automation summary
**root_cause:** The CloudBase all-in-one skill (`config/source/guideline/cloudbase/SKILL.md`) and the platform skill (`config/source/skills/cloudbase-platform/SKILL.md`) mentioned the `envQuery` tool but lacked a clear, dedicated section with examples showing how to get environment lists. The existing guidance was buried in a single mcporter CLI example without explaining:
- The purpose of getting environment lists
- When to use it (e.g., resolving aliases)
- Multiple usage methods (MCP tool call vs mcporter CLI)
- Available fields and filtering options
This lack of clear guidance caused the agent to fail with "400 invalid parameter value" when attempting to call DescribeEnvs.
**changes:**
1. **config/source/guideline/cloudbase/SKILL.md** - Added a dedicated "### Getting Environment List" section with:
- Clear purpose statement
- When-to-use scenarios
- Three method examples: Direct MCP tool call, mcporter CLI, and alias filtering
- Important notes about available fields, alias resolution, and action=info vs action=list differences
2. **config/source/skills/cloudbase-platform/SKILL.md** - Added a dedicated "### Getting Environment List" subsection under Environment and Authenticati

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/skills/cloudbase-platform/SKILL.md`