### PR TITLE
fix: callCloudApi MCP 工具的 schema/prompt 未清晰标注 CreateUser 必填参数（EnvId），且参数命名约定不明确导致模型首次调用失败

### DIFF
--- a/mcp/src/tools/capi.ts
+++ b/mcp/src/tools/capi.ts
@@ -189,7 +189,9 @@ export function registerCapiTools(server: ExtendedMcpServer) {
 **云函数**: \`DescribeFunctions\`、\`CreateFunction\`、\`UpdateFunctionCode\`、\`DeleteFunction\`
 **数据库**: \`CreateMySQLInstance\`、\`DescribeMySQLInstances\`、\`DestroyMySQLInstance\`
 
-销毁环境时，常见做法是至少带上 \`EnvId\` 和 \`BypassCheck: true\`，如果环境已经处于隔离期再按文档补 \`IsForce: true\`。`,
+销毁环境时，常见做法是至少带上 \`EnvId\` 和 \`BypassCheck: true\`，如果环境已经处于隔离期再按文档补 \`IsForce: true\`。
+
+**重要提示：** 几乎所有 tcb Action 都要求 \`EnvId\` 为顶层必填参数（如 \`CreateUser\`、\`ModifyUser\`、\`DescribeUserList\` 等）。调用前须先通过 auth 工具获取 \`current_env_id\`，并在 params 顶层传入 \`"EnvId": "<envId>"\`。参数须为扁平键值对，与官方 API 定义一致，不要嵌套包裹。例如创建用户：\`{ "EnvId": "env-xxx", "Name": "zhangsan", "Phone": "13800138000", "Type": "internalUser", "UserStatus": "ACTIVE" }\`（注意字段名为 \`Name\` 而非 \`UserName\`，\`Type\` 而非 \`UserType\`，\`UserStatus\` 而非 \`Status\`）。`,
             inputSchema: {
                 service: z
                     .enum(ALLOWED_SERVICES)
@@ -204,7 +206,7 @@ export function registerCapiTools(server: ExtendedMcpServer) {
                     .record(z.any())
                     .optional()
                     .describe(
-                        "Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；更新环境别名则可用 `{ \"service\": \"tcb\", \"action\": \"ModifyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"Alias\": \"demo\" } }`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。",
+                        "Action 对应的参数对象，键名为扁平键值对（与官方 API 定义一致，不要嵌套包裹）。几乎所有 tcb Action 都要求顶层传入 `EnvId`（可通过 auth 工具获取 `current_env_id`）；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；创建用户：`{ \"service\": \"tcb\", \"action\": \"CreateUser\", \"params\": { \"EnvId\": \"env-xxx\", \"Name\": \"zhangsan\", \"Phone\": \"13800138000\", \"Type\": \"internalUser\", \"UserStatus\": \"ACTIVE\" } }`。注意 CreateUser 的必填字段是 `EnvId` 和 `Name`（不是 `UserName`），用户类型字段是 `Type`（不是 `UserType`），状态字段是 `UserStatus`（不是 `Status`）。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。",
                     ),
             },
             annotations: {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojd35i1_ptw5mr
- category: tool
- canonicalTitle: callCloudApi MCP 工具的 schema/prompt 未清晰标注 CreateUser 必填参数（EnvId），且参数命名约定不明确导致模型首次调用失败
- representativeRun: atomic-js-cloudbase-cli-user-create/2026-04-29T01-10-03-cz94u1

## Automation summary
符号链接删除是之前就存在的，与我的更改无关。唯一修改的文件是 `mcp/src/tools/capi.ts`。 总结： - **根本原因**：`callCloudApi` 工具的描述模糊地写着“某些 Action 需要携带 EnvId”（某些操作需要 EnvId），这太弱了——几乎所有 `tcb` 操作都需要 `EnvId` 作为顶级必需参数。代理调用 `CreateUser` 时没有包含 `EnvId`，使用了错误的参数名（`UserName` 而不是 `Name`，`UserType` 而不是 `Type`，`Status` 而不是 `UserStatus`），并将参数嵌套在 `User` 对象中，而不是以扁平结构传递。该工具没有提供 `CreateUser` 的示例，也没有澄清参数命名约定。 - **更改**：更新了 `mcp/src/tools/capi.ts` 中 `callCloudApi` 工具的描述和 `params` 字段描述，以： 1. 明确指出几乎所有 `tcb` 操作都需要 `EnvId` 作为顶级参数（而不是模糊的“某些”） 2. 指导用户从 `auth` 工具的 `current_env_id` 获取 `EnvId` 3. 说明参数必须是扁平键值对（没有嵌套封装） 4. 添加一个 `CreateUser` 示例，展示正确的扁平参数结构 5. 明确澄清常见的命名混淆：`Name`（不是 `UserName`），`Type`（不是 `UserType`），`UserStatus`（不是 `Status`） - **验证**：TypeScript 编译干净，所有 3 个必选技能质量测试通过（10/10 测试），diff 中没有评估工件泄露。 - **后续行动**：无。这是一项真正的产品缺陷——工具描述不足导致模型在首次尝试时使用 `callCloudApi` 时失败。

## Changed files
- `mcp/src/tools/capi.ts`