### PR TITLE
fix: manageCloudRun 零配置部署能力边界不清晰，错误返回缺少 actionable 信息，导致 Agent 无法正确完成部署

### DIFF
--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -38,8 +38,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ### Do NOT use for
 
 - Simple Event Function or HTTP Function workflows that fit the function model better.
-- Frontend-only projects with no backend service.
 - Database-schema design tasks.
+
+> **Note**: CloudRun **does** support deploying frontend projects (React/Vue/Vite etc.) as container services. The system can auto-detect the framework and build configuration — see the **Zero-config deployment** section below.
 
 ### Common mistakes / gotchas
 
@@ -48,6 +49,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating CloudRun as stateful app hosting and storing important state on local disk.
 - Assuming local run is available for Container mode.
 - Opening public access by default when the scenario only needs private or mini-program internal access.
+- Over-specifying `serverConfig` when zero-config deployment would work — the system auto-detects framework type and applies sensible defaults; only override when the user explicitly requests custom CPU/memory/replicas.
+- Forgetting to call `queryCloudRun(action="detail")` after deploy to verify the deployment status and catch build failures early.
 
 ### Minimal checklist
 
@@ -123,7 +126,41 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="delete")` -> delete service
 - `manageCloudRun(action="createAgent")` -> create Agent service
 
-## Access guidance
+## Zero-config deployment
+
+CloudRun supports **zero-config deployment** — the system auto-detects the project framework (React, Vue, Vite, etc.) and generates a build configuration automatically. This is the recommended approach for most frontend and Node.js projects.
+
+### When to use zero-config
+
+- The project has a `package.json` with a `build` script (e.g. Vite, Create React App, Next.js)
+- The user says "deploy without manual configuration" or "auto-detect"
+- You are unsure about the correct build parameters — let the system figure it out
+
+### When you still need serverConfig
+
+- The user explicitly requests specific CPU, memory, or replica counts
+- The service needs a non-default access type (e.g. VPC-only, mini-program internal)
+- The deployment fails with zero-config and you need to override auto-detected values
+
+### How zero-config deploy works
+
+1. Call `manageCloudRun(action="deploy")` with only `serverName` and `targetPath` — omit `serverConfig` entirely.
+2. The system auto-detects `serverType` (function vs container) based on the project structure:
+   - Has Dockerfile → container
+   - Has `@cloudbase/aiagent-framework` dependency → function
+   - Otherwise → container (suitable for frontend projects)
+3. After deploy, call `queryCloudRun(action="detail")` to check the deployment status.
+4. If the build fails, call `queryCloudRun(action="getDeployLog")` to read the build log and diagnose the issue.
+
+### Frontend project deployment flow
+
+For deploying a React/Vue/Vite frontend project:
+
+1. Ensure the project has `package.json` with a `build` script that outputs to `dist/`.
+2. Call `manageCloudRun(action="deploy", serverName="my-app", targetPath="/abs/path/to/project")`.
+3. Wait for deployment, then check status with `queryCloudRun(action="detail", detailServerName="my-app")`.
+4. The deployed service URL follows the pattern `https://<domain>/<serviceName>`.
+5. A `cloudbaserc.json` file is auto-generated in the project directory after deployment.
 
 - **Web/public scenarios** -> enable WEB access intentionally and pair it with the right auth flow.
 - **Mini Program** -> prefer internal direct connection and avoid unnecessary public exposure.
