### PR TITLE
fix: CloudBase Skill JS SDK 数据操作示例不足，Agent 无法识别正确执行路径

### DIFF
--- a/config/source/skills/no-sql-web-sdk/SKILL.md
+++ b/config/source/skills/no-sql-web-sdk/SKILL.md
@@ -41,6 +41,21 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - SQL / MySQL database operations.
 - Pure resource-permission administration with no browser SDK code.
 
+### SDK Code vs MCP Tools
+
+**When to write SDK code (use this skill):**
+- The task explicitly asks to "modify code" or "use SDK"
+- The task asks to implement app/frontend logic
+- The task mentions specific SDK methods like `db.collection().add()`, `.get()`, `.update()`
+- The context shows an existing Web project with SDK initialization (e.g., `index.js` already has `cloudbase.init()`)
+
+**When to use MCP tools instead:**
+- The task asks to manage CloudBase resources (create collection, set permissions, etc.)
+- The task involves admin/management operations without writing app code
+- The task mentions tools like `writeNoSqlDatabaseContent`, `managePermissions`, etc.
+
+**Key distinction:** If the user says "使用 JS SDK 执行 XX 操作" (use JS SDK to perform XX operation) or "修改代码" (modify code), write SDK code in the project files. Do not use MCP database write tools for app-level data operations.
+
 ### Common mistakes / gotchas
 
 - Querying before the user is signed in when the collection rules require identity.


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8wii1o_geapz9
- category: skill
- canonicalTitle: CloudBase Skill JS SDK 数据操作示例不足，Agent 无法识别正确执行路径
- representativeRun: atomic-js-clientsdk-init-login-insert-data/2026-04-21T17-31-07-oy9r63

## Automation summary
- **root_cause**: The agent was tasked to "使用 JS SDK 执行插入数据操作" (use JS SDK to perform insert operation) and "修改代码" (modify code), but didn't know whether to write SDK code or use MCP tools. The skill lacked guidance on when to write SDK code vs when to use MCP tools, causing the agent to try using an MCP tool (which failed with "400 invalid parameter value") instead of writing SDK code in the project files.
- **changes**: Added a new "SDK Code vs MCP Tools" section to `config/source/skills/no-sql-web-sdk/SKILL.md` that clarifies:
- When to write SDK code: task explicitly asks to "modify code" or "use SDK", mentions SDK methods like `db.collection().add()`, context shows existing Web project with SDK initialization
- When to use MCP tools: resource management (create collection, set permissions), admin operations
- Key distinction: If user says "使用 JS SDK 执行 XX 操作" or "修改代码", write SDK code in project files, not MCP database write tools
- **validation**: All 10 skill tests pass (`build-skills-repo`, `build-compat-config`, `skill-quality-standards`)
- **follow_up**: None required - the fix is complete. The skill now provides clear guidance for agents to identify the correct execution

## Changed files
- `config/source/skills/no-sql-web-sdk/SKILL.md`