### PR TITLE
feat(skills): update anonymous login policy — disabled by default

### DIFF
--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -146,7 +146,7 @@ CloudBase (Tencent CloudBase) is a good fit when the user needs any of the follo
 | **Host a static site, docs, or blog** | Deploy to CloudBase static hosting |
 | **Run a backend API, long job, or WebSocket** | Cloud Functions or Cloud Run, DB/message-queue support |
 | **Design data: collections or tables + permissions** | NoSQL collections or MySQL tables, resource permissions and role policies |
-| **Add login (WeChat, anonymous, or custom)** | Built-in identity providers |
+| **Add login (WeChat, username/password, email, phone, or custom)** | Built-in identity providers (anonymous login disabled by default) |
 | **Upload/download files or get CDN links** | Cloud storage and temporary URLs |
 | **Add AI (text/chat/image) in Web, mini program, or backend** | CloudBase AI model integration, streaming, image generation |
 | **Build an AI Agent with streaming UI** | CloudBase Agent SDK (TS/Python), AG-UI protocol|

--- a/config/source/skills/ai-model-web/SKILL.md
+++ b/config/source/skills/ai-model-web/SKILL.md
@@ -224,12 +224,12 @@ npm install @cloudbase/js-sdk
 
 ## Initialization
 
-> ⚠️ **Do not use anonymous sign-in as the default.** Anonymous accounts are easy to abuse and weaken downstream permission rules. The AI-model skill does **not** prescribe a specific login UI — delegate that concern:
+> ⚠️ **Do not use anonymous sign-in as the default.** Anonymous login is **disabled by default** for new environments, and inactive existing environments have also been automatically disabled. Even when anonymous login is manually enabled, **anonymous users are denied AI model invocation permissions by default**. The AI-model skill does **not** prescribe a specific login UI — delegate that concern:
 >
 > - **Enabling / configuring login providers** (phone SMS, email, WeChat Open Platform, username+password, OAuth, …) → follow the **`auth-tool`** skill (backend config via `callCloudApi`).
 > - **Building the actual sign-in flow in the browser** (login form, callbacks, session guarding) → follow the **`auth-web`** skill (`@cloudbase/js-sdk` auth API, e.g. `signInWithPassword`, `signInWithPhone`, `getLoginState`).
 >
