### PR TITLE
fix: MCP writeNoSqlDatabaseContent 缺少嵌套对象部分更新的清晰文档与示例，易导致整块替换而非局部更新

### DIFF
--- a/mcp/src/tools/databaseNoSQL.test.ts
+++ b/mcp/src/tools/databaseNoSQL.test.ts
@@ -250,11 +250,11 @@ describe("NoSQL database tools", () => {
     expect(meta.description).toContain("MongoDB updateOne/updateMany");
     expect(meta.description).toContain("`$set`、`$inc`、`$push`");
     expect(meta.description).toContain("`_id` 就是该 `uid`");
-    expect(meta.description).toContain("`address.city`");
+    expect(meta.description).toContain("`shipping.city`");
     expect(meta.inputSchema.update.description).toContain("MgoUpdate");
     expect(meta.inputSchema.update.description).toContain("`$set`");
     expect(meta.inputSchema.update.description).toContain("`status`");
-    expect(meta.inputSchema.update.description).toContain("`address.city`");
+    expect(meta.inputSchema.update.description).toContain("`shipping.city`");
   });
 
   it("writeNoSqlDatabaseContent should warn when auth-linked role docs are upserted by uid query", async () => {

--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -773,7 +773,7 @@ deleteCollection: 删除集合`),
     {
       title: "修改 NoSQL 数据库数据记录",
       description:
-        "修改 NoSQL 数据库数据记录。⚠️ 本工具为服务端管理工具，用于管理端/运维端操作（如后台脚本、数据迁移、批量修改）。当任务要求编写客户端应用代码时（例如「用 JS SDK 登录并插入数据」、「在前端读写数据库」），不应使用本工具，而应在项目代码中编写 @cloudbase/js-sdk 客户端代码（如 app.database().collection().add()、db.collection().where().get() 等）。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传「字段到值的普通对象」这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。更新嵌套对象中的某个字段时必须使用点号路径，例如把 `address.city` 设为 `shenzhen`；如果把整个 `address` 对象作为 `$set` 的值传入，则整个 `address` 对象会被替换，同级其他字段将丢失。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
+        "修改 NoSQL 数据库数据记录。⚠️ 本工具为服务端管理工具，用于管理端/运维端操作（如后台脚本、数据迁移、批量修改）。当任务要求编写客户端应用代码时（例如「用 JS SDK 登录并插入数据」、「在前端读写数据库」），不应使用本工具，而应在项目代码中编写 @cloudbase/js-sdk 客户端代码（如 app.database().collection().add()、db.collection().where().get() 等）。可按 MongoDB updateOne/updateMany 的心智模型理解：部分更新必须使用 `$set`、`$inc`、`$push` 等更新操作符；如果直接传「字段到值的普通对象」这类内容，底层会把它当作替换内容，存在覆盖整条文档的风险。⚠️ 嵌套对象部分更新务必使用点号路径：要更新 `shipping.city`，应传 `$set: {\"shipping.city\": \"guangzhou\"}`，绝不能传 `$set: {\"shipping\": {\"city\": \"guangzhou\"}}`（后者会丢失 shipping 下的其他字段）。若集合中的角色/档案文档会在前端通过 `db.collection(...).doc(uid)` 读取，请确保文档 `_id` 就是该 `uid`；不要用按 `uid` 条件查询再配合 `upsert=true` 的方式去更新 `users` / `profiles`，否则经常会生成一个不同的 `_id`，导致后续 `doc(uid)` 读取命中不到。",
       inputSchema: {
         action: z
           .enum(["insert", "update", "delete"])
@@ -797,7 +797,11 @@ deleteCollection: 删除集合`),
           .union([z.object({}).passthrough(), z.string()])
           .optional()
           .describe(
-            "更新内容(对象或字符串,推荐对象)(update 操作必填)。按 MongoDB 更新语义传入 MgoUpdate：部分更新请使用 `$set`、`$inc`、`$unset`、`$push` 等操作符，例如使用 `$set` 更新 `status`；不要直接传“字段到值的普通对象”，否则可能替换整条文档。更新嵌套字段时必须使用点号路径，例如通过 `$set` 更新 `address.city`；不要把整个 `address` 对象作为 `$set` 的值传入，否则会替换整个 `address` 对象。",
+            `更新内容(对象或字符串,推荐对象)(update 操作必填)。按 MongoDB 更新语义传入 MgoUpdate：部分更新请使用 \`$set\`、\`$inc\`、\`$unset\`、\`$push\` 等操作符，例如使用 \`$set\` 更新 \`status\`；不要直接传"字段到值的普通对象"，否则可能替换整条文档。
+
+⚠️ 嵌套字段必须用点号路径（如 \`shipping.city\`），禁止整对象替换：
+- ❌ 错误：{ "$set": { "shipping": { "city": "guangzhou" } } } — shipping 被整块替换，原有 address/province 等字段全部丢失
+- ✅ 正确：{ "$set": { "shipping.city": "guangzhou" } } — 仅更新 city，shipping 下其他字段保留`,
           ),
         isMulti: z
           .boolean()


### PR DESCRIPTION
## Attribution issue
- issueId: issue_mojxi9ss_hae7qn
- category: tool
- canonicalTitle: MCP writeNoSqlDatabaseContent 缺少嵌套对象部分更新的清晰文档与示例，易导致整块替换而非局部更新
- representativeRun: atomic-js-none-update-nosql-nested-object-implicit/2026-04-29T10-43-30-4c5bj3

## Automation summary
- root_cause: The `writeNoSqlDatabaseContent` MCP tool's description and `update` parameter description mentioned using dot notation for nested field updates, but the warning was generic and lacked concrete JSON examples showing the exact WRONG vs CORRECT `$set` payload format. When an agent saw a prompt like "update shipping to {city: guangzhou}", it naturally translated this into `$set: { "shipping": { "city": "guangzhou" } }` (replacing the entire object) instead of `$set: { "shipping.city": "guangzhou" }` (partial update). The abstract `address.city` example didn't clearly show the JSON structure difference.
- changes: (1) In `mcp/src/tools/databaseNoSQL.ts`, enhanced the tool description with a prominent `⚠️` warning showing both the WRONG `$set: {"shipping": {"city": "guangzhou"}}` and CORRECT `$set: {"shipping.city": "guangzhou"}` JSON payloads. (2) In the `update` parameter description, added a `❌`/`✅` block with the same concrete WRONG vs CORRECT JSON examples, plus a backtick-wrapped `shipping.city` code reference. (3) Updated `mcp/src/tools/databaseNoSQL.test.ts` to assert the new `shipping.city` reference instead of the old `address.city`.
- validation: All 15 databaseN

## Changed files
- `mcp/src/tools/databaseNoSQL.test.ts`
- `mcp/src/tools/databaseNoSQL.ts`