@@ -143,7 +180,19 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 { "action": "run", "serverName": "my-svc", "targetPath": "/abs/ws/my-svc", "runOptions": { "port": 3000 } }
 ```
 
-### Deploy
+### Deploy (zero-config — recommended default)
+
+Omit `serverConfig` to let the system auto-detect framework type and apply defaults. This is the simplest and most reliable way to deploy.
+
+```json
+{
+  "action": "deploy",
+  "serverName": "my-svc",
+  "targetPath": "/abs/ws/my-svc"
+}
+```
+
+### Deploy (with custom config — only when user requests specific resources)
 
 ```json
 {
@@ -162,6 +211,20 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 `MinNum: 1` is the recommended default when you want to reduce cold-start latency. If the user explicitly prefers lower cost and accepts more cold starts, explain the tradeoff and let them reduce `MinNum` to `0`.
 
+### Verify deployment after deploy
+
+Always check the deployment result after triggering a deploy:
+
+```json
+{ "action": "detail", "detailServerName": "my-svc" }
+```
+
+If the deploy status shows `failed`, retrieve the build log:
+
+```json
+{ "action": "getDeployLog", "detailServerName": "my-svc" }
+```
+
 ## Best practices
 
 1. Prefer PRIVATE/VPC or mini-program internal access when possible.
@@ -173,6 +236,16 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 ## Troubleshooting hints
 
 - **Access failure** -> check access type, domain setup, and whether the instance scaled to zero.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> inspect build logs with `queryCloudRun(action="getDeployLog")`. Common causes:
+  - Missing `build` script in `package.json` — add a script that outputs to `dist/`.
+  - Build command exits non-zero — run `npm run build` locally first to verify.
+  - Dockerfile syntax error (container mode) — validate locally with `docker build`.
+  - CPU/memory ratio invalid — ensure `Mem = 2 × CPU` (e.g. 0.5 CPU / 1 GB Mem).
+  - Port mismatch — the app must listen on the port specified in `serverConfig.Port` (default: auto-detected).
+  - "已有部署发布任务运行中" -> wait for the existing deploy to finish or retry with `force: true`.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
+- **Deploy triggered but service unreachable** -> call `queryCloudRun(action="detail")` to check:
+  1. Deploy status — is it still `creating`? Wait a few minutes.
+  2. Access type — if `OpenAccessTypes` does not include `WEB`, the service has no public URL.
+  3. Instance count — if `MinNum: 0` and there is no traffic, instances may have scaled down.

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -38,8 +38,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ### Do NOT use for
 
 - Simple Event Function or HTTP Function workflows that fit the function model better.
-- Frontend-only projects with no backend service.
 - Database-schema design tasks.
+
+> **Note**: CloudRun **does** support deploying frontend projects (React/Vue/Vite etc.) as container services. The system can auto-detect the framework and build configuration — see the **Zero-config deployment** section below.
 
 ### Common mistakes / gotchas
 
@@ -48,6 +49,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating CloudRun as stateful app hosting and storing important state on local disk.
 - Assuming local run is available for Container mode.
 - Opening public access by default when the scenario only needs private or mini-program internal access.
+- Over-specifying `serverConfig` when zero-config deployment would work — the system auto-detects framework type and applies sensible defaults; only override when the user explicitly requests custom CPU/memory/replicas.
+- Forgetting to call `queryCloudRun(action="detail")` after deploy to verify the deployment status and catch build failures early.
 
 ### Minimal checklist
 
@@ -123,7 +126,41 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="delete")` -> delete service
 - `manageCloudRun(action="createAgent")` -> create Agent service
 
-## Access guidance
+## Zero-config deployment
+
+CloudRun supports **zero-config deployment** — the system auto-detects the project framework (React, Vue, Vite, etc.) and generates a build configuration automatically. This is the recommended approach for most frontend and Node.js projects.
+
+### When to use zero-config
+
+- The project has a `package.json` with a `build` script (e.g. Vite, Create React App, Next.js)
+- The user says "deploy without manual configuration" or "auto-detect"
+- You are unsure about the correct build parameters — let the system figure it out
+
+### When you still need serverConfig
+
+- The user explicitly requests specific CPU, memory, or replica counts
+- The service needs a non-default access type (e.g. VPC-only, mini-program internal)
+- The deployment fails with zero-config and you need to override auto-detected values
+
+### How zero-config deploy works
+
+1. Call `manageCloudRun(action="deploy")` with only `serverName` and `targetPath` — omit `serverConfig` entirely.
+2. The system auto-detects `serverType` (function vs container) based on the project structure:
+   - Has Dockerfile → container
+   - Has `@cloudbase/aiagent-framework` dependency → function
+   - Otherwise → container (suitable for frontend projects)
+3. After deploy, call `queryCloudRun(action="detail")` to check the deployment status.
+4. If the build fails, call `queryCloudRun(action="getDeployLog")` to read the build log and diagnose the issue.
+
+### Frontend project deployment flow
+
+For deploying a React/Vue/Vite frontend project:
+
+1. Ensure the project has `package.json` with a `build` script that outputs to `dist/`.
+2. Call `manageCloudRun(action="deploy", serverName="my-app", targetPath="/abs/path/to/project")`.
+3. Wait for deployment, then check status with `queryCloudRun(action="detail", detailServerName="my-app")`.
+4. The deployed service URL follows the pattern `https://<domain>/<serviceName>`.
+5. A `cloudbaserc.json` file is auto-generated in the project directory after deployment.
 
 - **Web/public scenarios** -> enable WEB access intentionally and pair it with the right auth flow.
 - **Mini Program** -> prefer internal direct connection and avoid unnecessary public exposure.
