### PR TITLE
fix(hosting): fix upload failure and empty accessUrl on Mini Program environments

### DIFF
--- a/mcp/src/tools/hosting.test.ts
+++ b/mcp/src/tools/hosting.test.ts
@@ -329,9 +329,9 @@ describe('hosting tools', () => {
     expect(mockUploadFiles).not.toHaveBeenCalled();
   });
 
-  it('manageHosting(action=upload) should succeed for Mini Program env where getEnvInfo StaticStorages is empty but DescribeStaticStore has Bucket', async () => {
+  it('manageHosting(action=upload) should succeed and return CdnDomain-based accessUrl for Mini Program env where getEnvInfo StaticStorages is empty', async () => {
     // Mini Program-sourced environments don't populate StaticStorages in
-    // DescribeEnvs, but DescribeStaticStore returns the real bucket config.
+    // DescribeEnvs, but DescribeStaticStore returns the real bucket + CdnDomain.
     mockDescribeStaticStore.mockResolvedValueOnce({
       Data: [
         {
@@ -340,6 +340,12 @@ describe('hosting tools', () => {
           Bucket: 'hosting-bucket-mp',
         },
       ],
+    });
+    // getEnvInfo returns no StaticStorages (simulates Mini Program env)
+    mockGetEnvInfo.mockResolvedValueOnce({
+      EnvInfo: {
+        StaticStorages: undefined,
+      },
     });
 
     const tools = createMockServer();
@@ -351,6 +357,8 @@ describe('hosting tools', () => {
 
     expect(payload.success).toBe(true);
     expect(mockUploadFiles).toHaveBeenCalled();
+    expect(payload.data.accessUrl).toBe('https://miniprogram-static.example.com/site/');
+    expect(payload.data.staticDomain).toBe('miniprogram-static.example.com');
   });
 
   it('manageHosting(action=delete) should require explicit confirm=true', async () => {

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -424,23 +424,21 @@ async function resolveHostingStaticDomain(cloudbase: any, logger?: ExtendedMcpSe
   }
 }
 
-async function assertHostingUploadEnvironmentReady(
+// Returns the first hosting store record from DescribeStaticStore, which is
+// the authoritative source for Mini Program-sourced environments (those envs
+// do not populate StaticStorages in DescribeEnvs / getEnvInfo).
+// Throws when no valid store is found so upload can fail fast with a clear msg.
+async function getHostingStoreOrThrow(
   cloudbase: any,
   cloudBaseOptions?: { envId?: string },
   logger?: ExtendedMcpServer['logger'],
-) {
+): Promise<Record<string, unknown>> {
   const envId = await getEnvId(cloudBaseOptions);
-
-  // Use DescribeStaticStore (same API as queryHosting status) instead of
-  // getEnvInfo(). Mini Program-sourced environments do not populate
-  // EnvInfo.StaticStorages[0].Bucket in DescribeEnvs, causing a false
-  // "no hosting config" error even when the store is online and the tcb
-  // CLI can upload successfully.
   const result = await callTcbHostingAction(cloudbase, 'DescribeStaticStore', { EnvId: envId }, logger);
   const hostingInfo = extractStaticStores(result);
 
   if (hostingInfo.length > 0 && hostingInfo[0].Bucket) {
-    return;
+    return hostingInfo[0];
   }
 
   throw new Error(
@@ -680,8 +678,9 @@ export function registerHostingTools(server: ExtendedMcpServer) {
             }
 
             let result: unknown;
+            let store: Record<string, unknown>;
             try {
-              await assertHostingUploadEnvironmentReady(cloudbase, cloudBaseOptions, server.logger);
+              store = await getHostingStoreOrThrow(cloudbase, cloudBaseOptions, server.logger);
               result = await cloudbase.hosting.uploadFiles({
                 localPath: input.localPath,
                 cloudPath: input.cloudPath,
@@ -693,7 +692,11 @@ export function registerHostingTools(server: ExtendedMcpServer) {
             }
 
             logCloudBaseResult(server.logger, result);
-            const staticDomain = await resolveHostingStaticDomain(cloudbase, server.logger);
+            // Prefer CdnDomain from the DescribeStaticStore result we already
+            // fetched; fall back to getEnvInfo for environments that populate
+            // StaticDomain there but not in DescribeStaticStore.
+            const cdnFromStore = (store.CdnDomain ?? store.StaticDomain) as string | undefined;
+            const staticDomain = cdnFromStore || await resolveHostingStaticDomain(cloudbase, server.logger);
             const accessUrl = buildHostingAccessUrl(staticDomain, input.cloudPath, input.localPath);
 
             try {


### PR DESCRIPTION
## 问题

在小程序来源（Source=miniapp）的 CloudBase 环境中：

1. `manageHosting(action=upload)` 稳定失败：`HOSTING_UPLOAD_FAILED: 未发现静态托管资源配置`
2. 即使修复了第一个问题，上传成功后 `accessUrl` 为空，deploy notification 也发送空 URL

而同一环境 `tcb hosting deploy` 可以正常上传。通过实测验证（miniapp 环境 `cloud1-5g39elugeec5ba0f`）：
- `getEnvInfo().EnvInfo.StaticStorages` = `undefined`（旧 gate 依赖这个字段，必然失败）
- `DescribeStaticStore` 返回完整的 Bucket + CdnDomain（托管实际正常运行）

## 修复

将 pre-flight 检查函数 `assertHostingUploadEnvironmentReady()` 替换为 `getHostingStoreOrThrow()`，后者：

1. 使用 `DescribeStaticStore`（与 `queryHosting(action=status)` 相同的 API）作为唯一数据源
2. 返回完整的 store 记录（含 CdnDomain）
3. upload handler 直接复用该记录中的域名字段构建 `accessUrl`，不再二次调用 `resolveHostingStaticDomain()`（后者也依赖 getEnvInfo，同样对 miniapp 环境返回空）

兜底逻辑：若 DescribeStaticStore 结果中没有域名字段，仍 fallback 到 `resolveHostingStaticDomain()`，保持对其他环境类型的兼容。

## 变更文件

- `mcp/src/tools/hosting.ts`：替换 gate 函数，upload handler 从 store 记录取域名
- `mcp/src/tools/hosting.test.ts`：
  - 更新失败用例 mock（改为 `mockDescribeStaticStore` 返回空数组）
  - 新增 miniapp 环境用例，验证 `accessUrl` 正确包含 CdnDomain