### PR TITLE
fix: manageSqlDatabase provisionMySQL 在 MySQL 未开通时失败：工具内部先调用 DescribeMySQLClusterDetail，因实例不存在而报错，未实际发起创建请求

### DIFF
--- a/mcp/src/tools/databaseSQL.test.ts
+++ b/mcp/src/tools/databaseSQL.test.ts
@@ -575,4 +575,101 @@ describe("SQL database tools", () => {
       },
     });
   });
+
+  it("manageSqlDatabase(provisionMySQL) proceeds when DescribeCreateMySQLResult throws ResourceNotFound", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "DescribeCreateMySQLResult") {
+        throw Object.assign(new Error("ResourceNotFound"), {
+          code: "ResourceNotFound",
+        });
+      }
+      if (Action === "CreateMySQL") {
+        return {
+          RequestId: "req-provision",
+          Data: {
+            TaskId: "38662",
+          },
+        };
+      }
+      throw new Error(`unexpected action: ${Action}`);
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.manageSqlDatabase.handler({
+      action: "provisionMySQL",
+      confirm: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCommonServiceCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Action: "CreateMySQL",
+        Param: expect.objectContaining({
+          EnvId: "env-test",
+          DbInstanceType: "MYSQL",
+        }),
+      }),
+    );
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        task: {
+          request: {
+            TaskId: "38662",
+          },
+        },
+      },
+    });
+  });
+
+  it("manageSqlDatabase(provisionMySQL) proceeds when DescribeMySQLClusterDetail throws unexpected not-found error", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+        };
+      }
+      if (Action === "DescribeMySQLClusterDetail") {
+        throw Object.assign(new Error("cluster not found"), {
+          code: "ClusterNotFound",
+        });
+      }
+      if (Action === "CreateMySQL") {
+        return {
+          RequestId: "req-provision",
+          Data: {
+            TaskId: "38663",
+          },
+        };
+      }
+      throw new Error(`unexpected action: ${Action}`);
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.manageSqlDatabase.handler({
+      action: "provisionMySQL",
+      confirm: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCommonServiceCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Action: "CreateMySQL",
+        Param: expect.objectContaining({
+          EnvId: "env-test",
+          DbInstanceType: "MYSQL",
+        }),
+      }),
+    );
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        task: {
+          request: {
+            TaskId: "38663",
+          },
+        },
+      },
+    });
+  });
 });

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -390,6 +390,35 @@ async function callSqlControlPlane(
   }) as Promise<TcbServiceResult>;
 }
 
