### PR TITLE
feat(http-api): 🔌 add NoSQL REST + AI Model API support

### DIFF
--- a/config/.claude/skills/ai-model-nodejs/SKILL.md
+++ b/config/.claude/skills/ai-model-nodejs/SKILL.md
@@ -31,7 +31,7 @@ Use this skill for **calling AI models from Node.js backends, cloud functions, o
 
 - Browser/Web apps → use the `ai-model-web` skill
 - WeChat Mini Program → use the `ai-model-wechat` skill
-- HTTP API integration → use the `http-api` skill
+- Runtimes without a CloudBase SDK (Python, Go, PHP, curl, etc.) → use the `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls to the AI model endpoint; do NOT wrap this SDK behind an HTTP proxy)
 
 ---
 

--- a/config/.claude/skills/ai-model-web/SKILL.md
+++ b/config/.claude/skills/ai-model-web/SKILL.md
@@ -31,7 +31,7 @@ Use this skill for **calling AI models in browser/Web applications** via `@cloud
 - Node.js backend or cloud functions → use the `ai-model-nodejs` skill
 - WeChat Mini Program → use the `ai-model-wechat` skill
 - Image generation → use the `ai-model-nodejs` skill (Node SDK only)
-- HTTP API integration → use the `http-api` skill
+- Runtimes without a CloudBase SDK (native apps, Python, Go, etc.) → use the `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls; do NOT build a custom HTTP proxy)
 
 ---
 

--- a/config/.claude/skills/ai-model-wechat/SKILL.md
+++ b/config/.claude/skills/ai-model-wechat/SKILL.md
@@ -29,7 +29,7 @@ Use this skill for **calling AI models in WeChat Mini Program** using `wx.cloud.
 - Browser/Web apps → use `ai-model-web` skill
 - Node.js backend or cloud functions → use `ai-model-nodejs` skill
 - Image generation → use `ai-model-nodejs` skill (not available in Mini Program)
-- HTTP API integration → use `http-api` skill
+- Runtimes without a CloudBase SDK (native apps, Python, etc.) → use `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls)
 
 ---
 

--- a/config/.claude/skills/http-api/SKILL.md
+++ b/config/.claude/skills/http-api/SKILL.md
@@ -54,7 +54,7 @@ Use this skill whenever you need to call **CloudBase platform features** via **r
 
 - Non-Node backends (Go, Python, Java, PHP, etc.)
 - Integration tests or admin scripts that use curl or language HTTP clients
-- Direct database operations via MySQL RESTful API
+- Direct database operations via 关系型数据库 RESTful API (MySQL/PostgreSQL)
 - Cloud function invocation via HTTP
 - Any scenario where SDKs are not available or not preferred
 
@@ -85,11 +85,13 @@ Do **not** use this skill for:
 4. **Reference OpenAPI Swagger documentation**
    - **MUST use `searchKnowledgeBase` tool** to get OpenAPI specifications
    - Use the tool with `mode=openapi` and specify the `apiName`:
-     - `mysqldb` - MySQL RESTful API
+     - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+     - `nosql` - NoSQL RESTful API (文档型数据库)
      - `functions` - Cloud Functions API
      - `auth` - Authentication API
      - `cloudrun` - CloudRun API
      - `storage` - Storage API
+     - `ai_model` - AI 大模型接入 API
    - Example: `searchKnowledgeBase({ mode: "openapi", apiName: "mysqldb" })`
    - Parse the returned YAML content to understand exact endpoint paths, parameters, request/response schemas
    - Never invent endpoints or parameters - always reference the swagger documentation
@@ -112,11 +114,13 @@ Before implementing any HTTP API calls, you should:
    ```
 
 2. **Available API names**:
-   - `mysqldb` - MySQL RESTful API
+   - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+   - `nosql` - NoSQL RESTful API (文档型数据库)
    - `functions` - Cloud Functions API
    - `auth` - Authentication API
    - `cloudrun` - CloudRun API
    - `storage` - Storage API
+   - `ai_model` - AI 大模型接入 API
 
 3. **Parse and use the swagger documentation**:
    - Extract exact endpoint paths and HTTP methods
@@ -228,9 +232,11 @@ curl -X POST "https://your-env-id.api.tcloudbasegateway.com/v1/functions/YOUR_FU
 
 For detailed API specifications, always download and reference the OpenAPI Swagger files mentioned above.
 
-## MySQL RESTful API
+## 关系型数据库 RESTful API (PostgREST 风格)
 
