### PR TITLE
chore(release): 📝 update skill versions to v2.19.0

### DIFF
--- a/config/.claude/skills/ai-model-nodejs/SKILL.md
+++ b/config/.claude/skills/ai-model-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-nodejs
 description: "Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express, Koa, NestJS, serverless APIs, scheduled jobs, LLM proxies. Only SDK supporting image generation (ai.createImageModel + generateImage). Text models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field of generateText/streamText. MUST run two-step preflight before code — see body. Keywords: backend, 云函数, 云托管, serverless, LLM proxy, agent orchestration, generateText, streamText, generateImage, createModel, hunyuan-image, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat)."
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-web/SKILL.md
+++ b/config/.claude/skills/ai-model-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-web
 description: "Use this skill when a browser/Web app (React, Vue, Angular, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI) needs AI models via @cloudbase/js-sdk. Default routing for page/页面/Web/前端/frontend/网页/H5 AI — call directly from browser, do NOT propose a Node.js proxy. Covers generateText and streamText. Models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field. MUST run two-step preflight before code — see body. Keywords: 页面, Web, 前端, React, Vue, Next, Nuxt, SPA, AI chat UI, generateText, streamText, createModel, hunyuan-exp, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only)."
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-wechat/SKILL.md
+++ b/config/.claude/skills/ai-model-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-wechat
 description: "Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, 企业微信小程序, wx.cloud apps). Features generateText and streamText with callbacks (onText, onEvent, onFinish). Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the data wrapper model field. API differs from JS/Node SDK — streamText needs data wrapper, generateText returns raw response. MUST run two-step preflight before code — see body. Keywords: Mini Program AI, wx.cloud.extend.AI, 小程序成长计划, ai_miniprogram_inspire_plan, Token Credits 资源包, generateText, streamText, createModel, hunyuan-exp, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs)."
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-nodejs/SKILL.md
+++ b/config/.claude/skills/auth-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-nodejs-cloudbase
 description: CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-tool/SKILL.md
+++ b/config/.claude/skills/auth-tool/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-tool-cloudbase
 description: CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-web/SKILL.md
+++ b/config/.claude/skills/auth-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-web-cloudbase
 description: CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-wechat/SKILL.md
+++ b/config/.claude/skills/auth-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-wechat-miniprogram
 description: CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-storage-web
 description: Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-agent/SKILL.md
+++ b/config/.claude/skills/cloudbase-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-agent
 description: Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 allowed-tools: 
 disable: false

--- a/config/.claude/skills/cloudbase-cli/SKILL.md
+++ b/config/.claude/skills/cloudbase-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-cli
 description: CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. This skill should be used when users need to deploy cloud functions, manage CloudRun apps, upload files to storage, query NoSQL/MySQL databases, deploy static hosting, set access permissions, or configure CORS/domains/routing via tcb commands. Also use for CI/CD pipeline scripting, batch operations, terminal-based CloudBase management, or when the user prefers CLI over SDK/MCP.
-version: 1.0.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-platform/SKILL.md
+++ b/config/.claude/skills/cloudbase-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-platform
 description: CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudrun-development
 description: CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, or AI agent development.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/data-model-creation/SKILL.md
+++ b/config/.claude/skills/data-model-creation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-model-creation
 description: Optional advanced tool for complex data modeling. For simple table creation, use relational-database-tool directly with SQL statements.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/http-api/SKILL.md
+++ b/config/.claude/skills/http-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: http-api-cloudbase
 description: CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/miniprogram-development/SKILL.md
+++ b/config/.claude/skills/miniprogram-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: miniprogram-development
 description: WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools workflows, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, or 云开发 in a mini program project.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/no-sql-web-sdk/SKILL.md
+++ b/config/.claude/skills/no-sql-web-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-web-sdk
 description: Use CloudBase document database Web SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, realtime, and geolocation queries.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/no-sql-wx-mp-sdk/SKILL.md
+++ b/config/.claude/skills/no-sql-wx-mp-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-in-wechat-miniprogram
 description: Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ops-inspector/SKILL.md
+++ b/config/.claude/skills/ops-inspector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inspector
 description: AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/relational-database-tool/SKILL.md
