### PR TITLE
fix: MCP 域名管理工具参数约定不清晰，且缺乏文件写入类任务的处理指引

### DIFF
--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -48,6 +48,9 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Staying here after the correct implementation skill is already clear.
 - Mixing platform overview with platform-specific API shapes or SDK details.
 - Using this overview skill as a detour in an existing application where the active auth, storage, and data files are already obvious.
+- **Confusing security domains with custom domains**: These are two completely different tools for different purposes:
+  - `envDomainManagement` (action: create/delete) = Security domains (安全域名) for CORS/request source validation - used for browser upload whitelisting. Does NOT accept certificateId.
+  - `manageGateway(action="bindCustomDomain")` = Custom domains (自定义域名) for public HTTPS access with SSL certificates - requires domain and certificateId parameters.
 
 ## When to use this skill
 
@@ -92,6 +95,45 @@ Use this skill for **CloudBase platform knowledge** when you need to:
 ---
 
 # CloudBase Platform Knowledge
+
+### Domain Management Tools: Clear Distinction
+
+When working with domain-related tasks, use the correct tool based on the requirement:
+
+| Requirement | Tool | Parameters | Purpose |
+|-------------|------|------------|---------|
+| **Security Domain (安全域名)** | `envDomainManagement` | `action`, `domains` (array of host:port strings) | CORS/request source validation for browser uploads. No certificate involved. |
+| **Custom Domain (自定义域名)** | `manageGateway(action="bindCustomDomain")` | `domain` (string), `certificateId` (string) | Public HTTPS access with SSL certificate. Requires certId from SSL console. |
+| **Delete Custom Domain** | `manageGateway(action="deleteCustomDomain")` | `domain` (string) | Remove custom domain binding. |
+
+**Key indicators for choosing the right tool:**
+- Task mentions "certificate ID" or "SSL" → Use `manageGateway(action="bindCustomDomain")`
+- Task mentions "浏览器上传" or "CORS" or "安全域名" → Use `envDomainManagement`
+- Task mentions "public access" or "HTTPS" with domain → Use `manageGateway`
+
+### Recording Operation Results
+
+When a task explicitly requires recording operation steps or results to a file (e.g., `RESULT.json`):
+
+1. Perform the tool calls first to get actual results
+2. Collect all operation steps with their success/failure status
+3. Write the complete record to the specified file in the required format
+4. Include both successful operations and failed attempts with error messages
+
+Example structure for operation recording:
+```json
+{
+  "steps": [
+    {"action": "listDomains", "success": true, "message": "Found 3 domains"},
+    {"action": "bindDomain", "success": false, "message": "Certificate not found"}
+  ],
+  "summary": {
+    "totalAttempted": 2,
+    "succeeded": 1,
+    "failed": 1
+  }
+}
+```
 
 ## Storage and Hosting
 

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -1480,14 +1480,14 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "envDomainManagement",
     {
-      title: "环境域名管理",
+      title: "环境域名管理（安全域名 / CORS 白名单）",
       description:
-        "管理云开发环境的安全域名，支持添加和删除操作。（原工具名：createEnvDomain/deleteEnvDomain，为兼容旧AI规则可继续使用这些名称）当浏览器 Web 应用需要从本地 Vite / dev server 或自定义域名直接访问 CloudBase 资源时，应先用 envQuery(action=domains) 检查当前实际浏览器 origin 对应的 host:port 是否已在白名单中，再按该实际值添加。新增或删除后通常需要继续轮询 envQuery(action=domains) 确认状态收敛；安全域名一般约 10 分钟生效。",
+        "管理云开发环境的安全域名（安全域名 / CORS 白名单），支持添加和删除操作。（原工具名：createEnvDomain/deleteEnvDomain，为兼容旧AI规则可继续使用这些名称）当浏览器 Web 应用需要从本地 Vite / dev server 直接访问 CloudBase 资源时，应先用 envQuery(action=domains) 检查当前实际浏览器 origin 对应的 host:port 是否已在白名单中，再按该实际值添加。新增或删除后通常需要继续轮询 envQuery(action=domains) 确认状态收敛；安全域名一般约 10 分钟生效。⚠️ 重要：此工具仅用于 CORS/请求来源验证，不涉及 SSL 证书。如需绑定自定义域名供公网 HTTPS 访问，请使用 manageGateway(action=\"bindCustomDomain\")。",
       inputSchema: {
         action: z
           .enum(["create", "delete"])
-          .describe("操作类型：create=添加域名，delete=删除域名"),
-        domains: z.array(z.string()).describe("安全域名数组"),
+          .describe("操作类型：create=添加安全域名，delete=删除安全域名"),
+        domains: z.array(z.string()).describe("安全域名数组（格式：host:port，例如 localhost:5173 或 127.0.0.1:4173）。注意：不是自定义域名，不需要证书。"),
       },
       annotations: {
         readOnlyHint: false,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -576,9 +576,9 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "manageGateway",
     {
-      title: "管理网关域资源",
+      title: "管理网关域资源（含自定义域名绑定）",
       description:
-        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。",
+        "网关域统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。⚠️ 如需绑定带 SSL 证书的自定义域名供公网 HTTPS 访问，使用 action=\"bindCustomDomain\"（需要 domain 和 certificateId 参数）；如需配置 CORS/安全域名（无证书），请使用 envDomainManagement 工具。",
       inputSchema: {
         action: z
           .enum(MANAGE_GATEWAY_ACTIONS)


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8xfv8b_20m1lv
- category: tool
- canonicalTitle: MCP 域名管理工具参数约定不清晰，且缺乏文件写入类任务的处理指引
- representativeRun: atomic-js-cloudbase-cli-domains-lifecycle/2026-04-21T17-57-15-30bior

## Automation summary
- **root_cause**: Two distinct but related issues caused the agent to fail:
1. **Tool confusion**: The agent confused `envDomainManagement` (for security domains/CORS whitelisting) with `manageGateway(action="bindCustomDomain")` (for custom domains with SSL certificates). The task asked to bind a domain with a certificate ID (`WOjHRISM`), which clearly requires `manageGateway`, but the agent likely attempted to use `envDomainManagement` which doesn't accept certificate parameters.
2. **Missing file-writing guidance**: The task required recording operation results to `internal evaluation artifact`, but no skill/tool documentation provided guidance on how to handle such file-writing tasks.
- **changes**:
1. **`config/source/skills/cloudbase-platform/SKILL.md`**: Added clear distinction between domain management tools with a comparison table, key indicators for choosing the right tool, and a new section on "Recording Operation Results" with guidance for file-writing tasks.
2. **`mcp/src/tools/env.ts`**: Updated `envDomainManagement` tool title to include "(安全域名 / CORS 白名单)" and enhanced description to explicitly state it does NOT involve SSL certificates and refers to `manageGateway` for custom domain

## Changed files
- `config/source/skills/cloudbase-platform/SKILL.md`
- `mcp/src/tools/env.ts`
- `mcp/src/tools/gateway.ts`