-The MySQL RESTful API provides all MySQL database operations via HTTP endpoints.
+> **适用于 MySQL 和 PostgreSQL**：两者均基于 PostgREST 风格暴露 REST API，端点格式和请求语义一致。
+
+提供关系型数据库（MySQL / PostgreSQL）的 HTTP 操作接口。
 
 ### Base URL Patterns
 
@@ -374,6 +380,87 @@ curl -i -X GET 'https://{{host}}/v1/rdb/rest/course?select=name,position&name=li
 curl -i -X GET 'https://{{host}}/v1/rdb/rest/course?select=name,position&name=like.%%E5%BC%A0%E4%B8%89%&title=eq.%E6%96%87%E7%AB%A0%E6%A0%87%E9%A2%98'
 ```
 
+## NoSQL RESTful API
+
+NoSQL RESTful API 提供文档型数据库（NoSQL）的 HTTP 操作接口，支持集合管理、文档 CRUD、聚合查询、事务操作和数据库命令。
+
+### Base URL
+
+```
+https://{envId}.api.tcloudbasegateway.com/v1/database/instances/{instance}/databases/{database}/
+```
+
+| 参数 | 说明 |
+|------|------|
+| `envId` | 环境 ID |
+| `instance` | 数据库实例 ID，默认实例使用 `(default)` |
+| `database` | 数据库名称，默认数据库使用 `(default)` |
+
+示例：
+- 默认实例 + 默认数据库：`/v1/database/instances/(default)/databases/(default)/`
+- 指定实例 + 默认数据库：`/v1/database/instances/test_instance/databases/(default)/`
+
+### 请求与响应格式
+
+- 请求支持 Relaxed 和 Strict EJSON 格式
+- 响应均为 Strict EJSON 格式
+- EJSON 支持的特殊类型：`ObjectId`、`Date`、`Int`、`Long`、`Decimal128`、`Binary`、`RegExp`
+
+### 错误码与 HTTP 状态码
+
+| 错误码 | HTTP 状态码 | 说明 |
+|--------|-------------|------|
+| `INVALID_PARAM` | 400 | 参数错误 |
+| `DATABASE_PERMISSION_DENIED` | 401 | 权限不足 |
+| `DATABASE_INVALID_OPERRATOR` | 403 | 不支持的操作 |
+| `DATABASE_COLLECTION_NOT_EXIST` | 404 | 集合不存在 |
+| `DOCUMENT_NOT_FOUND` | 404 | 文档不存在 |
+| `DATABASE_COLLECTION_ALREADY_EXIST` | 409 | 集合已存在 |
+| `DATABASE_DUPLICATE_WRITE` | 409 | 唯一索引冲突 |
+| `EXCEED_REQUEST_LIMIT` | 422 | 请求次数超限 |
+| `EXCEED_CONCURRENT_REQUEST_LIMIT` | 422 | 并发请求超限 |
+| `DATABASE_REQUEST_FAILED` | 500 | 数据库请求失败 |
+| `SYS_ERR` | 500 | 内部错误 |
+| `DATABASE_TRANSACTION_CONFLICT` | 503 | 事务冲突 |
+| `DATABASE_TRANSACTION_FAIL` | 503 | 事务执行失败 |
+| `DATABASE_TIMEOUT` | 504 | 数据库操作超时 |
+
+详细端点使用和请求示例，请参考官方文档：https://docs.cloudbase.net/http-api/nosql/nosql-restful-api
+
+---
+
+## AI 大模型接入 API
+
+统一的大模型接入 API，支持通过 HTTP 调用已配置的 AI 大模型（支持 SSE 流式响应）。
+
+### 认证方式
+
+| 方式 | 说明 |
+|------|------|
+| `Authorization: Bearer <token>` | AccessToken 认证（推荐） |
+| TC3-HMAC-SHA256 签名 | 腾讯云 API v3 签名方式 |
+| `Authorization: <apikey>` | APIKey 认证 |
+
+> AccessToken 获取方式：参考 Auth OpenAPI (`searchKnowledgeBase({ mode: "openapi", apiName: "auth" })`)
+
+### 错误码
+
+| 错误码 | 说明 |
+|--------|------|
+| `AI_MODEL_CONFIG_MISSING` | 缺少模型 API Key 或配置 |
+| `AI_MODEL_PARAM_INVALID` | 输入参数无效 |
+| `AI_MODEL_DISABLED` | 模型已禁用，请在控制台检查或等待约 2 分钟 |
+| `AI_MODEL_NOT_SUPPORTED` | 请求模型不支持或未启用 |
+| `AI_MODEL_PARAM_REQUIRED` | 缺少必需参数 `model` |
+| `AI_MODEL_NOT_FOUND` | 指定的模型组不存在 |
+| `EXCEED_CONCURRENT_REQUEST_LIMIT` | 并发请求超限，请稍后重试或申请更高配额 |
+| `EXCEED_TOKEN_QUOTA_LIMIT` | 模型 Token 配额超限，请购买资源或调整模型组 |
+
+详细端点和请求格式，请参考官方文档：https://docs.cloudbase.net/http-api/ai-model/ai-%E5%A4%A7%E6%A8%A1%E5%9E%8B%E6%8E%A5%E5%85%A5
+以及 OpenAPI 规范：`https://docs.cloudbase.net/openapi/ai_model.v1.openapi.yaml`
+
+---
+
 ## Online Debugging Tool
 
 CloudBase platform provides an [online debugging tool](/http-api/basic/online-api-call) where you can test API interfaces without writing code:
