### PR TITLE
fix: queryGateway 工具未返回明确的外部调用 URL，导致评测系统使用错误主机名触发 SSL 证书不匹配

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -272,10 +272,13 @@ describe("gateway tools", () => {
         targetName: "helloFn",
         total: 1,
         domains: ["env-test.app.tcloudbase.com", "api.example.com"],
+        defaultDomain: "env-test.app.tcloudbase.com",
+        customDomains: ["api.example.com"],
         urls: [
           "https://env-test.app.tcloudbase.com/api/hello",
           "https://api.example.com/api/hello",
         ],
+        defaultUrl: "https://env-test.app.tcloudbase.com/api/hello",
         enableService: true,
       },
       nextActions: [

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -207,6 +207,8 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         {
           action: input.action,
           domains: result.domains,
+          defaultDomain: result.raw.DefaultDomain,
+          customDomains: result.raw.ServiceSet?.map((item) => item.Domain) ?? [],
           enableService: result.enableService,
           raw: result.raw,
         },
@@ -226,6 +228,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         {
           action: input.action,
           domains: result.raw.ServiceSet ?? [],
+          defaultDomain: result.raw.DefaultDomain,
           total: (result.raw.ServiceSet ?? []).length,
           raw: result.raw,
         },
@@ -241,6 +244,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           action: input.action,
           routes,
           total: result.TotalCount ?? routes.length,
+          defaultDomain: result.OriginDomain,
           raw: result,
         },
         `已获取 ${result.TotalCount ?? routes.length} 条 HTTP 路由`,
@@ -260,6 +264,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           action: input.action,
           routeId: input.routeId ?? null,
           route,
+          defaultDomain: result.OriginDomain,
           raw: result,
         },
         route ? "已获取路由详情" : "未找到对应路由",
@@ -289,6 +294,12 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         ),
       );
 
+      // 使用默认域名生成外部调用 URL，避免使用自定义域名导致 SSL 证书不匹配
+      const defaultDomain = domainInfo.raw.DefaultDomain;
+      const defaultUrl = (accessList.APISet || []).length > 0
+        ? `https://${defaultDomain}${normalizeAccessPath(accessList.APISet[0].Path)}`
+        : null;
+
       return buildEnvelope(
         {
           action: input.action,
@@ -297,7 +308,10 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           apis: accessList.APISet || [],
           total: accessList.Total || 0,
           domains: domainInfo.domains,
+          defaultDomain,
+          customDomains: domainInfo.raw.ServiceSet?.map((item) => item.Domain) ?? [],
           urls,
+          defaultUrl,
           enableService:
             accessList.EnableService ?? domainInfo.enableService ?? false,
           raw: {


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojgqzg4_otl94f
- category: tool
- canonicalTitle: queryGateway 工具未返回明确的外部调用 URL，导致评测系统使用错误主机名触发 SSL 证书不匹配
- representativeRun: atomic-js-cloudbase-http-function-deploy/2026-04-29T02-50-37-pwc47p

## Automation summary
- **root_cause**: The `queryGateway` tool's `getAccess` action returned multiple domains and URLs without explicitly indicating which one is the "external" URL to use. This caused evaluation systems to potentially pick the wrong hostname (e.g., a custom domain without proper SSL certificate), leading to SSL certificate mismatch errors.
- **changes**:
1. Added `defaultDomain` field to `listDomains`, `listCustomDomains`, `listRoutes`, and `getRoute` actions to explicitly indicate the default domain.
2. Added `customDomains` field to `listDomains` and `getAccess` actions to list only custom domains separately.
3. Added `defaultUrl` field to `getAccess` action - this provides a clear, explicit external call URL using the default domain (`DefaultDomain`) which is guaranteed to have SSL configured by CloudBase.
- **validation**:
- All gateway tests pass (9/9)
- All skill quality tests pass (9/9)
- TypeScript compilation succeeds without errors
- Build completes successfully
- **follow_up**: The fix adds explicit `defaultUrl` field that returns a URL like `<redacted-url> using the CloudBase-provided default domain. This ensures evaluators and users can clea

## Changed files
- `mcp/src/tools/gateway.test.ts`
- `mcp/src/tools/gateway.ts`