### PR TITLE
chore: add .workbuddy/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ mcp/.trae/
 mcp/.vscode/
 mcp/.windsurf/
 mcp/rules/
+.workbuddy/


### PR DESCRIPTION
Add `.workbuddy/` to `.gitignore` to prevent local AI IDE memory files from being tracked.