### PR TITLE
fix: manageGateway 的 deleteRoute 操作在环境已绑定情况下返回"需要已绑定 envId"错误

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -14,6 +14,7 @@ const {
   mockDeleteCustomDomain,
   mockGetCloudBaseManager,
   mockLogCloudBaseResult,
+  mockGetEnvId,
 } = vi.hoisted(() => ({
   mockGetAccessList: vi.fn(),
   mockGetDomainList: vi.fn(),
@@ -26,10 +27,12 @@ const {
   mockDeleteCustomDomain: vi.fn(),
   mockGetCloudBaseManager: vi.fn(),
   mockLogCloudBaseResult: vi.fn(),
+  mockGetEnvId: vi.fn(),
 }));
 
 vi.mock("../cloudbase-manager.js", () => ({
   getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
   logCloudBaseResult: mockLogCloudBaseResult,
 }));
 
@@ -65,6 +68,11 @@ describe("gateway tools", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+
+    // Mock getEnvId to return the envId from cloudBaseOptions
+    mockGetEnvId.mockImplementation(async (options?: { envId?: string }) => {
+      return options?.envId || "env-test";
+    });
 
     mockGetAccessList.mockResolvedValue({
       Total: 1,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { getCloudBaseManager, logCloudBaseResult } from "../cloudbase-manager.js";
+import { getCloudBaseManager, getEnvId, logCloudBaseResult } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import { jsonContent } from "../utils/json-content.js";
 
@@ -82,7 +82,8 @@ function ensureGatewayEnvId(cloudBaseOptions?: { envId?: string }) {
 export function registerGatewayTools(server: ExtendedMcpServer) {
   const cloudBaseOptions = server.cloudBaseOptions;
   const getManager = () => getCloudBaseManager({ cloudBaseOptions });
-  const getGatewayEnvId = () => ensureGatewayEnvId(cloudBaseOptions);
+  // Use getEnvId to resolve envId from multiple sources: cloudBaseOptions, cache, login state, or default env manager
+  const getGatewayEnvId = () => getEnvId(cloudBaseOptions);
 
   const buildEnvelope = (
     data: Record<string, unknown>,
@@ -129,7 +130,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
   const listHttpServiceRoutes = async (domain?: string) => {
     const cloudbase = await getManager();
     const result = await cloudbase.env.describeHttpServiceRoute({
-      EnvId: getGatewayEnvId(),
+      EnvId: await getGatewayEnvId(),
       ...(domain
         ? {
             Filters: [
@@ -177,7 +178,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     }
 
     return {
-      EnvId: getGatewayEnvId(),
+      EnvId: await getGatewayEnvId(),
       Domain: {
         Domain: await resolveRouteDomain(domain),
         Routes: [
@@ -423,7 +424,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       const cloudbase = await getManager();
       const domain = await resolveRouteDomain(input.domain);
       const result = await cloudbase.env.deleteHttpServiceRoute({
-        EnvId: getGatewayEnvId(),
+        EnvId: await getGatewayEnvId(),
         Domain: domain,
         Paths: [normalizeAccessPath(routePath)],
       } as any);
@@ -445,7 +446,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       }
       const cloudbase = await getManager();
       const result = await cloudbase.env.bindCustomDomain({
-        EnvId: getGatewayEnvId(),
+        EnvId: await getGatewayEnvId(),
         Domain: {
           Domain: input.domain,
           CertId: input.certificateId,
@@ -469,7 +470,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       }
       const cloudbase = await getManager();
       const result = await cloudbase.env.deleteCustomDomain({
-        EnvId: getGatewayEnvId(),
+        EnvId: await getGatewayEnvId(),
         Domain: input.domain,
       });
       logCloudBaseResult(server.logger, result);


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moj0kqe7_al9299
- category: tool
- canonicalTitle: manageGateway 的 deleteRoute 操作在环境已绑定情况下返回"需要已绑定 envId"错误
- representativeRun: atomic-js-cloudbase-cli-routes-lifecycle/2026-04-28T19-17-44-51e14f

## Automation summary
**
- **root_cause:** The `manageGateway` and `queryGateway` tools were using a custom `ensureGatewayEnvId` function that only checked if `cloudBaseOptions.envId` was explicitly provided. When the environment is bound via authentication (as shown in the trace with `current_env_id: "booker-eval-8g4tb1du9a5a0bf3"`), the `cloudBaseOptions.envId` might not be set, but the envId is available through the login state or cached environment. Other tools like `cloudrun.ts`, `permissions.ts` use `getEnvId` from `cloudbase-manager.ts` which properly resolves from multiple sources, but the gateway tools were using a custom function that only checked one source.
- **changes:**
- `mcp/src/tools/gateway.ts`: Changed `getGatewayEnvId` to use `getEnvId(cloudBaseOptions)` instead of the custom `ensureGatewayEnvId` function, which resolves envId from cloudBaseOptions, cache, login state, or default env manager. Updated all 5 call sites to await the now-async function.
- `mcp/src/tools/gateway.test.ts`: Added mock for `getEnvId` to make tests pass.
- **validation:**
- TypeScript compilation passes (`npx tsc --noEmit`)
- All 9 gateway tests pass (`npx vitest run src/tools/gateway.test.ts`)
- **follow_up:

## Changed files
- `mcp/src/tools/gateway.test.ts`
- `mcp/src/tools/gateway.ts`