### PR TITLE
fix(hosting): use DescribeStaticStore for upload env readiness check

### DIFF
--- a/mcp/src/tools/hosting.test.ts
+++ b/mcp/src/tools/hosting.test.ts
@@ -310,10 +310,8 @@ describe('hosting tools', () => {
   });
 
   it('manageHosting(action=upload) should fail fast when current env lacks static hosting storage config', async () => {
-    mockGetEnvInfo.mockResolvedValueOnce({
-      EnvInfo: {
-        StaticStorages: null,
-      },
+    mockDescribeStaticStore.mockResolvedValueOnce({
+      Data: [],
     });
 
     const tools = createMockServer();
@@ -329,6 +327,30 @@ describe('hosting tools', () => {
     expect(payload.message).toContain('当前环境 env-test 未发现静态托管资源配置');
     expect(payload.message).toContain('auth(action="set_env"');
     expect(mockUploadFiles).not.toHaveBeenCalled();
+  });
+
+  it('manageHosting(action=upload) should succeed for Mini Program env where getEnvInfo StaticStorages is empty but DescribeStaticStore has Bucket', async () => {
+    // Mini Program-sourced environments don't populate StaticStorages in
+    // DescribeEnvs, but DescribeStaticStore returns the real bucket config.
+    mockDescribeStaticStore.mockResolvedValueOnce({
+      Data: [
+        {
+          Status: 'online',
+          CdnDomain: 'miniprogram-static.example.com',
+          Bucket: 'hosting-bucket-mp',
+        },
+      ],
+    });
+
+    const tools = createMockServer();
+    const payload = JSON.parse((await tools.manageHosting.handler({
+      action: 'upload',
+      localPath: '/tmp/site-dist',
+      cloudPath: 'site',
+    })).content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(mockUploadFiles).toHaveBeenCalled();
   });
 
   it('manageHosting(action=delete) should require explicit confirm=true', async () => {

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -430,11 +430,16 @@ async function assertHostingUploadEnvironmentReady(
   logger?: ExtendedMcpServer['logger'],
 ) {
   const envId = await getEnvId(cloudBaseOptions);
-  const envInfo = await cloudbase.env.getEnvInfo() as ExtendedEnvInfo;
-  logCloudBaseResult(logger, envInfo);
 
-  const staticStorage = envInfo.EnvInfo?.StaticStorages?.[0];
-  if (staticStorage?.Bucket) {
+  // Use DescribeStaticStore (same API as queryHosting status) instead of
+  // getEnvInfo(). Mini Program-sourced environments do not populate
+  // EnvInfo.StaticStorages[0].Bucket in DescribeEnvs, causing a false
+  // "no hosting config" error even when the store is online and the tcb
+  // CLI can upload successfully.
+  const result = await callTcbHostingAction(cloudbase, 'DescribeStaticStore', { EnvId: envId }, logger);
+  const hostingInfo = extractStaticStores(result);
+
+  if (hostingInfo.length > 0 && hostingInfo[0].Bucket) {
     return;
   }
 


### PR DESCRIPTION
## 问题

在小程序来源的 CloudBase 环境中，`manageHosting(action=upload)` 稳定失败：

```
errorCode: HOSTING_UPLOAD_FAILED
message: 当前环境 <ENV_ID> 未发现静态托管资源配置，无法上传文件
```

而同一环境用 `tcb hosting deploy` 可以正常上传。

## 根本原因

`assertHostingUploadEnvironmentReady()`（hosting.ts:427）使用 `getEnvInfo()`（即 DescribeEnvs API）来检查 `EnvInfo.StaticStorages[0].Bucket` 是否存在。

小程序来源的环境不会在 DescribeEnvs 响应中填充该字段，导致检查始终失败——即使静态托管实际上已开通、文件可以被 `queryHosting(status)` 查到、tcb CLI 也能正常上传。

## 修复

将 pre-flight 检查从 `getEnvInfo()` 切换为 `DescribeStaticStore`，与 `queryHosting(action=status)` 使用相同的 API 和数据源。两条路径现在一致，小程序环境可以正确通过检查。

## 变更文件

- `mcp/src/tools/hosting.ts`：`assertHostingUploadEnvironmentReady()` 改用 `DescribeStaticStore`
- `mcp/src/tools/hosting.test.ts`：
  - 更新失败用例的 mock（改为 `mockDescribeStaticStore`）
  - 新增小程序环境复现用例（getEnvInfo StaticStorages 为空但 DescribeStaticStore 有 Bucket）