### PR TITLE
fix: MCP 工具缺失：NoSQL 数据库回档时间查询能力

### DIFF
--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -900,6 +900,80 @@ deleteCollection: 删除集合`),
       throw new Error(`不支持的操作类型: ${action}`);
     },
   );
+
+  // queryNoSqlDatabaseBackupTime - 查询 NoSQL 数据库可回档时间范围
+  server.registerTool?.(
+    "queryNoSqlDatabaseBackupTime",
+    {
+      title: "查询 NoSQL 数据库可回档时间范围",
+      description:
+        "查询 NoSQL 数据库（文档型数据库）的可回档时间范围，返回最早可回档时间和最晚可回档时间。适用于需要了解数据库备份恢复时间范围的场景。",
+      inputSchema: {
+        collectionName: z
+          .string()
+          .optional()
+          .describe("集合名称（可选），如需查询特定集合的回档时间范围可传入"),
+        instanceId: z
+          .string()
+          .optional()
+          .describe("可选：显式指定数据库实例ID；未传时会自动解析并缓存"),
+      },
+      annotations: {
+        readOnlyHint: true,
+        openWorldHint: true,
+        category: CATEGORY,
+      },
+    },
+    async ({ collectionName, instanceId }) => {
+      const cloudbase = await getManager();
+
+      const resolvedInstance = await resolveNoSqlInstanceId({
+        toolName: "queryNoSqlDatabaseBackupTime",
+        cloudbase,
+        cloudBaseOptions,
+        instanceIdOverride: instanceId,
+        collectionName: collectionName || "default",
+      });
+
+      const result = await cloudbase
+        .commonService("tcb", "2018-06-08")
+        .call({
+          Action: "DescribeBackupTime",
+          Param: {
+            EnvId: cloudBaseOptions?.envId,
+            TableName: collectionName,
+            Tag: resolvedInstance.instanceId,
+          },
+        });
+
+      logCloudBaseResult(server.logger, result);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                success: true,
+                requestId: result?.RequestId,
+                backupTimeRange: {
+                  earliestTime: result?.EarliestTime,
+                  latestTime: result?.LatestTime,
+                  startTime: result?.StartTime,
+                  endTime: result?.EndTime,
+                },
+                instanceId: resolvedInstance.instanceId,
+                collectionName: collectionName || null,
+                message: "获取 NoSQL 数据库可回档时间范围成功",
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+  );
 }
 
 async function insertDocuments({


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mo4ea1oa_jz44d0
- category: tool
- canonicalTitle: MCP 工具缺失：NoSQL 数据库回档时间查询能力
- representativeRun: atomic-js-cli-tcb-db-nosql-backup-time/2026-04-21T17-29-35-whmbre

## Automation summary
- **root_cause**: The MCP tools for NoSQL database were missing a tool to query backup/restore time range (回档时间). The evaluation expected a command like `tcb db nosql backup time` to query the backup time range, but this tool did not exist in the toolset.
- **changes**: Added a new tool `queryNoSqlDatabaseBackupTime` in `mcp/src/tools/databaseNoSQL.ts` with the following features:
- Tool name: `queryNoSqlDatabaseBackupTime`
- Purpose: Query NoSQL database backup/restore time range
- Parameters: `collectionName` (optional, for collection-specific queries) and `instanceId` (optional, for explicit instance specification)
- API call: Uses CloudBase API action `DescribeBackupTime` with `EnvId`, `TableName`, and `Tag` parameters
- Returns: JSON response with `backupTimeRange` containing `earliestTime`, `latestTime`, `startTime`, `endTime`, plus `instanceId` and `collectionName`
- Annotations: Marked as `readOnlyHint: true` and categorized under "NoSQL database"
- **validation**:
- TypeScript compilation passes with no errors
- All 15 existing NoSQL database tests pass
- All 10 skill-related regression tests pass (build-skills-repo, build-compat-config, skill-quality-standards)
- **follow

## Changed files
- `mcp/src/tools/databaseNoSQL.ts`