### PR TITLE
fix: allinone Skill 云函数示例缺少 Node.js/CommonJS 环境说明，导致 LLM Judge 评估时报 require is not defined

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -238,7 +238,7 @@ Prefer long-term memory when available: write the scenarios and working rules th
 
 ### When Developing a Mini Program Project:
 1. **Platform**: Read the `miniprogram-development` skill for project structure, WeChat Developer Tools, and wx.cloud usage
-2. **Authentication**: Read the `auth-wechat` skill - Naturally login-free, get OPENID in cloud functions
+2. **Authentication**: Read the `auth-wechat` skill - Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)
 3. **Database**:
    - NoSQL: `no-sql-wx-mp-sdk` skill
    - MySQL: `relational-database-tool` skill (via tools)
@@ -319,7 +319,7 @@ For better UI/UX design, consider reading the `ui-design` skill which provides:
 
 ### Authentication Skills
 - **Web**: `auth-web` - Use Web SDK built-in authentication
-- **Mini Program**: `auth-wechat` - Naturally login-free, get OPENID in cloud functions
+- **Mini Program**: `auth-wechat` - Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)
 - **Node.js**: `auth-nodejs`
 - **Auth Tool**: `auth-tool` - Configure and manage authentication providers
 
@@ -359,7 +359,7 @@ For better UI/UX design, consider reading the `ui-design` skill which provides:
 4. **Deployment Order**: When there are backend dependencies, prioritize deploying backend before previewing frontend
 5. **Authentication Rules**: Use built-in authentication functions, distinguish authentication methods by platform
    - **Web Projects**: Use CloudBase Web SDK built-in authentication (refer to `auth-web`)
-   - **Mini Program Projects**: Naturally login-free, get OPENID in cloud functions (refer to `auth-wechat`)
+   - **Mini Program Projects**: Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`) (refer to `auth-wechat`)
    - **Native Apps**: Use HTTP API for authentication (refer to `http-api`)
 6. **Native App Development**: CloudBase SDK is NOT available for native apps, MUST use HTTP API. Only MySQL database is supported.
 

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -375,7 +375,7 @@ When users request deployment to CloudBase:
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `manageFunctions(action="createFunction")` / `manageFunctions(action="updateFunctionCode")`
      - Legacy compatibility: if older materials mention `createFunction`, `updateFunctionCode`, or `getFunctionList`, map them to `manageFunctions(...)` and `queryFunctions(...)`
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must use CommonJS (`require()`, `exports.main`) — do not use `import`/`export` syntax in Event Functions.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - **Alternative: CLI Deployment** — If MCP is unavailable or the user prefers CLI, read the `cloudbase-cli` skill for `tcb`-based deployment workflows (functions, CloudRun, hosting).
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -47,7 +47,7 @@ If a skill points to its own `references/...` files, keep following those relati
 | Web login / registration / auth UI | `auth-tool` | `auth-web`, `web-development` | `cloud-functions`, `http-api` | Provider status and publishable key |
 | WeChat mini program + CloudBase | `miniprogram-development` | `auth-wechat`, `no-sql-wx-mp-sdk` | `auth-web`, `web-development` | Whether the project really uses CloudBase / `wx.cloud` |
 | Native App / Flutter / React Native | `http-api` | `auth-tool`, `relational-database-tool` | `auth-web`, `web-development`, `no-sql-web-sdk` | SDK boundary, OpenAPI, auth method |
-| Cloud Functions | `cloud-functions` | domain skill as needed | `cloudrun-development` | Event vs HTTP function, runtime, `scf_bootstrap` |
+| Cloud Functions | `cloud-functions` | domain skill as needed | `cloudrun-development` | Event vs HTTP function, CommonJS vs ESM, runtime, `scf_bootstrap` |
 | CloudRun backend | `cloudrun-development` | domain skill as needed | `cloud-functions` | Container boundary, Dockerfile, CORS |
 | AI Agent (智能体开发) | `cloudbase-agent` |  domain skill as needed | `cloud-functions`,`cloudrun-development`, | AG-UI protocol, scf_bootstrap, SSE streaming |
 | UI generation | `ui-design` | platform skill | backend-only skills | Design specification first |

--- a/config/source/skills/auth-wechat/SKILL.md
+++ b/config/source/skills/auth-wechat/SKILL.md
@@ -85,6 +85,7 @@ Use it when you need to:
 
 4. **Follow CloudBase API shapes exactly**
    - Use `wx-server-sdk` in cloud functions
+   - Treat cloud-function examples in this file as Node.js Event Functions that must stay in CommonJS: use `require()` and `exports.main`, keep the entry file as `index.js`, and do not add `"type": "module"` to `package.json`
    - Use `wx.cloud` in Mini Program client code
    - Treat method names and parameter shapes in this file as canonical
 
@@ -151,7 +152,9 @@ App({
 
 ### Scenario 2: Get user identity in a cloud function
 
-Use this when you need to know **who is calling** your cloud function:
+Use this when you need to know **who is calling** your cloud function.
+
+This example is a **Node.js Event Function**. Keep the entry file as `index.js`, use CommonJS (`require()`, `exports.main`), and do not set `"type": "module"` in `package.json`, or the function can fail with `require is not defined` / `Cannot use import statement outside a module`.
 
 ```js
 // Cloud function: cloudfunctions/getUserInfo/index.js

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -49,6 +49,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Picking the wrong function type and trying to compensate later.
 - Confusing official CloudBase API client work with building your own HTTP function.
 - Mixing Event Function code shape (`exports.main(event, context)`) with HTTP Function code shape (`req` / `res` on port `9000`).
