### PR TITLE
fix: MCP manageGateway/queryGateway 工具 envId 绑定失效，导致模型浪费大量轮次

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -14,6 +14,7 @@ const {
   mockDeleteCustomDomain,
   mockGetCloudBaseManager,
   mockLogCloudBaseResult,
+  mockGetEnvId,
 } = vi.hoisted(() => ({
   mockGetAccessList: vi.fn(),
   mockGetDomainList: vi.fn(),
@@ -26,11 +27,13 @@ const {
   mockDeleteCustomDomain: vi.fn(),
   mockGetCloudBaseManager: vi.fn(),
   mockLogCloudBaseResult: vi.fn(),
+  mockGetEnvId: vi.fn(),
 }));
 
 vi.mock("../cloudbase-manager.js", () => ({
   getCloudBaseManager: mockGetCloudBaseManager,
   logCloudBaseResult: mockLogCloudBaseResult,
+  getEnvId: mockGetEnvId,
 }));
 
 function createMockServer() {
@@ -66,6 +69,7 @@ describe("gateway tools", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
+    mockGetEnvId.mockResolvedValue("env-test");
     mockGetAccessList.mockResolvedValue({
       Total: 1,
       EnableService: true,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -1,5 +1,9 @@
 import { z } from "zod";
-import { getCloudBaseManager, logCloudBaseResult } from "../cloudbase-manager.js";
+import {
+  getCloudBaseManager,
+  getEnvId,
+  logCloudBaseResult,
+} from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import { jsonContent } from "../utils/json-content.js";
 
@@ -71,18 +75,10 @@ function normalizeAccessPath(path: string | undefined): string {
   return path.startsWith("/") ? path : `/${path}`;
 }
 
-function ensureGatewayEnvId(cloudBaseOptions?: { envId?: string }) {
-  const envId = cloudBaseOptions?.envId;
-  if (!envId) {
-    throw new Error("当前网关操作需要已绑定 envId");
-  }
-  return envId;
-}
-
 export function registerGatewayTools(server: ExtendedMcpServer) {
   const cloudBaseOptions = server.cloudBaseOptions;
   const getManager = () => getCloudBaseManager({ cloudBaseOptions });
-  const getGatewayEnvId = () => ensureGatewayEnvId(cloudBaseOptions);
+  const resolveEnvId = () => getEnvId(cloudBaseOptions);
 
   const buildEnvelope = (
     data: Record<string, unknown>,
@@ -129,7 +125,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
   const listHttpServiceRoutes = async (domain?: string) => {
     const cloudbase = await getManager();
     const result = await cloudbase.env.describeHttpServiceRoute({
-      EnvId: getGatewayEnvId(),
+      EnvId: await resolveEnvId(),
       ...(domain
         ? {
             Filters: [
@@ -177,7 +173,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     }
 
     return {
-      EnvId: getGatewayEnvId(),
+      EnvId: await resolveEnvId(),
       Domain: {
         Domain: await resolveRouteDomain(domain),
         Routes: [
@@ -423,7 +419,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       const cloudbase = await getManager();
       const domain = await resolveRouteDomain(input.domain);
       const result = await cloudbase.env.deleteHttpServiceRoute({
-        EnvId: getGatewayEnvId(),
+        EnvId: await resolveEnvId(),
         Domain: domain,
         Paths: [normalizeAccessPath(routePath)],
       } as any);
@@ -445,7 +441,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       }
       const cloudbase = await getManager();
       const result = await cloudbase.env.bindCustomDomain({
-        EnvId: getGatewayEnvId(),
+        EnvId: await resolveEnvId(),
         Domain: {
           Domain: input.domain,
           CertId: input.certificateId,
@@ -469,7 +465,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       }
       const cloudbase = await getManager();
       const result = await cloudbase.env.deleteCustomDomain({
-        EnvId: getGatewayEnvId(),
+        EnvId: await resolveEnvId(),
         Domain: input.domain,
       });
       logCloudBaseResult(server.logger, result);


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojcryx3_5bwnmf
- category: tool
- canonicalTitle: MCP manageGateway/queryGateway 工具 envId 绑定失效，导致模型浪费大量轮次
- representativeRun: atomic-js-cloudbase-cli-routes-lifecycle/2026-04-29T00-52-22-ysuwfx

## Automation summary
- root_cause: The `manageGateway` and `queryGateway` tools used a synchronous `ensureGatewayEnvId()` function that only checked `cloudBaseOptions?.envId` directly. When `cloudBaseOptions.envId` was not set at tool registration time (common when envId is auto-resolved via login state, cache, or env vars), the tools threw "当前网关操作需要已绑定 envId" instead of resolving the envId. Other tools like `manageFunctions` correctly use the async `getEnvId()` which auto-resolves from multiple sources (cloudBaseOptions, cached envId, CLOUDBASE_ENV_ID env var, login state, or EnvironmentManager). This mismatch caused the model to waste many turns retrying gateway operations that always failed.
- changes: In `mcp/src/tools/gateway.ts`, replaced the synchronous `ensureGatewayEnvId()` with the async `getEnvId()` from `cloudbase-manager.js`. Changed `getGatewayEnvId()` → `resolveEnvId()` (returns `Promise<string>`), and updated all 5 call sites to `await resolveEnvId()`. Updated `mcp/src/tools/gateway.test.ts` to mock `getEnvId` with `mockGetEnvId.mockResolvedValue("env-test")`.
- validation: All 9 gateway unit tests pass. All 10 regression tests (build-skills-repo, build-compat-config, skill-quality-stan

## Changed files
- `mcp/src/tools/gateway.test.ts`
- `mcp/src/tools/gateway.ts`