### PR TITLE
🐛 fix(ci): use local tsx binary in build-clawhub-publish-artifacts

### DIFF
--- a/scripts/build-clawhub-publish-artifacts.mjs
+++ b/scripts/build-clawhub-publish-artifacts.mjs
@@ -152,9 +152,10 @@ function buildAllInOneTarget(target, destinationDir) {
   const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), "clawhub-allinone-"));
 
   try {
+    const tsxPath = path.join(projectRoot, "node_modules/.bin/tsx");
     execFileSync(
-      "npx",
-      ["tsx", "scripts/build-allinone-skill.ts", "--dir", tempRoot],
+      tsxPath,
+      ["scripts/build-allinone-skill.ts", "--dir", tempRoot],
       {
         cwd: projectRoot,
         stdio: "pipe",


### PR DESCRIPTION
## Summary
Fix `Cannot find module 'js-yaml'` in CI `publish` job.

## Root Cause
`npx tsx scripts/build-allinone-skill.ts` was falling back to installing `tsx` into the npx cache because it couldn't find the local `node_modules/.bin/tsx`. The cached `tsx` binary then failed to resolve project-local `js-yaml` from `node_modules/`.

## Fix
Use `path.join(projectRoot, 'node_modules/.bin/tsx')` directly instead of `'npx'` + `'tsx'`.

## Changes
- `scripts/build-clawhub-publish-artifacts.mjs`: resolve local `tsx` binary path

🤖 Generated with [CodeBuddy Code](https://cnb.cool/codebuddy/codebuddy-code)