+- Using ES Module syntax (`import ...`, `export ...`) in Event Functions. Event Functions run in a CommonJS environment — always use `require()` and `exports.main`. Using `import` will cause a `require is not defined` or `Cannot use import statement outside a module` runtime error.
 - Treating HTTP Access as the implementation model for HTTP Functions. HTTP Access is a gateway configuration for Event Functions, not the HTTP Function runtime model.
 - Assuming `db.collection("name").add(...)` will create a missing document-database collection automatically. Collection creation is a separate management step.
 - Forgetting that runtime cannot be changed after creation.

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -7,15 +7,17 @@ Use this checklist before creating or updating a CloudBase function.
 1. Decide whether this is an Event Function or an HTTP Function.
    - Event Function: `exports.main(event, context)`, SDK/timer driven
    - HTTP Function: `req` / `res`, listens on port `9000`
-2. Pick the runtime before creation and state it explicitly.
-3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
-4. Confirm the function root path points to the parent directory, not the function directory itself.
-5. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
-6. If the request is really for a long-running container service, reroute to `cloudrun-development`.
+2. For Event Functions, confirm the code uses CommonJS: `require()` for imports, `exports.main` for the handler. Do not use `import` or `export` syntax — the runtime is CommonJS only.
+3. Pick the runtime before creation and state it explicitly.
+4. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
+5. Confirm the function root path points to the parent directory, not the function directory itself.
+6. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
+7. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
 
 - Choosing the wrong function type and compensating later.
+- Using ES Module syntax (`import`, `export`) in Event Functions instead of CommonJS (`require()`, `exports.main`).
 - Mixing Event Function and HTTP Function handler shapes in the same implementation.
 - Forgetting that runtime cannot be changed after creation.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.