@@ -389,10 +476,12 @@ CloudBase platform provides an [online debugging tool](/http-api/basic/online-ap
 
 Use `searchKnowledgeBase({ mode: "openapi", apiName: "<api-name>" })` with these API names:
 - `auth` - Authentication API
-- `mysqldb` - MySQL RESTful API
+- `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+- `nosql` - NoSQL RESTful API (文档型数据库)
 - `functions` - Cloud Functions API
 - `cloudrun` - CloudRun API
 - `storage` - Storage API
+- `ai_model` - AI 大模型接入 API
 
 **How to use the OpenAPI documentation:**
 1. Call `searchKnowledgeBase` tool with the appropriate `apiName`

--- a/config/.claude/skills/http-api/checklist.md
+++ b/config/.claude/skills/http-api/checklist.md
@@ -8,16 +8,28 @@ Use this checklist when the request comes from Android, iOS, Flutter, React Nati
 2. Confirm environment ID, region, and gateway base URL.
 3. Choose the auth mechanism: AccessToken, API Key, or Publishable Key.
 4. Query the matching OpenAPI definition before writing request code.
-5. For database work, confirm whether the task is MySQL REST API, MCP SQL management, or Web SDK data access.
+5. For database work, confirm which REST API is needed:
+   - **关系型数据库 REST** (MySQL / PostgreSQL): `https://{envId}.api.tcloudbasegateway.com/v1/rdb/rest/{table}` — PostgREST 风格
+   - **NoSQL REST**: `https://{envId}.api.tcloudbasegateway.com/v1/database/instances/{instance}/databases/{database}/` — EJSON 格式
+6. For AI model access, confirm the calling pattern:
+   - **SDK 方式** (Node/Web/微信小程序): 走各端 SDK，不需要裸调 HTTP
+   - **HTTP API 方式**: `https://{envId}.api.tcloudbasegateway.com/...` — 参考 OpenAPI `ai_model`
+7. Verify the OpenAPI spec is available in `searchKnowledgeBase` before writing code:
+   - `mysqldb` — 关系型数据库 REST
+   - `nosql` — NoSQL REST
+   - `ai_model` — AI 大模型接入
+   - `auth` / `functions` / `cloudrun` / `storage` — 其他
 
 ## Do not route here when
 
 - The user is building a Web frontend with `@cloudbase/js-sdk`.
 - The user is building a CloudBase mini program with `wx.cloud`.
 - The task is MCP-driven database management rather than raw HTTP calls.
+- The user is calling AI models from Node/Web/微信 — use `ai-model-*` skills instead; only use HTTP API for unsupported runtimes.
 
 ## Done criteria
 
 - SDK support boundary is explicit.
-- OpenAPI source has been checked.
+- The correct REST API variant (关系型 / NoSQL / AI) has been identified.
+- OpenAPI source has been checked (`searchKnowledgeBase` with the right `apiName`).
 - The auth method and request base URL are fixed before code generation.

--- a/config/source/skills/ai-model-nodejs/SKILL.md
+++ b/config/source/skills/ai-model-nodejs/SKILL.md
@@ -31,7 +31,7 @@ Use this skill for **calling AI models from Node.js backends, cloud functions, o
 
 - Browser/Web apps → use the `ai-model-web` skill
 - WeChat Mini Program → use the `ai-model-wechat` skill
-- HTTP API integration → use the `http-api` skill
+- Runtimes without a CloudBase SDK (Python, Go, PHP, curl, etc.) → use the `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls to the AI model endpoint; do NOT wrap this SDK behind an HTTP proxy)
 
 ---
 

--- a/config/source/skills/ai-model-web/SKILL.md
+++ b/config/source/skills/ai-model-web/SKILL.md
@@ -31,7 +31,7 @@ Use this skill for **calling AI models in browser/Web applications** via `@cloud
 - Node.js backend or cloud functions → use the `ai-model-nodejs` skill
 - WeChat Mini Program → use the `ai-model-wechat` skill
 - Image generation → use the `ai-model-nodejs` skill (Node SDK only)
-- HTTP API integration → use the `http-api` skill
+- Runtimes without a CloudBase SDK (native apps, Python, Go, etc.) → use the `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls; do NOT build a custom HTTP proxy)
 
 ---
 

--- a/config/source/skills/ai-model-wechat/SKILL.md
+++ b/config/source/skills/ai-model-wechat/SKILL.md
@@ -29,7 +29,7 @@ Use this skill for **calling AI models in WeChat Mini Program** using `wx.cloud.
 - Browser/Web apps → use `ai-model-web` skill
 - Node.js backend or cloud functions → use `ai-model-nodejs` skill
 - Image generation → use `ai-model-nodejs` skill (not available in Mini Program)
-- HTTP API integration → use `http-api` skill
+- Runtimes without a CloudBase SDK (native apps, Python, etc.) → use `http-api` skill (it now includes the `ai_model` OpenAPI spec for direct HTTP calls)
 
 ---
 

--- a/config/source/skills/http-api/SKILL.md
+++ b/config/source/skills/http-api/SKILL.md
@@ -54,7 +54,7 @@ Use this skill whenever you need to call **CloudBase platform features** via **r
 
 - Non-Node backends (Go, Python, Java, PHP, etc.)
 - Integration tests or admin scripts that use curl or language HTTP clients
-- Direct database operations via MySQL RESTful API
+- Direct database operations via 关系型数据库 RESTful API (MySQL/PostgreSQL)
 - Cloud function invocation via HTTP
 - Any scenario where SDKs are not available or not preferred
 
@@ -85,11 +85,13 @@ Do **not** use this skill for:
 4. **Reference OpenAPI Swagger documentation**
    - **MUST use `searchKnowledgeBase` tool** to get OpenAPI specifications
    - Use the tool with `mode=openapi` and specify the `apiName`:
-     - `mysqldb` - MySQL RESTful API
+     - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+     - `nosql` - NoSQL RESTful API (文档型数据库)
      - `functions` - Cloud Functions API
      - `auth` - Authentication API
      - `cloudrun` - CloudRun API
      - `storage` - Storage API
+     - `ai_model` - AI 大模型接入 API
    - Example: `searchKnowledgeBase({ mode: "openapi", apiName: "mysqldb" })`
    - Parse the returned YAML content to understand exact endpoint paths, parameters, request/response schemas
    - Never invent endpoints or parameters - always reference the swagger documentation
@@ -112,11 +114,13 @@ Before implementing any HTTP API calls, you should:
    ```
 
 2. **Available API names**:
-   - `mysqldb` - MySQL RESTful API
+   - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+   - `nosql` - NoSQL RESTful API (文档型数据库)
    - `functions` - Cloud Functions API
    - `auth` - Authentication API
    - `cloudrun` - CloudRun API
    - `storage` - Storage API
+   - `ai_model` - AI 大模型接入 API
 
 3. **Parse and use the swagger documentation**:
    - Extract exact endpoint paths and HTTP methods
@@ -228,9 +232,11 @@ curl -X POST "https://your-env-id.api.tcloudbasegateway.com/v1/functions/YOUR_FU
 
 For detailed API specifications, always download and reference the OpenAPI Swagger files mentioned above.
 
-## MySQL RESTful API
+## 关系型数据库 RESTful API (PostgREST 风格)
 
-The MySQL RESTful API provides all MySQL database operations via HTTP endpoints.
+> **适用于 MySQL 和 PostgreSQL**：两者均基于 PostgREST 风格暴露 REST API，端点格式和请求语义一致。
+
+提供关系型数据库（MySQL / PostgreSQL）的 HTTP 操作接口。
 
 ### Base URL Patterns
 
@@ -374,6 +380,87 @@ curl -i -X GET 'https://{{host}}/v1/rdb/rest/course?select=name,position&name=li
 curl -i -X GET 'https://{{host}}/v1/rdb/rest/course?select=name,position&name=like.%%E5%BC%A0%E4%B8%89%&title=eq.%E6%96%87%E7%AB%A0%E6%A0%87%E9%A2%98'
 ```
 
+## NoSQL RESTful API
+
+NoSQL RESTful API 提供文档型数据库（NoSQL）的 HTTP 操作接口，支持集合管理、文档 CRUD、聚合查询、事务操作和数据库命令。
+
+### Base URL
+
+```
+https://{envId}.api.tcloudbasegateway.com/v1/database/instances/{instance}/databases/{database}/
+```
+
+| 参数 | 说明 |
+|------|------|
+| `envId` | 环境 ID |
+| `instance` | 数据库实例 ID，默认实例使用 `(default)` |
+| `database` | 数据库名称，默认数据库使用 `(default)` |
+
+示例：
+- 默认实例 + 默认数据库：`/v1/database/instances/(default)/databases/(default)/`
+- 指定实例 + 默认数据库：`/v1/database/instances/test_instance/databases/(default)/`
+
+### 请求与响应格式
+
+- 请求支持 Relaxed 和 Strict EJSON 格式
+- 响应均为 Strict EJSON 格式
+- EJSON 支持的特殊类型：`ObjectId`、`Date`、`Int`、`Long`、`Decimal128`、`Binary`、`RegExp`
+
+### 错误码与 HTTP 状态码
+
+| 错误码 | HTTP 状态码 | 说明 |
+|--------|-------------|------|
+| `INVALID_PARAM` | 400 | 参数错误 |
+| `DATABASE_PERMISSION_DENIED` | 401 | 权限不足 |
+| `DATABASE_INVALID_OPERRATOR` | 403 | 不支持的操作 |
+| `DATABASE_COLLECTION_NOT_EXIST` | 404 | 集合不存在 |
+| `DOCUMENT_NOT_FOUND` | 404 | 文档不存在 |
+| `DATABASE_COLLECTION_ALREADY_EXIST` | 409 | 集合已存在 |
+| `DATABASE_DUPLICATE_WRITE` | 409 | 唯一索引冲突 |
+| `EXCEED_REQUEST_LIMIT` | 422 | 请求次数超限 |
+| `EXCEED_CONCURRENT_REQUEST_LIMIT` | 422 | 并发请求超限 |
+| `DATABASE_REQUEST_FAILED` | 500 | 数据库请求失败 |
+| `SYS_ERR` | 500 | 内部错误 |
+| `DATABASE_TRANSACTION_CONFLICT` | 503 | 事务冲突 |
+| `DATABASE_TRANSACTION_FAIL` | 503 | 事务执行失败 |
+| `DATABASE_TIMEOUT` | 504 | 数据库操作超时 |
+
+详细端点使用和请求示例，请参考官方文档：https://docs.cloudbase.net/http-api/nosql/nosql-restful-api
+
+---
+
+## AI 大模型接入 API
+
+统一的大模型接入 API，支持通过 HTTP 调用已配置的 AI 大模型（支持 SSE 流式响应）。
+
+### 认证方式
+
+| 方式 | 说明 |
+|------|------|
+| `Authorization: Bearer <token>` | AccessToken 认证（推荐） |
+| TC3-HMAC-SHA256 签名 | 腾讯云 API v3 签名方式 |
+| `Authorization: <apikey>` | APIKey 认证 |
+
+> AccessToken 获取方式：参考 Auth OpenAPI (`searchKnowledgeBase({ mode: "openapi", apiName: "auth" })`)
+
+### 错误码
+
+| 错误码 | 说明 |
+|--------|------|
+| `AI_MODEL_CONFIG_MISSING` | 缺少模型 API Key 或配置 |
+| `AI_MODEL_PARAM_INVALID` | 输入参数无效 |
+| `AI_MODEL_DISABLED` | 模型已禁用，请在控制台检查或等待约 2 分钟 |
+| `AI_MODEL_NOT_SUPPORTED` | 请求模型不支持或未启用 |
+| `AI_MODEL_PARAM_REQUIRED` | 缺少必需参数 `model` |
+| `AI_MODEL_NOT_FOUND` | 指定的模型组不存在 |
+| `EXCEED_CONCURRENT_REQUEST_LIMIT` | 并发请求超限，请稍后重试或申请更高配额 |
+| `EXCEED_TOKEN_QUOTA_LIMIT` | 模型 Token 配额超限，请购买资源或调整模型组 |
+
+详细端点和请求格式，请参考官方文档：https://docs.cloudbase.net/http-api/ai-model/ai-%E5%A4%A7%E6%A8%A1%E5%9E%8B%E6%8E%A5%E5%85%A5
+以及 OpenAPI 规范：`https://docs.cloudbase.net/openapi/ai_model.v1.openapi.yaml`
+
+---
+
 ## Online Debugging Tool
 
 CloudBase platform provides an [online debugging tool](/http-api/basic/online-api-call) where you can test API interfaces without writing code:
@@ -389,10 +476,12 @@ CloudBase platform provides an [online debugging tool](/http-api/basic/online-ap
 
 Use `searchKnowledgeBase({ mode: "openapi", apiName: "<api-name>" })` with these API names:
 - `auth` - Authentication API
-- `mysqldb` - MySQL RESTful API
+- `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+- `nosql` - NoSQL RESTful API (文档型数据库)
 - `functions` - Cloud Functions API
 - `cloudrun` - CloudRun API
 - `storage` - Storage API
+- `ai_model` - AI 大模型接入 API
 
 **How to use the OpenAPI documentation:**
 1. Call `searchKnowledgeBase` tool with the appropriate `apiName`

--- a/config/source/skills/http-api/checklist.md
+++ b/config/source/skills/http-api/checklist.md
@@ -8,16 +8,28 @@ Use this checklist when the request comes from Android, iOS, Flutter, React Nati
 2. Confirm environment ID, region, and gateway base URL.
 3. Choose the auth mechanism: AccessToken, API Key, or Publishable Key.
 4. Query the matching OpenAPI definition before writing request code.
-5. For database work, confirm whether the task is MySQL REST API, MCP SQL management, or Web SDK data access.
+5. For database work, confirm which REST API is needed:
+   - **关系型数据库 REST** (MySQL / PostgreSQL): `https://{envId}.api.tcloudbasegateway.com/v1/rdb/rest/{table}` — PostgREST 风格
+   - **NoSQL REST**: `https://{envId}.api.tcloudbasegateway.com/v1/database/instances/{instance}/databases/{database}/` — EJSON 格式
+6. For AI model access, confirm the calling pattern:
+   - **SDK 方式** (Node/Web/微信小程序): 走各端 SDK，不需要裸调 HTTP
+   - **HTTP API 方式**: `https://{envId}.api.tcloudbasegateway.com/...` — 参考 OpenAPI `ai_model`
+7. Verify the OpenAPI spec is available in `searchKnowledgeBase` before writing code:
+   - `mysqldb` — 关系型数据库 REST
+   - `nosql` — NoSQL REST
+   - `ai_model` — AI 大模型接入
+   - `auth` / `functions` / `cloudrun` / `storage` — 其他
 
 ## Do not route here when
 
 - The user is building a Web frontend with `@cloudbase/js-sdk`.
 - The user is building a CloudBase mini program with `wx.cloud`.
 - The task is MCP-driven database management rather than raw HTTP calls.
+- The user is calling AI models from Node/Web/微信 — use `ai-model-*` skills instead; only use HTTP API for unsupported runtimes.
 
 ## Done criteria
 
 - SDK support boundary is explicit.
-- OpenAPI source has been checked.
+- The correct REST API variant (关系型 / NoSQL / AI) has been identified.
+- OpenAPI source has been checked (`searchKnowledgeBase` with the right `apiName`).
 - The auth method and request base URL are fixed before code generation.

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1427,12 +1427,14 @@ rameterTable
 文档名：ui-design 文档介绍：Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.
 文档名：web-development 文档介绍：Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
 
-      OpenAPI 文档 (openapi) 查询当前支持 5 个 API 文档，分别是：
+      OpenAPI 文档 (openapi) 查询当前支持 7 个 API 文档，分别是：
       API名：functions API介绍：Cloud Functions API - 云函数 HTTP API
 API名：storage API介绍：Storage API - 云存储 HTTP API
-API名：mysqldb API介绍：MySQL RESTful API - 云开发 MySQL 数据库 HTTP API
+API名：mysqldb API介绍：关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API
+API名：nosql API介绍：NoSQL RESTful API - 文档型数据库 HTTP API
 API名：auth API介绍：Authentication API - 身份认证 HTTP API
 API名：cloudrun API介绍：CloudRun API - 云托管服务 HTTP API
+API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 
 #### 参数
 

--- a/doc/prompts/auth-http-api.mdx
+++ b/doc/prompts/auth-http-api.mdx
@@ -90,7 +90,7 @@ Use this skill whenever you need to call **CloudBase platform features** via **r
 
 - Non-Node backends (Go, Python, Java, PHP, etc.)
 - Integration tests or admin scripts that use curl or language HTTP clients
-- Direct database operations via MySQL RESTful API
+- Direct database operations via 关系型数据库 RESTful API (MySQL/PostgreSQL)
 - Cloud function invocation via HTTP
 - Any scenario where SDKs are not available or not preferred
 
@@ -148,11 +148,13 @@ Before implementing any HTTP API calls, you should:
    ```
 
 2. **Available API names**:
-   - `mysqldb` - MySQL RESTful API
+   - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+   - `nosql` - NoSQL RESTful API (文档型数据库)
    - `functions` - Cloud Functions API
    - `auth` - Authentication API
    - `cloudrun` - CloudRun API
    - `storage` - Storage API
+   - `ai_model` - AI 大模型接入 API
 
 3. **Parse and use the swagger documentation**:
    - Extract exact endpoint paths and HTTP methods
@@ -264,9 +266,11 @@ curl -X POST "https://your-env-id.api.tcloudbasegateway.com/v1/functions/YOUR_FU
 
 For detailed API specifications, always download and reference the OpenAPI Swagger files mentioned above.
 
-## MySQL RESTful API
+## 关系型数据库 RESTful API (PostgREST 风格)
 
-The MySQL RESTful API provides all MySQL database operations via HTTP endpoints.
+> **适用于 MySQL 和 PostgreSQL**：两者均基于 PostgREST 风格暴露 REST API，端点格式和请求语义一致。
+
+提供关系型数据库（MySQL / PostgreSQL）的 HTTP 操作接口。
 
 ### Base URL Patterns
 
@@ -425,10 +429,12 @@ CloudBase platform provides an [online debugging tool](/http-api/basic/online-ap
 
 Use `searchKnowledgeBase({ mode: "openapi", apiName: "<api-name>" })` with these API names:
 - `auth` - Authentication API
-- `mysqldb` - MySQL RESTful API
+- `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+- `nosql` - NoSQL RESTful API (文档型数据库)
 - `functions` - Cloud Functions API
 - `cloudrun` - CloudRun API
 - `storage` - Storage API
+- `ai_model` - AI 大模型接入 API
 
 **How to use the OpenAPI documentation:**
 1. Call `searchKnowledgeBase` tool with the appropriate `apiName`

--- a/doc/prompts/database-http-api.mdx
+++ b/doc/prompts/database-http-api.mdx
@@ -90,7 +90,7 @@ Use this skill whenever you need to call **CloudBase platform features** via **r
 
 - Non-Node backends (Go, Python, Java, PHP, etc.)
 - Integration tests or admin scripts that use curl or language HTTP clients
-- Direct database operations via MySQL RESTful API
+- Direct database operations via 关系型数据库 RESTful API (MySQL/PostgreSQL)
 - Cloud function invocation via HTTP
 - Any scenario where SDKs are not available or not preferred
 
@@ -148,11 +148,13 @@ Before implementing any HTTP API calls, you should:
    ```
 
 2. **Available API names**:
-   - `mysqldb` - MySQL RESTful API
+   - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+   - `nosql` - NoSQL RESTful API (文档型数据库)
    - `functions` - Cloud Functions API
    - `auth` - Authentication API
    - `cloudrun` - CloudRun API
    - `storage` - Storage API
+   - `ai_model` - AI 大模型接入 API
 
 3. **Parse and use the swagger documentation**:
    - Extract exact endpoint paths and HTTP methods
@@ -264,9 +266,11 @@ curl -X POST "https://your-env-id.api.tcloudbasegateway.com/v1/functions/YOUR_FU
 
 For detailed API specifications, always download and reference the OpenAPI Swagger files mentioned above.
 
-## MySQL RESTful API
+## 关系型数据库 RESTful API (PostgREST 风格)
 
-The MySQL RESTful API provides all MySQL database operations via HTTP endpoints.
+> **适用于 MySQL 和 PostgreSQL**：两者均基于 PostgREST 风格暴露 REST API，端点格式和请求语义一致。
+
+提供关系型数据库（MySQL / PostgreSQL）的 HTTP 操作接口。
 
 ### Base URL Patterns
 
@@ -425,10 +429,12 @@ CloudBase platform provides an [online debugging tool](/http-api/basic/online-ap
 
 Use `searchKnowledgeBase({ mode: "openapi", apiName: "<api-name>" })` with these API names:
 - `auth` - Authentication API
-- `mysqldb` - MySQL RESTful API
+- `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+- `nosql` - NoSQL RESTful API (文档型数据库)
 - `functions` - Cloud Functions API
 - `cloudrun` - CloudRun API
 - `storage` - Storage API
+- `ai_model` - AI 大模型接入 API
 
 **How to use the OpenAPI documentation:**
 1. Call `searchKnowledgeBase` tool with the appropriate `apiName`

--- a/doc/prompts/http-api.mdx
+++ b/doc/prompts/http-api.mdx
@@ -91,7 +91,7 @@ Use this skill whenever you need to call **CloudBase platform features** via **r
 
 - Non-Node backends (Go, Python, Java, PHP, etc.)
 - Integration tests or admin scripts that use curl or language HTTP clients
-- Direct database operations via MySQL RESTful API
+- Direct database operations via 关系型数据库 RESTful API (MySQL/PostgreSQL)
 - Cloud function invocation via HTTP
 - Any scenario where SDKs are not available or not preferred
 
@@ -122,11 +122,13 @@ Do **not** use this skill for:
 4. **Reference OpenAPI Swagger documentation**
    - **MUST use `searchKnowledgeBase` tool** to get OpenAPI specifications
    - Use the tool with `mode=openapi` and specify the `apiName`:
-     - `mysqldb` - MySQL RESTful API
+     - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+     - `nosql` - NoSQL RESTful API (文档型数据库)
      - `functions` - Cloud Functions API
      - `auth` - Authentication API
      - `cloudrun` - CloudRun API
      - `storage` - Storage API
+     - `ai_model` - AI 大模型接入 API
    - Example: `searchKnowledgeBase({ mode: "openapi", apiName: "mysqldb" })`
    - Parse the returned YAML content to understand exact endpoint paths, parameters, request/response schemas
    - Never invent endpoints or parameters - always reference the swagger documentation
@@ -149,11 +151,13 @@ Before implementing any HTTP API calls, you should:
    ```
 
 2. **Available API names**:
-   - `mysqldb` - MySQL RESTful API
+   - `mysqldb` - 关系型数据库 RESTful API (MySQL/PostgreSQL)
+   - `nosql` - NoSQL RESTful API (文档型数据库)
    - `functions` - Cloud Functions API
    - `auth` - Authentication API
    - `cloudrun` - CloudRun API
    - `storage` - Storage API
+   - `ai_model` - AI 大模型接入 API
 
 3. **Parse and use the swagger documentation**:
    - Extract exact endpoint paths and HTTP methods
@@ -265,9 +269,11 @@ curl -X POST "https://your-env-id.api.tcloudbasegateway.com/v1/functions/YOUR_FU
 
 For detailed API specifications, always download and reference the OpenAPI Swagger files mentioned above.
 
-## MySQL RESTful API
+## 关系型数据库 RESTful API (PostgREST 风格)
 
-The MySQL RESTful API provides all MySQL database operations via HTTP endpoints.
+> **适用于 MySQL 和 PostgreSQL**：两者均基于 PostgREST 风格暴露 REST API，端点格式和请求语义一致。
+
+提供关系型数据库（MySQL / PostgreSQL）的 HTTP 操作接口。
 
 ### Base URL Patterns
 

--- a/mcp/src/tools/rag.ts
+++ b/mcp/src/tools/rag.ts
@@ -263,7 +263,7 @@ const OPENAPI_SOURCES: Array<{
 }> = [
     {
       name: "mysqldb",
-      description: "MySQL RESTful API - 云开发 MySQL 数据库 HTTP API",
+      description: "关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API",
       url: "https://docs.cloudbase.net/openapi/mysqldb.v1.openapi.yaml",
     },
     {
@@ -285,6 +285,16 @@ const OPENAPI_SOURCES: Array<{
       name: "storage",
       description: "Storage API - 云存储 HTTP API",
       url: "https://docs.cloudbase.net/openapi/storage.v1.openapi.yaml",
+    },
+    {
+      name: "nosql",
+      description: "NoSQL RESTful API - 文档型数据库 HTTP API",
+      url: "https://docs.cloudbase.net/openapi/nosql.v1.openapi.yaml",
+    },
+    {
+      name: "ai_model",
+      description: "AI 大模型接入 API - 统一 AI 模型 HTTP API",
+      url: "https://docs.cloudbase.net/openapi/ai_model.v1.openapi.yaml",
     },
   ];
 


### PR DESCRIPTION
## Summary
- Add `nosql` and `ai_model` to `OPENAPI_SOURCES` in `rag.ts`
- Update `http-api/SKILL.md`: fix MySQL → 关系型数据库 title, add NoSQL REST + AI Model sections
- Update `http-api/checklist.md`: add routing checks for new APIs
- Update `ai-model-*/SKILL.md`: add HTTP API fallback note
- Update `doc/mcp-tools.md` and `doc/prompts/*.mdx`: 5 → 7 APIs in lists
- Sync compat configs via `build-compat-config.mjs` and `sync-claude-skills-mirror.mjs`

## Checklist
- [x] `mcp/src/tools/rag.ts` updated
- [x] `config/source/skills/http-api/SKILL.md` updated
- [x] `doc/mcp-tools.md` updated
- [x] Compat configs regenerated