### PR TITLE
fix: MCP工具缺乏对禁用CLI任务的替代指引与能力映射

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -236,17 +236,41 @@ The `scf_bootstrap` binary path must match the runtime — see the full mapping 
 
 ## Preferred tool map
 
+### When CLI is disabled but MCP is available
+
+If the runtime capability notice shows **CloudBase CLI is DISABLED** but **CloudBase MCP tools are ENABLED**, and the task explicitly asks to "use CLI":
+
+1. **Do NOT attempt to use CLI commands** - they will fail with unavailable errors
+2. **Use the equivalent MCP tools instead** - they provide the same capabilities
+3. **Follow this capability mapping**:
+
+| CLI Task | Equivalent MCP Tool | Action/Parameters |
+|----------|--------------------|--------------------|
+| `tcb fn list` | `queryFunctions` | `action="listFunctions"` |
+| `tcb fn deploy <name>` | `manageFunctions` | `action="createFunction"` or `action="updateFunctionCode"` |
+| `tcb fn get <name>` | `queryFunctions` | `action="getFunctionDetail"` with `functionName` |
+| `tcb fn invoke <name>` | `manageFunctions` | `action="invokeFunction"` with `functionName` |
+| `tcb fn log <name>` | `queryFunctions` | `action="listFunctionLogs"` with `functionName` |
+| `tcb fn log --reqId <id>` | `queryLogs` | `action="searchLogs"` with `queryString` containing `requestId` |
+| `tcb fn delete <name>` | `manageFunctions` | `action="deleteFunction"` with `functionName` |
+| `tcb fn gateway create` | `manageGateway` | `action="createAccess"` |
+| `tcb fn gateway list` | `queryGateway` | `action="getAccess"` |
+
+**Important**: When calling functions via MCP, the `requestId` returned is `FunctionRequestId`. Use this value for log queries.
+
 ### Function management
 
 - `queryFunctions(action="listFunctions"|"getFunctionDetail")`
 - `manageFunctions(action="createFunction")`
 - `manageFunctions(action="updateFunctionCode")`
 - `manageFunctions(action="updateFunctionConfig")`
+- `manageFunctions(action="invokeFunction")` - Call a function directly via MCP
 
 ### Logs
 
 - `queryFunctions(action="listFunctionLogs")`
 - `queryFunctions(action="getFunctionLogDetail")`
+- `queryLogs(action="searchLogs")` - Search CLS logs by requestId or query string
 - If these are unavailable, read `./references/operations-and-config.md` before any `callCloudApi` fallback
 
 ### Gateway exposure

--- a/config/source/skills/cloudbase-cli/SKILL.md
+++ b/config/source/skills/cloudbase-cli/SKILL.md
@@ -57,6 +57,18 @@ Use when the user wants to manage CloudBase resources via command line:
 - Console UI operations
 - CloudBase Agent SDK development → use `cloudbase-agent-ts`
 
+## When CLI is disabled
+
+If you receive a runtime notice that **CloudBase CLI is DISABLED** but **CloudBase MCP tools are ENABLED**:
+
+1. **Do NOT attempt CLI commands** (`tcb fn ...`, etc.) - they will fail
+2. **Use equivalent MCP tools instead** - see `cloud-functions` skill for CLI-to-MCP capability mapping
+3. **Key equivalencies**:
+   - `tcb fn list` → `queryFunctions(action="listFunctions")`
+   - `tcb fn deploy <name>` → `manageFunctions(action="createFunction"|"updateFunctionCode")`
+   - `tcb fn invoke <name>` → `manageFunctions(action="invokeFunction")`
+   - `tcb fn log <name>` → `queryFunctions(action="listFunctionLogs")` or `queryLogs(action="searchLogs")`
+
 ## How to use this skill (for a coding agent)
 
 1. **Always load `references/core.md` first** — it covers authentication,


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8xicmr_y3lqj3
- category: tool
- canonicalTitle: MCP工具缺乏对禁用CLI任务的替代指引与能力映射
- representativeRun: atomic-js-cloudbase-cli-log-query-by-request-id/2026-04-21T17-58-43-zmic3p

## Automation summary
---
**SUMMARY:**
- **root_cause**: When the runtime has CloudBase CLI disabled but MCP tools enabled, and the task explicitly asks to "use CloudBase CLI", the agent has no guidance on how to map CLI commands to equivalent MCP tools. The runtime capability notice clearly states CLI is disabled, but without explicit capability mapping guidance, agents don't know which MCP tools to use as alternatives.
- **changes**: Added CLI-to-MCP capability mapping guidance to two skill files:
1. `config/source/skills/cloud-functions/SKILL.md` (lines 239-273): Added "When CLI is disabled but MCP is available" section with a detailed mapping table translating common CLI commands (`tcb fn list`, `tcb fn deploy`, `tcb fn invoke`, `tcb fn log`, etc.) to their equivalent MCP tool actions. Also added `invokeFunction` and `queryLogs` references to the relevant tool sections.
2. `config/source/skills/cloudbase-cli/SKILL.md` (lines 60-70): Added "When CLI is disabled" section that explicitly tells agents NOT to attempt CLI commands when disabled, and points them to the `cloud-functions` skill for the capability mapping.
- **validation**: All 3 regression tests pass (10 tests total):
- `build-skills-repo.te

## Changed files
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloudbase-cli/SKILL.md`