### PR TITLE
fix: MCP工具描述/可发现性不足：创建集合工具未被调用

### DIFF
--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -498,9 +498,9 @@ checkIndex: 检查指定索引是否存在`),
   server.registerTool?.(
     "writeNoSqlDatabaseStructure",
     {
-      title: "修改 NoSQL 数据库结构",
+      title: "创建并管理 NoSQL 数据库集合",
       description:
-        "修改 NoSQL 数据库结构，支持创建/删除集合，以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。",
+        "创建、删除和管理 NoSQL 数据库集合（collection）。支持创建新集合、删除现有集合，以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。当需要新建集合时，使用 action=createCollection。",
       inputSchema: {
         action: z.enum([
           "createCollection",


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8yjrtw_ai79l8
- category: tool
- canonicalTitle: MCP工具描述/可发现性不足：创建集合工具未被调用
- representativeRun: atomic-js-cloudbase-db-create-collection/2026-04-21T18-28-19-gcqxjb

## Automation summary
- **root_cause**: The MCP tool `writeNoSqlDatabaseStructure` had a title "修改 NoSQL 数据库结构" (Modify NoSQL database structure) that focused on "modifying" rather than "creating". When users asked to "create a database collection", the AI agent couldn't discover this tool because the title and description didn't clearly signal that it handles collection creation. The tool was never called, resulting in a "400 invalid parameter value" error from an unrelated attempt.
- **changes**: Updated the tool title from "修改 NoSQL 数据库结构" to "创建并管理 NoSQL 数据库集合" (Create and manage NoSQL database collections) and enhanced the description to explicitly mention "创建新集合" (create new collections) and guide users to use `action=createCollection` when creating collections. The change is in `mcp/src/tools/databaseNoSQL.ts:501-503`.
- **validation**:
- All 15 NoSQL database tool tests passed
- All 10 skill quality regression tests passed (build-skills-repo, build-compat-config, skill-quality-standards)
- No cross-file references needed updating (the tool name `writeNoSqlDatabaseStructure` remains unchanged)
- **follow_up**: None. This is a Layer 1 (skill/tool description) fix that improves tool discoverability

## Changed files
- `mcp/src/tools/databaseNoSQL.ts`