+++ b/config/.claude/skills/relational-database-tool/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-mcp-cloudbase
 description: This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `querySqlDatabase`, `manageSqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/relational-database-web/SKILL.md
+++ b/config/.claude/skills/relational-database-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-web-cloudbase
 description: Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/spec-workflow/SKILL.md
+++ b/config/.claude/skills/spec-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-workflow
 description: Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ui-design/SKILL.md
+++ b/config/.claude/skills/ui-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-design
 description: Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/web-development/SKILL.md
+++ b/config/.claude/skills/web-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-development
 description: Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
-version: 2.18.0
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/guideline/cloudbase/SKILL.md
+++ b/config/source/guideline/cloudbase/SKILL.md
@@ -3,7 +3,7 @@ name: cloudbase
 description: "Use this skill when you develop, design, build, deploy, debug, migrate, or troubleshoot CloudBase (腾讯云开发, 云开发, TCB, 微信云开发) projects. Covers Web apps (React, Vue, Vite, Next, Nuxt, 网站, dashboards, 管理后台), 微信小程序, 小程序, uni-app, native/mobile (iOS, Android, Flutter, React Native) via HTTP API. Includes UI (页面, 界面, 登录页, 表单, form, dashboard, 仪表盘, prototype, 原型), auth (登录, 注册, OAuth, 微信登录, publishable key), databases (NoSQL 文档数据库, MySQL 关系型数据库, CRUD, security rules), 云函数 (serverless, scf_bootstrap, HTTP Functions), CloudRun (云托管, Dockerfile), 云存储 (file upload, hosting, 静态托管). Built-in AI (内置大模型, streaming, 流式输出, image generation, 图片生成, 图像生成, generateText, streamText, createModel, generateImage, TokenHub, Hunyuan, hunyuan-exp, DeepSeek, deepseek, GLM, Kimi, MiniMax, Token Credits 资源包, 小程序成长计划), 第三方大模型, 大模型接入, 大模型调用, LLM API, chatbot, AI 助手, AI agent, 智能体, AG-UI, LangGraph, LangChain. Ops (巡检, 诊断, health check, 日志, troubleshooting, 排查). Spec workflow (需求文档, 技术方案, 架构设计, requirements, tasks.md)."
 description_zh: 为你的小程序和 Web/H5 提供一体化运行与部署环境，包括数据库、云函数、云存储、身份权限和静态托管
 description_en: An all-in-one runtime and deployment environment for WeChat Mini Programs and Web/H5 apps, including database, cloud functions, cloud storage, identity and access control, and static hosting.
-version: 2.18.1
+version: 2.19.0
 ---
 
 # CloudBase Development Guidelines

--- a/config/source/skills/SKILL.md
+++ b/config/source/skills/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-all-in-one
 description: Unified CloudBase execution guide for all-in-one skill installs. Use this as the first entry point for CloudBase app tasks, especially existing applications that already contain TODOs, fixed pages, and active handlers.
-version: 2.16.2
+version: 2.19.0
 alwaysApply: true
 ---
 

--- a/config/source/skills/ai-model-nodejs/SKILL.md
+++ b/config/source/skills/ai-model-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-nodejs
 description: "Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express, Koa, NestJS, serverless APIs, scheduled jobs, LLM proxies. Only SDK supporting image generation (ai.createImageModel + generateImage). Text models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field of generateText/streamText. MUST run two-step preflight before code — see body. Keywords: backend, 云函数, 云托管, serverless, LLM proxy, agent orchestration, generateText, streamText, generateImage, createModel, hunyuan-image, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat)."
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/ai-model-web/SKILL.md
+++ b/config/source/skills/ai-model-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-web
 description: "Use this skill when a browser/Web app (React, Vue, Angular, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI) needs AI models via @cloudbase/js-sdk. Default routing for page/页面/Web/前端/frontend/网页/H5 AI — call directly from browser, do NOT propose a Node.js proxy. Covers generateText and streamText. Models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field. MUST run two-step preflight before code — see body. Keywords: 页面, Web, 前端, React, Vue, Next, Nuxt, SPA, AI chat UI, generateText, streamText, createModel, hunyuan-exp, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only)."
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/ai-model-wechat/SKILL.md
+++ b/config/source/skills/ai-model-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-wechat
 description: "Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, 企业微信小程序, wx.cloud apps). Features generateText and streamText with callbacks (onText, onEvent, onFinish). Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the data wrapper model field. API differs from JS/Node SDK — streamText needs data wrapper, generateText returns raw response. MUST run two-step preflight before code — see body. Keywords: Mini Program AI, wx.cloud.extend.AI, 小程序成长计划, ai_miniprogram_inspire_plan, Token Credits 资源包, generateText, streamText, createModel, hunyuan-exp, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs)."
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/auth-nodejs/SKILL.md
+++ b/config/source/skills/auth-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-nodejs-cloudbase
 description: CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/auth-tool/SKILL.md
+++ b/config/source/skills/auth-tool/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-tool-cloudbase
 description: CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-web-cloudbase
 description: CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/auth-wechat/SKILL.md
+++ b/config/source/skills/auth-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-wechat-miniprogram
 description: CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/cloud-storage-web/SKILL.md
+++ b/config/source/skills/cloud-storage-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-storage-web
 description: Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/cloudbase-agent/SKILL.md
+++ b/config/source/skills/cloudbase-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-agent
 description: Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 allowed-tools: 
 disable: false

--- a/config/source/skills/cloudbase-cli/SKILL.md
+++ b/config/source/skills/cloudbase-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-cli
 description: CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. This skill should be used when users need to deploy cloud functions, manage CloudRun apps, upload files to storage, query NoSQL/MySQL databases, deploy static hosting, set access permissions, or configure CORS/domains/routing via tcb commands. Also use for CI/CD pipeline scripting, batch operations, terminal-based CloudBase management, or when the user prefers CLI over SDK/MCP.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-platform
 description: CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudrun-development
 description: CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, or AI agent development.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/data-model-creation/SKILL.md
+++ b/config/source/skills/data-model-creation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-model-creation
 description: Optional advanced tool for complex data modeling. For simple table creation, use relational-database-tool directly with SQL statements.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/http-api/SKILL.md
+++ b/config/source/skills/http-api/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: http-api-cloudbase
 description: CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/miniprogram-development/SKILL.md
+++ b/config/source/skills/miniprogram-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: miniprogram-development
 description: WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools workflows, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, or 云开发 in a mini program project.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/no-sql-web-sdk/SKILL.md
+++ b/config/source/skills/no-sql-web-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-web-sdk
 description: Use CloudBase document database Web SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, realtime, and geolocation queries.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/no-sql-wx-mp-sdk/SKILL.md
+++ b/config/source/skills/no-sql-wx-mp-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-in-wechat-miniprogram
 description: Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/ops-inspector/SKILL.md
+++ b/config/source/skills/ops-inspector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inspector
 description: AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/relational-database-tool/SKILL.md
+++ b/config/source/skills/relational-database-tool/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-mcp-cloudbase
 description: This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `querySqlDatabase`, `manageSqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/relational-database-web/SKILL.md
+++ b/config/source/skills/relational-database-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-web-cloudbase
 description: Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/spec-workflow/SKILL.md
+++ b/config/source/skills/spec-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-workflow
 description: Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/ui-design/SKILL.md
+++ b/config/source/skills/ui-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-design
 description: Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/config/source/skills/web-development/SKILL.md
+++ b/config/source/skills/web-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-development
 description: Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
-version: 2.18.1
+version: 2.19.0
 alwaysApply: false
 ---
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1396,7 +1396,7 @@ Manage SQL database resources. Supports MySQL provisioning, MySQL destruction, w
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.18.0），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.19.0），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数


### PR DESCRIPTION
## Summary
- Update all skill `version:` fields from `2.18.1` → `2.19.0` (config/source/skills/*/SKILL.md, config/source/guideline/cloudbase/SKILL.md)
- Update `doc/mcp-tools.md` version reference: `2.18.0` → `2.19.0`
- Copy `README.md` to `mcp/README.md`
- Sync Claude skills mirror (`config/.claude/skills/`)

## Related
Prep for v2.19.0 release (tag already published).