### PR TITLE
fix(ci): 🔧 install root deps in allinone-skill sync workflows

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -66,6 +66,9 @@ jobs:
         with:
           node-version: '24'
 
+      - name: Install root dependencies (for build-allinone-skill scripts)
+        run: npm ci --ignore-scripts
+
       - name: Build publish artifacts
         run: node scripts/build-clawhub-publish-artifacts.mjs --targets "$TARGETS"
 

--- a/.github/workflows/push-allinone-skill.yml
+++ b/.github/workflows/push-allinone-skill.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install root dependencies (for build-allinone-skill scripts)
+        run: npm ci --ignore-scripts
+
       - name: Build allinone skill
         run: npx tsx scripts/build-allinone-skill.ts --dir /tmp/allinone-build
 

--- a/.github/workflows/sync-derived-branches.yml
+++ b/.github/workflows/sync-derived-branches.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           node-version: '22'
 
+      - name: Install root dependencies (for build-allinone-skill scripts)
+        run: npm ci --ignore-scripts
+
       - name: Build all-in-one skill
         run: npx tsx scripts/build-allinone-skill.ts --dir config/allinone
 
@@ -73,6 +76,9 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '22'
+
+      - name: Install root dependencies (for build-allinone-skill scripts)
+        run: npm ci --ignore-scripts
 
       - name: Sync codebuddy plugin
         run: npx tsx scripts/sync-codebuddy-plugin.ts


### PR DESCRIPTION
## Context

After PR #690 merged to main (commit `16edba00`), three post-merge workflows failed on the same root cause:

- [`Sync Derived Branches`](https://github.com/TencentCloudBase/CloudBase-MCP/actions/runs/25160654238/job/73753927239) — failure
- `Push Allinone Skill Repository` — failure
- `Publish ClawHub Registry` — failure

All three shell out to \`scripts/build-allinone-skill.ts\` (directly or transitively) which imports \`js-yaml\` from the repository root \`node_modules\`. None of the three jobs ran \`npm ci\` at the repo root, so each hit:

\`\`\`
Error: Cannot find module 'js-yaml'
requireStack: [ 'scripts/build-allinone-skill.ts' ]
\`\`\`

PR #690 already fixed this for \`nightly-build.yaml\` (see [PR #690 commit \`4de08d03\`](https://github.com/TencentCloudBase/CloudBase-MCP/pull/690/commits/4de08d03)) but missed the other three workflows. This PR applies the same one-liner to them.

## Changes

| Workflow | Reason |
| --- | --- |
| \`.github/workflows/sync-derived-branches.yml\` | Both \`sync-allinone\` and \`sync-codebuddy\` jobs need it — the latter's \`sync-codebuddy-plugin.ts\` imports \`buildAllInOneSkill\` from \`build-allinone-skill.ts\`, which transitively needs \`js-yaml\`. |
| \`.github/workflows/push-allinone-skill.yml\` | Runs \`build-allinone-skill.ts\` directly. |
| \`.github/workflows/publish-clawhub-registry.yml\` | Runs \`build-clawhub-publish-artifacts.mjs\` which spawns \`build-allinone-skill.ts\` via \`execFileSync\`. |

Each gets one step inserted right after \`Setup Node.js\`:

\`\`\`yaml
- name: Install root dependencies (for build-allinone-skill scripts)
  run: npm ci --ignore-scripts
\`\`\`

\`--ignore-scripts\` matches the nightly-build pattern — we only need the packages on disk, not postinstall hooks, and it keeps the install fast and side-effect-free.

## Verification

- \`git diff --stat\`: 3 files, +12 lines, no other changes.
- Each of the three workflows has matching \`workflow_dispatch\` triggers, so after merge we can manually rerun them on \`main\` to confirm green before waiting for the next natural trigger.