### PR TITLE
fix: MCP 工具集无创建内部用户工具，Assistant 无从下手导致用户未创建

### DIFF
--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -595,6 +595,11 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
         username: z.string().optional(),
         password: z.string().optional(),
         userStatus: z.enum(["ACTIVE", "BLOCKED"]).optional(),
+        userType: z.enum(["internalUser", "externalUser"]).optional().describe("用户类型：internalUser（内部用户）或 externalUser（外部用户）"),
+        nickname: z.string().optional().describe("用户昵称"),
+        phone: z.string().optional().describe("手机号（11位中国大陆号码）"),
+        email: z.string().optional().describe("邮箱地址"),
+        avatarUrl: z.string().optional().describe("头像图片URL"),
       },
       annotations: {
         readOnlyHint: false,
@@ -622,6 +627,11 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username,
       password,
       userStatus,
+      userType,
+      nickname,
+      phone,
+      email,
+      avatarUrl,
     }: {
       action: ManagePermissionAction;
       resourceType?: LegacyResourceType;
@@ -640,6 +650,11 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username?: string;
       password?: string;
       userStatus?: "ACTIVE" | "BLOCKED";
+      userType?: "internalUser" | "externalUser";
+      nickname?: string;
+      phone?: string;
+      email?: string;
+      avatarUrl?: string;
     }) =>
       withEnvelope(async () => {
         const envId = await getEnvId(cloudBaseOptions);
@@ -763,7 +778,12 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
             const result = await cloudbase.user.createUser({
               name: username,
               password,
+              type: userType,
               userStatus,
+              nickName: nickname,
+              phone,
+              email,
+              avatarUrl,
               description,
             });
             logCloudBaseResult(server.logger, result);
@@ -784,8 +804,13 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
             const result = await cloudbase.user.modifyUser({
               uid,
               name: username,
+              type: userType,
               password,
               userStatus,
+              nickName: nickname,
+              phone,
+              email,
+              avatarUrl,
               description,
             });
             logCloudBaseResult(server.logger, result);


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moj1eq6r_gwt9rh
- category: tool
- canonicalTitle: MCP 工具集无创建内部用户工具，Assistant 无从下手导致用户未创建
- representativeRun: atomic-js-cloudbase-cli-user-create/2026-04-28T19-44-37-74be05

## Automation summary
**root_cause**: The MCP `managePermissions` tool's `createUser` action only supported `username`, `password`, `userStatus`, and `description` fields. However, the CloudBase Manager SDK's `createUser` API supports many more fields including `type` (user type), `nickName`, `phone`, `email`, and `avatarUrl`. When the Assistant tried to create a user with the required fields (nickname, phone, email, user type), it couldn't because these parameters weren't exposed in the MCP tool schema.
**changes**: Updated `mcp/src/tools/permissions.ts` to:
1. Added new input schema fields: `userType` (enum: internalUser/externalUser), `nickname`, `phone`, `email`, `avatarUrl`
2. Added destructuring of these fields in the async handler
3. Passed these fields to both `cloudbase.user.createUser()` and `cloudbase.user.modifyUser()` calls
4. Mapped `nickname` parameter to SDK's `nickName` field (camelCase)
**validation**:
- All 3 required skill/doc regression tests pass: `build-skills-repo.test.js`, `build-compat-config.test.js`, `skill-quality-standards.test.js`
- TypeScript compilation succeeds with no new errors
**follow_up**: None. The Assistant will now be able to create internal users with all requi

## Changed files
- `mcp/src/tools/permissions.ts`