--- a/config/source/skills/cloud-functions/references/event-functions.md
+++ b/config/source/skills/cloud-functions/references/event-functions.md
@@ -9,7 +9,37 @@ Use this reference when the task is clearly about an Event Function (`exports.ma
 - Event Functions auto-install dependencies from `package.json` during deployment, so you normally do not ship `node_modules`.
 - The function root path must point to the parent directory that contains the function folder.
 
-## Minimal structure
+## Module system: CommonJS only
+
+Event Functions run in a **CommonJS** Node.js environment. This has important implications for how you write function code:
+
+- **Use `require()` to import dependencies** — not `import`. The Event Function runtime does not support ES Module syntax.
+- **Use `exports.main` or `module.exports` to export the handler** — the `exports.main = async (event, context) => {}` pattern is CommonJS.
+- **Do not add `"type": "module"` to `package.json`** — this will cause the function to fail at runtime with `require is not defined` or `Cannot use import statement outside a module`.
+- **Do not use `import ... from ...` syntax** in Event Function code. If you need the `wx-server-sdk` or `@cloudbase/node-sdk`, load it with `require()`.
+
+```javascript
+// ✅ Correct: CommonJS in Event Function
+const cloud = require("wx-server-sdk");
+cloud.init();
+
+exports.main = async (event, context) => {
+  const wxContext = cloud.getWXContext();
+  return {
+    OPENID: wxContext.OPENID,
+    APPID: wxContext.APPID,
+  };
+};
+```
+
+```javascript
+// ❌ Wrong: ESM in Event Function — will fail at runtime
+import cloud from "wx-server-sdk"; // SyntaxError: Cannot use import statement
+
+export const main = async (event, context) => { ... }; // Also wrong
+```
+
+### Minimal structure
 
 ```text
 cloudfunctions/

--- a/config/source/skills/miniprogram-development/references/cloudbase-integration.md
+++ b/config/source/skills/miniprogram-development/references/cloudbase-integration.md
@@ -78,6 +78,8 @@ Mini program CloudBase is **naturally login-free**.
 - Do **not** generate login pages or login flows.
 - Do **not** port Web authentication patterns into mini programs.
 - In cloud functions, retrieve user identity with `cloud.getWXContext().OPENID`.
+- This cloud-function pattern is a Node.js Event Function, so keep it in CommonJS: use `require()` + `exports.main`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
+- If you want ES Modules for shared business logic, keep the CloudBase entrypoint as CommonJS and delegate with dynamic `import()` from `index.js` rather than changing the handler itself to ESM.
 
 ```js
 const cloud = require("wx-server-sdk");

--- a/mcp/AGENTS.md
+++ b/mcp/AGENTS.md
@@ -113,7 +113,7 @@ When you see "Read `{auth-web}` rule file" in this document:
 3. **⚠️ UI Design (CRITICAL)**: **MUST read `rules/ui-design/rule.md` FIRST before generating any page, interface, component, or style** - This is NOT optional. You MUST explicitly read this file and output the design specification before writing any UI code.
 4. **Core Capabilities**: Read Core Capabilities section below (especially UI Design and Database + Authentication for Mini Program)
 5. **Platform Rules**: Read `rules/miniprogram-development/rule.md` for platform-specific rules (project structure, WeChat Developer Tools, wx.cloud usage)
-6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 7. **Database**:
    - NoSQL: `rules/no-sql-wx-mp-sdk/rule.md`
    - MySQL: `rules/relational-database-tool/rule.md` (via tools)
@@ -397,7 +397,7 @@ For example, many interfaces require a confirm parameter, which is a boolean typ
 
 ### Authentication Skills
 - **Web**: `rules/auth-web/rule.md` - **MUST use Web SDK built-in authentication**
-- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 - **Node.js**: `rules/auth-nodejs/rule.md`
 - **Auth Tool (MCP)**: `rules/auth-tool/rule.md` - Configure and manage authentication providers (enable/disable login methods, setup provider settings) via MCP tools
 
@@ -476,7 +476,7 @@ When users request deployment to CloudBase:
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `manageFunctions(action="createFunction")` / `manageFunctions(action="updateFunctionCode")`
      - Legacy compatibility: if older materials mention `createFunction`, `updateFunctionCode`, or `getFunctionList`, map them to the converged tools first
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must stay in CommonJS: use `require()`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run
    - Ensure backend code supports CORS by default

--- a/mcp/CLAUDE.md
+++ b/mcp/CLAUDE.md
@@ -102,7 +102,7 @@ When you see "Read `{auth-web}` rule file" in this document:
 3. **⚠️ UI Design (CRITICAL)**: **MUST read `rules/ui-design/rule.md` FIRST before generating any page, interface, component, or style** - This is NOT optional. You MUST explicitly read this file and output the design specification before writing any UI code.
 4. **Core Capabilities**: Read Core Capabilities section below (especially UI Design and Database + Authentication for Mini Program)
 5. **Platform Rules**: Read `rules/miniprogram-development/rule.md` for platform-specific rules (project structure, WeChat Developer Tools, wx.cloud usage)
-6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 7. **Database**:
    - NoSQL: `rules/no-sql-wx-mp-sdk/rule.md`
    - MySQL: `rules/relational-database-tool/rule.md` (via tools)
@@ -386,7 +386,7 @@ For example, many interfaces require a confirm parameter, which is a boolean typ
 
 ### Authentication Skills
 - **Web**: `rules/auth-web/rule.md` - **MUST use Web SDK built-in authentication**
-- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 - **Node.js**: `rules/auth-nodejs/rule.md`
 - **Auth Tool (MCP)**: `rules/auth-tool/rule.md` - Configure and manage authentication providers (enable/disable login methods, setup provider settings) via MCP tools
 
@@ -465,7 +465,7 @@ When users request deployment to CloudBase:
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `manageFunctions(action="createFunction")` / `manageFunctions(action="updateFunctionCode")`
      - Legacy compatibility: if older materials mention `createFunction`, `updateFunctionCode`, or `getFunctionList`, map them to the converged tools first
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must stay in CommonJS: use `require()`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run
    - Ensure backend code supports CORS by default

--- a/mcp/CODEBUDDY.md
+++ b/mcp/CODEBUDDY.md
@@ -76,7 +76,7 @@ When you see "Read `{auth-web}` rule file" in this document:
 3. **⚠️ UI Design (CRITICAL)**: **MUST read `rules/ui-design/rule.md` FIRST before generating any page, interface, component, or style** - This is NOT optional. You MUST explicitly read this file and output the design specification before writing any UI code.
 4. **Core Capabilities**: Read Core Capabilities section below (especially UI Design and Database + Authentication for Mini Program)
 5. **Platform Rules**: Read `rules/miniprogram-development/rule.md` for platform-specific rules (project structure, WeChat Developer Tools, wx.cloud usage)
-6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 7. **Database**: 
    - NoSQL: `rules/no-sql-wx-mp-sdk/rule.md`
    - MySQL: `rules/relational-database-tool/rule.md` (via tools)
@@ -353,7 +353,7 @@ For example, many interfaces require a confirm parameter, which is a boolean typ
 
 ### Authentication Skills
 - **Web**: `rules/auth-web/rule.md` - **MUST use Web SDK built-in authentication**
-- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 - **Node.js**: `rules/auth-nodejs/rule.md`
 - **HTTP API**: `rules/auth-http-api/rule.md`
 - **Auth Tool (MCP)**: `rules/auth-tool/rule.md` - Configure and manage authentication providers (enable/disable login methods, setup provider settings) via MCP tools

--- a/mcp/IFLOW.md
+++ b/mcp/IFLOW.md
@@ -102,7 +102,7 @@ When you see "Read `{auth-web}` rule file" in this document:
 3. **⚠️ UI Design (CRITICAL)**: **MUST read `rules/ui-design/rule.md` FIRST before generating any page, interface, component, or style** - This is NOT optional. You MUST explicitly read this file and output the design specification before writing any UI code.
 4. **Core Capabilities**: Read Core Capabilities section below (especially UI Design and Database + Authentication for Mini Program)
 5. **Platform Rules**: Read `rules/miniprogram-development/rule.md` for platform-specific rules (project structure, WeChat Developer Tools, wx.cloud usage)
-6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+6. **Authentication**: Read `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 7. **Database**:
    - NoSQL: `rules/no-sql-wx-mp-sdk/rule.md`
    - MySQL: `rules/relational-database-tool/rule.md` (via tools)
@@ -386,7 +386,7 @@ For example, many interfaces require a confirm parameter, which is a boolean typ
 
 ### Authentication Skills
 - **Web**: `rules/auth-web/rule.md` - **MUST use Web SDK built-in authentication**
-- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free, get OPENID in cloud functions**
+- **Mini Program**: `rules/auth-wechat/rule.md` - **Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)**
 - **Node.js**: `rules/auth-nodejs/rule.md`
 - **Auth Tool (MCP)**: `rules/auth-tool/rule.md` - Configure and manage authentication providers (enable/disable login methods, setup provider settings) via MCP tools
 