@@ -143,7 +180,19 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 { "action": "run", "serverName": "my-svc", "targetPath": "/abs/ws/my-svc", "runOptions": { "port": 3000 } }
 ```
 
-### Deploy
+### Deploy (zero-config — recommended default)
+
+Omit `serverConfig` to let the system auto-detect framework type and apply defaults. This is the simplest and most reliable way to deploy.
+
+```json
+{
+  "action": "deploy",
+  "serverName": "my-svc",
+  "targetPath": "/abs/ws/my-svc"
+}
+```
+
+### Deploy (with custom config — only when user requests specific resources)
 
 ```json
 {
@@ -162,6 +211,20 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 `MinNum: 1` is the recommended default when you want to reduce cold-start latency. If the user explicitly prefers lower cost and accepts more cold starts, explain the tradeoff and let them reduce `MinNum` to `0`.
 
+### Verify deployment after deploy
+
+Always check the deployment result after triggering a deploy:
+
+```json
+{ "action": "detail", "detailServerName": "my-svc" }
+```
+
+If the deploy status shows `failed`, retrieve the build log:
+
+```json
+{ "action": "getDeployLog", "detailServerName": "my-svc" }
+```
+
 ## Best practices
 
 1. Prefer PRIVATE/VPC or mini-program internal access when possible.
@@ -173,6 +236,16 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 ## Troubleshooting hints
 
 - **Access failure** -> check access type, domain setup, and whether the instance scaled to zero.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> inspect build logs with `queryCloudRun(action="getDeployLog")`. Common causes:
+  - Missing `build` script in `package.json` — add a script that outputs to `dist/`.
+  - Build command exits non-zero — run `npm run build` locally first to verify.
+  - Dockerfile syntax error (container mode) — validate locally with `docker build`.
+  - CPU/memory ratio invalid — ensure `Mem = 2 × CPU` (e.g. 0.5 CPU / 1 GB Mem).
+  - Port mismatch — the app must listen on the port specified in `serverConfig.Port` (default: auto-detected).
+  - "已有部署发布任务运行中" -> wait for the existing deploy to finish or retry with `force: true`.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
+- **Deploy triggered but service unreachable** -> call `queryCloudRun(action="detail")` to check:
+  1. Deploy status — is it still `creating`? Wait a few minutes.
+  2. Access type — if `OpenAccessTypes` does not include `WEB`, the service has no public URL.
+  3. Instance count — if `MinNum: 0` and there is no traffic, instances may have scaled down.

--- a/doc/prompts/auth-web.mdx
+++ b/doc/prompts/auth-web.mdx
@@ -143,10 +143,9 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 **1. Phone OTP (Recommended)**
 - Automatically use `auth-tool-cloudbase` to turn on `SMS Login` through `manageAppAuth`
-- Send the phone number to `auth.signInWithOtp({ phone, ... })`, then call the returned `verifyOtp({ token })`.
-- `signInWithOtp` can automatically create a new user if the user does not exist; control this via `shouldCreateUser` parameter (default `true`).
+- For phone registration, send the phone number to `auth.signUp({ phone, ... })` first, then call the returned `verifyOtp({ token })`. Do not swap the order.
 ```js
-const { data, error } = await auth.signInWithOtp({ phone: '13800138000' })
+const { data, error } = await auth.signUp({ phone: '13800138000' })
 const { data: loginData, error: loginError } = await data.verifyOtp({ token:'123456' })
 ```
 

--- a/doc/prompts/cloudrun-development.mdx
+++ b/doc/prompts/cloudrun-development.mdx
@@ -74,8 +74,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ### Do NOT use for
 
 - Simple Event Function or HTTP Function workflows that fit the function model better.
-- Frontend-only projects with no backend service.
 - Database-schema design tasks.
+
+> **Note**: CloudRun **does** support deploying frontend projects (React/Vue/Vite etc.) as container services. The system can auto-detect the framework and build configuration — see the **Zero-config deployment** section below.
 
 ### Common mistakes / gotchas
 
@@ -84,6 +85,8 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating CloudRun as stateful app hosting and storing important state on local disk.
 - Assuming local run is available for Container mode.
 - Opening public access by default when the scenario only needs private or mini-program internal access.
+- Over-specifying `serverConfig` when zero-config deployment would work — the system auto-detects framework type and applies sensible defaults; only override when the user explicitly requests custom CPU/memory/replicas.
+- Forgetting to call `queryCloudRun(action="detail")` after deploy to verify the deployment status and catch build failures early.
 
 ### Minimal checklist
 
@@ -159,7 +162,41 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="delete")` -> delete service
 - `manageCloudRun(action="createAgent")` -> create Agent service
 
-## Access guidance
+## Zero-config deployment
+
+CloudRun supports **zero-config deployment** — the system auto-detects the project framework (React, Vue, Vite, etc.) and generates a build configuration automatically. This is the recommended approach for most frontend and Node.js projects.
+
+### When to use zero-config
+
+- The project has a `package.json` with a `build` script (e.g. Vite, Create React App, Next.js)
+- The user says "deploy without manual configuration" or "auto-detect"
+- You are unsure about the correct build parameters — let the system figure it out
+
+### When you still need serverConfig
+
+- The user explicitly requests specific CPU, memory, or replica counts
+- The service needs a non-default access type (e.g. VPC-only, mini-program internal)
+- The deployment fails with zero-config and you need to override auto-detected values
+
+### How zero-config deploy works
+
+1. Call `manageCloudRun(action="deploy")` with only `serverName` and `targetPath` — omit `serverConfig` entirely.
+2. The system auto-detects `serverType` (function vs container) based on the project structure:
+   - Has Dockerfile → container
+   - Has `@cloudbase/aiagent-framework` dependency → function
+   - Otherwise → container (suitable for frontend projects)
+3. After deploy, call `queryCloudRun(action="detail")` to check the deployment status.
+4. If the build fails, call `queryCloudRun(action="getDeployLog")` to read the build log and diagnose the issue.
+
+### Frontend project deployment flow
+
+For deploying a React/Vue/Vite frontend project:
+
+1. Ensure the project has `package.json` with a `build` script that outputs to `dist/`.
+2. Call `manageCloudRun(action="deploy", serverName="my-app", targetPath="/abs/path/to/project")`.
+3. Wait for deployment, then check status with `queryCloudRun(action="detail", detailServerName="my-app")`.
+4. The deployed service URL follows the pattern `https://<domain>/<serviceName>`.
+5. A `cloudbaserc.json` file is auto-generated in the project directory after deployment.
 
 - **Web/public scenarios** -> enable WEB access intentionally and pair it with the right auth flow.
 - **Mini Program** -> prefer internal direct connection and avoid unnecessary public exposure.
