### PR TITLE
fix(mcp): 🔒 harden remote download safety and vitest compatibility

### DIFF
--- a/mcp/postcss.config.cjs
+++ b/mcp/postcss.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  plugins: {},
+};

--- a/mcp/src/server.test.ts
+++ b/mcp/src/server.test.ts
@@ -67,7 +67,13 @@ vi.mock("./utils/cloud-mode.js", () => ({
   isCloudMode: vi.fn(() => false),
 }));
 vi.mock("./utils/tencent-cloud.js", () => ({ isInternationalRegion: vi.fn(() => false) }));
-vi.mock("@modelcontextprotocol/sdk/types.js", () => ({ SetLevelRequestSchema: {} }));
+vi.mock("@modelcontextprotocol/sdk/types.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@modelcontextprotocol/sdk/types.js")>();
+  return {
+    ...actual,
+    SetLevelRequestSchema: actual.SetLevelRequestSchema ?? {},
+  };
+});
 
 describe("server plugin registration", () => {
   beforeEach(() => {

--- a/mcp/src/tools/download.test.ts
+++ b/mcp/src/tools/download.test.ts
@@ -1,0 +1,202 @@
+import * as dns from "dns";
+import * as fs from "fs/promises";
+import * as http from "http";
+import { EventEmitter } from "node:events";
+import * as os from "os";
+import * as path from "path";
+import { PassThrough } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtendedMcpServer } from "../server.js";
+
+type RegisteredTool = { meta: any; handler: (args: any) => Promise<any> };
+
+async function createMockServer() {
+  const tools: Record<string, RegisteredTool> = {};
+  const server: ExtendedMcpServer = {
+    registerTool: vi.fn((name: string, meta: any, handler: (args: any) => Promise<any>) => {
+      tools[name] = { meta, handler };
+    }),
+  } as unknown as ExtendedMcpServer;
+
+  const { registerDownloadTools } = await import("./download.js");
+  registerDownloadTools(server);
+  return tools;
+}
+
+function createMockRequest(): http.ClientRequest {
+  return new EventEmitter() as http.ClientRequest;
+}
+
+function createMockResponse(
+  statusCode: number,
+  headers: http.IncomingHttpHeaders,
+  body = "",
+): http.IncomingMessage {
+  const response = new PassThrough() as PassThrough & http.IncomingMessage;
+  response.statusCode = statusCode;
+  response.headers = headers;
+  process.nextTick(() => {
+    response.end(body);
+  });
+  return response;
+}
+
+function mockPublicDnsLookup(hostnames: string[]) {
+  vi.spyOn(dns.promises, "lookup").mockImplementation((async (hostname: string, options?: dns.LookupOneOptions | dns.LookupAllOptions) => {
+    if (!hostnames.includes(hostname)) {
+      throw new Error(`unexpected hostname: ${hostname}`);
+    }
+
+    const result = { address: "93.184.216.34", family: 4 };
+    if (typeof options === "object" && options?.all) {
+      return [result];
+    }
+
+    return result;
+  }) as any);
+}
+
+describe("downloadRemoteFile security", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "download-tool-test-"));
+    process.env.PROJECT_ROOT = tempRoot;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("http");
+    delete process.env.PROJECT_ROOT;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("should block localhost targets before any request is sent", async () => {
+    const tools = await createMockServer();
+    let hitCount = 0;
+
+    const localServer = http.createServer((req, res) => {
+      hitCount += 1;
+      res.writeHead(200, { "Content-Type": "text/plain" });
+      res.end("ok");
+    });
+
+    await new Promise<void>((resolve) => localServer.listen(18090, "127.0.0.1", () => resolve()));
+
+    try {
+      await expect(
+        tools.downloadRemoteFile.handler({
+          url: "http://127.0.0.1:18090/poc.txt",
+          relativePath: "tmp/poc.txt",
+        }),
+      ).rejects.toThrow(/内网地址|不安全/);
+
+      expect(hitCount).toBe(0);
+    } finally {
+      await new Promise<void>((resolve, reject) => localServer.close((error) => (error ? reject(error) : resolve())));
+    }
+  });
+
+  it("should reject localhost closed ports before connect errors leak", async () => {
+    const tools = await createMockServer();
+
+    await expect(
+      tools.downloadRemoteFile.handler({
+        url: "http://127.0.0.1:18091/poc.txt",
+        relativePath: "tmp/poc.txt",
+      }),
+    ).rejects.toThrow(/内网地址|不安全/);
+  });
+
+  it("should reject ipv6-mapped localhost targets before any request is sent", async () => {
+    const tools = await createMockServer();
+
+    await expect(
+      tools.downloadRemoteFile.handler({
+        url: "http://[::ffff:127.0.0.1]:18092/poc.txt",
+        relativePath: "tmp/poc.txt",
+      }),
+    ).rejects.toThrow(/内网地址|不安全/);
+  });
+
+  it("should block redirects to localhost before sending the next request", async () => {
+    mockPublicDnsLookup(["safe.example"]);
+
+    const mockedGet = vi.fn((url: URL, options: http.RequestOptions, callback: (res: http.IncomingMessage) => void) => {
+      expect(typeof options.lookup).toBe("function");
+      process.nextTick(() => {
+        callback(
+          createMockResponse(302, {
+            location: "http://localhost:18090/blocked.txt",
+          }),
+        );
+      });
+      return createMockRequest();
+    });
+
+    vi.doMock("http", async () => {
+      const actual = await vi.importActual<typeof import("http")>("http");
+      return {
+        ...actual,
+        get: mockedGet,
+      };
+    });
+
+    const tools = await createMockServer();
+
+    await expect(
+      tools.downloadRemoteFile.handler({
+        url: "http://safe.example/entry.txt",
+        relativePath: "tmp/redirected.txt",
+      }),
+    ).rejects.toThrow(/内网地址|不安全/);
+
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+    expect(mockedGet.mock.calls[0]?.[0].toString()).toBe("http://safe.example/entry.txt");
+  });
+
+  it("should download allowed public content to the target path", async () => {
+    mockPublicDnsLookup(["safe.example"]);
+
+    const mockedGet = vi.fn((url: URL, options: http.RequestOptions, callback: (res: http.IncomingMessage) => void) => {
+      expect(url.toString()).toBe("http://safe.example/file.txt");
+      expect(typeof options.lookup).toBe("function");
+      process.nextTick(() => {
+        callback(
+          createMockResponse(
+            200,
+            {
+              "content-type": "text/plain",
+              "content-length": "5",
+            },
+            "hello",
+          ),
+        );
+      });
+      return createMockRequest();
+    });
+
+    vi.doMock("http", async () => {
+      const actual = await vi.importActual<typeof import("http")>("http");
+      return {
+        ...actual,
+        get: mockedGet,
+      };
+    });
+
+    const tools = await createMockServer();
+    const result = await tools.downloadRemoteFile.handler({
+      url: "http://safe.example/file.txt",
+      relativePath: "tmp/safe-file.txt",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(true);
+    expect(payload.relativePath).toBe("tmp/safe-file.txt");
+    expect(payload.contentType).toBe("text/plain");
+    expect(payload.fileSize).toBe(5);
+    await expect(fs.readFile(path.join(tempRoot, "tmp/safe-file.txt"), "utf8")).resolves.toBe("hello");
+    expect(mockedGet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/mcp/src/tools/download.ts
+++ b/mcp/src/tools/download.ts
@@ -3,18 +3,17 @@ import * as fs from "fs";
 import * as fsPromises from "fs/promises";
 import * as http from "http";
 import * as https from "https";
-import * as net from "net";
 import * as os from "os";
 import * as path from "path";
 import { URL } from "url";
 import { z } from "zod";
 
-import * as dns from "dns";
-import { ExtendedMcpServer } from '../server.js';
+import { ExtendedMcpServer } from "../server.js";
+import { prepareSafeRemoteRequest } from "../utils/remote-url-safety.js";
 
 // 常量定义
 const MAX_FILE_SIZE = 100 * 1024 * 1024; // 100MB
-const ALLOWED_PROTOCOLS = ["http:", "https:"];
+const MAX_REDIRECT_HOPS = 5;
 const ALLOWED_CONTENT_TYPES = [
   "text/",
   "image/",
@@ -70,69 +69,6 @@ function calculateDownloadPath(relativePath: string): string {
   }
   
   return finalPath;
-}
-
-// 检查是否为内网 IP
-function isPrivateIP(ip: string): boolean {
-  // 如果不是有效的 IP 地址，返回 true（保守处理）
-  if (!net.isIP(ip)) {
-    return true;
-  }
-
-  // 检查特殊地址
-  if (ip === '127.0.0.1' || 
-      ip === 'localhost' ||
-      ip === '::1' || // IPv6 本地回环
-      ip.startsWith('169.254.') || // 链路本地地址
-      ip.startsWith('0.')) { // 特殊用途地址
-    return true;
-  }
-
-  // 转换 IP 地址为长整数进行范围检查
-  const ipv4Parts = ip.split('.').map(part => parseInt(part, 10));
-  if (ipv4Parts.length === 4) {
-    const ipNum = ((ipv4Parts[0] << 24) >>> 0) + (ipv4Parts[1] << 16) + (ipv4Parts[2] << 8) + ipv4Parts[3];
-    
-    // 检查私有 IP 范围
-    // 10.0.0.0 - 10.255.255.255
-    if (ipNum >= 167772160 && ipNum <= 184549375) return true;
-    
-    // 172.16.0.0 - 172.31.255.255
-    if (ipNum >= 2886729728 && ipNum <= 2887778303) return true;
-    
-    // 192.168.0.0 - 192.168.255.255
-    if (ipNum >= 3232235520 && ipNum <= 3232301055) return true;
-  }
-  
-  // 检查 IPv6 私有地址
-  if (net.isIPv6(ip)) {
-    const normalizedIP = ip.toLowerCase();
-    if (normalizedIP.startsWith('fc00:') || // 唯一本地地址
-        normalizedIP.startsWith('fe80:') || // 链路本地地址
-        normalizedIP.startsWith('fec0:') || // 站点本地地址
-        normalizedIP.startsWith('::1')) { // 本地回环
-      return true;
-    }
-  }
-
-  return false;
-}
-
-// 检查域名是否解析到内网 IP
-async function doesDomainResolveToPrivateIP(hostname: string): Promise<boolean> {
-  try {
-    const addresses = await new Promise<string[]>((resolve, reject) => {
-      dns.resolve(hostname, (err, addresses) => {
-        if (err) reject(err);
-        else resolve(addresses);
-      });
-    });
-    
-    return addresses.some(ip => isPrivateIP(ip));
-  } catch (error) {
-    // 如果解析失败，为安全起见返回 true
-    return true;
-  }
 }
 
 // 生成随机文件名
@@ -192,32 +128,8 @@ function getFileExtension(url: string, contentType: string, contentDisposition?:
   return extension;
 }
 
-// 验证 URL 和内容类型是否安全
-async function isUrlAndContentTypeSafe(url: string, contentType: string): Promise<boolean> {
-  try {
-    const parsedUrl = new URL(url);
-    
-    // 检查协议
-    if (!ALLOWED_PROTOCOLS.includes(parsedUrl.protocol)) {
-      return false;
-    }
-    
-    // 检查主机名是否为 IP 地址
-    const hostname = parsedUrl.hostname;
-    if (net.isIP(hostname) && isPrivateIP(hostname)) {
-      return false;
-    }
-    
-    // 如果是域名，检查它是否解析到内网 IP
-    if (!net.isIP(hostname) && await doesDomainResolveToPrivateIP(hostname)) {
-      return false;
-    }
-    
-    // 检查内容类型
-    return ALLOWED_CONTENT_TYPES.some(allowedType => contentType.startsWith(allowedType));
-  } catch {
-    return false;
-  }
+function isAllowedContentType(contentType: string): boolean {
+  return ALLOWED_CONTENT_TYPES.some((allowedType) => contentType.startsWith(allowedType));
 }
 
 // 检查是否为可重试的网络错误
@@ -236,7 +148,12 @@ function isRetryableError(error: NodeJS.ErrnoException): boolean {
 }
 
 // 下载文件到指定路径（带重试逻辑）
-function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Promise<{
+async function downloadFileToPath(
+  url: string,
+  targetPath: string,
+  retryCount = 0,
+  redirectCount = 0,
+): Promise<{
   filePath: string;
   contentType: string;
   fileSize: number;
@@ -244,14 +161,20 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
   const MAX_RETRIES = 3;
   const BASE_DELAY_MS = 1000; // 1秒基础延迟
 
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https:') ? https : http;
+  if (redirectCount > MAX_REDIRECT_HOPS) {
+    throw new Error(`重定向次数超过 ${MAX_REDIRECT_HOPS} 次限制`);
+  }
 
-    const request = client.get(url, async (res) => {
+  const { requestUrl, requestOptions } = await prepareSafeRemoteRequest(url);
+  const client = requestUrl.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const request = client.get(requestUrl, requestOptions ?? {}, async (res) => {
       // 处理重定向
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         try {
-          return resolve(await downloadFileToPath(res.headers.location, targetPath, retryCount));
+          const redirectUrl = new URL(res.headers.location, requestUrl).toString();
+          return resolve(await downloadFileToPath(redirectUrl, targetPath, retryCount, redirectCount + 1));
         } catch (error) {
           return reject(error);
         }
@@ -262,13 +185,11 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
         return;
       }
 
-      const contentType = res.headers['content-type'] || '';
-      const contentLength = parseInt(res.headers['content-length'] || '0', 10);
-      const contentDisposition = res.headers['content-disposition'];
+      const contentType = res.headers["content-type"] || "";
+      const contentLength = parseInt(res.headers["content-length"] || "0", 10);
 
-      // 安全检查
-      if (!await isUrlAndContentTypeSafe(url, contentType)) {
-        reject(new Error('不安全的 URL 或内容类型，或者目标为内网地址'));
+      if (!isAllowedContentType(contentType)) {
+        reject(new Error(`不允许的内容类型: ${contentType || "unknown"}`));
         return;
       }
 
@@ -283,7 +204,7 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
       try {
         await fsPromises.mkdir(targetDir, { recursive: true });
       } catch (error) {
-        reject(new Error(`无法创建目标目录: ${error instanceof Error ? error.message : '未知错误'}`));
+        reject(new Error(`无法创建目标目录: ${error instanceof Error ? error.message : "未知错误"}`));
         return;
       }
 
@@ -291,7 +212,7 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
       const fileStream = fs.createWriteStream(targetPath);
       let downloadedSize = 0;
 
-      res.on('data', (chunk) => {
+      res.on("data", (chunk) => {
         downloadedSize += chunk.length;
         if (downloadedSize > MAX_FILE_SIZE) {
           fileStream.destroy();
@@ -302,28 +223,28 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
 
       res.pipe(fileStream);
 
-      fileStream.on('finish', () => {
+      fileStream.on("finish", () => {
         resolve({
           filePath: targetPath,
           contentType,
-          fileSize: downloadedSize
+          fileSize: downloadedSize,
         });
       });
 
-      fileStream.on('error', (error: NodeJS.ErrnoException) => {
+      fileStream.on("error", (error: NodeJS.ErrnoException) => {
         fsPromises.unlink(targetPath).catch(() => {});
         reject(error);
       });
     });
 
-    request.on('error', async (error: NodeJS.ErrnoException) => {
+    request.on("error", async (error: NodeJS.ErrnoException) => {
       // 检查是否可重试
       if (isRetryableError(error) && retryCount < MAX_RETRIES) {
         const delay = BASE_DELAY_MS * Math.pow(2, retryCount); // 指数退避
         console.warn(`下载失败 (${error.code})，${delay}ms 后重试 (${retryCount + 1}/${MAX_RETRIES})...`);
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
         try {
-          return resolve(await downloadFileToPath(url, targetPath, retryCount + 1));
+          return resolve(await downloadFileToPath(url, targetPath, retryCount + 1, redirectCount));
         } catch (retryError) {
           return reject(retryError);
         }
@@ -334,7 +255,11 @@ function downloadFileToPath(url: string, targetPath: string, retryCount = 0): Pr
 }
 
 // 下载文件到临时目录（保持向后兼容，带重试逻辑）
-function downloadFile(url: string, retryCount = 0): Promise<{
+async function downloadFile(
+  url: string,
+  retryCount = 0,
+  redirectCount = 0,
+): Promise<{
   filePath: string;
   contentType: string;
   fileSize: number;
@@ -342,14 +267,20 @@ function downloadFile(url: string, retryCount = 0): Promise<{
   const MAX_RETRIES = 3;
   const BASE_DELAY_MS = 1000; // 1秒基础延迟
 
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith('https:') ? https : http;
+  if (redirectCount > MAX_REDIRECT_HOPS) {
+    throw new Error(`重定向次数超过 ${MAX_REDIRECT_HOPS} 次限制`);
+  }
 
-    const request = client.get(url, async (res) => {
+  const { requestUrl, requestOptions } = await prepareSafeRemoteRequest(url);
+  const client = requestUrl.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
+    const request = client.get(requestUrl, requestOptions ?? {}, async (res) => {
       // 处理重定向
       if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
         try {
-          return resolve(await downloadFile(res.headers.location, retryCount));
+          const redirectUrl = new URL(res.headers.location, requestUrl).toString();
+          return resolve(await downloadFile(redirectUrl, retryCount, redirectCount + 1));
         } catch (error) {
           return reject(error);
         }
@@ -360,13 +291,12 @@ function downloadFile(url: string, retryCount = 0): Promise<{
         return;
       }
 
-      const contentType = res.headers['content-type'] || '';
-      const contentLength = parseInt(res.headers['content-length'] || '0', 10);
-      const contentDisposition = res.headers['content-disposition'];
+      const contentType = res.headers["content-type"] || "";
+      const contentLength = parseInt(res.headers["content-length"] || "0", 10);
+      const contentDisposition = res.headers["content-disposition"];
 
-      // 安全检查
-      if (!await isUrlAndContentTypeSafe(url, contentType)) {
-        reject(new Error('不安全的 URL 或内容类型，或者目标为内网地址'));
+      if (!isAllowedContentType(contentType)) {
+        reject(new Error(`不允许的内容类型: ${contentType || "unknown"}`));
         return;
       }
 
@@ -377,7 +307,7 @@ function downloadFile(url: string, retryCount = 0): Promise<{
       }
 
       // 生成临时文件路径
-      const extension = getFileExtension(url, contentType, contentDisposition);
+      const extension = getFileExtension(requestUrl.toString(), contentType, contentDisposition);
       const fileName = generateRandomFileName(extension);
       const filePath = getSafeTempFilePath(fileName);
 
@@ -385,7 +315,7 @@ function downloadFile(url: string, retryCount = 0): Promise<{
       const fileStream = fs.createWriteStream(filePath);
       let downloadedSize = 0;
 
-      res.on('data', (chunk) => {
+      res.on("data", (chunk) => {
         downloadedSize += chunk.length;
         if (downloadedSize > MAX_FILE_SIZE) {
           fileStream.destroy();
@@ -396,28 +326,28 @@ function downloadFile(url: string, retryCount = 0): Promise<{
 
       res.pipe(fileStream);
 
-      fileStream.on('finish', () => {
+      fileStream.on("finish", () => {
         resolve({
           filePath,
           contentType,
-          fileSize: downloadedSize
+          fileSize: downloadedSize,
         });
       });
 
-      fileStream.on('error', (error: NodeJS.ErrnoException) => {
+      fileStream.on("error", (error: NodeJS.ErrnoException) => {
         fsPromises.unlink(filePath).catch(() => {});
         reject(error);
       });
     });
 
-    request.on('error', async (error: NodeJS.ErrnoException) => {
+    request.on("error", async (error: NodeJS.ErrnoException) => {
       // 检查是否可重试
       if (isRetryableError(error) && retryCount < MAX_RETRIES) {
         const delay = BASE_DELAY_MS * Math.pow(2, retryCount); // 指数退避
         console.warn(`下载失败 (${error.code})，${delay}ms 后重试 (${retryCount + 1}/${MAX_RETRIES})...`);
-        await new Promise(resolve => setTimeout(resolve, delay));
+        await new Promise((resolveDelay) => setTimeout(resolveDelay, delay));
         try {
-          return resolve(await downloadFile(url, retryCount + 1));
+          return resolve(await downloadFile(url, retryCount + 1, redirectCount));
         } catch (retryError) {
           return reject(retryError);
         }

--- a/mcp/src/tools/setup.test.ts
+++ b/mcp/src/tools/setup.test.ts
@@ -1,0 +1,130 @@
+import AdmZip from "adm-zip";
+import * as dns from "dns";
+import * as fs from "fs/promises";
+import * as https from "https";
+import type { ClientRequest, IncomingHttpHeaders, IncomingMessage, RequestOptions } from "http";
+import { EventEmitter } from "node:events";
+import * as os from "os";
+import * as path from "path";
+import { PassThrough } from "stream";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ExtendedMcpServer } from "../server.js";
+
+type RegisteredTool = { meta: any; handler: (args: any) => Promise<any> };
+
+async function createMockServer() {
+  const tools: Record<string, RegisteredTool> = {};
+  const server: ExtendedMcpServer = {
+    registerTool: vi.fn((name: string, meta: any, handler: (args: any) => Promise<any>) => {
+      tools[name] = { meta, handler };
+    }),
+  } as unknown as ExtendedMcpServer;
+
+  const { registerSetupTools } = await import("./setup.js");
+  registerSetupTools(server);
+  return tools;
+}
+
+function createZipBuffer(): Buffer {
+  const zip = new AdmZip();
+  zip.addFile("CODEBUDDY.md", Buffer.from("cloudbase rules"));
+  return zip.toBuffer();
+}
+
+function createMockRequest(): ClientRequest {
+  return new EventEmitter() as ClientRequest;
+}
+
+function createMockResponse(
+  statusCode: number,
+  headers: IncomingHttpHeaders,
+  body: Buffer | string = "",
+): IncomingMessage {
+  const response = new PassThrough() as PassThrough & IncomingMessage;
+  response.statusCode = statusCode;
+  response.headers = headers;
+  process.nextTick(() => {
+    response.end(body);
+  });
+  return response;
+}
+
+function mockPublicDnsLookup(hostnames: string[]) {
+  vi.spyOn(dns.promises, "lookup").mockImplementation((async (hostname: string, options?: dns.LookupOneOptions | dns.LookupAllOptions) => {
+    if (!hostnames.includes(hostname)) {
+      throw new Error(`unexpected hostname: ${hostname}`);
+    }
+
+    const result = { address: "93.184.216.34", family: 4 };
+    if (typeof options === "object" && options?.all) {
+      return [result];
+    }
+
+    return result;
+  }) as any);
+}
+
+describe("downloadTemplate redirect handling", () => {
+  let tempRoot: string;
+
+  beforeEach(async () => {
+    tempRoot = await fs.mkdtemp(path.join(os.tmpdir(), "setup-tool-test-"));
+    process.env.WORKSPACE_FOLDER_PATHS = tempRoot;
+  });
+
+  afterEach(async () => {
+    vi.restoreAllMocks();
+    vi.resetModules();
+    vi.doUnmock("https");
+    delete process.env.WORKSPACE_FOLDER_PATHS;
+    await fs.rm(tempRoot, { recursive: true, force: true });
+  });
+
+  it("should follow 307 redirects when downloading templates", async () => {
+    const zipBuffer = createZipBuffer();
+
+    mockPublicDnsLookup(["static.cloudbase.net", "cdn.safe.example"]);
+
+    const mockedGet = vi.fn((url: URL, options: RequestOptions, callback: (res: IncomingMessage) => void) => {
+      expect(typeof options.lookup).toBe("function");
+      process.nextTick(() => {
+        if (url.hostname === "static.cloudbase.net") {
+          callback(
+            createMockResponse(307, {
+              location: "https://cdn.safe.example/template.zip",
+            }),
+          );
+          return;
+        }
+
+        if (url.hostname === "cdn.safe.example") {
+          callback(createMockResponse(200, {}, zipBuffer));
+          return;
+        }
+
+        throw new Error(`unexpected request target: ${url.toString()}`);
+      });
+      return createMockRequest();
+    });
+
+    vi.doMock("https", async () => {
+      const actual = await vi.importActual<typeof import("https")>("https");
+      return {
+        ...actual,
+        get: mockedGet,
+      };
+    });
+
+    const tools = await createMockServer();
+    const result = await tools.downloadTemplate.handler({
+      template: "rules",
+      ide: "codebuddy",
+      overwrite: false,
+    });
+
+    const text = result.content[0].text as string;
+    expect(text).toContain("同步完成");
+    await expect(fs.readFile(path.join(tempRoot, "CODEBUDDY.md"), "utf8")).resolves.toBe("cloudbase rules");
+    expect(mockedGet).toHaveBeenCalledTimes(2);
+  });
+});

--- a/mcp/src/tools/setup.test.ts
+++ b/mcp/src/tools/setup.test.ts
@@ -1,7 +1,6 @@
 import AdmZip from "adm-zip";
 import * as dns from "dns";
 import * as fs from "fs/promises";
-import * as https from "https";
 import type { ClientRequest, IncomingHttpHeaders, IncomingMessage, RequestOptions } from "http";
 import { EventEmitter } from "node:events";
 import * as os from "os";

--- a/mcp/src/tools/setup.ts
+++ b/mcp/src/tools/setup.ts
@@ -5,8 +5,10 @@ import * as http from "http";
 import * as https from "https";
 import * as os from "os";
 import * as path from "path";
+import { URL } from "url";
 import { z } from "zod";
 import { ExtendedMcpServer } from "../server.js";
+import { prepareSafeRemoteRequest } from "../utils/remote-url-safety.js";
 
 // 构建时注入的版本号
 // @ts-ignore
@@ -247,14 +249,21 @@ export function resolveDownloadTemplateIDE(
   };
 }
 
+const MAX_REDIRECT_HOPS = 5;
+
 // 根据 INTEGRATION_IDE 环境变量获取默认 IDE 类型
 // 下载文件到临时目录
-async function downloadFile(url: string, filePath: string): Promise<void> {
-  return new Promise((resolve, reject) => {
-    const client = url.startsWith("https:") ? https : http;
+async function downloadFile(url: string, filePath: string, redirectCount = 0): Promise<void> {
+  if (redirectCount > MAX_REDIRECT_HOPS) {
+    throw new Error(`重定向次数超过 ${MAX_REDIRECT_HOPS} 次限制`);
+  }
 
+  const { requestUrl, requestOptions } = await prepareSafeRemoteRequest(url);
+  const client = requestUrl.protocol === "https:" ? https : http;
+
+  return new Promise((resolve, reject) => {
     client
-      .get(url, (res) => {
+      .get(requestUrl, requestOptions ?? {}, (res) => {
         if (res.statusCode === 200) {
           const file = fs.createWriteStream(filePath);
           res.pipe(file);
@@ -263,10 +272,11 @@ async function downloadFile(url: string, filePath: string): Promise<void> {
             resolve();
           });
           file.on("error", reject);
-        } else if (res.statusCode === 302 || res.statusCode === 301) {
+        } else if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400) {
           // 处理重定向
           if (res.headers.location) {
-            downloadFile(res.headers.location, filePath)
+            const redirectUrl = new URL(res.headers.location, requestUrl).toString();
+            downloadFile(redirectUrl, filePath, redirectCount + 1)
               .then(resolve)
               .catch(reject);
           } else {

--- a/mcp/src/utils/remote-url-safety.ts
+++ b/mcp/src/utils/remote-url-safety.ts
@@ -1,0 +1,178 @@
+import * as dns from "dns";
+import * as net from "net";
+import type { RequestOptions } from "http";
+import { URL } from "url";
+
+const ALLOWED_PROTOCOLS = new Set(["http:", "https:"]);
+const DISALLOWED_ERROR_MESSAGE = "不安全的 URL 或目标为内网地址";
+
+type LookupAddress = {
+  address: string;
+  family: number;
+};
+
+function ipv4ToNumber(ip: string): number {
+  const parts = ip.split(".").map((part) => Number.parseInt(part, 10));
+  return ((parts[0] << 24) >>> 0) + (parts[1] << 16) + (parts[2] << 8) + parts[3];
+}
+
+function isIpv4InRange(ip: string, start: string, end: string): boolean {
+  const ipNumber = ipv4ToNumber(ip);
+  return ipNumber >= ipv4ToNumber(start) && ipNumber <= ipv4ToNumber(end);
+}
+
+function normalizeIpAddress(ip: string): string {
+  const normalized = ip.toLowerCase();
+  if (normalized.startsWith("::ffff:")) {
+    const mappedIpv4 = normalized.slice(7);
+    if (net.isIPv4(mappedIpv4)) {
+      return mappedIpv4;
+    }
+  }
+  return normalized;
+}
+
+export function isPrivateIP(ip: string): boolean {
+  const normalizedIp = normalizeIpAddress(ip);
+
+  if (!net.isIP(normalizedIp)) {
+    return true;
+  }
+
+  if (net.isIPv4(normalizedIp)) {
+    return [
+      ["0.0.0.0", "0.255.255.255"],
+      ["10.0.0.0", "10.255.255.255"],
+      ["100.64.0.0", "100.127.255.255"],
+      ["127.0.0.0", "127.255.255.255"],
+      ["169.254.0.0", "169.254.255.255"],
+      ["172.16.0.0", "172.31.255.255"],
+      ["192.0.0.0", "192.0.0.255"],
+      ["192.0.2.0", "192.0.2.255"],
+      ["192.168.0.0", "192.168.255.255"],
+      ["198.18.0.0", "198.19.255.255"],
+      ["198.51.100.0", "198.51.100.255"],
+      ["203.0.113.0", "203.0.113.255"],
+      ["224.0.0.0", "255.255.255.255"],
+    ].some(([start, end]) => isIpv4InRange(normalizedIp, start, end));
+  }
+
+  return normalizedIp === "::" ||
+    normalizedIp === "::1" ||
+    normalizedIp.startsWith("fc") ||
+    normalizedIp.startsWith("fd") ||
+    normalizedIp.startsWith("fe8") ||
+    normalizedIp.startsWith("fe9") ||
+    normalizedIp.startsWith("fea") ||
+    normalizedIp.startsWith("feb") ||
+    normalizedIp.startsWith("fec0:") ||
+    normalizedIp.startsWith("ff") ||
+    normalizedIp.startsWith("2001:db8:");
+}
+
+async function resolveSafeAddresses(hostname: string): Promise<LookupAddress[]> {
+  let resolvedAddresses: dns.LookupAddress[];
+
+  try {
+    resolvedAddresses = await dns.promises.lookup(hostname, {
+      all: true,
+      verbatim: true,
+    });
+  } catch {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  if (resolvedAddresses.length === 0) {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  const normalizedAddresses = resolvedAddresses.map(({ address, family }) => ({
+    address: normalizeIpAddress(address),
+    family,
+  }));
+
+  if (normalizedAddresses.some(({ address }) => isPrivateIP(address))) {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  return normalizedAddresses.filter(
+    (candidate, index, collection) =>
+      collection.findIndex(
+        ({ address, family }) => address === candidate.address && family === candidate.family,
+      ) === index,
+  );
+}
+
+function createPinnedLookup(addresses: LookupAddress[]): NonNullable<RequestOptions["lookup"]> {
+  return ((hostname: string, options: any, callback: any) => {
+    const normalizedOptions = typeof options === "number" ? { family: options } : (options ?? {});
+    const family = normalizedOptions.family;
+    const candidates = family === 4 || family === 6
+      ? addresses.filter((address) => address.family === family)
+      : addresses;
+
+    if (candidates.length === 0) {
+      const error = Object.assign(new Error(`No safe address resolved for ${hostname}`), {
+        code: "ENOTFOUND",
+      });
+      callback(error);
+      return;
+    }
+
+    if (normalizedOptions.all) {
+      callback(null, candidates);
+      return;
+    }
+
+    callback(null, candidates[0].address, candidates[0].family);
+  }) as NonNullable<RequestOptions["lookup"]>;
+}
+
+export async function prepareSafeRemoteRequest(url: string): Promise<{
+  requestUrl: URL;
+  requestOptions?: Pick<RequestOptions, "lookup">;
+}> {
+  let requestUrl: URL;
+
+  try {
+    requestUrl = new URL(url);
+  } catch {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  if (!ALLOWED_PROTOCOLS.has(requestUrl.protocol)) {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  const hostname = requestUrl.hostname;
+  if (!hostname) {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  if (hostname.toLowerCase() === "localhost") {
+    throw new Error(DISALLOWED_ERROR_MESSAGE);
+  }
+
+  if (net.isIP(hostname)) {
+    if (isPrivateIP(hostname)) {
+      throw new Error(DISALLOWED_ERROR_MESSAGE);
+    }
+    return { requestUrl };
+  }
+
+  const safeAddresses = await resolveSafeAddresses(hostname);
+  return {
+    requestUrl,
+    requestOptions: {
+      lookup: createPinnedLookup(safeAddresses),
+    },
+  };
+}
+
+export async function assertRemoteUrlSafe(url: string): Promise<void> {
+  await prepareSafeRemoteRequest(url);
+}
+
+export function getRemoteUrlSafetyErrorMessage(): string {
+  return DISALLOWED_ERROR_MESSAGE;
+}

--- a/mcp/vitest.config.js
+++ b/mcp/vitest.config.js
@@ -2,8 +2,8 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   resolve: {
-    // Help Vitest resolve CommonJS packages correctly
-    conditions: ["node", "import", "module", "require"],
+    // Prefer CommonJS export branches for transitive dependency chains exercised in Vitest.
+    conditions: ["node", "require"],
   },
   test: {
     // Test environment variables
@@ -27,8 +27,24 @@ export default defineConfig({
     // Setup hooks
     globalSetup: [],
     setupFiles: [],
-    // Externalization settings for CommonJS packages
-    noExternal: [],
-    external: ["@cloudbase/manager-node", "@cloudbase/toolbox"],
+    server: {
+      deps: {
+        fallbackCJS: true,
+        inline: [
+          "@cloudbase/manager-node",
+          "@cloudbase/toolbox",
+          "cos-nodejs-sdk-v5",
+          "request",
+          "tough-cookie",
+          "psl",
+          "mustache",
+          "express",
+          "router",
+          "is-promise",
+          "uuid",
+        ],
+        external: [],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary
- add shared remote URL safety guards for `downloadRemoteFile` and template downloads to block localhost/private targets before connect
- add regression coverage for SSRF blocking, redirect handling, and successful public downloads
- stabilize local Vitest execution by isolating PostCSS config lookup and preferring CommonJS dependency branches

## Test Plan
- [x] cd mcp && npm test

## Notes
- updates `server.test.ts` mock coverage to stay compatible with newer MCP SDK exports