### PR TITLE
fix: MCP 工具可发现性不足：CLI 被禁用时未引导使用 MCP 替代方案

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -248,6 +248,10 @@ Prefer long-term memory when available: write the scenarios and working rules th
 1. **CLI Operations**: Read the `cloudbase-cli` skill for managing CloudBase via `tcb` commands
 2. Covers: function deployment, CloudRun, hosting, storage, databases, permissions, access config
 3. **Best for**: CI/CD pipelines, scripting, batch operations, or when users prefer CLI over SDK/MCP
+4. **⚠️ When CLI is unavailable or disabled**: Use MCP tools as alternatives. Read `cloudbase-platform` skill for the full CLI → MCP mapping. Key mappings:
+   - `tcb role list/get` → `queryPermissions(action="listRoles"/"getRole")`
+   - `tcb permission get/set` → `queryPermissions(action="getResourcePermission"/"listResourcePermissions")` / `managePermissions(action="updateResourcePermission")`
+   - `tcb user list/create/update/delete` → `queryPermissions(action="listUsers"/"getUser")` / `managePermissions(action="createUser"/"updateUser"/"deleteUsers")`
 
 ### When Developing a Native App Project (iOS/Android/Flutter/React Native/etc.):
 1. **⚠️ Platform Limitation**: Native apps do NOT support CloudBase SDK - Must use HTTP API

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -195,6 +195,48 @@ Compatibility note:
    - If involving cloud functions, while ensuring security, can minimize the number of cloud functions as much as possible
    - For example: implement one cloud function for client-side requests, implement one cloud function for data initialization
 
