### PR TITLE
fix(ci): force install latest CodeBuddy CLI in issue processor 🔧

### DIFF
--- a/.github/workflows/issue-auto-processor-simple.yml
+++ b/.github/workflows/issue-auto-processor-simple.yml
@@ -42,7 +42,7 @@ jobs:
           node-version: '20'
 
       - name: Install CodeBuddy CLI
-        run: npm install -g @tencent-ai/codebuddy-code
+        run: npm cache clean --force && npm install -g @tencent-ai/codebuddy-code@latest
 
       - name: Validate CodeBuddy credentials
         env:


### PR DESCRIPTION
## Summary
- Force clean npm cache and install @tencent-ai/codebuddy-code@latest in issue-auto-processor-simple.yml
- Ensures the workflow always uses the latest CodeBuddy CLI version, avoiding stale cached versions that may contain known issues (e.g. issue #429)

## Changes
- Updated `.github/workflows/issue-auto-processor-simple.yml` line 45: `npm install -g @tencent-ai/codebuddy-code` → `npm cache clean --force && npm install -g @tencent-ai/codebuddy-code@latest`

## Verification
- [ ] Workflow should install latest CodeBuddy CLI version
- [ ] Issue #429 related errors should be resolved with latest version