-> Only fall back to `signInAnonymously()` if the user explicitly requests a read-only anonymous demo and accepts the trade-off.
+> Do **not** fall back to `signInAnonymously()` for AI features — anonymous users cannot call AI models. Only use anonymous login for non-AI read-only demos where the user explicitly requests it and accepts the trade-off.
 
 ```js
 import cloudbase from "@cloudbase/js-sdk";
@@ -258,7 +258,7 @@ const ai = app.ai();
 **Important notes:**
 
 - Use synchronous initialization with a top-level import
-- The user MUST be authenticated before using AI features — use a verified login (phone, email, WeChat, username+password, custom), never anonymous, as the default. The exact flow is the responsibility of the `auth-web` skill.
+- The user MUST be authenticated before using AI features — use a verified login (phone, email, WeChat, username+password, custom), never anonymous. Anonymous users are denied AI model permissions by default. The exact flow is the responsibility of the `auth-web` skill.
 - Get `accessKey` from the CloudBase console
 
 ---
@@ -382,7 +382,7 @@ interface Usage {
 7. **Handle errors gracefully** — wrap AI calls in try/catch.
 8. **Keep `accessKey` safe** — use a publishable key, never a secret key.
 9. **Initialize early** — set up the SDK at app entry so auth and AI are both ready before routing.
-10. **Do NOT default to anonymous auth** — require a verified sign-in before calling any AI API. Delegate provider configuration to the `auth-tool` skill and the browser sign-in flow to the `auth-web` skill; the AI-model skill only checks `auth.getLoginState()` and gates the call.
+10. **Do NOT use anonymous auth for AI features** — anonymous login is disabled by default for new environments, and anonymous users are denied AI model permissions. Require a verified sign-in (phone, email, username+password, WeChat, custom) before calling any AI API. Delegate provider configuration to the `auth-tool` skill and the browser sign-in flow to the `auth-web` skill; the AI-model skill only checks `auth.getLoginState()` and gates the call.
 11. **Distinguish "preflight failure" from "model call failure"** — the former means the user needs to buy a resource pack or call `UpdateAIModel`; the latter is a prompt / parameter / network issue. Give the user different guidance for each.
 12. **TypeScript: do NOT use `any` to silence type errors from the SDK.** The SDK ships its own types; if an error shows up, narrow with `unknown` + a type guard, write a precise `interface` for the shape you actually consume, or augment types in a local `.d.ts`. Never `: any`, `as any`, `@ts-ignore`, or `@ts-nocheck`. See the Engineering constitution in the `web-development` skill.
 13. **Self-verify before claiming done.** Run `tsc --noEmit` + the project build + open the page with `agent-browser` and actually trigger the AI call. Confirm: (a) the text stream reaches the UI, (b) no new console errors, (c) `result.usage` is non-zero. Saying "it should work" without evidence is not acceptable — follow `web-development/browser-testing.md`.

--- a/config/source/skills/auth-nodejs/SKILL.md
+++ b/config/source/skills/auth-nodejs/SKILL.md
@@ -123,7 +123,7 @@ When you load this skill to work on a task:
 
 CloudBase Auth v2 separates **where users log in** from **where backend code runs**:
 
-- Users log in through the supported auth methods (anonymous, username/password, SMS, email, WeChat, custom login, etc.) using client SDKs or HTTP interfaces, as described in the official CloudBase Auth overview documentation.
+- Users log in through the supported auth methods (username/password, SMS, email, WeChat, custom login, anonymous — disabled by default, etc.) using client SDKs or HTTP interfaces, as described in the official CloudBase Auth overview documentation.
 - Once logged in, CloudBase attaches the user identity and tokens to the environment.
 - Node code then **reads** that identity using the Node SDK, or **bridges** external identities into CloudBase using custom login.
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -98,7 +98,7 @@ Recommended MCP request:
   "loginMethods": {
     "usernamePassword": true,
     "email": true,
-    "anonymous": true,
+    "anonymous": false,
     "phone": false
   }
 }
@@ -149,9 +149,11 @@ Internal behavior of `manageAppAuth(action="patchLoginStrategy")`:
 
 ### 2. Anonymous Login
 
+> ⚠️ **Anonymous login is disabled by default for new environments.** Inactive existing environments (no anonymous login usage within the past month) have also been automatically disabled. Additionally, anonymous users are denied AI model invocation permissions by default. Only enable anonymous login when the application explicitly requires unauthenticated access and you accept the associated security trade-offs.
+
 Preferred MCP tool path: `manageAppAuth(action="patchLoginStrategy")`
 
-Recommended MCP request:
+To explicitly enable anonymous login (only when required):
 
 ```json
 {
@@ -163,6 +165,8 @@ Recommended MCP request:
 ```
 
 The tool handles read-merge-write internally. The model does not need to build a full `ModifyLoginConfig` payload.
+
+**Important**: Even after enabling anonymous login, anonymous users cannot call AI models by default. This permission must be explicitly granted separately if needed.
 
 ---
 

--- a/config/source/skills/auth-tool/checklist.md
+++ b/config/source/skills/auth-tool/checklist.md
@@ -5,7 +5,7 @@ Use this checklist before generating any CloudBase authentication flow.
 ## When this checklist applies
 
 - Web login or registration
-- SMS, email, anonymous, Google, or WeChat provider setup
+- SMS, email, anonymous (disabled by default), Google, or WeChat provider setup
 - HTTP API auth flows for native apps or backend integrations
 
 ## Required checks

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -47,7 +47,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Using `signInWithEmailAndPassword` or `signUpWithEmailAndPassword` for username-style accounts such as `admin` and `editor`.
 - Keeping the login or register account input as `type="email"` when the task explicitly says the account identifier is a plain username string.
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
-- **Treating `auth.getUser()` returning a user as proof of real login.** When the SDK is initialized with a `publishableKey` / `accessKey`, it may silently create an anonymous session. A route guard's `checkAuth()` must verify that the user actually signed in with username/password (e.g. check `session.loginType !== 'ANONYMOUS'` or that `user.user_metadata?.username` exists), not just that `getUser()` returns non-null. Otherwise unauthenticated visitors pass the guard, protected pages render without a real user, and role-based UI (edit / delete buttons gated on `currentUser.role`) breaks because `currentUser` has no role record.
+- **Treating `auth.getUser()` returning a user as proof of real login.** In environments where anonymous login is still enabled, the SDK initialized with a `publishableKey` / `accessKey` may create an anonymous session. A route guard's `checkAuth()` must verify that the user actually signed in with username/password (e.g. check `session.loginType !== 'ANONYMOUS'` or that `user.user_metadata?.username` exists), not just that `getUser()` returns non-null. Note: anonymous login is now **disabled by default** for new environments and inactive existing environments, so this scenario is less common but still must be guarded against.
 
 ## Overview
 
@@ -59,7 +59,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 ## Core Capabilities
 
 **Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
-**Key Benefits**: Supabase-like Auth API shape, supports phone, email, anonymous, username/password, and third-party login methods
+**Key Benefits**: Supabase-like Auth API shape, supports phone, email, anonymous (disabled by default), username/password, and third-party login methods
 
 Use npm installation for modern Web projects. In React, Vue, Vite, and other bundler-based apps, install and import `@cloudbase/js-sdk` from the project dependencies instead of using a CDN script.
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -54,7 +54,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Forgetting that runtime cannot be changed after creation.
 - Using cloud functions as the first answer for Web login.
 - Forgetting that HTTP Functions must ship `scf_bootstrap`, listen on port `9000`, and include dependencies.
-- Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Use `managePermissions(action="updateResourcePermission", resourceType="function")` to allow public access.
+- Forgetting to configure function security rules after creating an HTTP Function. Default rules reject anonymous callers with `EXCEED_AUTHORITY`. Note: anonymous login is disabled by default for new environments — if the function needs public access without authentication, configure the security rule to allow all callers rather than relying on anonymous login.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime (e.g. using `/var/lang/node18/bin/node` but setting `runtime: "Nodejs16.13"`).
 
 ### Minimal checklist
@@ -91,7 +91,7 @@ Use these rules whenever you are writing the function code itself:
 - Return responses explicitly with `res.writeHead(...)` and `res.end(...)`, including `Content-Type` such as `application/json; charset=utf-8` for JSON APIs.
 - Keep routing and method handling explicit. Unknown paths should return `404`, and known paths with unsupported methods should normally return `405`.
 - Keep gateway setup and security-rule changes separate from the runtime code. They affect access, not the HTTP Function programming model.
-- Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; anonymous or public invocation requirements should be handled through the function security rule workflow.
+- Do not add HTTP access service configuration when the task is only to create an HTTP Function itself. Gateway paths or custom domains are separate access-layer work; public invocation requirements should be handled through the function security rule workflow (note: anonymous login is disabled by default).
 
 ## Quick decision table
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -10,7 +10,7 @@ Use this checklist before creating or updating a CloudBase function.
 2. Pick the runtime before creation and state it explicitly.
 3. For HTTP Functions, confirm `scf_bootstrap` exists and the Node.js binary path matches the runtime (e.g. `Nodejs18.15` → `/var/lang/node18/bin/node`).
 4. Confirm the function root path points to the parent directory, not the function directory itself.
-5. For HTTP Functions that need anonymous access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject anonymous callers with `EXCEED_AUTHORITY`.
+5. For HTTP Functions that need public access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject unauthenticated callers with `EXCEED_AUTHORITY`. Note: anonymous login is disabled by default — use `rule: "true"` for public endpoints.
 6. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
@@ -19,7 +19,7 @@ Use this checklist before creating or updating a CloudBase function.
 - Mixing Event Function and HTTP Function handler shapes in the same implementation.
 - Forgetting that runtime cannot be changed after creation.
 - Mismatching the `scf_bootstrap` Node.js binary path with the function runtime.
-- Forgetting to configure function security rules for HTTP Functions that need anonymous access.
+- Forgetting to configure function security rules for HTTP Functions that need public access.
 - Treating Cloud Functions as the default answer for Web authentication.
 
 ## Done criteria

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -219,7 +219,7 @@ Follow these steps in order when creating an HTTP Function:
 
 1. **Write the function code** — create the directory with `index.js`, `scf_bootstrap`, and `package.json`.
 2. **Deploy with `manageFunctions`** — set `type: "HTTP"`, `protocolType: "HTTP"`, and `runtime` explicitly.
-3. **Configure security rules** — HTTP Functions default to a restrictive security rule. If the function should be publicly accessible (anonymous access), call `managePermissions(action="updateResourcePermission")` with `resourceType="function"`.
+3. **Configure security rules** — HTTP Functions default to a restrictive security rule. If the function should be publicly accessible, call `managePermissions(action="updateResourcePermission")` with `resourceType="function"`. Note: anonymous login is disabled by default for new environments; use `permission: "CUSTOM"` with `securityRule: '{"invoke":"true"}'` for truly public endpoints rather than relying on anonymous auth.
 4. **Verify** — call the function URL and confirm it returns the expected response. If you get `EXCEED_AUTHORITY`, the security rule needs to be updated (step 3).
 
 ## Deployment flow
@@ -249,7 +249,9 @@ manageFunctions({
 
 ### Security rule configuration
 
-After creating an HTTP Function, it will reject anonymous callers with `EXCEED_AUTHORITY` by default. If the function should be publicly accessible:
+After creating an HTTP Function, it will reject unauthenticated callers with `EXCEED_AUTHORITY` by default. If the function should be publicly accessible:
+
+> ⚠️ **Note:** Anonymous login is disabled by default for new environments. For public endpoints, use `rule: "true"` to allow all callers regardless of auth state, rather than relying on anonymous login being enabled.
 
 ```javascript
 managePermissions({
@@ -263,7 +265,7 @@ managePermissions({
 });
 ```
 
-- `aclTag: "CUSTOM"` with `rule: "true"` allows all callers (anonymous access).
+- `aclTag: "CUSTOM"` with `rule: "true"` allows all callers (public access without requiring any login).
 - Do NOT use `readSecurityRule` / `writeSecurityRule` — those are removed. Use `queryPermissions` / `managePermissions` instead.
 - Security rule semantics for `resourceType="function"` differ from NoSQL database rules. Do not reuse `doc._openid` or `auth.openid` expressions from NoSQL security rules.
 - Official reference: `https://docs.cloudbase.net/cloud-function/security-rules`
@@ -311,10 +313,10 @@ manageGateway({
 });
 ```
 
-Before enabling anonymous access, confirm both of these:
+Before enabling public access, confirm both of these:
 
 1. The access path exists.
-2. The function security rule allows the intended caller identity (see Security rule configuration above).
+2. The function security rule allows the intended caller identity (see Security rule configuration above). Note: anonymous login is disabled by default — for public endpoints, use `rule: "true"` instead of requiring anonymous auth.
 
 ## SSE and WebSocket notes
 

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -168,7 +168,7 @@ Example structure for operation recording:
    - For Web, always initialize synchronously:
      - `import cloudbase from "@cloudbase/js-sdk"; const app = cloudbase.init({ env: "your-full-env-id" });`
      - Do **not** use dynamic imports like `import("@cloudbase/js-sdk")` or async wrappers such as `initCloudBase()` with internal `initPromise`
-   - Then proceed with login, for example using anonymous login
+   - Then proceed with login using a verified method (username/password, phone, email, or WeChat)
 
 ## Authentication Best Practices
 

--- a/config/source/skills/http-api/SKILL.md
+++ b/config/source/skills/http-api/SKILL.md
@@ -491,6 +491,6 @@ This is the **preferred** authentication flow for native mobile apps (iOS/Androi
 6. **Use appropriate authentication method** based on your use case:
    - AccessToken for user-specific operations
    - API Key for server-side admin operations
-   - Publishable Key for public/anonymous access
+   - Publishable Key for public access (note: anonymous login is disabled by default for new environments)
 7. **Phone number format**: Always use international format with space: `"+86 13800138000"`
 8. **Verification flow**: Save `verification_id` from send step, use it in verify step

--- a/config/source/skills/no-sql-web-sdk/security-rules.md
+++ b/config/source/skills/no-sql-web-sdk/security-rules.md
@@ -562,7 +562,7 @@ For that CMS pattern, `.doc(id).update()` / `.doc(id).remove()` is a validated p
 **Key Understanding**:
 - `ADMINWRITE` = Cloud functions have write access, Frontend SDK **can only read**
 - `CUSTOM` = Configurable read/write permissions for Frontend SDK
-- `READONLY` = All authenticated users can read, creator and admin can write (anonymous login is disabled by default, so anonymous users typically cannot access)
+- `READONLY` = All users (including anonymous) can read, creator and admin can write. Note: although `READONLY` permits anonymous reads at the ACL level, anonymous login is disabled by default for new environments — callers still need an active login method to obtain a session.
 
 ### Role-Based Access Limitations
 

--- a/config/source/skills/no-sql-web-sdk/security-rules.md
+++ b/config/source/skills/no-sql-web-sdk/security-rules.md
@@ -219,7 +219,7 @@ Custom rules can use these predefined variables:
 **LoginType Values:**
 - `WECHAT_PUBLIC`: WeChat Official Account
 - `WECHAT_OPEN`: WeChat Open Platform
-- `ANONYMOUS`: Anonymous login
+- `ANONYMOUS`: Anonymous login (disabled by default for new environments)
 - `EMAIL`: Email login
 - `CUSTOM`: Custom login
 
@@ -562,7 +562,7 @@ For that CMS pattern, `.doc(id).update()` / `.doc(id).remove()` is a validated p
 **Key Understanding**:
 - `ADMINWRITE` = Cloud functions have write access, Frontend SDK **can only read**
 - `CUSTOM` = Configurable read/write permissions for Frontend SDK
-- `READONLY` = All users (including anonymous) can read, creator and admin can write
+- `READONLY` = All authenticated users can read, creator and admin can write (anonymous login is disabled by default, so anonymous users typically cannot access)
 
 ### Role-Based Access Limitations
 


### PR DESCRIPTION
## Summary

- 匿名登录方式新增环境默认关闭，存量不活跃环境（一月内无匿名登录使用）也已自动关闭
- 新增环境匿名用户的 AI 模型权限默认拒绝
- 更新 12 个 skill 文件，反映上述平台策略变更

## Changes

- **auth-tool**: 示例中 `anonymous: true` → `false`，Anonymous Login 段增加默认关闭警告及 AI 权限说明
- **auth-tool/checklist**: 标注 anonymous (disabled by default)
- **ai-model-web**: 强化匿名用户无 AI 模型调用权限的说明（3处）
- **auth-web**: 说明新环境不会再静默创建匿名会话
- **cloudbase-platform**: 登录示例不再推荐匿名登录
- **cloud-functions** (SKILL.md / checklist / http-functions.md): "anonymous access" → "public access"，增加前置条件说明
- **no-sql-web-sdk/security-rules**: ANONYMOUS loginType 标注默认关闭，READONLY 权限说明更新
- **http-api**: Publishable Key 说明更新
- **auth-nodejs**: 登录方式列表调整顺序，匿名标注 disabled by default
- **guideline/cloudbase/SKILL.md**: 能力表格更新

## Test plan

- [ ] 构建 allinone skill 产物，确认改动正确反映到输出
- [ ] 检查无遗漏的 "anonymous" 引用仍在推荐匿名登录作为默认路径

🤖 Generated with [Claude Code](https://claude.com/claude-code)