### PR TITLE
fix(nosql): use correct API field name for listCollections response

### DIFF
--- a/mcp/src/tools/databaseNoSQL.test.ts
+++ b/mcp/src/tools/databaseNoSQL.test.ts
@@ -323,6 +323,31 @@ describe("NoSQL database tools", () => {
     );
   });
 
+  it("listCollections should return Tables from ListTables API as collections", async () => {
+    const { tools } = createMockServer();
+
+    const result = await tools.readNoSqlDatabaseStructure.handler({
+      action: "listCollections",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.requestId).toBe("req-list");
+    expect(payload.collections).toEqual([{ TableName: "t_nosql_products" }]);
+    expect(payload.pager).toEqual({ Total: 1, Limit: 100, Offset: 0 });
+    expect(payload.message).toBe("获取 NoSQL 数据库集合列表成功");
+
+    expect(mockCommonServiceCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        Action: "ListTables",
+        Param: expect.objectContaining({
+          MgoOffset: 0,
+          MgoLimit: 100,
+        }),
+      }),
+    );
+  });
+
   it("collection-scoped responses should echo the requested collection name", async () => {
     const { tools } = createMockServer();
 

--- a/mcp/src/tools/databaseNoSQL.ts
+++ b/mcp/src/tools/databaseNoSQL.ts
@@ -360,7 +360,7 @@ checkIndex: 检查指定索引是否存在`),
                 {
                   success: true,
                   requestId: result.RequestId,
-                  collections: result.Collections,
+                  collections: result.Tables,
                   pager: result.Pager,
                   message: "获取 NoSQL 数据库集合列表成功",
                 },


### PR DESCRIPTION
## Summary

- **Fixed field name mismatch**: The `ListTables` API returns collection data in the `Tables` field, but the code was incorrectly reading `result.Collections` (which is always `undefined`). Changed to `result.Tables`.
- **Added missing unit test**: No test existed for the `listCollections` action — added one that verifies the correct field mapping, API parameters, and response structure.

## Root Cause

In `mcp/src/tools/databaseNoSQL.ts` line 363:
```typescript
// Before (bug): result.Collections is always undefined
collections: result.Collections,

// After (fix): correctly reads the Tables field from ListTables API
collections: result.Tables,
```

The test mock already documented the correct API response shape (`Tables: [...]`), but no test verified the handler's output actually contained the data.

## Test plan

- [x] Unit test added: `listCollections should return Tables from ListTables API as collections`
- [x] All 16 existing tests pass
- [ ] Manual verification: call `readNoSqlDatabaseStructure` with `action: "listCollections"` and confirm `collections` array is populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)