@@ -179,7 +216,19 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 { "action": "run", "serverName": "my-svc", "targetPath": "/abs/ws/my-svc", "runOptions": { "port": 3000 } }
 ```
 
-### Deploy
+### Deploy (zero-config — recommended default)
+
+Omit `serverConfig` to let the system auto-detect framework type and apply defaults. This is the simplest and most reliable way to deploy.
+
+```json
+{
+  "action": "deploy",
+  "serverName": "my-svc",
+  "targetPath": "/abs/ws/my-svc"
+}
+```
+
+### Deploy (with custom config — only when user requests specific resources)
 
 ```json
 {
@@ -198,6 +247,20 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 `MinNum: 1` is the recommended default when you want to reduce cold-start latency. If the user explicitly prefers lower cost and accepts more cold starts, explain the tradeoff and let them reduce `MinNum` to `0`.
 
+### Verify deployment after deploy
+
+Always check the deployment result after triggering a deploy:
+
+```json
+{ "action": "detail", "detailServerName": "my-svc" }
+```
+
+If the deploy status shows `failed`, retrieve the build log:
+
+```json
+{ "action": "getDeployLog", "detailServerName": "my-svc" }
+```
+
 ## Best practices
 
 1. Prefer PRIVATE/VPC or mini-program internal access when possible.
@@ -209,9 +272,19 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 ## Troubleshooting hints
 
 - **Access failure** -> check access type, domain setup, and whether the instance scaled to zero.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> inspect build logs with `queryCloudRun(action="getDeployLog")`. Common causes:
+  - Missing `build` script in `package.json` — add a script that outputs to `dist/`.
+  - Build command exits non-zero — run `npm run build` locally first to verify.
+  - Dockerfile syntax error (container mode) — validate locally with `docker build`.
+  - CPU/memory ratio invalid — ensure `Mem = 2 × CPU` (e.g. 0.5 CPU / 1 GB Mem).
+  - Port mismatch — the app must listen on the port specified in `serverConfig.Port` (default: auto-detected).
+  - "已有部署发布任务运行中" -> wait for the existing deploy to finish or retry with `force: true`.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
+- **Deploy triggered but service unreachable** -> call `queryCloudRun(action="detail")` to check:
+  1. Deploy status — is it still `creating`? Wait a few minutes.
+  2. Access type — if `OpenAccessTypes` does not include `WEB`, the service has no public URL.
+  3. Instance count — if `MinNum: 0` and there is no traffic, instances may have scaled down.
 ````
 
 </details>

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -176,8 +176,28 @@ function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["action"], 
     suggestions.push("如果你确认要覆盖当前流程，可在合适时机使用 `force=true` 再次发起。");
   }
 