+function isNotFoundErrorCode(errorCode: string | undefined): boolean {
+  if (!errorCode) return false;
+  const upper = errorCode.toUpperCase();
+  return (
+    upper.includes("DATASOURCENOTEXIST") ||
+    upper.includes("RESOURCENOTFOUND") ||
+    upper.includes("NOTFOUND") ||
+    upper.includes("NOT_EXIST") ||
+    upper.includes("NOTEXIST") ||
+    upper.includes("DOESNOTEXIST") ||
+    upper.includes("CLUSTERNOTFOUND") ||
+    upper.includes("INSTANCENOTFOUND")
+  );
+}
+
+function isNotFoundErrorMessage(message: string | undefined): boolean {
+  if (!message) return false;
+  const lower = message.toLowerCase();
+  return (
+    lower.includes("database instance not found") ||
+    lower.includes("not found") ||
+    lower.includes("not exist") ||
+    lower.includes("does not exist") ||
+    lower.includes("no such") ||
+    lower.includes("cluster not found") ||
+    lower.includes("instance not found")
+  );
+}
+
 async function getSqlInstanceInfo({
   getManager,
   cloudBaseOptions,
@@ -397,14 +426,36 @@ async function getSqlInstanceInfo({
 }: QueryManageContext): Promise<InstanceInfoResult> {
   const cloudbase = await getManager();
   const envId = await getEnvId(cloudBaseOptions);
-  const createResult = await callSqlControlPlane(cloudbase, "DescribeCreateMySQLResult", {
-    EnvId: envId,
-  });
-  logCloudBaseResult(server.logger, createResult);
 
-  const createData = pickDataPayload(createResult);
-  const createRawStatus = createData?.Status ?? pickLifecycleSource(createResult);
-  const createStatus = normalizeCreateResultStatus(createRawStatus);
+  let createResult: TcbServiceResult;
+  let createData: Record<string, unknown> | undefined;
+  let createRawStatus: unknown;
+  let createStatus: SqlLifecycleStatus;
+
+  try {
+    createResult = await callSqlControlPlane(cloudbase, "DescribeCreateMySQLResult", {
+      EnvId: envId,
+    });
+    logCloudBaseResult(server.logger, createResult);
+
+    createData = pickDataPayload(createResult);
+    createRawStatus = createData?.Status ?? pickLifecycleSource(createResult);
+    createStatus = normalizeCreateResultStatus(createRawStatus);
+  } catch (error) {
+    const errorCode = extractErrorCode(error);
+    if (isNotFoundErrorCode(errorCode) || isNotFoundErrorMessage((error as Error)?.message)) {
+      return {
+        exists: false,
+        envId,
+        instanceId: "default",
+        schema: envId,
+        rawStatus: null,
+        status: "NOT_CREATED",
+        createResult: undefined,
+      };
+    }
+    throw error;
+  }
 
   if (createStatus === "NOT_CREATED") {
     return {
@@ -471,20 +522,27 @@ async function getSqlInstanceInfo({
     };
   } catch (error) {
     const errorCode = extractErrorCode(error);
-    const isNotFound = errorCode === "FailedOperation.DataSourceNotExist";
+    const isNotFound =
+      isNotFoundErrorCode(errorCode) ||
+      isNotFoundErrorMessage((error as Error)?.message);
 
     if (!isNotFound) {
       throw error;
     }
 
+    const hasExplicitPendingStatus =
+      typeof createRawStatus === "string" &&
+      createRawStatus.trim().length > 0 &&
+      createStatus === "PENDING";
+
     return {
-      exists: createStatus === "PENDING" || createStatus === "RUNNING",
+      exists: hasExplicitPendingStatus || createStatus === "RUNNING",
       envId,
       instanceId: "default",
       schema: envId,
       rawStatus:
         typeof createRawStatus === "string" ? createRawStatus : null,
-      status: createStatus,
+      status: hasExplicitPendingStatus ? createStatus : "NOT_CREATED",
       createResult: createData ?? createResult,
     };
   }
@@ -622,7 +680,7 @@ async function handleRunQuery(
     logCloudBaseResult(context.server.logger, result);
   } catch (error: any) {
     const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-    if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
+    if (isNotFoundErrorCode(errorCode) || isNotFoundErrorMessage(error.message)) {
       return buildSqlToolResult({
         success: false,
         errorCode: "MYSQL_NOT_CREATED",
@@ -784,9 +842,11 @@ async function handleProvisionMySQL(
 
   const existing = await getSqlInstanceInfo(context);
   if (
-    existing.status === "READY" ||
-    existing.status === "PENDING" ||
-    existing.status === "RUNNING"
+    existing.exists && (
+      existing.status === "READY" ||
+      existing.status === "PENDING" ||
+      existing.status === "RUNNING"
+    )
   ) {
     return buildSqlToolResult({
       success: true,
@@ -991,7 +1051,7 @@ async function handleRunStatement(
     logCloudBaseResult(context.server.logger, result);
   } catch (error: any) {
     const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-    if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
+    if (isNotFoundErrorCode(errorCode) || isNotFoundErrorMessage(error.message)) {
       return buildSqlToolResult({
         success: false,
         errorCode: "MYSQL_NOT_CREATED",
@@ -1156,7 +1216,7 @@ async function handleInitializeSchema(
         logCloudBaseResult(context.server.logger, result);
       } catch (error: any) {
         const errorCode = typeof error === "object" && error && "code" in error ? (error as any).code : "";
-        if (errorCode === "FailedOperation.DataSourceNotExist" || error.message?.includes("Database instance not found")) {
+        if (isNotFoundErrorCode(errorCode) || isNotFoundErrorMessage(error.message)) {
           return buildSqlToolResult({
             success: false,
             errorCode: "MYSQL_NOT_CREATED",


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojq90qw_rpi3r0
- category: tool
- canonicalTitle: manageSqlDatabase provisionMySQL 在 MySQL 未开通时失败：工具内部先调用 DescribeMySQLClusterDetail，因实例不存在而报错，未实际发起创建请求
- representativeRun: atomic-js-none-chain-mysql-from-none-to-usable/2026-04-29T07-10-48-1inf0c

## Automation summary
- root_cause: `manageSqlDatabase provisionMySQL` failed when MySQL was not yet created because `getSqlInstanceInfo` had two bugs: (1) `DescribeCreateMySQLResult` was not wrapped in a try-catch, so if it threw an error (e.g., `ResourceNotFound`) when MySQL never existed, the error propagated unhandled and the `CreateMySQL` call was never made; (2) the `DescribeMySQLClusterDetail` catch only handled `FailedOperation.DataSourceNotExist` but not other not-found error codes (e.g., `ClusterNotFound`, `ResourceNotFound`), causing the error to be re-thrown instead of being treated as "instance doesn't exist"; (3) when `DescribeCreateMySQLResult` returned null/empty status (normalized to `PENDING`), the `DescribeMySQLClusterDetail` catch incorrectly set `exists: true`, causing `handleProvisionMySQL` to skip creating MySQL thinking it already existed.
- changes: In `mcp/src/tools/databaseSQL.ts`: (1) Added `isNotFoundErrorCode` and `isNotFoundErrorMessage` helper functions that match a broad range of not-found error patterns; (2) Wrapped `DescribeCreateMySQLResult` in a try-catch that returns `{exists: false, status: "NOT_CREATED"}` for not-found errors; (3) Broadened `DescribeMySQLClusterDe

## Changed files
- `mcp/src/tools/databaseSQL.test.ts`
- `mcp/src/tools/databaseSQL.ts`