### PR TITLE
fix: Skill 描述未清晰引导使用 MCP 工具调用

### DIFF
--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -113,6 +113,7 @@ Use this skill for **CloudBase platform knowledge** when you need to:
    - CloudBase SDK initialization requires environment ID
    - Can query environment ID via `envQuery` tool
    - If the user only provides an environment alias, nickname, or other short form, resolve it with `envQuery(action="list", alias=..., aliasExact=true)` first and use the returned full `EnvId`
+   - If you already have an EnvId and need detailed environment information (e.g., billing info, resource quotas), use `envQuery(action="info", envId="your-env-id")` - **do not use action="list" for this purpose as it only returns summary fields**
    - Do not pass alias-like short forms directly into SDK init, `auth.set_env`, console URLs, or generated config files
    - For Web, always initialize synchronously:
      - `import cloudbase from "@cloudbase/js-sdk"; const app = cloudbase.init({ env: "your-full-env-id" });`


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8ymrk4_ivh0q2
- category: skill
- canonicalTitle: Skill 描述未清晰引导使用 MCP 工具调用
- representativeRun: atomic-js-cloudbase-describe-env-by-id/2026-04-21T18-30-50-bkhkfr

## Automation summary
- **root_cause**: The skill didn't clearly guide users to use `envQuery(action="info")` to get detailed environment information when they already have an EnvId. The task was to "获取环境详细信息" (get detailed environment info) by passing an EnvId, but the skill only mentioned `envQuery(action="list")` which returns summary fields only.
- **changes**: Added one line to `config/source/skills/cloudbase-platform/SKILL.md` to clarify: "If you already have an EnvId and need detailed environment information (e.g., billing info, resource quotas), use `envQuery(action=\"info\", envId=\"your-env-id\")` - **do not use action=\"list\" for this purpose as it only returns summary fields**"
- **validation**: All three skill tests pass (build-skills-repo, build-compat-config, skill-quality-standards)
- **follow_up**: None - this is a complete minimal fix for the issue

## Changed files
- `config/source/skills/cloudbase-platform/SKILL.md`