@@ -465,7 +465,7 @@ When users request deployment to CloudBase:
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `manageFunctions(action="createFunction")` / `manageFunctions(action="updateFunctionCode")`
      - Legacy compatibility: if older materials mention `createFunction`, `updateFunctionCode`, or `getFunctionList`, map them to the converged tools first
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must stay in CommonJS: use `require()`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run
    - Ensure backend code supports CORS by default

--- a/scripts/prompts/cloudbase-integrated.md
+++ b/scripts/prompts/cloudbase-integrated.md
@@ -31,7 +31,7 @@ When user mentions login/auth requirements:
 - **MUST enable** required auth methods before implementing frontend code
 - **Platform differences**:
   - **Web**: MUST use Web SDK built-in auth (`.codebuddy/rules/tcb/rules/auth-web/rule.md`)
-  - **Mini Program**: Naturally login-free, get OPENID in cloud functions (`.codebuddy/rules/tcb/rules/auth-wechat/rule.md`)
+  - **Mini Program**: Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`) (`.codebuddy/rules/tcb/rules/auth-wechat/rule.md`)
   - **Native Apps**: MUST use HTTP API (`.codebuddy/rules/tcb/rules/http-api/rule.md`)
 
 ### 4. Platform-Specific Rules
@@ -83,7 +83,7 @@ When users request deployment to CloudBase:
 
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `manageFunctions(action="createFunction")` / `manageFunctions(action="updateFunctionCode")`
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must stay in CommonJS: use `require()`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run
    - Ensure backend code supports CORS by default

--- a/scripts/skills-repo-template/cloudbase-guidelines/SKILL.md
+++ b/scripts/skills-repo-template/cloudbase-guidelines/SKILL.md
@@ -198,7 +198,7 @@ Prefer long-term memory when available: write the scenarios and working rules th
 
 ### When Developing a Mini Program Project:
 1. **Platform**: Read the `miniprogram-development` skill for project structure, WeChat Developer Tools, and wx.cloud usage
-2. **Authentication**: Read the `auth-wechat` skill - Naturally login-free, get OPENID in cloud functions
+2. **Authentication**: Read the `auth-wechat` skill - Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)
 3. **Database**:
    - NoSQL: `no-sql-wx-mp-sdk` skill
    - MySQL: `relational-database-tool` skill (via tools)
@@ -298,7 +298,7 @@ For better UI/UX design, consider reading the `ui-design` skill which provides:
 
 ### Authentication Skills
 - **Web**: `auth-web` - Use Web SDK built-in authentication
-- **Mini Program**: `auth-wechat` - Naturally login-free, get OPENID in cloud functions
+- **Mini Program**: `auth-wechat` - Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`)
 - **Node.js**: `auth-nodejs`
 - **Auth Tool**: `auth-tool` - Configure and manage authentication providers
 
