### PR TITLE
fix: MCP 工具与 JS SDK 编码场景区分不清晰

### DIFF
--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -351,7 +351,7 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
     {
       title: "查询应用认证配置",
       description:
-        "应用侧认证配置只读入口。用于查询登录方式、provider、publishable key、API key、client 配置和静态域名等认证准备状态。若业务要接受普通用户名样式标识符，先查询 action=getLoginConfig；若 usernamePassword=false，下一步应立即调用 manageAppAuth(action=patchLoginStrategy, patch={ usernamePassword: true })，不要直接写 email 登录 API。",
+        "应用侧认证配置只读入口。用于查询登录方式、provider、publishable key、API key、client 配置和静态域名等认证准备状态。⚠️ 本工具为管理端配置查询工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具确认配置状态，再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若业务要接受普通用户名样式标识符，先查询 action=getLoginConfig；若 usernamePassword=false，下一步应立即调用 manageAppAuth(action=patchLoginStrategy, patch={ usernamePassword: true })，不要直接写 email 登录 API。",
       inputSchema: {
         action: z.enum(QUERY_APP_AUTH_ACTIONS),
         providerId: z.string().optional().describe("provider 标识，如 email、google"),
@@ -491,7 +491,7 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
     {
       title: "管理应用认证配置",
       description:
-        "应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。",
+        "应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。⚠️ 本工具为管理端配置工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具完成配置（如启用 usernamePassword、获取 publishable key），再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。",
       inputSchema: {
         action: z.enum(MANAGE_APP_AUTH_ACTIONS),
         patch: z

--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -312,7 +312,7 @@ export function registerDatabaseTools(server: ExtendedMcpServer) {
     {
       title: "读取 NoSQL 数据库结构",
       description:
-        "读取 NoSQL 数据库集合与索引结构，支持列出集合、查看集合详情、列出索引以及检查索引是否存在。",
+        "读取 NoSQL 数据库集合与索引结构，支持列出集合、查看集合详情、列出索引以及检查索引是否存在。本工具为服务端管理工具，用于管理端查询数据库结构，不用于编写客户端代码。",
       inputSchema: {
         action: z.enum([
           "listCollections",
@@ -500,7 +500,7 @@ checkIndex: 检查指定索引是否存在`),
     {
       title: "修改 NoSQL 数据库结构",
       description:
-        "修改 NoSQL 数据库结构，支持创建/删除集合，以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。",
+        "修改 NoSQL 数据库结构，支持创建/删除集合，以及通过 updateCollection 的 updateOptions.CreateIndexes / updateOptions.DropIndexes 添加索引和删除索引。本工具为服务端管理工具，用于管理端操作集合和索引结构，不用于编写客户端代码。",
       inputSchema: {
         action: z.enum([
           "createCollection",
@@ -670,7 +670,7 @@ deleteCollection: 删除集合`),
     "readNoSqlDatabaseContent",
     {
       title: "查询并获取 NoSQL 数据库数据记录",
-      description: "查询并获取 NoSQL 数据库数据记录",
+      description: "查询并获取 NoSQL 数据库数据记录。⚠️ 本工具为服务端管理工具，用于管理端/运维端查询。当任务要求编写客户端应用代码时（例如「用 JS SDK 读取数据」），不应使用本工具，而应在项目代码中编写 @cloudbase/js-sdk 客户端代码（如 db.collection().where().get()）。",
       inputSchema: {
         collectionName: z.string().describe("集合名称"),
         instanceId: z
@@ -773,7 +773,7 @@ deleteCollection: 删除集合`),
     {
       title: "修改 NoSQL 数据库数据记录",
       description:
-        "修改 NoSQL 数据库数据记录。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传“字段到值的普通对象”这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径，例如把 `address.city` 设为 `shenzhen`；如果把整个 `address` 对象作为 `$set` 的值传入，则整个 `address` 对象会被替换，同级其他字段将丢失。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
+        "修改 NoSQL 数据库数据记录。⚠️ 本工具为服务端管理工具，用于管理端/运维端操作（如后台脚本、数据迁移、批量修改）。当任务要求编写客户端应用代码时（例如「用 JS SDK 登录并插入数据」、「在前端读写数据库」），不应使用本工具，而应在项目代码中编写 @cloudbase/js-sdk 客户端代码（如 app.database().collection().add()、db.collection().where().get() 等）。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传「字段到值的普通对象」这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径，例如把 `address.city` 设为 `shenzhen`；如果把整个 `address` 对象作为 `$set` 的值传入，则整个 `address` 对象会被替换，同级其他字段将丢失。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
       inputSchema: {
         action: z
           .enum(["insert", "update", "delete"])


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo8whys6_7jpjt9
- category: tool
- canonicalTitle: MCP 工具与 JS SDK 编码场景区分不清晰
- representativeRun: atomic-js-clientsdk-init-login-insert-data/2026-04-21T17-30-58-l6lpkx

## Automation summary
- root_cause: MCP tool descriptions for NoSQL database tools (readNoSqlDatabaseContent, writeNoSqlDatabaseContent, readNoSqlDatabaseStructure, writeNoSqlDatabaseStructure) and auth tools (queryAppAuth, manageAppAuth) do not distinguish between server-side admin operations and client-side JS SDK coding scenarios. When a task asks to "write code using JS SDK to login and insert data", the agent cannot tell from the tool descriptions that it should write code files (using `@cloudbase/js-sdk` client APIs like `db.collection().add()` and `auth.signInWithPassword()`) rather than calling MCP admin tools. The tool descriptions lack any hint about their admin-only scope, causing the agent to either misuse MCP tools for client-side coding tasks or fail to act at all.
- changes: Added explicit ⚠️ scenario guidance to 6 MCP tool descriptions across 2 files:
- `mcp/src/tools/databaseNoSQL.ts`: Added "本工具为服务端管理工具" with concrete examples of when NOT to use the tool (e.g., when the task says "用 JS SDK 登录并插入数据", write `@cloudbase/js-sdk` client code instead) to `readNoSqlDatabaseStructure`, `writeNoSqlDatabaseStructure`, `readNoSqlDatabaseContent`, and `writeNoSqlDatabaseContent`.
- `mcp/src/tools/

## Changed files
- `mcp/src/tools/app-auth.ts`
- `mcp/src/tools/databaseNoSQL.ts`