+## CLI → MCP Alternative Mapping
+
+**When CloudBase CLI (`tcb`) is unavailable or disabled, use MCP tools instead.** The `queryPermissions` and `managePermissions` tools cover all CLI `tcb role`, `tcb permission`, and `tcb user` operations:
+
+### Role operations
+
+| CLI command | MCP alternative |
+|------------|-----------------|
+| `tcb role list` | `queryPermissions(action="listRoles")` |
+| `tcb role get --id <roleId>` | `queryPermissions(action="getRole", roleId="<roleId>")` |
+| `tcb role get --identity <roleIdentity>` | `queryPermissions(action="getRole", roleIdentity="<roleIdentity>")` |
+| `tcb role get --name <roleName>` | `queryPermissions(action="getRole", roleName="<roleName>")` |
+| `tcb role create` | `managePermissions(action="createRole", roleName=..., roleIdentity=..., policies=..., memberUids=...)` |
+| `tcb role update --add-users` | `managePermissions(action="addRoleMembers", roleId=..., memberUids=...)` |
+| `tcb role update --remove-users` | `managePermissions(action="removeRoleMembers", roleId=..., memberUids=...)` |
+| `tcb role update --add-policies` | `managePermissions(action="addRolePolicies", roleId=..., policies=...)` |
+| `tcb role update --remove-policies` | `managePermissions(action="removeRolePolicies", roleId=..., policies=...)` |
+| `tcb role delete` | `managePermissions(action="deleteRoles", roleIds=...)` |
+
+### Permission operations
+
+| CLI command | MCP alternative |
+|------------|-----------------|
+| `tcb permission get` | `queryPermissions(action="listResourcePermissions", resourceType=...)` |
+| `tcb permission get table:users` | `queryPermissions(action="getResourcePermission", resourceType="sqlDatabase", resourceId="users")` |
+| `tcb permission get collection:posts` | `queryPermissions(action="getResourcePermission", resourceType="noSqlDatabase", resourceId="posts")` |
+| `tcb permission get function` | `queryPermissions(action="listResourcePermissions", resourceType="function")` |
+| `tcb permission set table:users --level readonly` | `managePermissions(action="updateResourcePermission", resourceType="sqlDatabase", resourceId="users", permission="READONLY")` |
+| `tcb permission set collection:posts --level custom --rule '...'` | `managePermissions(action="updateResourcePermission", resourceType="noSqlDatabase", resourceId="posts", permission="CUSTOM", securityRule="...")` |
+
+### User operations
+
+| CLI command | MCP alternative |
+|------------|-----------------|
+| `tcb user list` | `queryPermissions(action="listUsers")` |
+| `tcb user list --name alice` | `queryPermissions(action="listUsers", username="alice")` |
+| `tcb user create` | `managePermissions(action="createUser", username=..., password=...)` |
+| `tcb user update <uid> --status BLOCKED` | `managePermissions(action="updateUser", uid=..., userStatus="BLOCKED")` |
+| `tcb user delete` | `managePermissions(action="deleteUsers", uids=...)` |
+
+**Important**: `role get` query conditions (`roleId` / `roleIdentity` / `roleName`) are mutually exclusive — pass exactly one, just like the CLI `--id` / `--identity` / `--name` flags.
+
 ## Data Models
 
 1. **Get Data Model Operation Object**:

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -342,7 +342,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
     {
       title: "查询权限与用户配置",
       description:
-        "权限域统一只读入口。支持查询资源权限、角色列表/详情、应用用户列表/详情。",
+        "权限域统一只读入口。支持查询资源权限、角色列表/详情、应用用户列表/详情。当 CLI (tcb) 不可用时，此工具是 `tcb role list/get`、`tcb permission get`、`tcb user list` 的 MCP 替代方案。action 参数映射：tcb role list → listRoles，tcb role get → getRole，tcb permission get → getResourcePermission/listResourcePermissions，tcb user list → listUsers，tcb user 按名/uid 查 → getUser。",
       inputSchema: {
         action: z.enum(QUERY_PERMISSION_ACTIONS),
         resourceType: z
@@ -563,7 +563,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
     {
       title: "管理权限与用户配置",
       description:
-        "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
+        "权限域统一写入口。支持修改资源权限、角色管理、成员与策略增删、应用用户 CRUD。当 CLI (tcb) 不可用时，此工具是 `tcb role create/update/delete`、`tcb permission set`、`tcb user create/update/delete` 的 MCP 替代方案。action 参数映射：tcb role create → createRole，tcb role update --add-users → addRoleMembers，tcb role update --remove-users → removeRoleMembers，tcb role update --add-policies → addRolePolicies，tcb role update --remove-policies → removeRolePolicies，tcb role delete → deleteRoles，tcb permission set → updateResourcePermission，tcb user create → createUser，tcb user update → updateUser，tcb user delete → deleteUsers。`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。注意：`securityRule` 的详细语义取决于 `resourceType`；`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则。配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。",
       inputSchema: {
         action: z.enum(MANAGE_PERMISSION_ACTIONS),
         resourceType: z


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8y7mwz_mlzskt
- category: tool
- canonicalTitle: MCP 工具可发现性不足：CLI 被禁用时未引导使用 MCP 替代方案
- representativeRun: atomic-js-cloudbase-cli-role-get/2026-04-21T18-17-19-bvs713

## Automation summary
- root_cause: When CloudBase CLI (`tcb`) is disabled (tcbCliEnabled=false), agents attempting role/permission/user management tasks have no discoverable guidance to use the MCP tools `queryPermissions`/`managePermissions` as alternatives. The `queryPermissions` tool supports `listRoles`, `getRole`, `listUsers`, `getUser` actions, and `managePermissions` supports `createRole`, `updateRole`, `deleteRoles`, `addRoleMembers`, etc. — but the skill docs and tool descriptions never mapped these to their CLI equivalents (`tcb role`, `tcb permission`, `tcb user`), so agents encountering CLI-disabled environments give up after errors instead of rerouting to MCP.
- changes: (1) Added a "CLI → MCP Alternative Mapping" section to `config/source/skills/cloudbase-platform/SKILL.md` with detailed tables mapping every `tcb role/permission/user` command to its `queryPermissions`/`managePermissions` equivalent with exact action names and parameter examples. (2) Added a 4th point to the "When Using CLI for Resource Management" section in `config/source/guideline/cloudbase/SKILL.md` directing agents to use MCP tools when CLI is unavailable, with key mappings. (3) Enhanced the `queryPermissions` and `ma

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/skills/cloudbase-platform/SKILL.md`
- `mcp/src/tools/permissions.ts`