### PR TITLE
fix(CI): 🔧 install root deps in npm-publish

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -34,6 +34,9 @@ jobs:
           npm -v
           node -e 'console.log(require("./package.json").version)'
 
+      - name: Install root dependencies
+        run: npm ci
+
       - name: Install dependencies
         working-directory: ./mcp
         run: npm ci


### PR DESCRIPTION
## Summary
Fix npm-publish workflow failing because tests need root `tsx` dependency.

## Changes
- Add root `npm ci` step before installing mcp dependencies
- Tests in `tests/` directory require `tsx` from root node_modules

## Fixes
- Closes failed publish for v2.19.3