### PR TITLE
fix: managePermissions工具createUser动作未将password声明为必填参数，导致模型遗漏该参数

### DIFF
--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -592,8 +592,14 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
         policies: z.array(z.record(z.any())).optional(),
         uid: z.string().optional(),
         uids: z.array(z.string()).optional(),
-        username: z.string().optional(),
-        password: z.string().optional(),
+        username: z
+          .string()
+          .optional()
+          .describe("用户名。`action=createUser` 时必填。"),
+        password: z
+          .string()
+          .optional()
+          .describe("密码。`action=createUser` 时必填。"),
         userStatus: z.enum(["ACTIVE", "BLOCKED"]).optional(),
       },
       annotations: {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moizl31y_hagnn4
- category: tool
- canonicalTitle: managePermissions工具createUser动作未将password声明为必填参数，导致模型遗漏该参数
- representativeRun: atomic-js-cloudbase-cli-user-create/2026-04-28T18-54-24-ba89b0

## Automation summary
- root_cause: In `mcp/src/tools/permissions.ts`, the `managePermissions` tool's inputSchema declares both `username` and `password` as plain `z.string().optional()` without any description. Since `password` (and `username`) are required when `action=createUser` (enforced at runtime on line 760: `if (!username || !password)`), but the schema doesn't communicate this, the model omits `password` when calling `createUser`, causing the call to fail.
- changes: Added `.describe()` annotations to `username` and `password` fields in the `managePermissions` tool inputSchema, explicitly stating they are required when `action=createUser`. This is a Layer 1 fix (tool description only, no logic change).
- validation: TypeScript compilation passes (`tsc --noEmit`), all 12 existing permissions unit tests pass, all 3 mandatory skill quality regression tests pass.
- follow_up: None. The fix is minimal and targeted — models reading the tool schema will now see that `password` is required for `createUser`.

## Changed files
- `mcp/src/tools/permissions.ts`