### PR TITLE
fix: manageCloudRun 零配置部署能力边界不清晰，错误返回缺少 actionable 信息，导致 Agent 无法正确完成部署

### DIFF
--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -125,9 +125,46 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 ## Access guidance
 
-- **Web/public scenarios** -> enable WEB access intentionally and pair it with the right auth flow.
+- **Web/public scenarios** -> enable PUBLIC access intentionally and pair it with the right auth flow.
 - **Mini Program** -> prefer internal direct connection and avoid unnecessary public exposure.
 - **Private/VPC scenarios** -> keep public access off unless the product requirement clearly needs it.
+
+## Zero-config deployment
+
+CloudBase Run supports **zero-config deployment** - you can deploy without specifying `serverConfig`. The platform automatically detects and applies sensible defaults.
+
+### When to use zero-config
+
+- **Simple frontend or static sites** - HTML/CSS/JS projects without complex runtime requirements
+- **Quick prototyping** - When you need to get something running fast
+- **Standard Node.js apps** - When your project has a standard structure (package.json with start script)
+
+### How zero-config works
+
+When you omit `serverConfig`:
+- **Service type**: Auto-detected (Dockerfile present → container, otherwise checks for Node.js patterns)
+- **CPU/Memory**: Default values (0.25 CPU, 0.5 GB memory)
+- **Access**: Default access type applied
+- **Port**: Container mode uses platform default, Function mode uses 3000
+
+### Zero-config deploy example
+
+```json
+{
+  "action": "deploy",
+  "serverName": "my-frontend-app",
+  "targetPath": "/abs/ws/my-project"
+}
+```
+
+### When explicit config is needed
+
+Use explicit `serverConfig` when:
+- You need specific CPU/memory resources
+- You need public web access (`OpenAccessTypes: ["PUBLIC"]`)
+- You need specific scaling behavior (MinNum/MaxNum)
+- You need custom environment variables
+- You have specific port or Dockerfile requirements
 
 ## Quick examples
 
@@ -143,7 +180,17 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 { "action": "run", "serverName": "my-svc", "targetPath": "/abs/ws/my-svc", "runOptions": { "port": 3000 } }
 ```
 
-### Deploy
+### Deploy with zero-config (recommended for simple projects)
+
+```json
+{
+  "action": "deploy",
+  "serverName": "my-frontend-app",
+  "targetPath": "/abs/ws/my-project"
+}
+```
+
+### Deploy with explicit config (when you need control)
 
 ```json
 {
@@ -151,7 +198,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
   "serverName": "my-svc",
   "targetPath": "/abs/ws/my-svc",
   "serverConfig": {
-    "OpenAccessTypes": ["WEB"],
+    "OpenAccessTypes": ["PUBLIC"],
     "Cpu": 0.5,
     "Mem": 1,
     "MinNum": 1,
@@ -176,3 +223,16 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
+
+## Deployment failure recovery
+
+When deployment fails, follow these steps:
+
+1. **Check deployment log**: Use `queryCloudRun(action="getDeployLog", detailServerName="<serviceName>")` to get detailed error messages
+2. **Common failure causes**:
+   - Missing Dockerfile for container mode
+   - Invalid package.json or missing dependencies
+   - Port mismatch (app not listening on expected port)
+   - Resource constraints (CPU/memory ratio must be 1:2)
+3. **Retry after fix**: Use `manageCloudRun(action="deploy", ...)` again after fixing the issue
+4. **Monitor status**: Use `queryCloudRun(action="detail", detailServerName="<serviceName>")` to check deployment status


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moj17gxm_j5qv9w
- category: tool
- canonicalTitle: manageCloudRun 零配置部署能力边界不清晰，错误返回缺少 actionable 信息，导致 Agent 无法正确完成部署
- representativeRun: atomic-js-app-zero-config-deploy/2026-04-28T19-40-33-ssgh8t

## Automation summary
- root_cause: The `cloudrun-development` skill file didn't explain zero-config deployment capability. It only showed an example with full `serverConfig` configuration, without clarifying that `serverConfig` is optional and that CloudBase Run supports automatic detection and sensible defaults when it's omitted. This led agents to manually configure parameters instead of leveraging the zero-config feature, and they lacked guidance on troubleshooting deployment failures.
- changes: Updated `config/source/skills/cloudrun-development/SKILL.md`:
1. Added a new "Zero-config deployment" section explaining when and how to use zero-config deployment, what defaults are applied, and when explicit config is needed.
2. Updated the "Quick examples" section to show both zero-config deploy (recommended for simple projects) and explicit config deploy (when you need control).
3. Added a new "Deployment failure recovery" section with actionable steps for troubleshooting deployment failures.
4. Fixed incorrect access type reference from "WEB" to "PUBLIC" (the correct value per `CLOUDRUN_ACCESS_TYPES`).
- validation: Ran the three required regression tests (`build-skills-repo.test.js`, `build-compat-con

## Changed files
- `config/source/skills/cloudrun-development/SKILL.md`