### PR TITLE
fix: managePermissions工具createUser动作未将password声明为必填参数，导致模型遗漏该参数

### DIFF
--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -592,8 +592,8 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
         policies: z.array(z.record(z.any())).optional(),
         uid: z.string().optional(),
         uids: z.array(z.string()).optional(),
-        username: z.string().optional(),
-        password: z.string().optional(),
+        username: z.string().optional().describe("用户名。action=createUser 时必填。"),
+        password: z.string().optional().describe("用户密码。action=createUser 时必填。"),
         userStatus: z.enum(["ACTIVE", "BLOCKED"]).optional(),
       },
       annotations: {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moizl31y_hagnn4
- category: tool
- canonicalTitle: managePermissions工具createUser动作未将password声明为必填参数，导致模型遗漏该参数
- representativeRun: atomic-js-cloudbase-cli-user-create/2026-04-28T18-54-24-ba89b0

## Automation summary
- root_cause: In `managePermissions` tool's inputSchema, `password` (and `username`) are declared as `z.string().optional()` without any description indicating they are required for `createUser`. The model sees "optional" in the generated MCP tool schema and omits the `password` parameter, causing a runtime error ("action=createUser requires username and password").
- changes: Added `.describe()` to both `username` and `password` fields in `mcp/src/tools/permissions.ts:595-596` to explicitly state "action=createUser 时必填" (required when action=createUser). This is a Layer 1 fix — only tool description text, no logic changes.
- validation: TypeScript compiles cleanly (`tsc --noEmit` passes). All 3 skill quality test suites pass (10/10 tests).
- follow_up: None needed. The fix is minimal and directly addresses the canonical title — the tool schema now makes it explicit that `password` is required for `createUser`, so models will include it.

## Changed files
- `mcp/src/tools/permissions.ts`