+  if (/Dockerfile|docker/i.test(baseMessage) && action === 'deploy') {
+    suggestions.push("部署容器型服务需要 Dockerfile。如果是前端项目，确认 package.json 中有 build 脚本，系统会自动检测框架并生成构建配置（零配置部署）。");
+  }
+
+  if (/build|构建/i.test(baseMessage) && action === 'deploy') {
+    suggestions.push("构建失败时，建议：(1) 本地运行 `npm run build` 确认构建成功；(2) 使用 `queryCloudRun(action=\"getDeployLog\", detailServerName=\"" + serverName + "\")` 查看构建日志定位具体错误。");
+  }
+
+  if (/port|端口/i.test(baseMessage)) {
+    suggestions.push("确保应用监听正确的端口。函数型服务端口固定为 3000，容器型服务需监听 serverConfig.Port 指定的端口（默认自动检测）。");
+  }
+
+  if (/CPU|内存|Mem|Cpu|资源/i.test(baseMessage)) {
+    suggestions.push("资源规格需满足 Mem = 2 × CPU（如 Cpu=0.5, Mem=1）。如果未指定 serverConfig，系统会使用默认配置。");
+  }
+
   if (suggestions.length === 0) {
     suggestions.push("请检查服务状态、部署参数和目标目录后重试。");
+    if (action === 'deploy') {
+      suggestions.push("如果未提供 serverConfig，系统会自动检测框架类型并使用默认配置（零配置部署）。");
+      suggestions.push(`使用 queryCloudRun(action="getDeployLog", detailServerName="${serverName}") 查看构建日志。`);
+    }
   }
 
   return `[manageCloudRun/${action}] ${baseMessage}\n建议：${suggestions.join(" ")}`;


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moj17gxm_j5qv9w
- category: tool
- canonicalTitle: manageCloudRun 零配置部署能力边界不清晰，错误返回缺少 actionable 信息，导致 Agent 无法正确完成部署
- representativeRun: atomic-js-app-zero-config-deploy/2026-04-28T20-08-14-02c40a

## Automation summary
- root_cause: The cloudrun-development SKILL.md explicitly said "Do NOT use for Frontend-only projects with no backend service", which blocked agents from using CloudRun to deploy frontend projects. The skill also had no zero-config deployment guidance — the deploy example always included a full `serverConfig`, leading agents to believe manual configuration was required. The error messages from `manageCloudRun` deploy only handled the "already deploying" case, providing generic advice for all other failures, giving agents no actionable next steps when deployment failed.
- changes: (1) **SKILL.md** — Removed "Frontend-only projects" from the "Do NOT use for" list, added a note that CloudRun supports frontend deployment with auto-detection. Added a full "Zero-config deployment" section explaining when/how to omit `serverConfig`, auto-detection rules for `serverType`, and a step-by-step frontend deployment flow. Added zero-config deploy example as the primary/recommended example, moved the full `serverConfig` example to secondary. Added "Verify deployment after deploy" examples with `queryCloudRun(action="detail")` and `getDeployLog`. Expanded Troubleshooting with actionable causes an

## Changed files
- `config/.claude/skills/cloudrun-development/SKILL.md`
- `config/source/skills/cloudrun-development/SKILL.md`
- `doc/prompts/auth-web.mdx`
- `doc/prompts/cloudrun-development.mdx`
- `mcp/src/tools/cloudrun.ts`