@@ -332,7 +332,7 @@ For better UI/UX design, consider reading the `ui-design` skill which provides:
 4. **Deployment Order**: When there are backend dependencies, prioritize deploying backend before previewing frontend
 5. **Authentication Rules**: Use built-in authentication functions, distinguish authentication methods by platform
    - **Web Projects**: Use CloudBase Web SDK built-in authentication (refer to `auth-web`)
-   - **Mini Program Projects**: Naturally login-free, get OPENID in cloud functions (refer to `auth-wechat`)
+   - **Mini Program Projects**: Naturally login-free; get OPENID in cloud functions, which are Node.js Event Functions that must stay in CommonJS (`require()`, `exports.main`, no `"type": "module"`) (refer to `auth-wechat`)
    - **Native Apps**: Use HTTP API for authentication (refer to `http-api`)
 6. **Native App Development**: CloudBase SDK is NOT available for native apps, MUST use HTTP API. Only MySQL database is supported.
 
@@ -347,7 +347,7 @@ When users request deployment to CloudBase:
 
 1. **Backend Deployment (if applicable)**:
    - Only for Node.js cloud functions: deploy directly using `createFunction` tools
-     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}`.
+     - Before deploying, decide whether the function is Event or HTTP. Event Functions use `exports.main = async (event, context) => {}` and must stay in CommonJS: use `require()`, keep the entry file as `index.js`, and do not set `"type": "module"` in `package.json`.
      - HTTP Functions are standard web services: they must listen on port `9000`, include `scf_bootstrap`, and for Node.js should default to native `http.createServer((req, res) => { ... })`. Parse `req.url` and the streamed request body manually, set response headers explicitly, and do not write the function as `exports.main` unless you intentionally choose Functions Framework.
    - For other languages backend server (Java, Go, PHP, Python, Node.js): deploy to Cloud Run
    - Ensure backend code supports CORS by default


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojfr7pz_cpmu9w
- category: skill
- canonicalTitle: allinone Skill 云函数示例缺少 Node.js/CommonJS 环境说明，导致 LLM Judge 评估时报 require is not defined
- representativeRun: atomic-js-cloudbase-get-wx-context/2026-04-29T02-24-06-mter1i

## Automation summary
SUMMARY:
- root_cause: The cloud-functions skill's Event Function documentation lacked any CommonJS/Node.js module system guidance. While HTTP Functions had explicit CommonJS vs ESM guidance (in both SKILL.md and http-functions.md), Event Functions had no such guidance. Agents reading the skill could infer ESM was acceptable since the Web invocation example used `import cloudbase from "@cloudbase/js-sdk"`, leading to `require is not defined` or `Cannot use import statement` runtime errors when writing Event Function code.
- changes: Added CommonJS/Node.js environment guidance across 4 files in `config/source/`:
1. `cloud-functions/references/event-functions.md` — Added new "Module system: CommonJS only" section with explicit rules (`require()` not `import`, `exports.main` not `export`, no `"type": "module"` in package.json), correct example using `wx-server-sdk` + `getWXContext()`, and wrong ESM example showing the failure.
2. `cloud-functions/SKILL.md` — Added gotcha: "Using ES Module syntax in Event Functions" to the Common mistakes section.
3. `cloud-functions/checklist.md` — Added CommonJS check as step 2 in Required checks, and added ESM failure pattern to Common failure patte

## Changed files
- `config/source/guideline/cloudbase/SKILL.md`
- `config/source/skills/cloud-functions/SKILL.md`
- `config/source/skills/cloud-functions/checklist.md`
- `config/source/skills/cloud-functions/references/event-functions.md`