### PR TITLE
fix: MCP 工具 envQuery 查询 domains 返回字段不完整，缺少 createTime

### DIFF
--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1099,7 +1099,7 @@ describe("env tools - envQuery", () => {
     const payload = JSON.parse((await tools.envQuery.handler({ action: "domains" })).content[0].text);
 
     expect(payload).toMatchObject({
-      Domains: [{ Domain: "localhost:5173", Status: "ENABLE", Type: "USER" }],
+      Domains: [{ Id: "domain-1", Domain: "localhost:5173", CreateTime: "2026-04-08 10:00:00", Status: "ENABLE", Type: "USER" }],
       localDevHint: {
         format: "host:port",
         useActualOrigin: true,
@@ -1121,8 +1121,8 @@ describe("env tools - envQuery", () => {
         domains: ["<actual-browser-host>:<actual-browser-port>"],
       },
     });
-    expect(payload.Domains[0]).not.toHaveProperty("Id");
-    expect(payload.Domains[0]).not.toHaveProperty("CreateTime");
+    expect(payload.Domains[0]).toHaveProperty("Id");
+    expect(payload.Domains[0]).toHaveProperty("CreateTime");
   });
 
   it("envQuery(domains) should report configured local entries without inferring completeness", async () => {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -184,7 +184,10 @@ function simplifyEnvDomains(domains: unknown) {
 
     const source = domain as Record<string, unknown>;
     return {
+      ...(source.Id !== undefined ? { Id: source.Id } : {}),
       ...(source.Domain !== undefined ? { Domain: source.Domain } : {}),
+      ...(source.CreateTime !== undefined ? { CreateTime: source.CreateTime } : {}),
+      ...(source.UpdateTime !== undefined ? { UpdateTime: source.UpdateTime } : {}),
       ...(source.Status !== undefined ? { Status: source.Status } : {}),
       ...(source.Type !== undefined ? { Type: source.Type } : {}),
     };


### PR DESCRIPTION
## Attribution issue
- issueId: issue_moj9jjpg_7qu7tm
- category: tool
- canonicalTitle: MCP 工具 envQuery 查询 domains 返回字段不完整，缺少 createTime
- representativeRun: atomic-js-cloudbase-cli-cors-list-query/2026-04-28T23-32-51-ffbsf9

## Automation summary
- root_cause: The `simplifyEnvDomains` function in `mcp/src/tools/env.ts:175-192` only preserved `Domain`, `Status`, and `Type` fields from the API response, stripping `Id`, `CreateTime`, and `UpdateTime` that the CloudBase `DescribeAuthDomains` API returns. This caused `envQuery(action=domains)` to return incomplete domain objects missing `CreateTime`.
- changes: Added `Id`, `CreateTime`, and `UpdateTime` to the field list in `simplifyEnvDomains` at `mcp/src/tools/env.ts:186-191`. Updated the corresponding test in `mcp/src/tools/env.test.ts:1101-1125` to assert these fields ARE present (previously asserted they should NOT be present).
- validation: All 35 env tests pass, all 3 mandatory skill quality tests pass, TypeScript compiles cleanly.
- follow_up: None.

## Changed files
- `mcp/src/tools/env.test.ts`
- `mcp/src/tools/env.ts`