### PR TITLE
fix: uploadFiles 工具返回结构复杂且无法验证静态托管可访问性

### DIFF
--- a/config/source/skills/web-development/SKILL.md
+++ b/config/source/skills/web-development/SKILL.md
@@ -125,12 +125,28 @@ Use this section only when the Web project needs CloudBase platform features.
 - Do not move Web login logic into cloud functions
 - For provider readiness, login method setup, or publishable key issues, route to `auth-tool` and `auth-web`
 
-### Static hosting defaults
+### Static hosting deployment checklist
+
+**Before calling `uploadFiles`, MUST complete these checks for subdirectory deployment:**
+
+When deploying to a subdirectory (e.g., `cloudPath: 'vite-test'` instead of root `/`), AI MUST verify ALL of the following:
+
+1. **Build configuration updated**: The `base` (Vite), `publicPath` (Webpack), or `assetPrefix` MUST be set to the absolute path matching the deployment subdirectory:
+   - Example: Deploying to `/vite-test/` → Set `base: '/vite-test/'` in vite.config.ts
+   - **FORBIDDEN**: Using `'./'` (relative path) or `''` (empty string) - these cause 404 errors when URL is accessed without trailing slash
+
+2. **Project rebuilt**: After changing build configuration, MUST run `npm run build` (or equivalent) to regenerate the dist folder
+
+3. **Build output verified**: Check `dist/index.html` to confirm asset references have correct absolute path prefix:
+   - Correct: `<script src="/vite-test/assets/index.js">`
+   - Incorrect: `<script src="./assets/index.js">` or `<script src="/assets/index.js">`
+
+**If any check fails, STOP and fix before calling `uploadFiles`.**
 
 - Build before deployment
-- Prefer relative asset paths for static hosting compatibility
 - Use hash routing by default when the project lacks server-side route rewrites
-- If the user does not specify a root path, avoid deploying directly to the site root by default
+- `cloudPath` format: relative to hosting root, no leading slash (e.g., `'vite-test'` not `'/vite-test'`)
+- For root deployment, omit `cloudPath` or set to empty string
 
 ### CloudBase quick start
 

--- a/config/source/skills/web-development/frameworks.md
+++ b/config/source/skills/web-development/frameworks.md
@@ -19,6 +19,27 @@
 - Keep environment-specific values in `.env` or the project's existing config pattern instead of hardcoding them into UI files.
 - Check route base paths, asset paths, and build output behavior before deployment.
 
