### PR TITLE
fix: all-in-one skill 未检测任务要求与环境能力不匹配

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -39,6 +39,7 @@ If a skill points to its own `references/...` files, keep following those relati
 - When saving MCP or tool results to a local file with a generic file-writing tool, pass text, not raw objects. For JSON output files, serialize first with `JSON.stringify(result, null, 2)` and write that string as the file content.
 - If the file-writing tool reports that a field such as `content` expected a string but received an object, do not retry with the same raw object. Serialize the object first, then retry once with the serialized text, and make sure the retried call actually passes the serialized string rather than the original object.
 - Keep scenario-specific pitfall lists in the matching child skills instead of expanding this entry file.
+- **Task-Environment Capability Check**: When the user task explicitly mentions "CLI", "tcb", "cloudbase CLI", "命令行", or similar CLI-specific terms, check the runtime capability notice (the first message in conversation) for enabled/disabled capabilities. If the task requires CLI but "CloudBase CLI" is listed under "Disabled capabilities", do NOT attempt CLI commands. Instead, inform the user that CLI is not available in the current environment and suggest using MCP tools (e.g., `manageGateway`, `queryGateway`) or the CloudBase console for the task. Do not silently fail or proceed with wrong tools.
 
 ### High-priority routing
 


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8ye7m9_wskeu8
- category: skill
- canonicalTitle: all-in-one skill 未检测任务要求与环境能力不匹配
- representativeRun: atomic-js-cloudbase-cli-routes-lifecycle/2026-04-21T18-24-06-k7v5al

## Automation summary
- **root_cause**: The all-in-one skill didn't have a guardrail to detect when a task explicitly requires CLI (e.g., "使用 CloudBase CLI") but CLI is disabled in the environment. The agent received a task requiring CLI but proceeded without checking the runtime capability notice, resulting in a silent failure with "400 invalid parameter value".
- **changes**: Added a new universal guardrail in `config/source/guideline/cloudbase/SKILL.md` (line 42) that:
1. Detects when the task explicitly mentions CLI-related terms ("CLI", "tcb", "cloudbase CLI", "命令行")
2. Checks the runtime capability notice for enabled/disabled capabilities
3. If CLI is required but disabled, warns the user and suggests using MCP tools (e.g., `manageGateway`, `queryGateway`) or the CloudBase console instead
- **validation**:
- All three skill tests pass: `build-skills-repo.test.js`, `build-compat-config.test.js`, `skill-quality-standards.test.js`
- The change is minimal and targeted to the "Universal guardrails" section
- **follow_up**: None - this is a skill documentation fix that adds a guardrail to prevent the agent from attempting CLI commands when CLI is disabled. The fix tells the agent to inform the user abou

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`