### PR TITLE
feat(sync): filter platform-specific skills when syncing to examples repo

### DIFF
--- a/scripts/sync-config.mjs
+++ b/scripts/sync-config.mjs
@@ -97,11 +97,14 @@ function getExcludedSkills(templateType) {
 
 /**
  * 检查给定路径是否对应被排除的 skill
- * skill 目录出现在以下位置：
+ * skill 目录/文件出现在以下位置：
  *   rules/{skill-name}/
  *   .cursor/rules/{skill-name}.mdc
  *   .codebuddy/skills/{skill-name}/
+ *   .claude/skills/{skill-name}/
  *   .{ide}/rules/{skill-name}.md(c)
+ *   .clinerules/{skill-name}/       — 扁平目录，skill 直接在 .clinerules 下
+ *   .kiro/steering/{skill-name}/
  * @param {string} relPath  相对于 configDir 的路径（使用 / 分隔）
  * @param {Set<string>} excludedSkills
  * @returns {boolean}
@@ -113,9 +116,19 @@ function isExcludedSkill(relPath, excludedSkills) {
   if (parts[0] === 'rules' && parts.length >= 2) {
     return excludedSkills.has(parts[1]);
   }
-  // .codebuddy/skills/{skill-name} or .codebuddy/skills/{skill-name}/...
-  if (parts[0] === '.codebuddy' && parts[1] === 'skills' && parts.length >= 3) {
+  // .codebuddy/skills/{skill-name} or .claude/skills/{skill-name}
+  if ((parts[0] === '.codebuddy' || parts[0] === '.claude') && parts[1] === 'skills' && parts.length >= 3) {
     return excludedSkills.has(parts[2]);
+  }
+  // .clinerules/{skill-name} — skill 目录直接在 .clinerules 下
+  if (parts[0] === '.clinerules' && parts.length >= 2) {
+    const name = parts[1].replace(/\.mdx?c?$/, '');
+    return excludedSkills.has(name);
+  }
+  // .kiro/steering/{skill-name}
+  if (parts[0] === '.kiro' && parts[1] === 'steering' && parts.length >= 3) {
+    const name = parts[2].replace(/\.mdx?c?$/, '');
+    return excludedSkills.has(name);
   }
   // .{ide}/rules/{skill-name}.md(c) — flat file under any IDE rules dir
   if (parts.length >= 3 && parts[parts.length - 2] === 'rules') {

--- a/scripts/sync-config.mjs
+++ b/scripts/sync-config.mjs
@@ -66,14 +66,74 @@ try {
   process.exit(1);
 }
 
+// Skills 分类：各平台专属 skill 目录名
+const WEB_ONLY_SKILLS = new Set([
+  'web-development',
+  'auth-web',
+  'ai-model-web',
+  'cloud-storage-web',
+  'no-sql-web-sdk',
+  'relational-database-web',
+  'http-api',
+]);
+
+const MINIPROGRAM_ONLY_SKILLS = new Set([
+  'miniprogram-development',
+  'auth-wechat',
+  'ai-model-wechat',
+  'no-sql-wx-mp-sdk',
+]);
+
+/**
+ * 根据模板类型推断需要排除的 skill 集合
+ * @param {string} templateType 'web' | 'miniprogram' | undefined
+ * @returns {Set<string>}
+ */
+function getExcludedSkills(templateType) {
+  if (templateType === 'web') return MINIPROGRAM_ONLY_SKILLS;
+  if (templateType === 'miniprogram') return WEB_ONLY_SKILLS;
+  return new Set();
+}
+
+/**
+ * 检查给定路径是否对应被排除的 skill
+ * skill 目录出现在以下位置：
+ *   rules/{skill-name}/
+ *   .cursor/rules/{skill-name}.mdc
+ *   .codebuddy/skills/{skill-name}/
+ *   .{ide}/rules/{skill-name}.md(c)
+ * @param {string} relPath  相对于 configDir 的路径（使用 / 分隔）
+ * @param {Set<string>} excludedSkills
+ * @returns {boolean}
+ */
+function isExcludedSkill(relPath, excludedSkills) {
+  if (excludedSkills.size === 0) return false;
+  const parts = relPath.split('/');
+  // rules/{skill-name} or rules/{skill-name}/...
+  if (parts[0] === 'rules' && parts.length >= 2) {
+    return excludedSkills.has(parts[1]);
+  }
+  // .codebuddy/skills/{skill-name} or .codebuddy/skills/{skill-name}/...
+  if (parts[0] === '.codebuddy' && parts[1] === 'skills' && parts.length >= 3) {
+    return excludedSkills.has(parts[2]);
+  }
+  // .{ide}/rules/{skill-name}.md(c) — flat file under any IDE rules dir
+  if (parts.length >= 3 && parts[parts.length - 2] === 'rules') {
+    const fileName = parts[parts.length - 1].replace(/\.mdx?c?$/, '');
+    return excludedSkills.has(fileName);
+  }
+  return false;
+}
+
 /**
  * 复制目录内容
  * @param {string} srcDir 源目录
  * @param {string} destDir 目标目录
  * @param {Array} excludePatterns 排除模式
  * @param {Array} includePatterns 包含模式（可选）
+ * @param {Set<string>} excludedSkills 需要过滤的 skill 名称集合（可选）
  */
-function copyDirectory(srcDir, destDir, excludePatterns = [], includePatterns = null) {
+function copyDirectory(srcDir, destDir, excludePatterns = [], includePatterns = null, excludedSkills = new Set()) {
   try {
     // 确保目标目录存在
     if (!fs.existsSync(destDir)) {
@@ -98,6 +158,15 @@ function copyDirectory(srcDir, destDir, excludePatterns = [], includePatterns = 
       const srcPath = path.join(srcDir, item);
       const destPath = path.join(destDir, item);
       
+      // 检查是否为被排除的 skill
+      if (excludedSkills.size > 0) {
+        const relPath = path.relative(configDir, srcPath).split(path.sep).join('/');
+        if (isExcludedSkill(relPath, excludedSkills)) {
+          console.log(`  ⏭️  跳过 skill: ${relPath} (平台不匹配)`);
+          continue;
+        }
+      }
+
       const stat = fs.statSync(srcPath);
       
       if (stat.isDirectory()) {
@@ -115,7 +184,7 @@ function copyDirectory(srcDir, destDir, excludePatterns = [], includePatterns = 
           }
         }
         
-        copyDirectory(srcPath, destPath, excludePatterns, includePatterns);
+        copyDirectory(srcPath, destPath, excludePatterns, includePatterns, excludedSkills);
       } else {
         // 如果有包含模式，检查当前文件是否在包含列表中
         if (includePatterns) {
@@ -319,10 +388,17 @@ async function syncConfigs(options = {}) {
     const templateConfig = templateConfigs[i];
     const templatePath = typeof templateConfig === 'string' ? templateConfig : templateConfig.path;
     const includePatterns = typeof templateConfig === 'object' ? templateConfig.includePatterns : null;
+    // 推断模板类型：优先使用显式 type 字段，否则从路径前缀推断
+    const templateType = (typeof templateConfig === 'object' && templateConfig.type)
+      || (templatePath.startsWith('web/') ? 'web' : templatePath.startsWith('miniprogram/') ? 'miniprogram' : null);
+    const excludedSkills = getExcludedSkills(templateType);
     
-    console.log(`\n[${i + 1}/${templateConfigs.length}] 处理模板: ${templatePath}`);
+    console.log(`\n[${i + 1}/${templateConfigs.length}] 处理模板: ${templatePath}${templateType ? ` [${templateType}]` : ''}`);
     if (includePatterns) {
       console.log(`  📁 包含模式: ${includePatterns.join(', ')}`);
+    }
+    if (excludedSkills.size > 0) {
+      console.log(`  🚫 过滤 skill: ${[...excludedSkills].join(', ')}`);
     }
     
     const cloudbaseExamplesPath = getCloudbaseExamplesPath();
@@ -368,7 +444,7 @@ async function syncConfigs(options = {}) {
     if (includePatterns) {
       // 如果有包含模式，只同步指定的目录和文件
       console.log(`  📂 按包含模式同步...`);
-      copyDirectory(configDir, targetDir, templateConfig.excludePatterns, includePatterns);
+      copyDirectory(configDir, targetDir, templateConfig.excludePatterns, includePatterns, excludedSkills);
     } else {
       // 如果没有包含模式，同步所有内容
       const configItems = fs.readdirSync(configDir);
@@ -378,7 +454,7 @@ async function syncConfigs(options = {}) {
         
         if (fs.statSync(srcPath).isDirectory()) {
           console.log(`  📂 同步目录: ${configItem}`);
-          copyDirectory(srcPath, destPath, templateConfig.excludePatterns);
+          copyDirectory(srcPath, destPath, templateConfig.excludePatterns, null, excludedSkills);
         } else {
           console.log(`  📄 同步文件: ${configItem}`);
           fs.copyFileSync(srcPath, destPath);

--- a/scripts/sync-config.mjs
+++ b/scripts/sync-config.mjs
@@ -541,7 +541,7 @@ async function handleGitOperations() {
   } catch (error) {
     console.error('❌ Git操作失败:', error.message);
     console.log('\n请手动检查并处理Git操作：');
-    console.log('1. cd ../awsome-cloudbase-examples');
+    console.log('1. cd ../awesome-cloudbase-examples');
     console.log('2. git add .');
     console.log('3. git commit -m "sync config and rules"');
     console.log('4. git push');

--- a/scripts/template-config.json
+++ b/scripts/template-config.json
@@ -1,5 +1,5 @@
 {
-  "description": "awsome-cloudbase-examples 项目模板路径配置",
+  "description": "awesome-cloudbase-examples 项目模板路径配置",
   "version": "1.0.0",
   "comment": "templates 支持两种格式：1) 字符串格式同步整个config目录，2) 对象格式可配置 includePatterns/type 等选项。type 字段用于 skill 过滤：web 类型过滤小程序专属 skills，miniprogram 类型过滤 web 专属 skills，不填则同步全部。",
   "templates": [

--- a/scripts/template-config.json
+++ b/scripts/template-config.json
@@ -1,20 +1,20 @@
 {
   "description": "awsome-cloudbase-examples 项目模板路径配置",
   "version": "1.0.0",
-  "comment": "templates 支持两种格式：1) 字符串格式同步整个config目录，2) 对象格式只同步指定目录",
+  "comment": "templates 支持两种格式：1) 字符串格式同步整个config目录，2) 对象格式可配置 includePatterns/type 等选项。type 字段用于 skill 过滤：web 类型过滤小程序专属 skills，miniprogram 类型过滤 web 专属 skills，不填则同步全部。",
   "templates": [
-    "web/art-exhibition",
-    "web/overcooked-game",
-    "web/gomoku-game",
-    "web/ecommerce-management-backend",
-    "web/simple-crm",
-    "web/cloudbase-project",
-    "web/cloudbase-react-template",
-    "web/cloudbase-vue-template",
-    "miniprogram/tcb-shop-ai-generate",
-    "miniprogram/dating",
-    "miniprogram/cloudbase-ai-video",
-    "miniprogram/cloudbase-miniprogram-template",
+    { "path": "web/art-exhibition", "type": "web" },
+    { "path": "web/overcooked-game", "type": "web" },
+    { "path": "web/gomoku-game", "type": "web" },
+    { "path": "web/ecommerce-management-backend", "type": "web" },
+    { "path": "web/simple-crm", "type": "web" },
+    { "path": "web/cloudbase-project", "type": "web" },
+    { "path": "web/cloudbase-react-template", "type": "web" },
+    { "path": "web/cloudbase-vue-template", "type": "web" },
+    { "path": "miniprogram/tcb-shop-ai-generate", "type": "miniprogram" },
+    { "path": "miniprogram/dating", "type": "miniprogram" },
+    { "path": "miniprogram/cloudbase-ai-video", "type": "miniprogram" },
+    { "path": "miniprogram/cloudbase-miniprogram-template", "type": "miniprogram" },
     "universal/cloudbase-uniapp-template",
     {
       "path": "airules/codebuddy",
@@ -38,4 +38,4 @@
     "autoCommit": true,
     "commitMessage": "chore: 🤣 sync rules from [CloudBase AI Toolkit](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit)"
   }
-} 
+}


### PR DESCRIPTION
## 背景

同步脚本 `sync-config.mjs` 此前会将所有 skills 无差别同步到每个模板项目，导致 web 模板中包含小程序专属 skills（如 `miniprogram-development`、`auth-wechat`），小程序模板中包含 web 专属 skills（如 `web-development`、`auth-web` 等）。

## 变更内容

### `scripts/template-config.json`
- 为所有 `web/*` 模板添加 `"type": "web"`
- 为所有 `miniprogram/*` 模板添加 `"type": "miniprogram"`
- `universal/*` 和 `airules/*` 不变，保留全部 skills

### `scripts/sync-config.mjs`
- 新增 `WEB_ONLY_SKILLS`（7个）和 `MINIPROGRAM_ONLY_SKILLS`（4个）分类常量
- `getExcludedSkills(type)`：根据模板类型返回要过滤的 skill 集合
- `isExcludedSkill(relPath, excludedSkills)`：覆盖三种路径模式：
  - `rules/{skill-name}/...`
  - `.codebuddy/skills/{skill-name}/...`
  - `.{any-ide}/rules/{skill-name}.md(c)`
- 支持从路径前缀自动推断类型（无需每条都显式配置）

## 过滤规则

| 模板类型 | 过滤掉 |
|---|---|
| `web/*` | `miniprogram-development`, `auth-wechat`, `ai-model-wechat`, `no-sql-wx-mp-sdk` |
| `miniprogram/*` | `web-development`, `auth-web`, `ai-model-web`, `cloud-storage-web`, `no-sql-web-sdk`, `relational-database-web`, `http-api` |
| `universal/*` | 不过滤，保留全部 |

## 验证

已通过 `--dry-run` 验证，输出显示每个模板的类型标注和过滤列表符合预期。