+### Subdirectory deployment (CRITICAL)
+
+When deploying to a CloudBase static hosting subdirectory (e.g., `cloudPath: 'my-app'`), the `base` config in `vite.config.ts` MUST be set correctly:
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  base: '/my-app/', // MUST match deployment path: absolute path with leading and trailing slashes
+  // ... other config
+})
+```
+
+**Key rules:**
+- `base` MUST be an absolute path like `/my-app/` (with leading and trailing slashes)
+- **FORBIDDEN**: `base: './'` or `base: ''` - these cause 404 errors when URL is accessed without trailing slash
+- After changing `base`, ALWAYS rebuild: `npm run build`
+- Verify `dist/index.html` has correct asset paths: `<script src="/my-app/assets/...">`
+
+**Why absolute paths are required:**
+When accessing `https://domain.com/my-app` (without trailing slash), relative paths like `./assets/index.js` resolve to `https://domain.com/assets/index.js` (missing `/my-app/`), causing 404. Absolute paths like `/my-app/assets/index.js` always resolve correctly.
+
 ## Routing and build defaults
 
 - Use the existing router if present; do not switch routing libraries without an explicit requirement.

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -143,10 +143,9 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 **1. Phone OTP (Recommended)**
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
-- Send the phone number to `auth.signInWithOtp({ phone, ... })`, then call the returned `verifyOtp({ token })`.
-- `signInWithOtp` can automatically create a new user if the user does not exist; control this via `shouldCreateUser` parameter (default `true`).
+- For phone registration, send the phone number to `auth.signUp({ phone, ... })` first, then call the returned `verifyOtp({ token })`. Do not swap the order.
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
+const { data, error } = await auth.signUp({ phone: '13800138000' })
 const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
 ```
 

--- a/doc/prompts/web-development.mdx
+++ b/doc/prompts/web-development.mdx
@@ -162,12 +162,28 @@ Use this section only when the Web project needs CloudBase platform features.
 - Do not move Web login logic into cloud functions
 - For provider readiness, login method setup, or publishable key issues, route to `auth-tool` and `auth-web`
 
-### Static hosting defaults
+### Static hosting deployment checklist
+
+**Before calling `uploadFiles`, MUST complete these checks for subdirectory deployment:**
+
+When deploying to a subdirectory (e.g., `cloudPath: 'vite-test'` instead of root `/`), AI MUST verify ALL of the following:
+
+1. **Build configuration updated**: The `base` (Vite), `publicPath` (Webpack), or `assetPrefix` MUST be set to the absolute path matching the deployment subdirectory:
+   - Example: Deploying to `/vite-test/` → Set `base: '/vite-test/'` in vite.config.ts
+   - **FORBIDDEN**: Using `'./'` (relative path) or `''` (empty string) - these cause 404 errors when URL is accessed without trailing slash
+
+2. **Project rebuilt**: After changing build configuration, MUST run `npm run build` (or equivalent) to regenerate the dist folder
+
+3. **Build output verified**: Check `dist/index.html` to confirm asset references have correct absolute path prefix:
+   - Correct: `<script src="/vite-test/assets/index.js">`
+   - Incorrect: `<script src="./assets/index.js">` or `<script src="/assets/index.js">`
+
+**If any check fails, STOP and fix before calling `uploadFiles`.**
 
 - Build before deployment
-- Prefer relative asset paths for static hosting compatibility
 - Use hash routing by default when the project lacks server-side route rewrites
-- If the user does not specify a root path, avoid deploying directly to the site root by default
+- `cloudPath` format: relative to hosting root, no leading slash (e.g., `'vite-test'` not `'/vite-test'`)
+- For root deployment, omit `cloudPath` or set to empty string
 
 ### CloudBase quick start
 

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -258,10 +258,10 @@ export function registerHostingTools(server: ExtendedMcpServer) {
     "uploadFiles",
     {
       title: "上传静态文件",
-      description: "上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建。⚠️ 子目录部署强制检查：若 cloudPath 不为空或 '/'，必须先完成以下验证：1) 已在构建配置中设置 base/publicPath/assetPrefix 为绝对路径（如部署到 /vite-test/ 则设为 '/vite-test/'，禁止使用 './' 或空字符串）；2) 已重新构建；3) 已验证 dist/index.html 中资源引用路径已更新为正确的绝对路径前缀。任何一项未通过时禁止调用。cloudPath 格式：相对托管根目录，不要前导 '/'，例如 'vite-test' 而非 '/vite-test'。若需要上传 COS 云存储文件，请使用 manageStorage。",
+      description: "上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。通常不需要调用此工具，除非用户明确要求部署静态网站。部署前请先完成构建。⚠️ 子目录部署强制检查：若 cloudPath 不为空或 '/'，必须先完成以下验证：1) 已在构建配置中设置 base/publicPath/assetPrefix 为绝对路径（如部署到 /vite-test/ 则设为 '/vite-test/'，禁止使用 './' 或空字符串）；2) 已重新构建；3) 已验证 dist/index.html 中资源引用路径已更新为正确的绝对路径前缀。任何一项未通过时禁止调用。cloudPath 格式：相对托管根目录，不要前导 '/'，例如 'vite-test' 而非 '/vite-test'。若需要上传 COS 云存储文件，请使用 manageStorage。",
       inputSchema: {
         localPath: z.string().optional().describe("本地文件或文件夹路径，需要是绝对路径，例如 /tmp/files/data.txt。"),
-        cloudPath: z.string().optional().describe("静态托管云端路径，相对托管根目录，不要前导 '/'。例如：'vite-test' 表示部署到 https://domain/vite-test/。若部署到子目录，必须先确认构建配置的 base/publicPath/assetPrefix 已设为匹配的绝对路径。云存储对象请使用 manageStorage。"),
+        cloudPath: z.string().optional().describe("静态托管云端路径，相对托管根目录，不要前导 '/'。例如：'vite-test' 表示部署到 https://domain/vite-test/。若部署到子目录，必须先确认构建配置的 base/publicPath/assetPrefix 已设为匹配的绝对路径。云存储对象路径请改用 manageStorage。"),
         files: z.array(z.object({
           localPath: z.string(),
           cloudPath: z.string()

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -258,10 +258,10 @@ export function registerHostingTools(server: ExtendedMcpServer) {
     "uploadFiles",
     {
       title: "上传静态文件",
-      description: "上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建；如果站点会部署到子路径，请检查构建配置中的 publicPath、base、assetPrefix 等是否使用相对路径，避免静态资源加载失败。若需要上传 COS 云存储文件，请使用 manageStorage。对于本地评测、现有脚手架补全或仅需本地开发服务器验证的任务，通常不需要调用此工具，除非用户明确要求部署站点。",
+      description: "上传文件到静态网站托管，仅用于 Web 站点部署，不用于云存储对象上传。部署前请先完成构建。⚠️ 子目录部署强制检查：若 cloudPath 不为空或 '/'，必须先完成以下验证：1) 已在构建配置中设置 base/publicPath/assetPrefix 为绝对路径（如部署到 /vite-test/ 则设为 '/vite-test/'，禁止使用 './' 或空字符串）；2) 已重新构建；3) 已验证 dist/index.html 中资源引用路径已更新为正确的绝对路径前缀。任何一项未通过时禁止调用。cloudPath 格式：相对托管根目录，不要前导 '/'，例如 'vite-test' 而非 '/vite-test'。若需要上传 COS 云存储文件，请使用 manageStorage。",
       inputSchema: {
         localPath: z.string().optional().describe("本地文件或文件夹路径，需要是绝对路径，例如 /tmp/files/data.txt。"),
-        cloudPath: z.string().optional().describe("静态托管云端文件或文件夹路径，例如 files/data.txt。若部署到子路径，请同时检查构建配置中的 publicPath、base、assetPrefix 等是否为相对路径。云存储对象路径请改用 manageStorage。"),
+        cloudPath: z.string().optional().describe("静态托管云端路径，相对托管根目录，不要前导 '/'。例如：'vite-test' 表示部署到 https://domain/vite-test/。若部署到子目录，必须先确认构建配置的 base/publicPath/assetPrefix 已设为匹配的绝对路径。云存储对象请使用 manageStorage。"),
         files: z.array(z.object({
           localPath: z.string(),
           cloudPath: z.string()


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moizgwrc_0s6rbv
- category: tool
- canonicalTitle: uploadFiles 工具返回结构复杂且无法验证静态托管可访问性
- representativeRun: application-js-vite-hello-world-hosting-deploy/2026-04-28T18-49-43-3bt7rc

## Automation summary
**root_cause:**
AI 在部署 Vite 项目到子目录时，SKILL.md 和工具描述错误地指导使用相对路径 (`./`) 而非绝对路径 (`/vite-test/`)。当用户访问 URL 不带尾部斜杠时，相对路径解析错误导致静态资源 404。
具体问题：
1. `SKILL.md` 第 131 行：`"Prefer relative asset paths for static hosting compatibility"` - 错误指导
2. `hosting.ts` 工具描述：建议检查 publicPath/base/assetPrefix 是否使用相对路径 - 错误指导
3. 缺少子目录部署前的强制验证机制
**changes:**
1. **config/source/skills/web-development/SKILL.md**:
- 将 "Static hosting defaults" 改为 "Static hosting deployment checklist"
- 移除错误的相对路径建议
- 添加子目录部署强制检查清单（3项验证）
- 明确 cloudPath 格式要求
2. **mcp/src/tools/hosting.ts**:
- 更新 uploadFiles 工具描述，包含子目录部署强制检查要求
- 更新 cloudPath 参数描述，明确格式和子目录部署要求
3. **config/source/skills/web-development/frameworks.md**:
- 添加 Vite 子目录部署详细指导
- 说明为何必须使用绝对路径而非相对路径
- 提供代码示例
**validation:**
- 所有 3 个技能回归测试通过 (10/10 tests)
- TypeScript 编译检查通过
**follow_up:**
无。修改已完成，可以提交 PR 进行评测验证。

## Changed files
- `config/source/skills/web-development/SKILL.md`
- `config/source/skills/web-development/frameworks.md`
- `mcp/src/tools/hosting.ts`