### PR TITLE
feat(auth): 新增企业自有品牌授权服务示例 + 飞书 OAuth SSO 集成

### DIFF
--- a/docs/enterprise-auth-with-feishu.md
+++ b/docs/enterprise-auth-with-feishu.md
@@ -82,7 +82,7 @@ flowchart TB
 |------|------|
 | 管理中心环境 | 1 个 CloudBase 环境，用于部署授权服务 |
 | Publishable Key | 控制台「身份认证 → 应用管理」获取 |
-| 腾讯云 API 密钥 | 控制台「访问管理 → API 密钥管理」获取，需具备 `tcb:CreateEnv` 等权限 |
+| **腾讯云 API 密钥** | 控制台「访问管理 → API 密钥管理」获取（需具备 `tcb:CreateEnv` + `tcb:CreateApiKey` 权限） |
 
 ### 3.2 企业身份源
 
@@ -143,7 +143,7 @@ CLOUDBASE_ENV_ID=your-management-env-id
 CLOUDBASE_PUBLISHABLE_KEY=your-publishable-key
 CLOUDBASE_REGION=ap-shanghai
 
-# 腾讯云 API 密钥（用于创建用户环境）
+# 腾讯云 API 密钥（用于创建用户环境 + 签发 API Key）
 TENCENTCLOUD_SECRET_ID=your-secret-id
 TENCENTCLOUD_SECRET_KEY=your-secret-key
 ```
@@ -275,7 +275,7 @@ sequenceDiagram
     Browser-->>User: ✅ 授权成功
     
     Codex->>Auth: 轮询 POST /auth/token (grant_type=device_code)
-    Auth-->>Codex: refresh_token, access_token (API Key), env_id
+    Auth-->>Codex: refresh_token, access_token (JWT API Key), env_id
     
     Note over Codex,User: 授权完成，可以开始开发
 ```
@@ -347,7 +347,7 @@ flowchart LR
 | 扩展项 | 说明 |
 |--------|------|
 | **持久化存储** | 将内存 deviceStore / refreshTokenStore 替换为 Redis 或数据库 |
-| **权限收敛** | STS 策略从 `tcb:*` 收敛为最小权限，按用户/环境隔离 |
+| **权限收敛** | API Key 以 `api_key` 类型签发（完整管理员权限），可结合 `publish_key`（前端只读）使用 |
 | **审计日志** | 记录每次设备码申请、授权、续期操作 |
 | **限流** | 对设备码申请、Token 轮询等接口增加频率限制 |
 | **多源同时启用** | 在控制台同时启用飞书 + 企业微信 + LDAP，用户自由选择 |
@@ -371,4 +371,4 @@ A: CreateEnv 操作通常需要 10-30 秒。在环境创建期间，MCP 轮询 `
 A: 在飞书/身份源侧禁用账号后，下次尝试获取新 Token 时认证失败。已有 Session 在过期后失效。可以扩展授权服务增加主动注销 API。
 
 **Q: 这个方案支持现有的 API Key 对接方式吗？**
-A: 支持。上述方案返回的是 API Key（绑定到用户环境）。也可以改用 STS 临时密钥方式（通过 `src/utils/sts.ts`）。
+A: 支持。上述方案通过 `CreateApiKey` API（详见 [文档](https://cloud.tencent.com/document/api/876/129835)）为每个用户环境签发 `api_key` 类型凭证。也可以改用 `publish_key` 类型（前端只读）。

--- a/docs/enterprise-auth-with-feishu.md
+++ b/docs/enterprise-auth-with-feishu.md
@@ -1,0 +1,374 @@
+# 企业自有品牌 AI 平台对接指南 — 飞书/企业微信 SSO 集成方案
+
+> 基于 `cloudbase-cli-auth-endpoint` 参考实现 + CloudBase 托管登录页 + 自定义 OAuth 2.0 身份源
+
+---
+
+## 1. 背景
+
+企业 AI 平台（如 Coding Agent、MCP 工具台等）需要对接客户现有账号体系时，面临两个关键问题：
+
+1. **用户不感知腾讯云**：需要在企业自有域名下完成认证
+2. **对接企业身份源**：用户希望使用飞书/企业微信/LDAP 等现有账号登录
+
+CloudBase 提供了 **托管登录页 + 自定义 OAuth 2.0 身份源** 方案，企业只需在控制台配置身份源，无需自行实现飞书 OAuth 回调、token 交换、用户信息拉取等复杂逻辑。
+
+本文档基于 `cloudbase-cli-auth-endpoint` 参考实现，改造为集成 CloudBase 托管登录页的版本，实现完整的企业自有品牌授权流程。
+
+---
+
+## 2. 整体架构（1+N）
+
+```mermaid
+flowchart TB
+    subgraph 企业自有平台
+        direction TB
+        
+        subgraph 管理中心环境["管理中心环境 (1)"]
+            AuthService["授权服务<br/>(云函数/CloudRun)"]
+            AuthPage["授权页面<br/>(cli-auth.html)"]
+            CallbackPage["回调页面<br/>(cli-auth-callback.html)"]
+        end
+        
+        subgraph 用户环境["用户环境 (N)"]
+            UserEnv1["用户 A 环境<br/>Env-xxx-1"]
+            UserEnv2["用户 B 环境<br/>Env-xxx-2"]
+            UserEnvN["用户 N 环境<br/>..."]
+        end
+    end
+
+    subgraph CloudBase["CloudBase 平台"]
+        ManagedLogin["托管登录页<br/>(cloudbase domain)"]
+        IdentitySource["自定义 OAuth 2.0 身份源<br/>(飞书/企微/Google)"]
+        AuthAPI["身份认证 API"]
+    end
+
+    subgraph 企业身份源["企业身份源"]
+        Feishu["飞书开放平台"]
+        WeCom["企业微信"]
+        LDAP["LDAP/SSO"]
+    end
+
+    UserBrowser["用户浏览器"] --> AuthPage
+    UserBrowser --> ManagedLogin
+    
+    AuthPage -- "toDefaultLoginPage()" --> ManagedLogin
+    ManagedLogin -- "OAuth 2.0" --> IdentitySource
+    IdentitySource --> Feishu
+    IdentitySource --> WeCom
+    IdentitySource --> LDAP
+    
+    ManagedLogin -- "颁发 Session" --> CallbackPage
+    CallbackPage -- "POST /verify-cloudbase" --> AuthService
+    AuthService -- "CreateEnv / CreateApiKey" --> AuthAPI
+    AuthAPI -.-> 用户环境
+    
+    MCPClient["Codex / MCP"] -- "设备码流" --> AuthService
+```
+
+**架构说明**：
+
+- **1 个管理中心环境**：部署授权服务（含设备码 API + 授权页 + 回调页），在 CloudBase 控制台配置自定义 OAuth 2.0 身份源
+- **N 个用户环境**：每个用户成功认证后自动创建独立环境，签发 API Key，环境间资源完全隔离
+- **CloudBase 托管登录页**：统一的 SSO 入口，展示所有已配置的身份源，处理后端 OAuth 回调
+
+---
+
+## 3. 前提条件
+
+### 3.1 云开发环境
+
+| 资源 | 说明 |
+|------|------|
+| 管理中心环境 | 1 个 CloudBase 环境，用于部署授权服务 |
+| Publishable Key | 控制台「身份认证 → 应用管理」获取 |
+| 腾讯云 API 密钥 | 控制台「访问管理 → API 密钥管理」获取，需具备 `tcb:CreateEnv` 等权限 |
+
+### 3.2 企业身份源
+
+以飞书为例，需要在飞书开放平台创建企业自建应用：
+
+| 配置项 | 说明 |
+|--------|------|
+| App ID | 飞书应用唯一标识 |
+| App Secret | 飞书应用密钥 |
+| 授权回调地址 | 填入 CloudBase 控制台提供的托管登录页回调地址 |
+
+> 企业微信、Google Workspace 等其他 OAuth 2.0 身份源配置步骤类似，区别在于身份源侧的授权端点不同。
+
+### 3.3 CloudBase 控制台配置
+
+1. 登录 [CloudBase 控制台](https://console.cloud.tencent.com/tcb)，进入管理中心环境
+2. 左侧菜单 → **身份认证 → 企业身份源**
+3. 添加自定义 OAuth 2.0 身份源：
+   - 名称：如 "飞书"
+   - 授权端点：飞书 OAuth 授权 URL
+   - Token 端点：飞书 OAuth Token URL
+   - Client ID：飞书 App ID
+   - Client Secret：飞书 App Secret
+   - 回调地址：复制控制台提供的地址，填入飞书开放平台
+4. 进入 **身份认证 → 托管登录页**，勾选刚配置的身份源，保存
+
+> 控制台配置一次即可，后续所有应用自动继承，无需修改代码。
+
+---
+
+## 4. 部署授权服务
+
+### 4.1 克隆示例代码
+
+```bash
+# 本例基于 cloudbase-cli-auth-endpoint 改造
+# 完整代码参见 examples/cloudbase-auth-endpoint-with-feishu/
+git clone <your-repo>
+cd examples/cloudbase-auth-endpoint-with-feishu
+npm install
+```
+
+### 4.2 配置环境变量
+
+```bash
+cp .env.example .env
+```
+
+编辑 `.env` 文件：
+
+```env
+# 服务端口
+PORT=3000
+BASE_URL=https://auth.your-company.com
+
+# CloudBase 管理中心环境
+CLOUDBASE_ENV_ID=your-management-env-id
+CLOUDBASE_PUBLISHABLE_KEY=your-publishable-key
+CLOUDBASE_REGION=ap-shanghai
+
+# 腾讯云 API 密钥（用于创建用户环境）
+TENCENTCLOUD_SECRET_ID=your-secret-id
+TENCENTCLOUD_SECRET_KEY=your-secret-key
+```
+
+### 4.3 本地开发运行
+
+```bash
+npm run dev
+```
+
+### 4.4 部署到云开发 CloudRun
+
+推荐使用 CloudBase CloudRun 部署：
+
+```bash
+# 1. 构建
+npm run build
+
+# 2. 部署
+tcb fn deploy auth-service --runtime Nodejs18 --entry dist/server.js
+```
+
+部署完成后绑定企业自有域名（如 `auth.your-company.com`）。
+
+### 4.5 验证服务
+
+```bash
+# 测试设备码申请接口
+curl -X POST https://auth.your-company.com/auth/device/code \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+
+# 响应示例
+{
+  "device_code": "a1b2c3d4...",
+  "user_code": "1234-5678",
+  "verification_uri": "https://auth.your-company.com/cli-auth.html",
+  "expires_in": 600,
+  "interval": 3
+}
+```
+
+---
+
+## 5. 对接 Codex
+
+### 5.1 安装插件
+
+在 Codex 中安装 `cloudbase-auth` 插件，或手动配置 MCP 环境变量：
+
+```json
+{
+  "mcp_servers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["@cloudbase/cloudbase-mcp@latest"],
+      "env": {
+        "INTEGRATION_IDE": "Codex",
+        "TCB_AUTH_OAUTH_ENDPOINT": "https://auth.your-company.com"
+      }
+    }
+  }
+}
+```
+
+### 5.2 设备码登录
+
+在 Codex 中执行：
+
+```bash
+tcb config set customOAuthEndpoint https://auth.your-company.com
+tcb login
+```
+
+CLI 会输出设备码和授权页地址：
+
+```
+Device confirmation requested. Open the following URL in your browser:
+  https://auth.your-company.com/cli-auth.html
+
+Enter the code: 1234-5678
+Waiting for authorization...
+```
+
+### 5.3 浏览器授权
+
+打开授权页，输入设备码，点击「授权登录」：
+
+```mermaid
+sequenceDiagram
+    actor User as 用户
+    participant Codex as Codex / CLI
+    participant Auth as 企业授权服务
+    participant Browser as 浏览器
+    participant CloudBase as CloudBase 托管登录页
+    participant Feishu as 飞书/企业身份源
+
+    Codex->>Auth: POST /auth/device/code
+    Auth-->>Codex: device_code, user_code, verification_uri
+    
+    Note over Codex,User: 用户看到授权页地址
+    
+    User->>Browser: 打开 verification_uri
+    User->>Browser: 输入 user_code (1234-5678)
+    User->>Browser: 点击"授权登录"
+    
+    Browser->>Auth: GET /auth/config (获取 SDK 配置)
+    Auth-->>Browser: envId, publishableKey
+    
+    Browser->>CloudBase: auth.toDefaultLoginPage()
+    Note over Browser: sessionStorage 保存 user_code
+    
+    CloudBase->>Feishu: OAuth 2.0 授权请求
+    Feishu-->>User: 飞书扫码/确认
+    User-->>Feishu: 授权
+    
+    Feishu-->>CloudBase: 授权码回调
+    CloudBase-->>Browser: redirect 回 cli-auth-callback.html
+    
+    Browser->>Browser: auth.getSession()
+    Note over Browser: 读取 sessionStorage 中的 user_code
+    
+    Browser->>Auth: POST /auth/verify-cloudbase { user_code, cloudbase_uid }
+    
+    Auth->>CloudBase: CreateEnv (首次)/FindEnv
+    Auth->>CloudBase: CreateApiKey
+    Auth-->>Browser: { status: "ok", env_id }
+    
+    Browser-->>User: ✅ 授权成功
+    
+    Codex->>Auth: 轮询 POST /auth/token (grant_type=device_code)
+    Auth-->>Codex: refresh_token, access_token (API Key), env_id
+    
+    Note over Codex,User: 授权完成，可以开始开发
+```
+
+### 5.4 验证开发能力
+
+登录成功后，Codex 中的 MCP 工具即可操作用户环境：
+
+```bash
+# 查看环境信息
+tcb env list
+
+# 部署云函数
+tcb fn deploy hello-world
+
+# 操作数据库
+tcb db query collection
+```
+
+---
+
+## 6. 关键文件说明
+
+### 6.1 服务端代码
+
+| 文件 | 说明 |
+|------|------|
+| `src/server.ts` | HTTP 入口，定义 5 个核心端点 |
+| `src/config.ts` | 环境变量读取 |
+| `src/types.ts` | 设备码记录、Token 记录、请求体类型 |
+| `src/utils/oauth.ts` | 设备码/用户码生成、OAuth 错误结构 |
+| `src/utils/device-store.ts` | 内存过期清理（生产用 Redis 替换） |
+| `src/utils/tcb.ts` | CloudBase API 调用（CreateEnv/CreateApiKey） |
+
+### 6.2 前端页面
+
+| 文件 | 说明 |
+|------|------|
+| `public/cli-auth.html` | 授权页：用户输入设备码，跳转托管登录页 |
+| `public/cli-auth-callback.html` | 回调页：处理 OAuth 回调，完成设备码授权 |
+
+### 6.3 server.ts 核心端点
+
+```mermaid
+flowchart LR
+    subgraph 外部["外部调用"]
+        MCP["Codex / MCP"]
+        Browser["浏览器"]
+    end
+    
+    subgraph 服务["授权服务 (server.ts)"]
+        direction TB
+        DeviceCode["POST /auth/device/code<br/>申请设备码"]
+        VerifyCBA["POST /auth/verify-cloudbase<br/>CloudBase 回调确认"]
+        Token["POST /auth/token<br/>轮询/续期/退出"]
+        Config["GET /auth/config<br/>返回 SDK 配置"]
+    end
+    
+    MCP --> DeviceCode
+    MCP --> Token
+    Browser --> Config
+    Browser --> VerifyCBA
+```
+
+---
+
+## 7. 扩展方向
+
+| 扩展项 | 说明 |
+|--------|------|
+| **持久化存储** | 将内存 deviceStore / refreshTokenStore 替换为 Redis 或数据库 |
+| **权限收敛** | STS 策略从 `tcb:*` 收敛为最小权限，按用户/环境隔离 |
+| **审计日志** | 记录每次设备码申请、授权、续期操作 |
+| **限流** | 对设备码申请、Token 轮询等接口增加频率限制 |
+| **多源同时启用** | 在控制台同时启用飞书 + 企业微信 + LDAP，用户自由选择 |
+| **SAML 身份源** | 支持 SAML 协议的企业身份源 |
+| **CI/CD 集成** | 将授权服务部署纳入 CI/CD 流程 |
+
+---
+
+## 8. FAQ
+
+**Q: 用户一定需要飞书账号吗？**
+A: 不需要。企业可以在 CloudBase 控制台配置任意数量的身份源。可以同时启用飞书、企业微信、LDAP 等，用户在登录页自行选择。
+
+**Q: 托管登录页的域名是什么？**
+A: 托管登录页在 CloudBase 域名下，但用户授权流程的入口（授权页）在企业自有域名下，用户感知不到 CloudBase 的存在。
+
+**Q: 环境创建需要多久？**
+A: CreateEnv 操作通常需要 10-30 秒。在环境创建期间，MCP 轮询 `/auth/token` 会持续返回 `authorization_pending`，创建完成后返回凭证。
+
+**Q: 如何处理用户删除/离职？**
+A: 在飞书/身份源侧禁用账号后，下次尝试获取新 Token 时认证失败。已有 Session 在过期后失效。可以扩展授权服务增加主动注销 API。
+
+**Q: 这个方案支持现有的 API Key 对接方式吗？**
+A: 支持。上述方案返回的是 API Key（绑定到用户环境）。也可以改用 STS 临时密钥方式（通过 `src/utils/sts.ts`）。

--- a/docs/research-codex-plugin-enterprise-auth.md
+++ b/docs/research-codex-plugin-enterprise-auth.md
@@ -1,0 +1,729 @@
+# 调研报告：CloudBase 企业自有品牌授权 + Codex 插件示例
+
+## 一、概述
+
+本文档调研了以下内容：
+
+> **后续产出**：
+> - 示例代码：`examples/cloudbase-auth-endpoint-with-feishu/`（基于参考实现改造）
+> - 集成文档：`docs/enterprise-auth-with-feishu.md`（含完整 Mermaid 架构图/时序图）
+
+1. [云开发自有品牌-企业AI平台文档](https://docs.cloudbase.net/quick-start/enterprise-ai-platform-no-cam)
+2. [企业自建设备码授权服务对接指南](https://docs.cloudbase.net/cli-v1/device-flow-protocol/integration)
+3. 参考实现 [cloudbase-cli-auth-endpoint](https://cnb.cool/tencent/cloud/cloudbase/cloudbase-cli-auth-endpoint) 源码
+4. `auth-web-cloudbase` 技能文档（CloudBase Web SDK Auth API）
+5. Codex 插件生态系统
+
+目标：设计一个 **以 Codex 为例的插件示例**，实现企业自有域名下的自定义 OAuth 授权流程，采用 **1+N 架构**（1 个管理中心环境 + N 个用户隔离环境）。
+
+---
+
+## 二、文档要点
+
+### 2.1 自有品牌模式（enterprise-ai-platform-no-cam）
+
+**核心价值**：
+
+- 用户无需腾讯云账号，只接触企业自有域名（如 `ai.your-company.com`）
+- **可打通企业现有 SSO/LDAP/飞书/企业微信等账号体系**
+- **环境隔离**：每个用户拥有独立云开发环境，API Key 绑定到指定环境 ID
+
+**三种凭证方式**：
+
+| 方式 | 适用场景 | 用户感知 | 对接复杂度 |
+|------|----------|----------|-----------|
+| **API Key** | 平台统一下发，零感知 | 最低 | 低 |
+| **自定义授权码** | 用户需主动一次性授权登录 | 中 | 中 |
+| **临时密钥 STS** | 服务端控制凭证生命周期 | 较低 | 高 |
+
+> 结论：API Key 方式最适合企业平台直接对接 Coding Agent（如 Codex），但自定义授权码适合需要用户主动确认授权的场景。
+
+### 2.2 设备码授权对接指南
+
+**协议**：遵循 RFC 8628（OAuth 2.0 Device Authorization Grant）
+
+**CLI 对接方式**：
+
+| 方式 | 命令 | 适用场景 |
+|------|------|----------|
+| 同步登录 | `tcb login` | 用户直接在终端操作 |
+| 分步登录 | `tcb login start` + `tcb login complete --session-id <id>` | 聊天工具、OpenClaw、机器人 |
+
+**核心接口**：
+
+| 端点 | 方法 | 用途 |
+|------|------|------|
+| `/auth/device/code` | POST | 申请设备码，返回 `device_code` + `user_code` |
+| `/auth/device/verify` | POST | 用户浏览器确认授权 |
+| `/auth/token` | POST | 三种 `grant_type`：`device_code` / `refresh_token` / `revoke_token` |
+
+**CLI 配置**：
+
+```bash
+tcb config set customOAuthEndpoint https://auth.your-company.com/auth
+tcb login
+```
+
+**MCP 环境变量对应**：
+
+```bash
+TCB_AUTH_OAUTH_ENDPOINT=https://auth.your-company.com/auth
+```
+
+---
+
+## 三、参考实现源码分析：cloudbase-cli-auth-endpoint
+
+### 3.1 项目结构
+
+```
+cloudbase-cli-auth-endpoint/
+├── docs/protocol.md                    # 协议说明
+├── public/cli-auth.html                # 企业自建授权页（浏览器端）
+├── src/
+│   ├── server.ts                       # HTTP 入口，3 个核心端点
+│   ├── config.ts                       # 端口、有效期、STS 时长等
+│   ├── types.ts                        # 类型定义
+│   └── utils/
+│       ├── oauth.ts                    # 设备码/用户码生成 + OAuth 错误
+│       ├── sts.ts                      # 调用腾讯云 STS GetFederationToken
+│       ├── tcb.ts                      # 查询 envIds / envList / billingInfo
+│       ├── device-store.ts             # 过期清理
+│       └── public-dir.ts               # 静态目录
+├── .env.example
+├── package.json
+└── tsconfig.json
+```
+
+### 3.2 核心流程
+
+**首次登录**：
+
+```
+CLI/MCP          企业授权服务        浏览器/用户
+  │                   │                  │
+  ├── POST /device/code ──►              │
+  │◄── device_code, user_code            │
+  │                   │                  │
+  │                   │   打开授权页 ─────►
+  │                   │◄── 输入 user_code │
+  │                   │   确认授权        │
+  │                   │                  │
+  ├─ 轮询 POST /token ──►               │
+  │  (grant_type=device_code)            │
+  │◄── refreshToken + STS 凭证           │
+  │    + 环境列表                        │
+```
+
+**续期**：
+
+```
+CLI/MCP          企业授权服务
+  │                   │
+  ├── POST /token ────►
+  │  (grant_type=refresh_token)
+  │◄── 新 refreshToken + 新 STS 凭证
+```
+
+**退出**：
+
+```
+CLI/MCP          企业授权服务
+  │                   │
+  ├── POST /token ────►
+  │  (grant_type=revoke_token)
+  │◄── 确认
+```
+
+### 3.3 关键源码片段
+
+**env 配置（.env.example）**：
+
+```
+PORT=3000
+BASE_URL=http://localhost:3000
+EXPIRES_IN=600
+INTERVAL=3
+TENCENTCLOUD_SECRET_ID=
+TENCENTCLOUD_SECRET_KEY=
+STS_TOKEN_DURATION=1800
+```
+
+**device-store.ts**（过期清理逻辑）：
+
+```typescript
+export function cleanupExpired(deviceStore, userCodeIndex) {
+  for (const [key, auth] of deviceStore.entries()) {
+    if (now > auth.expiresAt) {
+      deviceStore.delete(key);
+      userCodeIndex.delete(auth.userCode);
+    }
+  }
+}
+
+export function scheduleExpiry(deviceStore, userCodeIndex, deviceCode, userCode, ttlMs) {
+  setTimeout(() => {
+    const auth = deviceStore.get(deviceCode);
+    if (auth && (auth.status === 'pending' || auth.status === 'authorized')) {
+      auth.status = 'expired';
+      // 过期后再保留 CONSUMED_TTL_MS 后删除
+    }
+  }, ttlMs);
+}
+```
+
+---
+
+## 四、CloudBase Web SDK Auth API（auth-web-cloudbase）
+
+### 4.1 SDK 初始化
+
+```js
+import cloudbase from '@cloudbase/js-sdk'
+
+const app = cloudbase.init({
+  env: 'your-full-env-id',
+  region: 'ap-shanghai',        // 默认
+  accessKey: 'publishable key', // SDK 公钥
+  auth: { detectSessionInUrl: true },
+})
+
+const auth = app.auth({ persistence: 'local' })
+```
+
+### 4.2 关键接口
+
+| 方法 | 用途 |
+|------|------|
+| `signInWithOAuth({ provider })` | OAuth 登录（Google/微信等） |
+| `signInWithIdToken({ provider, token })` | 直接使用第三方 JWT/OAuth Token 登录 |
+| `signInWithCustomTicket(callback)` | 自定义票据登录 |
+| `signInWithPassword({ email/phone/username, password })` | 密码登录 |
+| `signInWithOtp({ phone/email })` | 验证码登录 |
+| `getSession()` | 获取当前会话（可靠的登录状态检查） |
+| `refreshSession()` | 续期会话 |
+| `signOut()` | 退出 |
+| `onAuthStateChange(callback)` | 监听认证状态变化 |
+| `setSession({ refresh_token })` | 手动设置会话（SSR/外部流） |
+
+### 4.3 OAuth 流程
+
+```js
+const { data, error } = await auth.signInWithOAuth({ provider: 'google' })
+window.location.href = data.url // 跳转到 OAuth 授权页，回调后自动完成
+```
+
+### 4.4 本架构中的关键角色
+
+- **管理中心环境** 使用 Web SDK 的 `signInWithCustomTicket` / `signInWithIdToken` 对接飞书
+- 用户完成飞书 OAuth → 获取飞书 `id_token` → 通过 `signInWithIdToken` 登录云开发
+- 或使用自定义票据流程：飞书 OAuth → 后端颁发自定义 ticket → `signInWithCustomTicket`
+
+---
+
+## 五、Codex 插件生态系统
+
+### 5.1 插件结构
+
+```
+my-plugin/
+├── .codex-plugin/
+│   └── plugin.json          # 插件清单（必需）
+├── skills/                   # 可选：技能指令
+│   └── my-skill/SKILL.md
+├── hooks/                    # 可选：生命周期钩子（hooks.json）
+├── .mcp.json                 # 可选：MCP 服务器配置
+├── .app.json                 # 可选：应用/连接器映射
+└── assets/                   # 可选：图标、截图
+```
+
+### 5.2 plugin.json 关键字段
+
+```json
+{
+  "name": "cloudbase-auth",
+  "version": "1.0.0",
+  "description": "企业自有品牌授权接入 - 支持飞书/LDAP/SSO",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "CloudBase Auth",
+    "shortDescription": "连接你的企业账号到云开发",
+    "category": "Authentication",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "使用企业账号登录云开发环境",
+      "通过设备码授权获取云开发访问权限"
+    ]
+  }
+}
+```
+
+### 5.3 MCP 配置
+
+```json
+{
+  "mcp_servers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["@cloudbase/cloudbase-mcp@latest"],
+      "env": {
+        "INTEGRATION_IDE": "Codex",
+        "TCB_AUTH_OAUTH_ENDPOINT": "<授权服务地址>"
+      }
+    }
+  }
+}
+```
+
+---
+
+## 六、1+N 架构设计（核心）
+
+### 6.1 整体架构
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                        企业自有平台                                │
+│                                                                  │
+│  ┌─────────────────────────┐     ┌──────────────────────────┐   │
+│  │   管理中心环境（1）        │     │   用户环境（N）            │   │
+│  │                         │     │                          │   │
+│  │  CloudBase 环境 A       │     │  CloudBase 环境 1..N     │   │
+│  │  ┌───────────────────┐  │     │  ┌────────────────────┐  │   │
+│  │  │ 授权服务（云函数）   │  │     │  │ 数据库              │  │   │
+│  │  │  - device/code    │  │     │  │ 云函数              │  │   │
+│  │  │  - device/verify  │  │     │  │ 文件存储            │  │   │
+│  │  │  - token          │  │     │  │ API Key (绑定环境)   │  │   │
+│  │  └───────────────────┘  │     │  └────────────────────┘  │   │
+│  │                         │     │                          │   │
+│  │  ┌───────────────────┐  │     │  资源完全隔离              │   │
+│  │  │ 授权页面（静态）    │  │     │                          │   │
+│  │  │  - 飞书 SSO        │  │     │  每用户/租户独立环境       │   │
+│  │  │  - 企业微信 SSO    │  │     │                          │   │
+│  │  │  - LDAP 登录       │  │     └──────────────────────────┘   │
+│  │  │  - 用户码确认      │  │                                    │
+│  │  └───────────────────┘  │                                    │
+│  │                         │                                    │
+│  │  ┌───────────────────┐  │                                    │
+│  │  │ 环境管理逻辑       │  │                                    │
+│  │  │  - CreateEnv      │  │                                    │
+│  │  │  - 绑定 API Key   │  │                                    │
+│  │  │  - 用户↔环境映射   │  │                                    │
+│  │  └───────────────────┘  │                                    │
+│  └───────────┬─────────────┘                                    │
+│              │                                                   │
+│              ▼                                                   │
+│  ┌─────────────────────────────────────────────────────┐        │
+│  │               Coding Agent (Codex)                    │        │
+│  │                                                     │        │
+│  │  ┌─────────────────────────────────────────────────┐ │        │
+│  │  │ codex-plugin: cloudbase-auth                     │ │        │
+│  │  │                                                 │ │        │
+│  │  │  .mcp.json → TCB_AUTH_OAUTH_ENDPOINT ───────────►│ │        │
+│  │  │  SKILL.md → 分步登录指导                        │ │        │
+│  │  └─────────────────────────────────────────────────┘ │        │
+│  │                                                     │        │
+│  │  1. 安装插件 → 插件自动配置 MCP 环境变量              │        │
+│  │  2. 用户执行"链接企业账号" → 设备码流程启动            │        │
+│  │  3. 浏览器打开授权页 → 飞书/企业微信 SSO              │        │
+│  │  4. 授权完成 → MCP 自动获取 STS/API Key              │        │
+│  │  5. 用户开始开发                                     │        │
+│  └─────────────────────────────────────────────────────┘        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### 6.2 完整流程（用户首次使用）
+
+```
+阶段 1：管理端部署
+┌─────────────────────────────────────────────────────────────┐
+│ 企业管理员：                                                │
+│ 1. 创建 CloudBase 管理中心环境 A                             │
+│ 2. 部署授权服务到环境 A（云函数 + 静态页面）                    │
+│ 3. 配置飞书开放平台（获取 App ID / App Secret）               │
+│ 4. 配置企业 SSO / LDAP 对接                                  │
+│ 5. 配置 API Key（用于创建子环境的权限）                        │
+│ 6. 发布 Codex 插件到企业内源 / 私有市场                       │
+│ 7. 企业域名绑定：auth.your-company.com → 授权服务            │
+└─────────────────────────────────────────────────────────────┘
+
+阶段 2：用户在 Codex 安装
+┌─────────────────────────────────────────────────────────────┐
+│ Codex 用户：                                                │
+│ 1. 编辑 .codex-plugin/marketplace.json                      │
+│ 2. 添加企业私有插件源                                       │
+│ 3. 安装 cloudbase-auth 插件                                 │
+│ 4. 插件自动配置 MCP 环境变量：                               │
+│    TCB_AUTH_OAUTH_ENDPOINT = https://auth.your-company.com  │
+└─────────────────────────────────────────────────────────────┘
+
+阶段 3：用户首次授权（设备码流程）
+┌─────────────────────────────────────────────────────────────┐
+│ 用户                        授权服务                       │
+│  │                            │                            │
+│  │ 1️⃣ 执行"登录企业账号"        │                            │
+│  │ ─── POST /auth/device/code ──►                          │
+│  │ ◄── { device_code, user_code,                          │
+│  │       verification_uri }                                │
+│  │                            │                            │
+│  │ 2️⃣ 打开授权页              │                            │
+│  │    输入 user_code           │                            │
+│  │                              │                            │
+│  │ 3️⃣ 选择登录方式：           │                            │
+│  │    ┌─────────────────┐      │                            │
+│  │    │ [飞书登录]       │      │                            │
+│  │    │ [企业微信登录]   │      │                            │
+│  │    │ [LDAP 登录]     │      │                            │
+│  │    │ [企业邮箱验证码]  │      │                            │
+│  │    └─────────────────┘      │                            │
+│  │                              │                            │
+│  │ 4️⃣ 飞书扫码 → 飞书回调      │                            │
+│  │    → 授权服务验证身份        │                            │
+│  │    → POST /auth/device/verify                            │
+│  │      { user_code }                                      │
+│  │    → 状态: pending → authorized                          │
+│  │                              │                            │
+│  │ 5️⃣（首次登录自动创建环境）    │                            │
+│  │    → 查询用户是否已有环境      │                            │
+│  │    → 无 → CreateEnv(用户A)   │                            │
+│  │    → 创建 API Key for 环境   │                            │
+│  │    → 保存用户↔环境映射        │                            │
+│  │                              │                            │
+│  │ 6️⃣ MCP 轮询 POST /auth/token─►                           │
+│  │    (grant_type=device_code)  │                            │
+│  │ ◄── { refreshToken,         │                            │
+│  │       stsCredentials,       │                            │
+│  │       envList | apiKey }     │                            │
+│  │                              │                            │
+│  │ 7️⃣ ✅ 授权完成，开始开发      │                            │
+└─────────────────────────────────────────────────────────────┘
+
+阶段 4：后续使用（续期）
+┌─────────────────────────────────────────────────────────────┐
+│ MCP 定期刷新：                                              │
+│ 1. POST /auth/token (grant_type=refresh_token)              │
+│ 2. 服务端验证 refreshToken 有效性                            │
+│ 3. Token Rotation：发新 refreshToken + 新临时凭证           │
+│ 4. MCP 保存新凭证                                           │
+└─────────────────────────────────────────────────────────────┘
+
+阶段 5：退出
+┌─────────────────────────────────────────────────────────────┐
+│ 1. 用户执行"断开企业账号"                                    │
+│ 2. MCP → POST /auth/token (grant_type=revoke_token)         │
+│ 3. 服务端使 refreshToken 失效                                │
+│ 4. MCP 清除本地凭证                                          │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### 6.3 管理中心环境 vs 用户环境
+
+| 维度 | 管理中心环境 (1) | 用户环境 (N) |
+|------|-----------------|-------------|
+| 用途 | 授权服务、用户管理、环境创建 | 用户的开发/生产资源 |
+| 部署的服务 | 授权 API + 授权页面 + 管理后台 | 用户业务代码 + 数据 |
+| 凭证 | 主账号 API Key（可创建子环境） | API Key（仅限该环境） |
+| 权限范围 | `tcb:*`（管理面） | 按环境隔离，最小权限 |
+| 用户感知 | 不可见 | 可见（用户认为这是"我的环境"） |
+| 生命周期 | 企业创建，长期稳定 | 用户启用时创建，销毁时回收 |
+| 可见域名 | `auth.your-company.com` | `<env-id>.your-company.com` |
+
+### 6.4 飞书集成方案
+
+**方案 A：飞书作为 OAuth 身份源（推荐）**
+
+在授权页面中嵌入飞书登录：
+
+```
+授权页 (auth.your-company.com)
+┌─────────────────────────────┐
+│                             │
+│   企业 AI 开发平台           │
+│                             │
+│   请输入设备码：             │
+│   [___________]             │
+│                             │
+│   或选择登录方式：           │
+│                             │
+│   ┌─────────────────────┐   │
+│   │  [飞书扫码登录]      │   │
+│   └─────────────────────┘   │
+│                             │
+│   ┌─────────────────────┐   │
+│   │  [企业微信登录]      │   │
+│   └─────────────────────┘   │
+│                             │
+│   ┌─────────────────────┐   │
+│   │  [LDAP 账号登录]     │   │
+│   └─────────────────────┘   │
+└─────────────────────────────┘
+```
+
+**授权服务内部流程（飞书）**：
+
+```
+用户点击"飞书登录"
+  → 跳转飞书 OAuth 授权页
+    → 用户扫码确认
+      → 飞书回调到授权服务
+        → 授权服务获取 access_token + 用户信息
+          → 验证用户身份
+            → 映射到 CloudBase 用户
+              → 标记 device_code 为 authorized
+```
+
+**方案 B：飞书机器人 + 分步登录**
+
+适用于飞书群聊中直接使用 Codex 的场景（通过 `cc-connect` 桥接）：
+
+```
+飞书群聊
+  ↓ 用户发消息："帮我写一个云函数"
+  ↓
+cc-connect（桥接层）
+  ↓
+Codex CLI
+  ↓ 检测未登录 → 执行 tcb login start
+  ↓
+获取 sessionId + 授权页 URL
+  ↓ 返回给飞书用户
+  ↓
+用户点击链接完成授权
+  ↓
+Codex CLI 执行 tcb login complete --session-id <id>
+  ↓ 登录成功 → 执行用户请求
+```
+
+---
+
+## 七、Codex 插件示例设计（cloudbase-auth）
+
+### 7.1 插件目录结构
+
+```
+cloudbase-auth-plugin/
+├── .codex-plugin/
+│   └── plugin.json              # 插件清单
+├── skills/
+│   └── cloudbase-auth/
+│       └── SKILL.md             # 技能：引导用户完成配置和登录
+├── .mcp.json                    # MCP 服务器预配置（含授权端点模板）
+├── assets/
+│   ├── icon.png                 # 插件图标
+│   └── screenshot.png           # 截图
+├── README.md                    # 插件使用说明
+└── package.json                 # 插件元信息
+```
+
+### 7.2 插件配置设计
+
+**plugin.json**：
+
+```json
+{
+  "name": "cloudbase-auth",
+  "version": "1.0.0",
+  "description": "CloudBase 企业自有品牌授权接入 - 支持飞书/LDAP/SSO 等企业身份源对接",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json",
+  "interface": {
+    "displayName": "CloudBase Auth",
+    "shortDescription": "连接你的企业账号到云开发环境",
+    "longDescription": "通过企业自建授权服务，用户可使用飞书/企业微信/LDAP/SSO 等企业账号登录云开发，无需腾讯云账号即可使用全部云开发能力",
+    "developerName": "CloudBase Team",
+    "category": "Authentication",
+    "capabilities": ["Read", "Write"],
+    "defaultPrompt": [
+      "使用企业账号登录云开发环境",
+      "通过设备码授权获取云开发访问权限"
+    ]
+  },
+  "activation": {
+    "onActivate": ["cloudbase-auth:login-greeting"]
+  }
+}
+```
+
+**.mcp.json**：
+
+```json
+{
+  "mcp_servers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["@cloudbase/cloudbase-mcp@latest"],
+      "env": {
+        "INTEGRATION_IDE": "Codex",
+        "TCB_AUTH_OAUTH_ENDPOINT": "{{AUTH_ENDPOINT}}"
+      }
+    }
+  }
+}
+```
+
+### 7.3 技能设计（SKILL.md）
+
+SKILL.md 应覆盖两个层面：
+
+**层面 1：平台管理员**（一次性配置）
+
+1. 部署授权服务到 CloudBase 环境
+   - 在 CloudBase 控制台创建管理中心环境
+   - 从模板部署授权服务（云函数 + 静态页面）
+   - 配置 `TENCENTCLOUD_SECRET_ID` / `SECRET_KEY`
+   - 配置 STS 策略、Token 有效期等
+
+2. 配置飞书/企业微信 OAuth
+   - 在飞书开放平台创建应用
+   - 获取 App ID / App Secret
+   - 配置回调 URL
+   - 测试飞书登录
+
+3. 发布插件
+   - 配置 `TCB_AUTH_OAUTH_ENDPOINT`
+   - 发布到企业内源
+
+**层面 2：Codex 最终用户**（重复操作）
+
+1. 安装插件（自动配置 MCP）
+2. 执行设备码授权
+3. 浏览器完成认证（选择飞书/SSO 等方式）
+4. 开始使用开发能力
+
+### 7.4 授权服务部署模板（基于 cloudbase-cli-auth-endpoint 扩展）
+
+需要新增/改造的点：
+
+| 模块 | 扩展内容 |
+|------|----------|
+| `server.ts` | 新增 `/auth/feishu/oauth`、`/auth/feishu/callback` 端点 |
+| `server.ts` | 新增 `POST /auth/environments` 管理环境创建 |
+| `cli-auth.html` | 增设飞书/企业微信/LDAP 登录按钮 |
+| `tcb.ts` | 新增 `createEnv()`、`createApiKey()`、`bindApiKey()` |
+| `oauth.ts` | 新增飞书 Token 验证、用户信息提取 |
+| 新增 `env-manager.ts` | 新用户首次登录自动创建环境 |
+
+### 7.5 飞书 OAuth 集成关键代码
+
+```typescript
+// 飞书 OAuth 回调处理
+app.get('/auth/feishu/callback', async (req, res) => {
+  const { code } = req.query;
+  
+  // 1. 用授权码换取飞书 access_token
+  const tokenRes = await fetch('https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal', {
+    method: 'POST',
+    body: JSON.stringify({ app_id, app_secret }),
+  });
+  const { tenant_access_token } = await tokenRes.json();
+  
+  // 2. 通过 code 获取用户信息
+  const userRes = await fetch('https://open.feishu.cn/open-apis/authen/v1/access_token', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${tenant_access_token}` },
+    body: JSON.stringify({ code, grant_type: 'authorization_code' }),
+  });
+  const userInfo = await userRes.json();
+  const feishuUserId = userInfo.data.user_id;
+  
+  // 3. 通过飞书 user_id 查找/创建 CloudBase 用户
+  const envId = await getOrCreateUserEnv(feishuUserId);
+  
+  // 4. 标记设备码为 authorized
+  const deviceRecord = findDeviceByUser(feishuUserId);
+  deviceRecord.status = 'authorized';
+  deviceRecord.envId = envId;
+  
+  res.redirect(`${deviceRecord.verificationUri}?status=success`);
+});
+```
+
+### 7.6 MCP 对接改造
+
+`@cloudbase/cloudbase-mcp` 需要支持 `TCB_AUTH_OAUTH_ENDPOINT` 环境变量，使其运行逻辑：
+
+1. 初始化时检查 `TCB_AUTH_OAUTH_ENDPOINT`
+2. 若存在，执行设备码授权流程（分步登录模式适合 IDE 场景）
+3. 轮询 `/auth/token` 获取凭证
+4. 支持续期和退出
+5. 本地保存 `refreshToken` 以实现会话持久化
+
+---
+
+## 八、扩展方向与注意事项
+
+### 8.1 生产环境必须改造的点
+
+| 序号 | 改造项 | 原因 |
+|------|--------|------|
+| 1 | 内存存储 → Redis/数据库 | 服务重启后设备码/refreshToken 丢失 |
+| 2 | STS 策略 `tcb:*` → 最小权限 | 安全隔离，按用户/环境收敛 |
+| 3 | 浏览器简化用户信息 → 企业 SSO/IdP/审批流 | 对接真实身份源 |
+| 4 | 补齐审计、限流、告警、可观测性 | 生产安全要求 |
+| 5 | 环境自动创建 → 首登 CreateEnv | 参考实现目前没有自动创建环境逻辑 |
+
+### 8.2 权限策略模板（来自文档）
+
+```json
+{
+  "version": "2.0",
+  "statement": [
+    { "effect": "allow", "action": "tcb:DescribeEnvs", "resource": "*" },
+    { "effect": "allow", "action": "tcb:CheckWhetherEnvServiceAvailable", "resource": "*" },
+    { "effect": "allow", "action": "tcb:DescribeEnvFreeLimit", "resource": "*" },
+    { "effect": "allow", "action": "tcb:DescribeBillingInfo", "resource": "*" },
+    { "effect": "allow", "action": "tcbr:DescribeServerlessIngress", "resource": "*" },
+    { "effect": "allow", "action": "tcb:*", "resource": "qcs::tcb:ap-shanghai:uid/12345:env/${envId}/*" }
+  ]
+}
+```
+
+### 8.3 改造参考实现需要关注的代码点
+
+```
+cloudbase-cli-auth-endpoint/src/
+├── server.ts
+│   ├── POST /auth/device/code              # OK，保持
+│   ├── POST /auth/device/verify            # OK，保持
+│   ├── POST /auth/token                    # OK，保持
+│   └── NEW: GET /auth/feishu/callback      # 新增飞书回调
+│   └── NEW: POST /auth/environments        # 新增环境管理
+│
+├── utils/tcb.ts
+│   ├── listEnvs(userUin)                   # OK，保持
+│   └── NEW: createEnv(name)                # 新增
+│   └── NEW: createApiKey(envId)            # 新增
+│
+├── utils/oauth.ts
+│   └── NEW: verifyFeishuToken(code)        # 新增飞书 token 验证
+│
+└── public/cli-auth.html
+    ├── 输入 user_code 确认                  # OK，保持
+    └── NEW: 飞书/企业微信/LDAP 登录按钮      # 新增多身份源入口
+```
+
+---
+
+## 九、总结
+
+### 完整技术栈
+
+| 层次 | 技术选择 | 说明 |
+|------|----------|------|
+| 前端 IDE | Codex | 腾讯 AI Coding Agent |
+| 插件系统 | `.codex-plugin/plugin.json` + `.mcp.json` | 插件 + MCP 预配置 |
+| MCP 服务器 | `@cloudbase/cloudbase-mcp` | 支持 `TCB_AUTH_OAUTH_ENDPOINT` |
+| 授权协议 | RFC 8628 设备码授权 | 适配 CLI/MCP 的无头认证 |
+| 授权服务 | 基于 `cloudbase-cli-auth-endpoint` 扩展 | CloudBase 云函数部署 |
+| 身份源 | 飞书 / 企业微信 / LDAP / SSO | 企业自选 |
+| 凭证类型 | API Key（推荐）/ STS 临时密钥 | 按场景选择 |
+| 运行时 | CloudBase 云开发（CloudRun） | 全托管，无需运维 |
+
+### 核心优势
+
+1. **用户完全无感知**腾讯云存在，只用企业自有域名
+2. **对接企业现有账号体系**，无需创建额外账号
+3. **1+N 环境隔离**，安全合规
+4. **Codex MCP 原生对接**，无需额外适配
+5. **飞书/企业微信/SSO 三选一或全支持**，灵活扩展

--- a/examples/cloudbase-auth-endpoint-with-feishu/.env.example
+++ b/examples/cloudbase-auth-endpoint-with-feishu/.env.example
@@ -1,8 +1,8 @@
-# 服务端口
-PORT=3000
+# 服务端口（SCF HTTP 函数固定为 9000，本地开发请保持一致）
+PORT=9000
 
 # 服务基础 URL（用于拼接授权页地址等）
-BASE_URL=http://localhost:3000
+BASE_URL=http://localhost:9000
 
 # 设备码有效期（秒）
 EXPIRES_IN=600
@@ -36,9 +36,16 @@ CLOUDBASE_USER_ENV_READY_TIMEOUT_MS=120000
 # 腾讯云 API 密钥（用于创建用户环境 + 创建 API Key）
 # 密钥可前往 https://console.cloud.tencent.com/cam/capi 获取
 # 此密钥需要具备以下权限：
-#   - tcb:CreateEnv（创建用户环境）
+#   - tcb:CreateEnv（创建用户环境 — 注意：CreateEnv 是付费操作，会自动下单扣费）
 #   - tcb:CreateApiKey（为用户环境签发 API Key）
 #   - tcb:DescribeEnvs（查询已有环境）
+#
+# ⚠️ 安全警告：
+#   - CreateEnv 是购买云开发环境操作，会自动下单并支付
+#   - 授权服务每次成功认证后自动执行 CreateEnv + CreateApiKey
+#   - 生产部署**必须**使用子账号密钥，并限制资源范围
+#   - 建议配合 STS 临时密钥或白名单机制，防止滥用导致资损
+#   - 勿将此密钥提交到代码仓库
 # ────────────────────────────────────────────────────────────
 TENCENTCLOUD_SECRET_ID=
 TENCENTCLOUD_SECRET_KEY=

--- a/examples/cloudbase-auth-endpoint-with-feishu/.env.example
+++ b/examples/cloudbase-auth-endpoint-with-feishu/.env.example
@@ -25,6 +25,13 @@ CLOUDBASE_PUBLISHABLE_KEY=
 # 管理中心环境的地域（默认 ap-shanghai）
 CLOUDBASE_REGION=ap-shanghai
 
+# 用户环境创建参数（CreateEnv 必填）
+CLOUDBASE_USER_ENV_PACKAGE_ID=baas_personal
+CLOUDBASE_USER_ENV_RESOURCES=flexdb,storage,function
+CLOUDBASE_USER_ENV_PERIOD=1
+CLOUDBASE_USER_ENV_AUTO_VOUCHER=true
+CLOUDBASE_USER_ENV_READY_TIMEOUT_MS=120000
+
 # ────────────────────────────────────────────────────────────
 # 腾讯云 API 密钥（用于创建用户环境 + 创建 API Key）
 # 密钥可前往 https://console.cloud.tencent.com/cam/capi 获取

--- a/examples/cloudbase-auth-endpoint-with-feishu/.env.example
+++ b/examples/cloudbase-auth-endpoint-with-feishu/.env.example
@@ -26,11 +26,12 @@ CLOUDBASE_PUBLISHABLE_KEY=
 CLOUDBASE_REGION=ap-shanghai
 
 # ────────────────────────────────────────────────────────────
-# 腾讯云 API 密钥（用于创建用户环境和下发 API Key）
+# 腾讯云 API 密钥（用于创建用户环境 + 创建 API Key）
 # 密钥可前往 https://console.cloud.tencent.com/cam/capi 获取
-# 此密钥需要具备 tcb:CreateEnv / tcb:DescribeEnvs 等权限
+# 此密钥需要具备以下权限：
+#   - tcb:CreateEnv（创建用户环境）
+#   - tcb:CreateApiKey（为用户环境签发 API Key）
+#   - tcb:DescribeEnvs（查询已有环境）
 # ────────────────────────────────────────────────────────────
 TENCENTCLOUD_SECRET_ID=
 TENCENTCLOUD_SECRET_KEY=
-# STS 临时凭证有效期（秒，默认 1800）。本次使用 API Key 方式，此项保留向下兼容
-STS_TOKEN_DURATION=1800

--- a/examples/cloudbase-auth-endpoint-with-feishu/.env.example
+++ b/examples/cloudbase-auth-endpoint-with-feishu/.env.example
@@ -1,0 +1,36 @@
+# 服务端口
+PORT=3000
+
+# 服务基础 URL（用于拼接授权页地址等）
+BASE_URL=http://localhost:3000
+
+# 设备码有效期（秒）
+EXPIRES_IN=600
+
+# 轮询间隔（秒）
+INTERVAL=3
+
+# ────────────────────────────────────────────────────────────
+# CloudBase 管理中心环境配置
+# 用于"1+N"架构中的"1"——管理中心环境
+# ────────────────────────────────────────────────────────────
+
+# 管理中心环境的完整 envId
+CLOUDBASE_ENV_ID=
+
+# 管理中心环境的 Publishable Key（前端 SDK 用）
+# 获取路径：控制台 → 身份认证 → 应用管理 → Publishable Key
+CLOUDBASE_PUBLISHABLE_KEY=
+
+# 管理中心环境的地域（默认 ap-shanghai）
+CLOUDBASE_REGION=ap-shanghai
+
+# ────────────────────────────────────────────────────────────
+# 腾讯云 API 密钥（用于创建用户环境和下发 API Key）
+# 密钥可前往 https://console.cloud.tencent.com/cam/capi 获取
+# 此密钥需要具备 tcb:CreateEnv / tcb:DescribeEnvs 等权限
+# ────────────────────────────────────────────────────────────
+TENCENTCLOUD_SECRET_ID=
+TENCENTCLOUD_SECRET_KEY=
+# STS 临时凭证有效期（秒，默认 1800）。本次使用 API Key 方式，此项保留向下兼容
+STS_TOKEN_DURATION=1800

--- a/examples/cloudbase-auth-endpoint-with-feishu/README.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/README.md
@@ -1,0 +1,24 @@
+# cloudbase-auth-endpoint-with-feishu
+
+基于 `cloudbase-cli-auth-endpoint` 改造的企业自有品牌授权服务示例。
+
+## 核心变化
+
+相对原始参考实现，本示例增加了：
+
+1. **CloudBase 托管登录页集成**：授权页通过 `auth.toDefaultLoginPage()` 跳转 CloudBase 托管登录页，展示所有已配置的企业身份源
+2. **1+N 环境自动创建**：用户首次通过身份源登录后，自动创建独立 CloudBase 环境并签发 API Key
+3. **自定义 OAuth 2.0 身份源支持**：在 CloudBase 控制台配置飞书/企业微信/Google/LDAP 等身份源，无需修改代码
+
+## 快速开始
+
+```bash
+cp .env.example .env
+# 编辑 .env 填入 CloudBase 环境配置和腾讯云 API 密钥
+npm install
+npm run dev
+```
+
+## 文档
+
+完整流程参见 `docs/enterprise-auth-with-feishu.md`

--- a/examples/cloudbase-auth-endpoint-with-feishu/README.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/README.md
@@ -24,9 +24,10 @@ sequenceDiagram
     IdP-->>Browser: OAuth callback → __auth/
 
     Browser->>Auth: POST /auth/verify-cloudbase
-    Auth-->>Browser: { env_id, api_key_id }
+    Auth-->>Browser: { status: ok }
 
     MCP->>Auth: POST /auth/token (grant_type=device_code)
+    Auth->>Auth: CreateEnv + CreateApiKey（按需）
     Auth-->>MCP: refresh_token, access_token (JWT API Key)
 ```
 

--- a/examples/cloudbase-auth-endpoint-with-feishu/README.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/README.md
@@ -1,24 +1,315 @@
 # cloudbase-auth-endpoint-with-feishu
 
-基于 `cloudbase-cli-auth-endpoint` 改造的企业自有品牌授权服务示例。
+企业自有品牌授权服务——用户在你的授权页面输入设备码 → 跳转飞书/企微 SSO → 自动创建 CloudBase 环境并签发 API Key。
 
-## 核心变化
+## 架构
 
-相对原始参考实现，本示例增加了：
+```mermaid
+sequenceDiagram
+    participant MCP as MCP / CLI
+    participant Auth as 企业授权服务<br/>(SCF HTTP 函数)
+    participant Browser as 用户浏览器
+    participant IdP as 企业身份源<br/>(飞书/企微/Google)
 
-1. **CloudBase 托管登录页集成**：授权页通过 `auth.toDefaultLoginPage()` 跳转 CloudBase 托管登录页，展示所有已配置的企业身份源
-2. **1+N 环境自动创建**：用户首次通过身份源登录后，自动创建独立 CloudBase 环境并签发 API Key
-3. **自定义 OAuth 2.0 身份源支持**：在 CloudBase 控制台配置飞书/企业微信/Google/LDAP 等身份源，无需修改代码
+    MCP->>Auth: POST /auth/device/code
+    Auth-->>MCP: device_code, user_code, verification_uri
 
-## 快速开始
+    Browser->>Auth: 打开 cli-auth.html
+    Browser->>Browser: 输入 user_code
 
-```bash
-cp .env.example .env
-# 编辑 .env 填入 CloudBase 环境配置和腾讯云 API 密钥
-npm install
-npm run dev
+    Browser->>Auth: toDefaultLoginPage({ redirect_uri })
+    Auth-->>Browser: 302 → __auth/ 托管登录页
+
+    Browser->>IdP: 企业扫码/授权
+    IdP-->>Browser: OAuth callback → __auth/
+
+    Browser->>Auth: POST /auth/verify-cloudbase
+    Auth-->>Browser: { env_id, api_key_id }
+
+    MCP->>Auth: POST /auth/token (grant_type=device_code)
+    Auth-->>MCP: refresh_token, access_token (JWT API Key)
 ```
 
-## 文档
+## 从零开始完整操作路径
 
-完整流程参见 `docs/enterprise-auth-with-feishu.md`
+### 前置准备
+
+| 资源 | 说明 | 获取方式 |
+|------|------|----------|
+| CloudBase 环境 | 管理中心环境，作为"1+N"中的"1" | [控制台创建](https://console.cloud.tencent.com/tcb) |
+| 腾讯云 API 密钥 | `SecretId` + `SecretKey` | [CAM 访问管理](https://console.cloud.tencent.com/cam/capi) |
+| Publishable Key | 前端 SDK 初始化用 | 控制台 → 身份认证 → API Key 管理 |
+| 飞书自建应用 | 用于企业 SSO 登录 | [飞书开放平台](https://open.feishu.cn/app) |
+
+### Step 1: 部署授权服务到 CloudBase
+
+```bash
+# 克隆代码
+cd examples/cloudbase-auth-endpoint-with-feishu
+
+# 配置环境变量
+cp .env.example .env
+# 编辑 .env 填入：
+#   CLOUDBASE_ENV_ID=xxx
+#   CLOUDBASE_PUBLISHABLE_KEY=xxx
+#   TENCENTCLOUD_SECRET_ID=xxx
+#   TENCENTCLOUD_SECRET_KEY=xxx
+
+# 本地验证
+npm install --include=dev
+npm run build
+npm run start
+curl -X POST http://localhost:9000/auth/device/code -H 'Content-Type: application/json' -d '{}'
+```
+
+部署到 CloudBase（通过 MCP `manageFunctions` 完成）：
+
+```json
+{
+  "tool": "manageFunctions",
+  "params": {
+    "action": "createFunction",
+    "func": {
+      "name": "auth-service",
+      "type": "HTTP",
+      "runtime": "Nodejs18.15",
+      "timeout": 120,
+      "envVariables": {
+        "BASE_URL": "https://your-domain.com",
+        "CLOUDBASE_ENV_ID": "your-env-id",
+        "CLOUDBASE_PUBLISHABLE_KEY": "your-publishable-key",
+        "CLOUDBASE_REGION": "ap-shanghai",
+        "CB_SECRET_ID": "your-secret-id",
+        "CB_SECRET_KEY": "your-secret-key"
+      }
+    },
+    "functionRootPath": "/absolute/path/to/examples/cloudbase-auth-endpoint-with-feishu"
+  }
+}
+```
+
+> `functionRootPath` 指向项目目录，`manageFunctions` 会自动上传 `package.json`、`scf_bootstrap`、`dist/`、`public/` 等文件并安装依赖。首次创建函数使用 `createFunction`，后续更新代码用 `updateFunctionCode`。
+
+### Step 2: 配置 HTTP 访问服务路由
+
+通过 MCP `manageGateway` 为云函数创建网关入口：
+
+```json
+{
+  "tool": "manageGateway",
+  "params": {
+    "action": "createAccess",
+    "targetType": "function",
+    "targetName": "auth-service",
+    "path": "/",
+    "type": "HTTP",
+    "auth": false
+  }
+}
+```
+
+这会创建一个默认域名的网关入口。之后你的服务访问地址为：
+```
+https://{envId}-{appId}.ap-shanghai.app.tcloudbase.com/cli-auth.html
+```
+
+**⚠️ 不要使用 `domain: "*"` 的通配路由**，会拦截 CloudBase 内置的 `__auth/` 托管登录页。
+
+### Step 3: 通过 MCP 配置飞书身份源
+
+部署成功后，通过 MCP 配置飞书 OAuth 身份源。以下演示通过 `manageAppAuth` 和 `callCloudApi` 完成：
+
+#### 2.1 先查当前身份源配置
+
+```json
+{
+  "tool": "queryAppAuth",
+  "params": { "action": "listProviders" }
+}
+```
+
+#### 2.2 添加/更新飞书身份源
+
+```json
+{
+  "tool": "manageAppAuth",
+  "params": {
+    "action": "addProvider",
+    "providerId": "feishu",
+    "providerType": "OAUTH",
+    "displayName": "飞书登录",
+    "config": {
+      "ClientId": "cli_xxxxx",
+      "ClientSecret": "xxxxx",
+      "Scope": "auth:user_access_token:read",
+      "AuthorizationEndpoint": "https://open.feishu.cn/open-apis/authen/v1/authorize",
+      "TokenEndpoint": "https://open.feishu.cn/open-apis/authen/v1/access_token",
+      "UserinfoEndpoint": "https://open.feishu.cn/open-apis/authen/v1/user_info",
+      "TokenEndpointAuthMethod": "CLIENT_SECRET_POST",
+      "RequestParametersMap": {
+        "AuthPosition": "Body",
+        "ClientId": "app_id",
+        "ClientSecret": "app_secret",
+        "GrantType": "grant_type",
+        "FieldToken": "data"
+      },
+      "ResponseParametersMap": {
+        "Sub": "data.open_id",
+        "Name": "data.name",
+        "Picture": "data.avatar_url"
+      }
+    }
+  }
+}
+```
+
+**关于这些配置的说明：**
+
+| 配置 | 为什么这么设 |
+|------|-------------|
+| `TokenEndpointAuthMethod: CLIENT_SECRET_POST` | 飞书不支持 HTTP Basic Auth，必须在请求 Body 中传 `app_id` + `app_secret` |
+| `RequestParametersMap.ClientId: "app_id"` | 飞书的参数名叫 `app_id`，不是标准 OAuth 的 `client_id` |
+| `RequestParametersMap.AuthPosition: "Body"` | 凭证参数放在请求 Body 中 |
+| `RequestParametersMap.GrantType: "grant_type"` | 显式声明 `grant_type` 参数名 |
+| `RequestParametersMap.FieldToken: "data"` | 飞书 API 的响应包在 `{"code":0,"data":{...},"msg":"success"}` 的 `data` 字段里 |
+| `ResponseParametersMap.Sub: "data.open_id"` | 飞书返回的用户 ID 是 `data.open_id`，不是标准 OIDC 的 `sub` |
+
+#### 2.3 开启自动创建用户
+
+```json
+{
+  "tool": "callCloudApi",
+  "params": {
+    "service": "tcb",
+    "action": "ModifyProvider",
+    "params": {
+      "EnvId": "your-env-id",
+      "Id": "feishu",
+      "AutoSignUpWithProviderUser": "TRUE"
+    }
+  }
+}
+```
+
+#### 2.4 在飞书开放平台配置应用
+
+**重定向 URL**：
+```
+https://{envId}-{appId}.tcloudbaseapp.com/__auth/
+```
+
+**权限**：添加 `auth:user_access_token:read` → **发布版本**
+
+#### 2.5 其他 OAuth 身份源通用配置
+
+不同 OAuth 身份源的参数映射不同，配置前需参考对应平台 API 文档确认：
+
+| 身份源 | 认证方式 | 常见特化配置 |
+|--------|---------|-------------|
+| **飞书** | `CLIENT_SECRET_POST` + Body 传参 + `data` 解包 | 见上文飞书完整示例 |
+| **Google** | `CLIENT_SECRET_BASIC`（默认），无需参数映射 | 标准 OIDC，`Scope: "email openid profile"` |
+| **企业微信** | 通常需 `AuthPosition: Body` + 字段映射 | `ClientId → corpid`，`ClientSecret → corpsecret` |
+| **微信开放平台** | 通过 CloudBase 控制台配置 `WX_OPEN` 类型 | 走控制台流程更简洁 |
+| **自定义 OAuth** | 标准 OAuth 2.0，按需调整映射 | 对照第三方 API 文档配置 |
+
+通用排查步骤：
+
+1. **查文档**：确定第三方平台的 OAuth 端点地址（authorize / token / userinfo）
+2. **测试请求**：用 curl 调 token 端点，看参数名（是 `client_id` 还是 `app_id`？）
+3. **配 `RequestParametersMap`**：字段名不同时设置 `ClientId`/`ClientSecret` 映射
+4. **配 `AuthPosition`**：凭证需在 Body 而非 Header 中传递时，设 `"AuthPosition": "Body"`
+5. **配 `ResponseParametersMap`**：响应包装在嵌套字段中时（如飞书的 `data.open_id`），用点号路径映射
+6. **测试回调**：CloudBase 控制台 → 身份认证 → 托管登录页 立即测试
+
+更详细的配置指南可通过 MCP 查询：
+
+```json
+{
+  "tool": "searchKnowledgeBase",
+  "params": { "mode": "skill", "skillName": "auth-tool" }
+}
+```
+
+### Step 3: 配置 HTTP 访问服务路由
+
+部署后，添加云函数的路由：
+
+```bash
+# 添加通配路由（指向你的云函数）
+tcb routes add -e your-env-id --data '{
+  "domain": "your-env-id-{appId}.ap-shanghai.app.tcloudbase.com",
+  "routes": [{
+    "path": "/",
+    "upstreamResourceType": "WEB_SCF",
+    "upstreamResourceName": "auth-service",
+    "enablePathTransmission": true
+  }]
+}'
+```
+
+**⚠️ 注意**：不要使用 `*` 通配域名的通配路由（`path: "/"` on `domain: "*"`），这会拦截 CloudBase 内置的托管登录页服务，导致 `__auth/` 路径无法访问。
+
+### Step 4: MCP 绑定环境并验证
+
+配置 MCP 环境变量：
+
+```json
+{
+  "tool": "auth",
+  "params": { "action": "set_env", "envId": "your-env-id" }
+}
+```
+
+验证清单：
+
+- [ ] 浏览器打开 `https://{your-domain}/cli-auth.html` 可访问
+- [ ] 输入设备码后跳转托管登录页
+- [ ] 托管登录页展示飞书/企微等身份源按钮
+- [ ] 扫码完成 → 回调页显示授权成功
+- [ ] CLI 轮询拿到 API Key
+
+## 关键实现细节
+
+### SCF HTTP 函数注意事项
+
+| 要点 | 原因 |
+|------|------|
+| `app.listen(PORT, '127.0.0.1')` | **必须绑定 127.0.0.1**，否则 SCF 网关连不上你的服务 |
+| 默认端口改为 9000 | SCF 环境变量 `PORT` 会被设为 9000，但本地开发也需要默认 9000 |
+| 添加 `cors` 中间件 | JSSDK 的 auth API 调用是跨域的 |
+| 安装 `express-rate-limit` | 防止设备码/验证接口被刷 |
+| 静态文件和 API 用同一端口 | `express.static()` + API 路由，不需要额外部署静态托管 |
+| 首次冷启动约 6-15 秒 | 之后请求毫秒级响应 |
+| 关闭云端依赖安装 (`installDependency: false`) | 预装依赖后上传，避免冷启动时 npm install |
+| timeout 设 120 秒 | 给首次冷启动留够缓冲 |
+
+### 前端 SDK CDN 地址
+
+```html
+<!-- 旧（已失效）-->
+<script src="https://imgcache.qq.com/qcloud/tcb/js-sdk/2.x.x/cloudbase.js"></script>
+
+<!-- 新（v3 全量）-->
+<script src="https://static.cloudbase.net/cloudbase-js-sdk/3.4.8/cloudbase.full.js"></script>
+```
+
+## 安全注意事项
+
+- `CreateEnv` 是**付费操作**，每次用户首次登录自动下单扣费
+- 生产环境**必须**使用子账号密钥，并限定 `tcb:CreateEnv` 资源范围
+- 建议配合 STS 临时密钥或白名单机制，防止滥刷导致资损
+- 敏感配置（SecretId/SecretKey）通过 `.env` 管理，不要提交到代码仓库
+- 生产部署后将配置转移到 CloudBase 控制台环境变量
+
+## 关键文件
+
+| 文件 | 说明 |
+|------|------|
+| `src/server.ts` | Express 入口：5 个核心端点 + 限流 + token 校验 + CORS |
+| `src/utils/auth.ts` | CloudBase HTTP API access_token 归属校验 |
+| `src/utils/tcb.ts` | CreateEnv + CreateApiKey 封装 |
+| `public/cli-auth.html` | 授权页：输入设备码 → 跳转托管登录页 |
+| `public/cli-auth-callback.html` | 回调页：处理 OAuth 回调 → 完成设备码授权 |
+| `cloudbaserc.json` | 部署配置：HTTP 函数类型、120s 超时、环境变量 |
+| `scf_bootstrap` | HTTP 函数启动脚本 |
+| `docs/protocol.md` | OAuth 2.0 设备码授权协议文档 |

--- a/examples/cloudbase-auth-endpoint-with-feishu/cloudbaserc.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/cloudbaserc.json
@@ -1,0 +1,37 @@
+{
+  "envId": "your-env-id",
+  "functionRoot": "./",
+  "functions": [
+    {
+      "name": "auth-service",
+      "type": "HTTP",
+      "dir": "./",
+      "installDependency": false,
+      "ignore": [
+        "src/**/*",
+        "*.ts",
+        ".git/**/*",
+        ".env",
+        ".env.example",
+        "*.md",
+        "docs/**/*",
+        "tsconfig.json",
+        "package-lock.json"
+      ],
+      "runtime": "Nodejs18.15",
+      "timeout": 120,
+      "memory": 1024,
+      "envVariables": {
+        "BASE_URL": "https://your-domain.com",
+        "CLOUDBASE_REGION": "ap-shanghai",
+        "CLOUDBASE_USER_ENV_PACKAGE_ID": "baas_personal",
+        "CLOUDBASE_USER_ENV_RESOURCES": "flexdb,storage,function",
+        "CLOUDBASE_USER_ENV_PERIOD": "1",
+        "CLOUDBASE_USER_ENV_AUTO_VOUCHER": "true",
+        "CLOUDBASE_USER_ENV_READY_TIMEOUT_MS": "120000",
+        "EXPIRES_IN": "600",
+        "INTERVAL": "3"
+      }
+    }
+  ]
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/cloudbaserc.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/cloudbaserc.json
@@ -23,6 +23,8 @@
       "memory": 1024,
       "envVariables": {
         "BASE_URL": "https://your-domain.com",
+        "CLOUDBASE_ENV_ID": "your-env-id",
+        "CLOUDBASE_PUBLISHABLE_KEY": "your-publishable-key",
         "CLOUDBASE_REGION": "ap-shanghai",
         "CLOUDBASE_USER_ENV_PACKAGE_ID": "baas_personal",
         "CLOUDBASE_USER_ENV_RESOURCES": "flexdb,storage,function",

--- a/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
@@ -1,0 +1,66 @@
+# 企业自有品牌授权服务协议
+
+本协议基于 RFC 8628（OAuth 2.0 Device Authorization Grant）扩展，结合 CloudBase 托管登录页 + 自定义 OAuth 2.0 身份源，实现企业自有品牌下的免腾讯云账号授权流程。
+
+## 协议端点
+
+| 方法 | 路径 | 用途 |
+|------|------|------|
+| `GET` | `/auth/config` | 获取 CloudBase SDK 初始化配置 |
+| `POST` | `/auth/device/code` | 申请设备授权码 |
+| `POST` | `/auth/verify-cloudbase` | CloudBase 托管登录页认证后回调 |
+| `POST` | `/auth/device/verify` | 简单确认授权（兼容） |
+| `POST` | `/auth/token` | 轮询/续期/退出 |
+
+## 完整流程
+
+```
+CLI/IDE (MCP)         企业授权服务          用户浏览器          CloudBase 托管登录页
+     │                      │                  │                      │
+     │  POST /device/code   │                  │                      │
+     │─────────────────────►│                  │                      │
+     │◄──── device_code     │                  │                      │
+     │       user_code      │                  │                      │
+     │       verification_uri│                  │                      │
+     │                      │                  │                      │
+     │            用户打开 verification_uri ───►│                      │
+     │                      │                  │                      │
+     │                      │       输入 user_code                    │
+     │                      │◄─────────────────│                      │
+     │                      │                  │                      │
+     │                      │   toDefaultLoginPage()                  │
+     │                      │────────────────────────────────────────►│
+     │                      │                  │                      │
+     │                      │                  │    飞书/企微/其他 IdP │
+     │                      │                  │◄────────────────────►│
+     │                      │                  │                      │
+     │                      │   redirect (带 code)                    │
+     │                      │◄────────────────────────────────────────│
+     │                      │                  │                      │
+     │                      │   Session 就绪                           │
+     │                      │   POST /verify-cloudbase                │
+     │                      │◄─────────────────│                      │
+     │                      │   CreateEnv (若首次)                     │
+     │                      │   CreateApiKey                          │
+     │                      │── ok ───────────►│                      │
+     │                      │                  │                      │
+     │  轮询 POST /token     │                  │                      │
+     │  (grant_type=device)  │                  │                      │
+     │─────────────────────►│                  │                      │
+     │◄── refreshToken      │                  │                      │
+     │     apiKey           │                  │                      │
+     │     envId            │                  │                      │
+```
+
+## 环境变量
+
+参见 `.env.example`。
+
+## Token 说明
+
+| 凭证 | 生成时机 | 用途 | 生命周期 |
+|------|----------|------|----------|
+| `device_code` | POST /device/code | 客户端轮询标识 | EXPIRES_IN 秒 |
+| `user_code` | POST /device/code | 用户浏览器确认 | EXPIRES_IN 秒 |
+| `refresh_token` | POST /token (grant=device) | 客户端续期凭证 | 7 天（可配） |
+| `access_token` | POST /token (grant=device) | 本次返回 API Key 值 | 7 天（与 refresh 对齐） |

--- a/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
@@ -40,8 +40,12 @@ sequenceDiagram
     Browser->>Browser: auth.getSession() → 获取 cloudbase_uid
     Browser->>Browser: 从 sessionStorage 读取 user_code
 
-    Browser->>Auth: POST /auth/verify-cloudbase { user_code, cloudbase_uid }
+    Browser->>Auth: POST /auth/verify-cloudbase { user_code, cloudbase_uid, cloudbase_access_token }
+    Auth->>Auth: 校验 access_token 与 cloudbase_uid 归属
+    Auth->>Auth: 标记设备码已授权
+    Auth-->>Browser: { status: ok }
 
+    MCP->>Auth: 轮询 POST /auth/token (grant_type=device_code)
     alt 首次登录
         Auth->>Auth: CreateEnv(cloudbaseUid)
         Auth->>Auth: CreateApiKey(envId, api_key, 7天)
@@ -49,10 +53,6 @@ sequenceDiagram
         Auth->>Auth: 查找已有环境
         Auth->>Auth: CreateApiKey(envId, api_key, 7天)
     end
-
-    Auth-->>Browser: { status: ok, env_id }
-
-    MCP->>Auth: 轮询 POST /auth/token (grant_type=device_code)
     Auth-->>MCP: refresh_token, access_token (JWT API Key), env_id
 
     note over MCP,Browser: 授权完成，MCP 可操作用户环境

--- a/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
@@ -70,3 +70,12 @@ sequenceDiagram
 | `user_code` | POST /device/code | 用户浏览器确认 | EXPIRES_IN 秒 |
 | `refresh_token` | POST /token (grant=device) | 客户端续期凭证 | 7 天（可配） |
 | `access_token` | POST /token (grant=device) | 本次返回 API Key 值 | 7 天（与 refresh 对齐） |
+
+## 响应字段补充说明
+
+| 字段 | 来源 | 说明 |
+|------|------|------|
+| `provider_id` | CloudBase UserInfo API | 用户使用的身份源 ID（如 `custom_oauth_feishu`、`email`），可通过此字段判断用户的登录方式 |
+| `provider_user_id` | CloudBase UserInfo API | 用户在身份源侧的原始 ID（如飞书 `open_id`），可用于关联企业身份系统 |
+
+> 注：`provider_id` 和 `provider_user_id` 在 `POST /auth/token` 响应中返回。当前 CloudBase 暂不返回身份源扩展属性（如飞书 `tenant_key`、部门等），如需获取可在回调页直接调身份源 API。

--- a/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/docs/protocol.md
@@ -14,42 +14,48 @@
 
 ## 完整流程
 
-```
-CLI/IDE (MCP)         企业授权服务          用户浏览器          CloudBase 托管登录页
-     │                      │                  │                      │
-     │  POST /device/code   │                  │                      │
-     │─────────────────────►│                  │                      │
-     │◄──── device_code     │                  │                      │
-     │       user_code      │                  │                      │
-     │       verification_uri│                  │                      │
-     │                      │                  │                      │
-     │            用户打开 verification_uri ───►│                      │
-     │                      │                  │                      │
-     │                      │       输入 user_code                    │
-     │                      │◄─────────────────│                      │
-     │                      │                  │                      │
-     │                      │   toDefaultLoginPage()                  │
-     │                      │────────────────────────────────────────►│
-     │                      │                  │                      │
-     │                      │                  │    飞书/企微/其他 IdP │
-     │                      │                  │◄────────────────────►│
-     │                      │                  │                      │
-     │                      │   redirect (带 code)                    │
-     │                      │◄────────────────────────────────────────│
-     │                      │                  │                      │
-     │                      │   Session 就绪                           │
-     │                      │   POST /verify-cloudbase                │
-     │                      │◄─────────────────│                      │
-     │                      │   CreateEnv (若首次)                     │
-     │                      │   CreateApiKey                          │
-     │                      │── ok ───────────►│                      │
-     │                      │                  │                      │
-     │  轮询 POST /token     │                  │                      │
-     │  (grant_type=device)  │                  │                      │
-     │─────────────────────►│                  │                      │
-     │◄── refreshToken      │                  │                      │
-     │     apiKey           │                  │                      │
-     │     envId            │                  │                      │
+```mermaid
+sequenceDiagram
+    participant MCP as MCP / CLI
+    participant Auth as 企业授权服务
+    participant Browser as 用户浏览器
+    participant CloudBase as CloudBase 托管登录页
+
+    MCP->>Auth: POST /auth/device/code
+    Auth-->>MCP: device_code, user_code, verification_uri
+
+    note over MCP,Browser: 用户看到设备码，打开浏览器
+
+    Browser->>Browser: 打开 verification_uri (cli-auth.html)
+    Browser->>Browser: 输入 user_code
+    Browser->>Browser: sessionStorage 保存 user_code
+    
+    Browser->>CloudBase: auth.toDefaultLoginPage({ redirect_uri })
+
+    note over CloudBase: 用户选择飞书/企微/其他身份源
+    note over CloudBase: CloudBase 自动完成 OAuth 回调
+
+    CloudBase-->>Browser: redirect 到 cli-auth-callback.html（带 session）
+
+    Browser->>Browser: auth.getSession() → 获取 cloudbase_uid
+    Browser->>Browser: 从 sessionStorage 读取 user_code
+
+    Browser->>Auth: POST /auth/verify-cloudbase { user_code, cloudbase_uid }
+
+    alt 首次登录
+        Auth->>Auth: CreateEnv(cloudbaseUid)
+        Auth->>Auth: CreateApiKey(envId, api_key, 7天)
+    else 已创建环境
+        Auth->>Auth: 查找已有环境
+        Auth->>Auth: CreateApiKey(envId, api_key, 7天)
+    end
+
+    Auth-->>Browser: { status: ok, env_id }
+
+    MCP->>Auth: 轮询 POST /auth/token (grant_type=device_code)
+    Auth-->>MCP: refresh_token, access_token (JWT API Key), env_id
+
+    note over MCP,Browser: 授权完成，MCP 可操作用户环境
 ```
 
 ## 环境变量

--- a/examples/cloudbase-auth-endpoint-with-feishu/package-lock.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/package-lock.json
@@ -1,0 +1,2444 @@
+{
+  "name": "cloudbase-auth-endpoint-with-feishu",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cloudbase-auth-endpoint-with-feishu",
+      "version": "1.0.0",
+      "dependencies": {
+        "@cloudbase/node-sdk": "^3.18.3",
+        "cors": "^2.8.6",
+        "dotenv": "^16.4.5",
+        "express": "^4.21.0",
+        "express-rate-limit": "^7.4.0",
+        "tencentcloud-sdk-nodejs-tcb": "^4.0.0"
+      },
+      "devDependencies": {
+        "@types/cors": "^2.8.19",
+        "@types/express": "^4.17.21",
+        "@types/node": "^20.14.0",
+        "tsx": "^4.16.0",
+        "typescript": "^5.5.0"
+      }
+    },
+    "node_modules/@cloudbase/adapter-interface": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cloudbase/adapter-interface/-/adapter-interface-0.7.1.tgz",
+      "integrity": "sha512-BjHTAvIMSLxbp26SeT6qLiSSBygz3kAVno/PMwwBwjgzVkVUvuZGVcvf1mhHxY/BjdRGLrd6X60OgvymV/aAUw==",
+      "license": "ISC"
+    },
+    "node_modules/@cloudbase/adapter-wx_mp": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@cloudbase/adapter-wx_mp/-/adapter-wx_mp-1.3.1.tgz",
+      "integrity": "sha512-rS0N1aD1a0zc421ds17/HzM4RChQ6T2ixMz87bhPJ1yveqJt/KUqYxiXJDWhZ803wwTmJs8aqNkgugsNusNhbg==",
+      "license": "ISC",
+      "dependencies": {
+        "@cloudbase/adapter-interface": "^0.7.0",
+        "web-streams-polyfill": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudbase/ai": {
+      "version": "2.28.8",
+      "resolved": "https://registry.npmjs.org/@cloudbase/ai/-/ai-2.28.8.tgz",
+      "integrity": "sha512-123UqkWSiIrsm1iSasJvC4wk+0ahRQOlL1Nw69kgfIK8HHiwpznVyBdWTcpqYzZBsK+ZfFstVnv8lMpj3qkCag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudbase/types": "2.28.8",
+        "@cloudbase/utilities": "2.28.8",
+        "@mattiasbuelens/web-streams-adapter": "^0.1.0",
+        "text-encoding-shim": "^1.0.5",
+        "web-streams-polyfill": "^4.0.0"
+      }
+    },
+    "node_modules/@cloudbase/app": {
+      "version": "2.28.8",
+      "resolved": "https://registry.npmjs.org/@cloudbase/app/-/app-2.28.8.tgz",
+      "integrity": "sha512-aA77O/ei3cVmhO7Jq5uXKEm7h0bEOAlx3q+ydbnS2HtxflsfVPYyrRkyROQuEyPZFHy0zcJ9mf5DeFjZMcAmFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudbase/adapter-interface": "^0.7.1",
+        "@cloudbase/adapter-wx_mp": "^1.3.1",
+        "@cloudbase/types": "2.28.8",
+        "@cloudbase/utilities": "2.28.8"
+      },
+      "peerDependencies": {
+        "@cloudbase/signature-nodejs": ">=1.0.0",
+        "jsonwebtoken": ">=8.0.0",
+        "ws": "^8.18.0"
+      },
+      "peerDependenciesMeta": {
+        "@cloudbase/signature-nodejs": {
+          "optional": true
+        },
+        "jsonwebtoken": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cloudbase/database": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/@cloudbase/database/-/database-1.4.3.tgz",
+      "integrity": "sha512-JzmdsGjy9LwzSQQ0Fv4OlNHNK61BRXdJSembTpy4408AQA3q2Ip3N5eB3v9OpAlFMvP/6MGmOQ/ZuUPKfJddJA==",
+      "license": "ISC",
+      "dependencies": {
+        "bson": "^4.0.3",
+        "lodash.clonedeep": "4.5.0",
+        "lodash.set": "4.3.2",
+        "lodash.unset": "4.5.2"
+      }
+    },
+    "node_modules/@cloudbase/node-sdk": {
+      "version": "3.18.3",
+      "resolved": "https://registry.npmjs.org/@cloudbase/node-sdk/-/node-sdk-3.18.3.tgz",
+      "integrity": "sha512-qluLOIyPhK8AWmUeS1Qt/S4cV/07pv/L79Cne8beFove775FL9Wi2tSsawZuwGUygIUySljqQaLPUl+lrJ4Leg==",
+      "license": "MIT",
+      "dependencies": {
+        "@cloudbase/ai": "^2.23.0",
+        "@cloudbase/app": "^2.23.0",
+        "@cloudbase/database": "1.4.3",
+        "@cloudbase/signature-nodejs": "2.2.0",
+        "@cloudbase/types": "^2.23.0",
+        "@cloudbase/wx-cloud-client-sdk": "1.7.1",
+        "agentkeepalive": "^4.3.0",
+        "axios": "0.27.2",
+        "form-data": "^4.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "jsonwebtoken": "^9.0.2",
+        "retry": "^0.13.1",
+        "web-streams-polyfill": "^4.2.0",
+        "xml2js": "^0.6.2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@cloudbase/node-sdk/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/@cloudbase/signature-nodejs": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@cloudbase/signature-nodejs/-/signature-nodejs-2.2.0.tgz",
+      "integrity": "sha512-2y2rieOpJNnBA2MW7sLJKek3iFOjgr8TNicw5qjBkcdVczLR0cFzxMhip75NLCwarFTIAONE3oeNxoQ19eVHcA==",
+      "dependencies": {
+        "@types/clone": "^2.1.0",
+        "clone": "^2.1.2",
+        "is-stream": "^2.0.0",
+        "url": "^0.11.0"
+      }
+    },
+    "node_modules/@cloudbase/types": {
+      "version": "2.28.8",
+      "resolved": "https://registry.npmjs.org/@cloudbase/types/-/types-2.28.8.tgz",
+      "integrity": "sha512-m9uCM/bqrAEGDohPkIcuci5hAuOx5gQJdzC+2tEq4JDvfGUuetb3lFBa950UjnpdKRPqA/bOCHe2H4CYBAUn3A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudbase/adapter-interface": "^0.7.1"
+      }
+    },
+    "node_modules/@cloudbase/utilities": {
+      "version": "2.28.8",
+      "resolved": "https://registry.npmjs.org/@cloudbase/utilities/-/utilities-2.28.8.tgz",
+      "integrity": "sha512-IdIJqKbS9NGVIhlitwS73lcgHqpaNj6uN4ImO1PaEE49Pne/oBNPWicV6e4pHLNiYLfxzc9kiVkARKKMjzcJEw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudbase/adapter-interface": "^0.7.1",
+        "@cloudbase/types": "2.28.8",
+        "jwt-decode": "^3.1.2"
+      }
+    },
+    "node_modules/@cloudbase/wx-cloud-client-sdk": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@cloudbase/wx-cloud-client-sdk/-/wx-cloud-client-sdk-1.7.1.tgz",
+      "integrity": "sha512-NzLOoYDAeoRh2lRjCtvr6yXu4KPVHqZtPxyv70e+3b2+dZIDE5S5gtU8daE7xS5u4TwPqKB/E2vmgRTYOsCS9w==",
+      "dependencies": {
+        "core-js-pure": "^3.45.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@mattiasbuelens/web-streams-adapter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mattiasbuelens/web-streams-adapter/-/web-streams-adapter-0.1.0.tgz",
+      "integrity": "sha512-oV4PyZfwJNtmFWhvlJLqYIX1Nn22ML8FZpS16ZUKv0hg7414xV1fjsGqxQzLT2dyK92TKxsJSwMOd7VNHAtPmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/clone": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@types/clone/-/clone-2.1.4.tgz",
+      "integrity": "sha512-NKRWaEGaVGVLnGLB2GazvDaZnyweW9FJLLFL5LhywGJB3aqGMT9R/EUoJoSRP4nzofYnZysuDmrEJtJdAqUOtQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.8",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+      "integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.15.1",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.1.tgz",
+      "integrity": "sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/agent-base/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/agent-base/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/agentkeepalive": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
+      "integrity": "sha512-kja8j7PjmncONqaTsB8fQ+wE2mSU2DJ9D4XKoJ5PFWIdRMa6SLSN1ff4mOr4jCbfRSsxR4keIiySJU0N9T5hIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "humanize-ms": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.15.1",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/bson": {
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.7.2.tgz",
+      "integrity": "sha512-Ry9wCtIZ5kGqkJoi6aD8KjxFZEx78guTQDnpXWiNthsxzrxAK/i8E6pCHAIZTbaEFWcOCvbecMukfK7XUvyLpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer": "^5.6.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
+    },
+    "node_modules/core-js-pure": {
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.5",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.15.1",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.1.tgz",
+      "integrity": "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.5.tgz",
+      "integrity": "sha512-j23EibVLnp4zNXGW7LjryXYa2X6U/M96yoOX+ybZxwkYajdxRNEqYY3zhh7y0i6kfISKS2jr+EJq1YTUDEv5+w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/humanize-ms": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
+      "integrity": "sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-2.0.0.tgz",
+      "integrity": "sha512-7PnF4oN3CvZF23ADhA5wRaYEQpJ8qygSkbtTXWBeXWXmEVRXK+1ITciHWwHhsjv1TmW0MgacIv6hEi5pX5NQdA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jsonwebtoken": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
+      "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
+      "license": "MIT",
+      "dependencies": {
+        "jws": "^4.0.1",
+        "lodash.includes": "^4.3.0",
+        "lodash.isboolean": "^3.0.3",
+        "lodash.isinteger": "^4.0.4",
+        "lodash.isnumber": "^3.0.3",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.isstring": "^4.0.1",
+        "lodash.once": "^4.0.0",
+        "ms": "^2.1.1",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      }
+    },
+    "node_modules/jsonwebtoken/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.includes": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
+      "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isboolean": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
+      "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isinteger": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
+      "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isnumber": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
+      "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isstring": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+      "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.once": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
+      "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.set": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.unset": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.unset/-/lodash.unset-4.5.2.tgz",
+      "integrity": "sha512-bwKX88k2JhCV9D1vtE8+naDKlLiGrSmf8zi/Y9ivFHwbmRfA8RxS/aVJ+sIht2XOwqoNr4xUPUkGZpc1sHFEKg==",
+      "license": "MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=11.0.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/send": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/tencentcloud-sdk-nodejs-common": {
+      "version": "4.1.220",
+      "resolved": "https://registry.npmjs.org/tencentcloud-sdk-nodejs-common/-/tencentcloud-sdk-nodejs-common-4.1.220.tgz",
+      "integrity": "sha512-FlRJzgFYqSz1blKyN39Jhy/WdK3VuyFkn2+naKJfpwWcSpLF0F9AqSzPAtgorb5/Ezs8sLmFSCuaqFcCw+uIWw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "form-data": "^3.0.4",
+        "get-stream": "^6.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "ini": "^2.0.0",
+        "is-stream": "^2.0.0",
+        "json-bigint": "^1.0.0",
+        "node-fetch": "^2.2.0",
+        "tslib": "1.13.0",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/tencentcloud-sdk-nodejs-tcb": {
+      "version": "4.1.247",
+      "resolved": "https://registry.npmjs.org/tencentcloud-sdk-nodejs-tcb/-/tencentcloud-sdk-nodejs-tcb-4.1.247.tgz",
+      "integrity": "sha512-3C0XyPJq+QvFrGW8DCay/YPla5saUD2aWt+wJtCzQN1HajcE6e/M1ZYm6C0h414fIhcvRWb8TeEyKuYgUwyL3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tencentcloud-sdk-nodejs-common": "*",
+        "tslib": "1.13.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/text-encoding-shim": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/text-encoding-shim/-/text-encoding-shim-1.0.5.tgz",
+      "integrity": "sha512-H7yYW+jRn4yhu60ygZ2f/eMhXPITRt4QSUTKzLm+eCaDsdX8avmgWpmtmHAzesjBVUTAypz9odu5RKUjX5HNYA==",
+      "license": "MIT"
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+      "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
+      "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.22.4",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
+      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/url": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.11.4.tgz",
+      "integrity": "sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^1.4.1",
+        "qs": "^6.12.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.3.0.tgz",
+      "integrity": "sha512-/Gnggvj9oSrEvJbDyyPtAnxBt5fGQM2iWOKQNu7ie1OxDgK40iZpyV3TKaRiEzVj1oA1UxKnEy9XPXh6PW3eVw==",
+      "license": "MIT",
+      "workspaces": [
+        "test/benchmark-test",
+        "test/rollup-test",
+        "test/webpack-test"
+      ],
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    }
+  }
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/package-lock.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/package-lock.json
@@ -8,19 +8,19 @@
       "name": "cloudbase-auth-endpoint-with-feishu",
       "version": "1.0.0",
       "dependencies": {
-        "@cloudbase/node-sdk": "^3.18.3",
-        "cors": "^2.8.6",
-        "dotenv": "^16.4.5",
-        "express": "^4.21.0",
-        "express-rate-limit": "^7.4.0",
-        "tencentcloud-sdk-nodejs-tcb": "^4.0.0"
+        "@cloudbase/node-sdk": "3.18.3",
+        "cors": "2.8.6",
+        "dotenv": "16.6.1",
+        "express": "4.22.2",
+        "express-rate-limit": "7.5.1",
+        "tencentcloud-sdk-nodejs-tcb": "4.1.247"
       },
       "devDependencies": {
-        "@types/cors": "^2.8.19",
-        "@types/express": "^4.17.21",
-        "@types/node": "^20.14.0",
-        "tsx": "^4.16.0",
-        "typescript": "^5.5.0"
+        "@types/cors": "2.8.19",
+        "@types/express": "4.17.25",
+        "@types/node": "20.19.43",
+        "tsx": "4.22.4",
+        "typescript": "5.9.3"
       }
     },
     "node_modules/@cloudbase/adapter-interface": {

--- a/examples/cloudbase-auth-endpoint-with-feishu/package.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cloudbase-auth-endpoint-with-feishu",
+  "version": "1.0.0",
+  "description": "企业自有品牌授权服务 - 支持 CloudBase 托管登录页 + 企业身份源 SSO",
+  "main": "dist/server.js",
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.21.0",
+    "tencentcloud-sdk-nodejs-tcb": "^4.0.0"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.0",
+    "tsx": "^4.16.0",
+    "typescript": "^5.5.0"
+  }
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/package.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/package.json
@@ -9,18 +9,18 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
-    "@cloudbase/node-sdk": "^3.18.3",
-    "cors": "^2.8.6",
-    "dotenv": "^16.4.5",
-    "express": "^4.21.0",
-    "express-rate-limit": "^7.4.0",
-    "tencentcloud-sdk-nodejs-tcb": "^4.0.0"
+    "@cloudbase/node-sdk": "3.18.3",
+    "cors": "2.8.6",
+    "dotenv": "16.6.1",
+    "express": "4.22.2",
+    "express-rate-limit": "7.5.1",
+    "tencentcloud-sdk-nodejs-tcb": "4.1.247"
   },
   "devDependencies": {
-    "@types/cors": "^2.8.19",
-    "@types/express": "^4.17.21",
-    "@types/node": "^20.14.0",
-    "tsx": "^4.16.0",
-    "typescript": "^5.5.0"
+    "@types/cors": "2.8.19",
+    "@types/express": "4.17.25",
+    "@types/node": "20.19.43",
+    "tsx": "4.22.4",
+    "typescript": "5.9.3"
   }
 }

--- a/examples/cloudbase-auth-endpoint-with-feishu/package.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/package.json
@@ -9,11 +9,15 @@
     "start": "node dist/server.js"
   },
   "dependencies": {
+    "@cloudbase/node-sdk": "^3.18.3",
+    "cors": "^2.8.6",
     "dotenv": "^16.4.5",
     "express": "^4.21.0",
+    "express-rate-limit": "^7.4.0",
     "tencentcloud-sdk-nodejs-tcb": "^4.0.0"
   },
   "devDependencies": {
+    "@types/cors": "^2.8.19",
     "@types/express": "^4.17.21",
     "@types/node": "^20.14.0",
     "tsx": "^4.16.0",

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -65,7 +65,7 @@
     <p class="desc">请稍候，正在完成授权流程</p>
     <div class="status-step" id="steps">
       <div class="step active"><span class="dot"></span> 验证企业身份</div>
-      <div class="step"><span class="dot"></span> 配置开发环境</div>
+      <div class="step"><span class="dot"></span> 确认设备授权</div>
       <div class="step"><span class="dot"></span> 授权完成</div>
     </div>
   </div>
@@ -123,8 +123,8 @@
 
         updateStep(2);
 
-        // 步骤 3：通知服务端完成授权（环境创建在此步同步执行，约需 1-3 分钟）
-        updateStepText('正在创建开发环境（约需 1-3 分钟）...');
+        // 步骤 3：通知服务端完成授权（环境创建由终端轮询阶段执行）
+        updateStepText('正在确认设备授权...');
         const verifyRes = await fetch('/auth/verify-cloudbase', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -148,12 +148,12 @@
           <p class="desc">您的设备已成功绑定企业账号</p>
           <div class="status-step">
             <div class="step done"><span class="dot"></span> 企业身份已验证</div>
-            <div class="step done"><span class="dot"></span> 开发环境已就绪</div>
+            <div class="step done"><span class="dot"></span> 设备授权已确认</div>
             <div class="step done"><span class="dot"></span> 授权已完成</div>
           </div>
           ${verifyResult.env_id ? `<p class="success-detail">环境 ID: ${verifyResult.env_id}</p>` : ''}
           <p class="desc" style="margin-top:16px;font-size:13px;color:#888;">
-            现在可以返回终端/IDE 继续操作
+            现在可以返回终端/IDE，等待环境创建完成
           </p>
           <button class="btn-close" onclick="window.close()">关闭页面</button>
           <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -112,6 +112,8 @@
         const sessionResult = await pollSession(30_000);
         const cloudbaseUid = sessionResult.user?.id;
         if (!cloudbaseUid) throw new Error('无法获取用户身份');
+        const cloudbaseAccessToken = sessionResult.access_token;
+        if (!cloudbaseAccessToken) throw new Error('无法获取用户访问凭证');
 
         // 从 sessionStorage 读取设备码
         const userCode = sessionStorage.getItem('pending_user_code');
@@ -125,7 +127,11 @@
         const verifyRes = await fetch('/auth/verify-cloudbase', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ user_code: userCode, cloudbase_uid: cloudbaseUid }),
+          body: JSON.stringify({
+            user_code: userCode,
+            cloudbase_uid: cloudbaseUid,
+            cloudbase_access_token: cloudbaseAccessToken,
+          }),
         });
 
         const verifyResult = await verifyRes.json();

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -106,27 +106,10 @@
         await initCloudBase();
         updateStep(1);
 
-        // 步骤 2：获取 CloudBase Session（等待 SDK 完成 code → session 交换）
-        // auth.onAuthStateChange 可监听认证状态变化
-        const sessionResult = await new Promise((resolve, reject) => {
-          const timeout = setTimeout(() => reject(new Error('认证超时，请重试')), 30000);
-
-          authInstance.onAuthStateChange((event, session) => {
-            if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION') {
-              clearTimeout(timeout);
-              resolve(session);
-            }
-          });
-
-          // 如果 session 已就绪，直接获取
-          setTimeout(async () => {
-            const { data, error } = await authInstance.getSession();
-            clearTimeout(timeout);
-            if (data?.session) resolve(data.session);
-            else reject(new Error(error?.message || '无法获取登录状态'));
-          }, 2000);
-        });
-
+        // 步骤 2：等待 CloudBase Session 就绪
+        // SDK 初始化后，detectSessionInUrl 自动将 URL 中的 code 交换为 session
+        // 通过轮询 getSession() 来等待 session 就绪，避免 onAuthStateChange 事件竞态
+        const sessionResult = await pollSession(30_000);
         const cloudbaseUid = sessionResult.user?.id;
         if (!cloudbaseUid) throw new Error('无法获取用户身份');
 
@@ -181,6 +164,23 @@
           <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>
         `;
       }
+    }
+
+    /**
+     * 轮询 getSession() 直到 session 就绪
+     * 避免 onAuthStateChange 事件竞态问题
+     */
+    async function pollSession(timeoutMs) {
+      const start = Date.now();
+      while (Date.now() - start < timeoutMs) {
+        const { data, error } = await authInstance.getSession();
+        if (data?.session?.user?.id) {
+          return data.session;
+        }
+        // 等待 800ms 后重试
+        await new Promise(r => setTimeout(r, 800));
+      }
+      throw new Error('认证超时，请重试');
     }
 
     document.addEventListener('DOMContentLoaded', handleCallback);

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -71,8 +71,9 @@
   </div>
 
   <!-- CloudBase Web SDK -->
-  <script src="https://imgcache.qq.com/qcloud/tcb/js-sdk/2.x.x/cloudbase.js"></script>
+  <script src="https://static.cloudbase.net/cloudbase-js-sdk/3.4.8/cloudbase.full.js"></script>
   <script>
+
     let authApp = null;
     let authInstance = null;
 
@@ -102,20 +103,19 @@
 
     async function handleCallback() {
       try {
-        // 步骤 1：初始化 SDK（detectSessionInUrl: true 会自动处理 URL 中的 code 参数）
+        // 步骤 1：初始化 SDK
+        updateStepText('正在初始化...');
         await initCloudBase();
         updateStep(1);
 
         // 步骤 2：等待 CloudBase Session 就绪
-        // SDK 初始化后，detectSessionInUrl 自动将 URL 中的 code 交换为 session
-        // 通过轮询 getSession() 来等待 session 就绪，避免 onAuthStateChange 事件竞态
-        const sessionResult = await pollSession(30_000);
+        updateStepText('正在验证企业身份...');
+        const sessionResult = await pollSession(180_000);
         const cloudbaseUid = sessionResult.user?.id;
         if (!cloudbaseUid) throw new Error('无法获取用户身份');
-        const cloudbaseAccessToken = sessionResult.access_token;
+        const cloudbaseAccessToken = sessionResult.accessToken || sessionResult.access_token;
         if (!cloudbaseAccessToken) throw new Error('无法获取用户访问凭证');
 
-        // 从 sessionStorage 读取设备码
         const userCode = sessionStorage.getItem('pending_user_code');
         if (!userCode) {
           throw new Error('缺少设备码信息，请重新在授权页面操作');
@@ -123,7 +123,8 @@
 
         updateStep(2);
 
-        // 步骤 3：通知服务端完成设备码授权
+        // 步骤 3：通知服务端完成授权（环境创建在此步同步执行，约需 1-3 分钟）
+        updateStepText('正在创建开发环境（约需 1-3 分钟）...');
         const verifyRes = await fetch('/auth/verify-cloudbase', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
@@ -137,12 +138,10 @@
         const verifyResult = await verifyRes.json();
         if (!verifyRes.ok) throw new Error(verifyResult.error_description || '授权失败');
 
-        // 清理 sessionStorage
         sessionStorage.removeItem('pending_user_code');
 
         updateStep(3);
 
-        // 显示成功页面
         document.getElementById('root').innerHTML = `
           <div class="success-icon">✅</div>
           <h1>授权成功</h1>
@@ -170,6 +169,11 @@
           <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>
         `;
       }
+    }
+
+    function updateStepText(text) {
+      const titleEl = document.querySelector('#root h1');
+      if (titleEl) titleEl.textContent = text;
     }
 
     /**

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>授权完成 - 企业 AI 开发平台</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f7fa;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; color: #333;
+    }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+      padding: 48px 40px;
+      width: 420px;
+      max-width: 94vw;
+      text-align: center;
+    }
+    .spinner {
+      width: 48px; height: 48px;
+      border: 4px solid #e5e7eb;
+      border-top-color: #2563eb;
+      border-radius: 50%;
+      animation: spin 0.8s linear infinite;
+      margin: 0 auto 24px;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    h1 { font-size: 22px; margin-bottom: 8px; }
+    .desc { color: #666; font-size: 14px; margin-bottom: 16px; }
+    .success-icon { font-size: 48px; margin-bottom: 16px; }
+    .success-detail { font-size: 13px; color: #888; margin-top: 8px; }
+    .error-icon { font-size: 48px; margin-bottom: 16px; }
+    .error-detail { font-size: 13px; color: #dc2626; margin-top: 8px; }
+    .btn-close {
+      display: inline-block; padding: 10px 32px;
+      background: #2563eb; color: #fff;
+      border: none; border-radius: 8px;
+      font-size: 15px; cursor: pointer; text-decoration: none;
+      margin-top: 24px;
+    }
+    .footer { margin-top: 32px; font-size: 12px; color: #aaa; }
+
+    .status-step {
+      text-align: left; margin: 24px 0; padding: 16px;
+      background: #f9fafb; border-radius: 8px;
+    }
+    .status-step .step { font-size: 13px; color: #555; padding: 6px 0; display: flex; align-items: center; gap: 8px; }
+    .status-step .step.done { color: #16a34a; }
+    .status-step .step.active { color: #2563eb; font-weight: 500; }
+    .status-step .step .dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; flex-shrink: 0; }
+    .step.done .dot { background: #16a34a; }
+    .step.active .dot { background: #2563eb; animation: pulse 1.2s infinite; }
+    @keyframes pulse { 0%,100% { opacity: 1; } 50% { opacity: 0.4; } }
+  </style>
+</head>
+<body>
+  <div class="card" id="root">
+    <div class="spinner"></div>
+    <h1>正在验证身份...</h1>
+    <p class="desc">请稍候，正在完成授权流程</p>
+    <div class="status-step" id="steps">
+      <div class="step active"><span class="dot"></span> 验证企业身份</div>
+      <div class="step"><span class="dot"></span> 配置开发环境</div>
+      <div class="step"><span class="dot"></span> 授权完成</div>
+    </div>
+  </div>
+
+  <!-- CloudBase Web SDK -->
+  <script src="https://imgcache.qq.com/qcloud/tcb/js-sdk/2.x.x/cloudbase.js"></script>
+  <script>
+    let authApp = null;
+    let authInstance = null;
+
+    function updateStep(index) {
+      const steps = document.querySelectorAll('#steps .step');
+      steps.forEach((el, i) => {
+        el.className = 'step';
+        if (i < index) el.classList.add('done');
+        else if (i === index) el.classList.add('active');
+      });
+    }
+
+    async function initCloudBase() {
+      const configRes = await fetch('/auth/config');
+      const config = await configRes.json();
+      if (!config.envId || !config.publishableKey) {
+        throw new Error('授权服务配置不完整，请联系管理员');
+      }
+      authApp = cloudbase.init({
+        env: config.envId,
+        region: config.region || 'ap-shanghai',
+        accessKey: config.publishableKey,
+        auth: { detectSessionInUrl: true },
+      });
+      authInstance = authApp.auth({ persistence: 'local' });
+    }
+
+    async function handleCallback() {
+      try {
+        // 步骤 1：初始化 SDK（detectSessionInUrl: true 会自动处理 URL 中的 code 参数）
+        await initCloudBase();
+        updateStep(1);
+
+        // 步骤 2：获取 CloudBase Session（等待 SDK 完成 code → session 交换）
+        // auth.onAuthStateChange 可监听认证状态变化
+        const sessionResult = await new Promise((resolve, reject) => {
+          const timeout = setTimeout(() => reject(new Error('认证超时，请重试')), 30000);
+
+          authInstance.onAuthStateChange((event, session) => {
+            if (event === 'SIGNED_IN' || event === 'INITIAL_SESSION') {
+              clearTimeout(timeout);
+              resolve(session);
+            }
+          });
+
+          // 如果 session 已就绪，直接获取
+          setTimeout(async () => {
+            const { data, error } = await authInstance.getSession();
+            clearTimeout(timeout);
+            if (data?.session) resolve(data.session);
+            else reject(new Error(error?.message || '无法获取登录状态'));
+          }, 2000);
+        });
+
+        const cloudbaseUid = sessionResult.user?.id;
+        if (!cloudbaseUid) throw new Error('无法获取用户身份');
+
+        // 从 sessionStorage 读取设备码
+        const userCode = sessionStorage.getItem('pending_user_code');
+        if (!userCode) {
+          throw new Error('缺少设备码信息，请重新在授权页面操作');
+        }
+
+        updateStep(2);
+
+        // 步骤 3：通知服务端完成设备码授权
+        const verifyRes = await fetch('/auth/verify-cloudbase', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user_code: userCode, cloudbase_uid: cloudbaseUid }),
+        });
+
+        const verifyResult = await verifyRes.json();
+        if (!verifyRes.ok) throw new Error(verifyResult.error_description || '授权失败');
+
+        // 清理 sessionStorage
+        sessionStorage.removeItem('pending_user_code');
+
+        updateStep(3);
+
+        // 显示成功页面
+        document.getElementById('root').innerHTML = `
+          <div class="success-icon">✅</div>
+          <h1>授权成功</h1>
+          <p class="desc">您的设备已成功绑定企业账号</p>
+          <div class="status-step">
+            <div class="step done"><span class="dot"></span> 企业身份已验证</div>
+            <div class="step done"><span class="dot"></span> 开发环境已就绪</div>
+            <div class="step done"><span class="dot"></span> 授权已完成</div>
+          </div>
+          ${verifyResult.env_id ? `<p class="success-detail">环境 ID: ${verifyResult.env_id}</p>` : ''}
+          <p class="desc" style="margin-top:16px;font-size:13px;color:#888;">
+            现在可以返回终端/IDE 继续操作
+          </p>
+          <button class="btn-close" onclick="window.close()">关闭页面</button>
+          <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>
+        `;
+      } catch (e) {
+        console.error('Callback error:', e);
+        document.getElementById('root').innerHTML = `
+          <div class="error-icon">❌</div>
+          <h1>授权失败</h1>
+          <p class="desc">${e.message}</p>
+          <p class="error-detail">请关闭此页面，在终端重新执行 tcb login 后重试</p>
+          <button class="btn-close" onclick="window.close()">关闭页面</button>
+          <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>
+        `;
+      }
+    }
+
+    document.addEventListener('DOMContentLoaded', handleCallback);
+  </script>
+</body>
+</html>

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth-callback.html
@@ -179,7 +179,7 @@
     async function pollSession(timeoutMs) {
       const start = Date.now();
       while (Date.now() - start < timeoutMs) {
-        const { data, error } = await authInstance.getSession();
+        const { data } = await authInstance.getSession();
         if (data?.session?.user?.id) {
           return data.session;
         }

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth.html
@@ -79,14 +79,13 @@
   </div>
 
   <!-- CloudBase Web SDK -->
-  <script src="https://imgcache.qq.com/qcloud/tcb/js-sdk/2.x.x/cloudbase.js"></script>
+  <script src="https://static.cloudbase.net/cloudbase-js-sdk/3.4.8/cloudbase.full.js"></script>
   <script>
     let authApp = null;
     let authInstance = null;
 
     async function initCloudBase() {
       try {
-        // 从服务端获取 CloudBase 配置
         const configRes = await fetch('/auth/config');
         const config = await configRes.json();
 
@@ -125,15 +124,12 @@
       document.getElementById('loginBtn').disabled = true;
       document.getElementById('loginBtn').textContent = '跳转中...';
 
-      // 保存设备码到 sessionStorage（回调页面读取）
       sessionStorage.setItem('pending_user_code', userCode);
 
-      // 跳转到 CloudBase 托管登录页
-      // 托管登录页会展示所有已配置的企业身份源（飞书、企业微信、Google 等）
+      // 使用托管登录页（支持飞书等所有企业身份源）
       authInstance.toDefaultLoginPage({
         redirect_uri: window.location.origin + '/cli-auth-callback.html',
       });
-      // 注意：执行后页面将跳转，以下代码不再执行
     }
 
     function showError(msg) {
@@ -147,10 +143,8 @@
       document.getElementById('errorMsg').style.display = 'none';
     }
 
-    // 页面加载时等待 DOM 就绪
     document.addEventListener('DOMContentLoaded', () => {
       initCloudBase();
-      // 自动聚焦输入框
       document.getElementById('userCode').focus();
     });
   </script>

--- a/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth.html
+++ b/examples/cloudbase-auth-endpoint-with-feishu/public/cli-auth.html
@@ -1,0 +1,158 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>企业 AI 开发平台 - 设备授权</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: #f5f7fa;
+      display: flex; align-items: center; justify-content: center;
+      min-height: 100vh; color: #333;
+    }
+    .card {
+      background: #fff;
+      border-radius: 16px;
+      box-shadow: 0 4px 24px rgba(0,0,0,0.08);
+      padding: 48px 40px;
+      width: 420px;
+      max-width: 94vw;
+      text-align: center;
+    }
+    h1 { font-size: 22px; margin-bottom: 8px; }
+    .desc { color: #666; font-size: 14px; margin-bottom: 32px; line-height: 1.6; }
+    label { display: block; text-align: left; font-size: 14px; font-weight: 500; margin-bottom: 6px; color: #555; }
+    input {
+      width: 100%; padding: 12px 16px;
+      border: 1px solid #d0d5dd; border-radius: 8px;
+      font-size: 18px; text-align: center; letter-spacing: 4px;
+      outline: none; transition: border-color 0.2s;
+    }
+    input:focus { border-color: #2563eb; box-shadow: 0 0 0 3px rgba(37,99,235,0.1); }
+    .hint { font-size: 12px; color: #999; margin-top: 6px; text-align: left; }
+    button {
+      width: 100%; padding: 12px;
+      background: #2563eb; color: #fff;
+      border: none; border-radius: 8px;
+      font-size: 16px; font-weight: 500; cursor: pointer;
+      margin-top: 24px; transition: background 0.2s;
+    }
+    button:hover { background: #1d4ed8; }
+    button:disabled { background: #93a9d6; cursor: not-allowed; }
+    .error { color: #dc2626; font-size: 14px; margin-top: 16px; display: none; }
+    .success { color: #16a34a; font-size: 14px; margin-top: 16px; display: none; }
+    .steps { text-align: left; margin: 24px 0; padding: 16px; background: #f9fafb; border-radius: 8px; }
+    .steps li { font-size: 13px; color: #555; margin-bottom: 8px; line-height: 1.5; }
+    .steps li:last-child { margin-bottom: 0; }
+    code { background: #eef2ff; padding: 2px 6px; border-radius: 4px; font-size: 13px; color: #2563eb; }
+    .footer { margin-top: 32px; font-size: 12px; color: #aaa; }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <h1>🔐 授权设备</h1>
+    <p class="desc">
+      在终端或 IDE 中输入 <code>tcb login</code> 后，将获得的设备码填入下方
+    </p>
+
+    <div class="steps">
+      <ol>
+        <li>在命令行中执行 <code>tcb login</code> 获取设备码</li>
+        <li>将设备码填入下方输入框</li>
+        <li>点击"授权登录"，使用企业账号完成认证</li>
+      </ol>
+    </div>
+
+    <label for="userCode">设备码</label>
+    <input id="userCode" type="text" placeholder="XXXX-XXXX" maxlength="9"
+           autocomplete="off" autocorrect="off" autocapitalize="off">
+    <div class="hint">格式：4位数字-4位数字，如 1234-5678</div>
+
+    <button id="loginBtn" onclick="startAuth()">授权登录</button>
+
+    <div id="errorMsg" class="error"></div>
+    <div id="successMsg" class="success"></div>
+
+    <div class="footer">企业 AI 开发平台 &middot; 云开发 CloudBase</div>
+  </div>
+
+  <!-- CloudBase Web SDK -->
+  <script src="https://imgcache.qq.com/qcloud/tcb/js-sdk/2.x.x/cloudbase.js"></script>
+  <script>
+    let authApp = null;
+    let authInstance = null;
+
+    async function initCloudBase() {
+      try {
+        // 从服务端获取 CloudBase 配置
+        const configRes = await fetch('/auth/config');
+        const config = await configRes.json();
+
+        if (!config.envId || !config.publishableKey) {
+          showError('授权服务未配置 CloudBase 环境，请联系管理员');
+          return false;
+        }
+
+        authApp = cloudbase.init({
+          env: config.envId,
+          region: config.region || 'ap-shanghai',
+          accessKey: config.publishableKey,
+          auth: { detectSessionInUrl: false },
+        });
+        authInstance = authApp.auth({ persistence: 'local' });
+        return true;
+      } catch (e) {
+        showError('初始化认证服务失败: ' + e.message);
+        return false;
+      }
+    }
+
+    async function startAuth() {
+      const userCode = document.getElementById('userCode').value.trim();
+      if (!userCode || !/^\d{4}-\d{4}$/.test(userCode)) {
+        showError('请输入正确的设备码格式（如 1234-5678）');
+        return;
+      }
+
+      if (!authInstance) {
+        const ok = await initCloudBase();
+        if (!ok) return;
+      }
+
+      hideError();
+      document.getElementById('loginBtn').disabled = true;
+      document.getElementById('loginBtn').textContent = '跳转中...';
+
+      // 保存设备码到 sessionStorage（回调页面读取）
+      sessionStorage.setItem('pending_user_code', userCode);
+
+      // 跳转到 CloudBase 托管登录页
+      // 托管登录页会展示所有已配置的企业身份源（飞书、企业微信、Google 等）
+      authInstance.toDefaultLoginPage({
+        redirect_uri: window.location.origin + '/cli-auth-callback.html',
+      });
+      // 注意：执行后页面将跳转，以下代码不再执行
+    }
+
+    function showError(msg) {
+      const el = document.getElementById('errorMsg');
+      el.textContent = msg;
+      el.style.display = 'block';
+      document.getElementById('successMsg').style.display = 'none';
+    }
+
+    function hideError() {
+      document.getElementById('errorMsg').style.display = 'none';
+    }
+
+    // 页面加载时等待 DOM 就绪
+    document.addEventListener('DOMContentLoaded', () => {
+      initCloudBase();
+      // 自动聚焦输入框
+      document.getElementById('userCode').focus();
+    });
+  </script>
+</body>
+</html>

--- a/examples/cloudbase-auth-endpoint-with-feishu/scf_bootstrap
+++ b/examples/cloudbase-auth-endpoint-with-feishu/scf_bootstrap
@@ -1,0 +1,2 @@
+#!/bin/bash
+node dist/server.js

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
@@ -10,5 +10,14 @@ export const CLOUDBASE_ENV_ID = process.env.CLOUDBASE_ENV_ID || '';
 export const CLOUDBASE_PUBLISHABLE_KEY = process.env.CLOUDBASE_PUBLISHABLE_KEY || '';
 export const CLOUDBASE_REGION = process.env.CLOUDBASE_REGION || 'ap-shanghai';
 
+export const CLOUDBASE_USER_ENV_PACKAGE_ID = process.env.CLOUDBASE_USER_ENV_PACKAGE_ID || 'baas_personal';
+export const CLOUDBASE_USER_ENV_RESOURCES = (process.env.CLOUDBASE_USER_ENV_RESOURCES || 'flexdb,storage,function')
+  .split(',')
+  .map(resource => resource.trim())
+  .filter(Boolean);
+export const CLOUDBASE_USER_ENV_PERIOD = Number(process.env.CLOUDBASE_USER_ENV_PERIOD) || 1;
+export const CLOUDBASE_USER_ENV_AUTO_VOUCHER = process.env.CLOUDBASE_USER_ENV_AUTO_VOUCHER !== 'false';
+export const CLOUDBASE_USER_ENV_READY_TIMEOUT_MS = Number(process.env.CLOUDBASE_USER_ENV_READY_TIMEOUT_MS) || 120_000;
+
 export const TENCENTCLOUD_SECRET_ID = process.env.TENCENTCLOUD_SECRET_ID || '';
 export const TENCENTCLOUD_SECRET_KEY = process.env.TENCENTCLOUD_SECRET_KEY || '';

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
@@ -12,4 +12,3 @@ export const CLOUDBASE_REGION = process.env.CLOUDBASE_REGION || 'ap-shanghai';
 
 export const TENCENTCLOUD_SECRET_ID = process.env.TENCENTCLOUD_SECRET_ID || '';
 export const TENCENTCLOUD_SECRET_KEY = process.env.TENCENTCLOUD_SECRET_KEY || '';
-export const STS_TOKEN_DURATION = Number(process.env.STS_TOKEN_DURATION) || 1800;

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
@@ -1,0 +1,15 @@
+import 'dotenv/config';
+
+export const PORT = Number(process.env.PORT) || 3000;
+export const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
+export const EXPIRES_IN = Number(process.env.EXPIRES_IN) || 600;
+export const INTERVAL = Number(process.env.INTERVAL) || 3;
+export const CONSUMED_TTL_MS = 10_000;
+
+export const CLOUDBASE_ENV_ID = process.env.CLOUDBASE_ENV_ID || '';
+export const CLOUDBASE_PUBLISHABLE_KEY = process.env.CLOUDBASE_PUBLISHABLE_KEY || '';
+export const CLOUDBASE_REGION = process.env.CLOUDBASE_REGION || 'ap-shanghai';
+
+export const TENCENTCLOUD_SECRET_ID = process.env.TENCENTCLOUD_SECRET_ID || '';
+export const TENCENTCLOUD_SECRET_KEY = process.env.TENCENTCLOUD_SECRET_KEY || '';
+export const STS_TOKEN_DURATION = Number(process.env.STS_TOKEN_DURATION) || 1800;

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/config.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 
-export const PORT = Number(process.env.PORT) || 3000;
+export const PORT = Number(process.env.PORT) || 9000;
 export const BASE_URL = process.env.BASE_URL || `http://localhost:${PORT}`;
 export const EXPIRES_IN = Number(process.env.EXPIRES_IN) || 600;
 export const INTERVAL = Number(process.env.INTERVAL) || 3;
@@ -19,5 +19,5 @@ export const CLOUDBASE_USER_ENV_PERIOD = Number(process.env.CLOUDBASE_USER_ENV_P
 export const CLOUDBASE_USER_ENV_AUTO_VOUCHER = process.env.CLOUDBASE_USER_ENV_AUTO_VOUCHER !== 'false';
 export const CLOUDBASE_USER_ENV_READY_TIMEOUT_MS = Number(process.env.CLOUDBASE_USER_ENV_READY_TIMEOUT_MS) || 120_000;
 
-export const TENCENTCLOUD_SECRET_ID = process.env.TENCENTCLOUD_SECRET_ID || '';
-export const TENCENTCLOUD_SECRET_KEY = process.env.TENCENTCLOUD_SECRET_KEY || '';
+export const TENCENTCLOUD_SECRET_ID = process.env.TENCENTCLOUD_SECRET_ID || process.env.CB_SECRET_ID || '';
+export const TENCENTCLOUD_SECRET_KEY = process.env.TENCENTCLOUD_SECRET_KEY || process.env.CB_SECRET_KEY || '';

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
@@ -1,9 +1,22 @@
 import express from 'express';
+import cors from 'cors';
 import { randomBytes } from 'crypto';
-import { cleanupExpired, scheduleExpiry } from './utils/device-store';
+import rateLimit from 'express-rate-limit';
+import {
+  getDeviceRecord,
+  findDeviceByUserCode,
+  saveDeviceRecord,
+  updateDeviceRecord,
+  deleteDeviceRecord,
+  getRefreshRecord,
+  saveRefreshRecord,
+  deleteRefreshRecord,
+  cleanupExpiredRecords,
+} from './utils/device-store';
 import { generateDeviceCode, generateUserCode, INVALID_GRANT_ERROR, AUTHORIZATION_PENDING_ERROR } from './utils/oauth';
 import { createEnv, createApiKey, findEnvByAlias } from './utils/tcb';
 import { resolvePublicDir } from './utils/public-dir';
+import { verifyCloudBaseAccessToken, CloudBaseUserInfo } from './utils/auth';
 import {
   PORT,
   BASE_URL,
@@ -16,16 +29,43 @@ import {
 import { AuthorizationRecord, RefreshTokenRecord } from './types';
 
 const app = express();
+app.set('trust proxy', 1);
+app.use(cors({ origin: true, credentials: true }));
 app.use(express.json());
 app.use(express.static(resolvePublicDir()));
 
-// ── 内存存储（生产环境请替换为 Redis/数据库） ──
-const deviceStore = new Map<string, AuthorizationRecord>();
-const userCodeIndex = new Map<string, string>();
-const refreshTokenStore = new Map<string, RefreshTokenRecord>();
+// ── 限流 ──────────────────────────────────────
+const deviceCodeLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'too_many_requests', error_description: 'Too many device code requests. Please try again later.' },
+});
+const verifyLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 30,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'too_many_requests', error_description: 'Too many verification requests. Please try again later.' },
+});
+const tokenLimiter = rateLimit({
+  windowMs: 60_000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'too_many_requests', error_description: 'Too many token requests. Please try again later.' },
+});
 
-// ── 定期清理过期记录 ──
-setInterval(() => cleanupExpired(deviceStore, userCodeIndex), 30_000);
+// ── 定期清理过期记录（CloudBase 数据库）──
+setInterval(() => { cleanupExpiredRecords().catch(err => console.error('cleanup error:', err)); }, 60_000);
+
+// ─────────────────────────────────────────────
+// GET / — 健康检查
+// ─────────────────────────────────────────────
+app.get('/', (_req, res) => {
+  res.json({ ok: true, boot: Date.now() - startTime + 'ms' });
+});
 
 // ─────────────────────────────────────────────
 // GET /auth/config — 返回前端 SDK 初始化配置
@@ -41,7 +81,7 @@ app.get('/auth/config', (_req, res) => {
 // ─────────────────────────────────────────────
 // POST /auth/device/code — 申请设备授权码
 // ─────────────────────────────────────────────
-app.post('/auth/device/code', (req, res) => {
+app.post('/auth/device/code', deviceCodeLimiter, async (req, res) => {
   const clientId = req.body?.client_id || 'default';
   const deviceCode = generateDeviceCode();
   const userCode = generateUserCode();
@@ -58,10 +98,7 @@ app.post('/auth/device/code', (req, res) => {
     expiresAt,
   };
 
-  deviceStore.set(deviceCode, record);
-  userCodeIndex.set(userCode, deviceCode);
-
-  scheduleExpiry(deviceStore, userCodeIndex, deviceCode, userCode, EXPIRES_IN * 1000);
+  await saveDeviceRecord(record);
 
   res.json({
     device_code: deviceCode,
@@ -76,7 +113,7 @@ app.post('/auth/device/code', (req, res) => {
 // POST /auth/verify-cloudbase — CloudBase 托管登录页认证后的回调
 // 浏览器端完成 OAuth 后调用此接口完成设备码授权
 // ─────────────────────────────────────────────
-app.post('/auth/verify-cloudbase', async (req, res) => {
+app.post('/auth/verify-cloudbase', verifyLimiter, async (req, res) => {
   const {
     user_code: userCode,
     cloudbase_uid: cloudbaseUid,
@@ -90,76 +127,72 @@ app.post('/auth/verify-cloudbase', async (req, res) => {
     });
   }
 
-  const deviceCode = userCodeIndex.get(userCode);
-  if (!deviceCode) {
-    return res.status(400).json(INVALID_GRANT_ERROR);
-  }
-
-  const record = deviceStore.get(deviceCode);
-  if (!record || record.status !== 'pending') {
-    return res.status(400).json(INVALID_GRANT_ERROR);
-  }
-
+  // 尝试校验 token 归属（非阻塞，仅获取 provider 信息）
+  // 注意：CloudBase Auth HTTP API 的 user/me 端点尚不稳定
+  // 因此 token 校验失败时不阻断流程，仅跳过 provider 信息
+  let verifiedUserInfo: CloudBaseUserInfo | null = null;
   try {
-    // 1. 查找用户是否已有环境（通过 cloudbaseUid 作为别名标识）
-    let envId = await findEnvByAlias(cloudbaseUid);
+    verifiedUserInfo = await verifyCloudBaseAccessToken(cloudbaseAccessToken);
+  } catch (err) {
+    console.warn('verify-cloudbase token check (non-blocking):', (err as Error).message);
+  }
 
-    // 2. 首次登录：自动创建环境 + 签发管理员 API Key
-    if (!envId) {
-      envId = await createEnv(cloudbaseUid);
-    }
+  // 查找设备码记录（CloudBase 数据库，跨容器共享）
+  let record: AuthorizationRecord | null = null;
+  try {
+    record = await findDeviceByUserCode(userCode);
+  } catch (err) {
+    console.error('find device record error:', err);
+  }
+  if (!record) {
+    console.warn('device code not found in DB, proceeding with cloudbaseUid');
+  }
 
-    // 3. 为该环境创建 API Key（api_key 类型，管理员权限）
-    // 设置 7 天有效期，到期需续期或重新创建
-    const { apiKey, apiKeyId } = await createApiKey(
-      envId,
-      `user-${cloudbaseUid}`,
-      7 * 24 * 3600, // 7 天有效期
-    );
-
-    // 4. 标记为已授权
+  // 授权确认：记录 cloudbaseUid 到设备码记录
+  // 环境和 API Key 在 POST /auth/token 轮询时按需创建
+  if (record) {
     record.status = 'authorized';
     record.cloudbaseUid = cloudbaseUid;
-    record.envId = envId;
-    record.apiKey = apiKey;
-    record.apiKeyId = apiKeyId;
-
-    res.json({ status: 'ok', env_id: envId });
-  } catch (err) {
-    console.error('verify-cloudbase error:', err);
-    record.status = 'pending';
-    res.status(500).json({ error: 'server_error', error_description: 'Failed to create environment or API key' });
+    if (verifiedUserInfo?.providers?.length) {
+      record.providerId = verifiedUserInfo.providers[0].id;
+      record.providerUserId = verifiedUserInfo.providers[0].provider_user_id;
+    }
+    await updateDeviceRecord(record.deviceCode, {
+      status: 'authorized',
+      cloudbaseUid,
+      providerId: record.providerId,
+      providerUserId: record.providerUserId,
+    }).catch(err => console.error('update device record error:', err));
   }
+
+  res.json({ status: 'ok', env_id: '' });
 });
 
 // ─────────────────────────────────────────────
 // POST /auth/device/verify — 原确认接口（兼容简单场景）
 // ─────────────────────────────────────────────
-app.post('/auth/device/verify', (req, res) => {
+app.post('/auth/device/verify', async (req, res) => {
   const { user_code: userCode } = req.body;
   if (!userCode) {
     return res.status(400).json({ error: 'invalid_request', error_description: 'user_code is required' });
   }
 
-  const deviceCode = userCodeIndex.get(userCode);
-  if (!deviceCode) return res.status(400).json(INVALID_GRANT_ERROR);
-
-  const record = deviceStore.get(deviceCode);
+  const record = await findDeviceByUserCode(userCode);
   if (!record || record.status !== 'pending') return res.status(400).json(INVALID_GRANT_ERROR);
 
-  record.status = 'authorized';
+  await updateDeviceRecord(record.deviceCode, { status: 'authorized' });
   res.json({ status: 'ok' });
 });
 
 // ─────────────────────────────────────────────
 // POST /auth/token — 轮询/续期/退出
 // ─────────────────────────────────────────────
-app.post('/auth/token', async (req, res) => {
+app.post('/auth/token', tokenLimiter, async (req, res) => {
   const { grant_type, device_code: deviceCode, refresh_token: refreshToken, client_id: clientId } = req.body;
 
   // ── device_code（轮询） ──
   if (grant_type === 'device_code') {
-    const record = deviceStore.get(deviceCode);
+    const record = await getDeviceRecord(deviceCode);
     if (!record || Date.now() > record.expiresAt) return res.status(400).json(INVALID_GRANT_ERROR);
 
     if (record.status === 'pending') {
@@ -170,6 +203,26 @@ app.post('/auth/token', async (req, res) => {
       return res.status(400).json(INVALID_GRANT_ERROR);
     }
 
+    // 按需创建环境 + API Key（首次轮询时触发）
+    if (!record.envId && record.cloudbaseUid) {
+      try {
+        let envId = await findEnvByAlias(record.cloudbaseUid);
+        if (!envId) {
+          envId = await createEnv(record.cloudbaseUid);
+        }
+        const { apiKey, apiKeyId } = await createApiKey(envId, `user-${record.cloudbaseUid}`, 7 * 24 * 3600);
+        record.envId = envId;
+        record.apiKey = apiKey;
+        record.apiKeyId = apiKeyId;
+        await updateDeviceRecord(deviceCode, { envId, apiKey, apiKeyId, status: 'consumed' });
+      } catch (err) {
+        console.error('token poll - deferred env setup error:', err);
+        return res.json({ error: 'authorization_pending', error_description: 'Environment creation in progress, please retry' });
+      }
+    } else if (record.status === 'authorized') {
+      await updateDeviceRecord(deviceCode, { status: 'consumed' });
+    }
+
     // 签发 refresh token
     const newRefreshToken = randomBytes(32).toString('hex');
     const refreshRecord: RefreshTokenRecord = {
@@ -178,15 +231,15 @@ app.post('/auth/token', async (req, res) => {
       uin: record.uin,
       ownerUin: record.ownerUin,
       regionId: record.regionId,
-      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 天
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000,
       cloudbaseUid: record.cloudbaseUid,
       envId: record.envId,
       apiKey: record.apiKey,
       apiKeyId: record.apiKeyId,
+      providerId: record.providerId,
+      providerUserId: record.providerUserId,
     };
-    refreshTokenStore.set(newRefreshToken, refreshRecord);
-
-    record.status = 'consumed';
+    await saveRefreshRecord(refreshRecord);
 
     return res.json({
       access_token: record.apiKey || '',
@@ -196,23 +249,25 @@ app.post('/auth/token', async (req, res) => {
       env_id: record.envId,
       api_key_id: record.apiKeyId,
       cloudbase_uid: record.cloudbaseUid,
+      provider_id: record.providerId,
+      provider_user_id: record.providerUserId,
     });
   }
 
   // ── refresh_token（续期） ──
   if (grant_type === 'refresh_token') {
-    const record = refreshTokenStore.get(refreshToken);
+    const record = await getRefreshRecord(refreshToken);
     if (!record) return res.status(400).json(INVALID_GRANT_ERROR);
     if (Date.now() > record.expiresAt) {
-      refreshTokenStore.delete(refreshToken);
+      await deleteRefreshRecord(refreshToken);
       return res.status(400).json(INVALID_GRANT_ERROR);
     }
 
-    // Token Rotation: 颁发新 refresh_token，使旧 token 失效
+    // Token Rotation
     const newRefreshToken = randomBytes(32).toString('hex');
     const newRecord: RefreshTokenRecord = { ...record, refreshToken: newRefreshToken, expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000 };
-    refreshTokenStore.set(newRefreshToken, newRecord);
-    refreshTokenStore.delete(refreshToken);
+    await saveRefreshRecord(newRecord);
+    await deleteRefreshRecord(refreshToken);
 
     return res.json({
       access_token: record.apiKey || '',
@@ -222,16 +277,18 @@ app.post('/auth/token', async (req, res) => {
       env_id: record.envId,
       api_key_id: record.apiKeyId,
       cloudbase_uid: record.cloudbaseUid,
+      provider_id: record.providerId,
+      provider_user_id: record.providerUserId,
     });
   }
 
   // ── revoke_token（退出） ──
   if (grant_type === 'revoke_token') {
     if (refreshToken) {
-      refreshTokenStore.delete(refreshToken);
+      await deleteRefreshRecord(refreshToken).catch(() => {});
     }
     if (deviceCode) {
-      deviceStore.delete(deviceCode);
+      await deleteDeviceRecord(deviceCode).catch(() => {});
     }
     return res.json({ status: 'ok' });
   }
@@ -240,7 +297,8 @@ app.post('/auth/token', async (req, res) => {
 });
 
 // ── 启动 ──
-app.listen(PORT, () => {
+const startTime = Date.now();
+app.listen(PORT, '127.0.0.1', () => {
   const base = BASE_URL;
   console.log(`\n  🚀 企业自有品牌授权服务已启动\n`);
   console.log(`  授权页面:    ${base}/cli-auth.html`);

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
@@ -77,10 +77,17 @@ app.post('/auth/device/code', (req, res) => {
 // 浏览器端完成 OAuth 后调用此接口完成设备码授权
 // ─────────────────────────────────────────────
 app.post('/auth/verify-cloudbase', async (req, res) => {
-  const { user_code: userCode, cloudbase_uid: cloudbaseUid } = req.body;
+  const {
+    user_code: userCode,
+    cloudbase_uid: cloudbaseUid,
+    cloudbase_access_token: cloudbaseAccessToken,
+  } = req.body;
 
-  if (!userCode || !cloudbaseUid) {
-    return res.status(400).json({ error: 'invalid_request', error_description: 'user_code and cloudbase_uid are required' });
+  if (!userCode || !cloudbaseUid || !cloudbaseAccessToken) {
+    return res.status(400).json({
+      error: 'invalid_request',
+      error_description: 'user_code, cloudbase_uid and cloudbase_access_token are required',
+    });
   }
 
   const deviceCode = userCodeIndex.get(userCode);
@@ -153,7 +160,7 @@ app.post('/auth/token', async (req, res) => {
   // ── device_code（轮询） ──
   if (grant_type === 'device_code') {
     const record = deviceStore.get(deviceCode);
-    if (!record) return res.status(400).json(INVALID_GRANT_ERROR);
+    if (!record || Date.now() > record.expiresAt) return res.status(400).json(INVALID_GRANT_ERROR);
 
     if (record.status === 'pending') {
       return res.json(AUTHORIZATION_PENDING_ERROR);
@@ -175,6 +182,7 @@ app.post('/auth/token', async (req, res) => {
       cloudbaseUid: record.cloudbaseUid,
       envId: record.envId,
       apiKey: record.apiKey,
+      apiKeyId: record.apiKeyId,
     };
     refreshTokenStore.set(newRefreshToken, refreshRecord);
 
@@ -195,6 +203,10 @@ app.post('/auth/token', async (req, res) => {
   if (grant_type === 'refresh_token') {
     const record = refreshTokenStore.get(refreshToken);
     if (!record) return res.status(400).json(INVALID_GRANT_ERROR);
+    if (Date.now() > record.expiresAt) {
+      refreshTokenStore.delete(refreshToken);
+      return res.status(400).json(INVALID_GRANT_ERROR);
+    }
 
     // Token Rotation: 颁发新 refresh_token，使旧 token 失效
     const newRefreshToken = randomBytes(32).toString('hex');
@@ -203,11 +215,13 @@ app.post('/auth/token', async (req, res) => {
     refreshTokenStore.delete(refreshToken);
 
     return res.json({
-      access_token: record.envId || '',
+      access_token: record.apiKey || '',
       refresh_token: newRefreshToken,
       expires_in: 7 * 24 * 3600,
       token_type: 'Bearer',
       env_id: record.envId,
+      api_key_id: record.apiKeyId,
+      cloudbase_uid: record.cloudbaseUid,
     });
   }
 

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
@@ -97,22 +97,30 @@ app.post('/auth/verify-cloudbase', async (req, res) => {
     // 1. 查找用户是否已有环境（通过 cloudbaseUid 作为别名标识）
     let envId = await findEnvByAlias(cloudbaseUid);
 
-    // 2. 首次登录：自动创建环境 + 签发 API Key
+    // 2. 首次登录：自动创建环境 + 签发管理员 API Key
     if (!envId) {
       envId = await createEnv(cloudbaseUid);
-      const { apiKey, apiKeyId } = await createApiKey(envId, `user-${cloudbaseUid}`);
-      record.envId = envId;
-      record.apiKey = apiKey;
     }
 
-    // 3. 标记为已授权
+    // 3. 为该环境创建 API Key（api_key 类型，管理员权限）
+    // 设置 7 天有效期，到期需续期或重新创建
+    const { apiKey, apiKeyId } = await createApiKey(
+      envId,
+      `user-${cloudbaseUid}`,
+      7 * 24 * 3600, // 7 天有效期
+    );
+
+    // 4. 标记为已授权
     record.status = 'authorized';
     record.cloudbaseUid = cloudbaseUid;
+    record.envId = envId;
+    record.apiKey = apiKey;
+    record.apiKeyId = apiKeyId;
 
     res.json({ status: 'ok', env_id: envId });
   } catch (err) {
     console.error('verify-cloudbase error:', err);
-    record.status = 'pending'; // 失败则恢复待授权状态
+    record.status = 'pending';
     res.status(500).json({ error: 'server_error', error_description: 'Failed to create environment or API key' });
   }
 });
@@ -166,17 +174,19 @@ app.post('/auth/token', async (req, res) => {
       expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 天
       cloudbaseUid: record.cloudbaseUid,
       envId: record.envId,
+      apiKey: record.apiKey,
     };
     refreshTokenStore.set(newRefreshToken, refreshRecord);
 
     record.status = 'consumed';
 
     return res.json({
-      access_token: record.apiKey || record.envId,
+      access_token: record.apiKey || '',
       refresh_token: newRefreshToken,
       expires_in: 7 * 24 * 3600,
       token_type: 'Bearer',
       env_id: record.envId,
+      api_key_id: record.apiKeyId,
       cloudbase_uid: record.cloudbaseUid,
     });
   }

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
@@ -1,0 +1,230 @@
+import express from 'express';
+import { randomBytes } from 'crypto';
+import { cleanupExpired, scheduleExpiry } from './utils/device-store';
+import { generateDeviceCode, generateUserCode, INVALID_GRANT_ERROR, AUTHORIZATION_PENDING_ERROR } from './utils/oauth';
+import { createEnv, createApiKey, findEnvByAlias } from './utils/tcb';
+import { resolvePublicDir } from './utils/public-dir';
+import {
+  PORT,
+  BASE_URL,
+  EXPIRES_IN,
+  INTERVAL,
+  CLOUDBASE_ENV_ID,
+  CLOUDBASE_PUBLISHABLE_KEY,
+  CLOUDBASE_REGION,
+} from './config';
+import { AuthorizationRecord, RefreshTokenRecord } from './types';
+
+const app = express();
+app.use(express.json());
+app.use(express.static(resolvePublicDir()));
+
+// ── 内存存储（生产环境请替换为 Redis/数据库） ──
+const deviceStore = new Map<string, AuthorizationRecord>();
+const userCodeIndex = new Map<string, string>();
+const refreshTokenStore = new Map<string, RefreshTokenRecord>();
+
+// ── 定期清理过期记录 ──
+setInterval(() => cleanupExpired(deviceStore, userCodeIndex), 30_000);
+
+// ─────────────────────────────────────────────
+// GET /auth/config — 返回前端 SDK 初始化配置
+// ─────────────────────────────────────────────
+app.get('/auth/config', (_req, res) => {
+  res.json({
+    envId: CLOUDBASE_ENV_ID,
+    region: CLOUDBASE_REGION,
+    publishableKey: CLOUDBASE_PUBLISHABLE_KEY,
+  });
+});
+
+// ─────────────────────────────────────────────
+// POST /auth/device/code — 申请设备授权码
+// ─────────────────────────────────────────────
+app.post('/auth/device/code', (req, res) => {
+  const clientId = req.body?.client_id || 'default';
+  const deviceCode = generateDeviceCode();
+  const userCode = generateUserCode();
+  const expiresAt = Date.now() + EXPIRES_IN * 1000;
+
+  const record: AuthorizationRecord = {
+    deviceCode,
+    userCode,
+    clientId,
+    status: 'pending',
+    uin: '',
+    ownerUin: '',
+    regionId: CLOUDBASE_REGION,
+    expiresAt,
+  };
+
+  deviceStore.set(deviceCode, record);
+  userCodeIndex.set(userCode, deviceCode);
+
+  scheduleExpiry(deviceStore, userCodeIndex, deviceCode, userCode, EXPIRES_IN * 1000);
+
+  res.json({
+    device_code: deviceCode,
+    user_code: userCode,
+    verification_uri: `${BASE_URL}/cli-auth.html`,
+    expires_in: EXPIRES_IN,
+    interval: INTERVAL,
+  });
+});
+
+// ─────────────────────────────────────────────
+// POST /auth/verify-cloudbase — CloudBase 托管登录页认证后的回调
+// 浏览器端完成 OAuth 后调用此接口完成设备码授权
+// ─────────────────────────────────────────────
+app.post('/auth/verify-cloudbase', async (req, res) => {
+  const { user_code: userCode, cloudbase_uid: cloudbaseUid } = req.body;
+
+  if (!userCode || !cloudbaseUid) {
+    return res.status(400).json({ error: 'invalid_request', error_description: 'user_code and cloudbase_uid are required' });
+  }
+
+  const deviceCode = userCodeIndex.get(userCode);
+  if (!deviceCode) {
+    return res.status(400).json(INVALID_GRANT_ERROR);
+  }
+
+  const record = deviceStore.get(deviceCode);
+  if (!record || record.status !== 'pending') {
+    return res.status(400).json(INVALID_GRANT_ERROR);
+  }
+
+  try {
+    // 1. 查找用户是否已有环境（通过 cloudbaseUid 作为别名标识）
+    let envId = await findEnvByAlias(cloudbaseUid);
+
+    // 2. 首次登录：自动创建环境 + 签发 API Key
+    if (!envId) {
+      envId = await createEnv(cloudbaseUid);
+      const { apiKey, apiKeyId } = await createApiKey(envId, `user-${cloudbaseUid}`);
+      record.envId = envId;
+      record.apiKey = apiKey;
+    }
+
+    // 3. 标记为已授权
+    record.status = 'authorized';
+    record.cloudbaseUid = cloudbaseUid;
+
+    res.json({ status: 'ok', env_id: envId });
+  } catch (err) {
+    console.error('verify-cloudbase error:', err);
+    record.status = 'pending'; // 失败则恢复待授权状态
+    res.status(500).json({ error: 'server_error', error_description: 'Failed to create environment or API key' });
+  }
+});
+
+// ─────────────────────────────────────────────
+// POST /auth/device/verify — 原确认接口（兼容简单场景）
+// ─────────────────────────────────────────────
+app.post('/auth/device/verify', (req, res) => {
+  const { user_code: userCode } = req.body;
+  if (!userCode) {
+    return res.status(400).json({ error: 'invalid_request', error_description: 'user_code is required' });
+  }
+
+  const deviceCode = userCodeIndex.get(userCode);
+  if (!deviceCode) return res.status(400).json(INVALID_GRANT_ERROR);
+
+  const record = deviceStore.get(deviceCode);
+  if (!record || record.status !== 'pending') return res.status(400).json(INVALID_GRANT_ERROR);
+
+  record.status = 'authorized';
+  res.json({ status: 'ok' });
+});
+
+// ─────────────────────────────────────────────
+// POST /auth/token — 轮询/续期/退出
+// ─────────────────────────────────────────────
+app.post('/auth/token', async (req, res) => {
+  const { grant_type, device_code: deviceCode, refresh_token: refreshToken, client_id: clientId } = req.body;
+
+  // ── device_code（轮询） ──
+  if (grant_type === 'device_code') {
+    const record = deviceStore.get(deviceCode);
+    if (!record) return res.status(400).json(INVALID_GRANT_ERROR);
+
+    if (record.status === 'pending') {
+      return res.json(AUTHORIZATION_PENDING_ERROR);
+    }
+
+    if (record.status !== 'authorized') {
+      return res.status(400).json(INVALID_GRANT_ERROR);
+    }
+
+    // 签发 refresh token
+    const newRefreshToken = randomBytes(32).toString('hex');
+    const refreshRecord: RefreshTokenRecord = {
+      refreshToken: newRefreshToken,
+      clientId: clientId || 'default',
+      uin: record.uin,
+      ownerUin: record.ownerUin,
+      regionId: record.regionId,
+      expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000, // 7 天
+      cloudbaseUid: record.cloudbaseUid,
+      envId: record.envId,
+    };
+    refreshTokenStore.set(newRefreshToken, refreshRecord);
+
+    record.status = 'consumed';
+
+    return res.json({
+      access_token: record.apiKey || record.envId,
+      refresh_token: newRefreshToken,
+      expires_in: 7 * 24 * 3600,
+      token_type: 'Bearer',
+      env_id: record.envId,
+      cloudbase_uid: record.cloudbaseUid,
+    });
+  }
+
+  // ── refresh_token（续期） ──
+  if (grant_type === 'refresh_token') {
+    const record = refreshTokenStore.get(refreshToken);
+    if (!record) return res.status(400).json(INVALID_GRANT_ERROR);
+
+    // Token Rotation: 颁发新 refresh_token，使旧 token 失效
+    const newRefreshToken = randomBytes(32).toString('hex');
+    const newRecord: RefreshTokenRecord = { ...record, refreshToken: newRefreshToken, expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000 };
+    refreshTokenStore.set(newRefreshToken, newRecord);
+    refreshTokenStore.delete(refreshToken);
+
+    return res.json({
+      access_token: record.envId || '',
+      refresh_token: newRefreshToken,
+      expires_in: 7 * 24 * 3600,
+      token_type: 'Bearer',
+      env_id: record.envId,
+    });
+  }
+
+  // ── revoke_token（退出） ──
+  if (grant_type === 'revoke_token') {
+    if (refreshToken) {
+      refreshTokenStore.delete(refreshToken);
+    }
+    if (deviceCode) {
+      deviceStore.delete(deviceCode);
+    }
+    return res.json({ status: 'ok' });
+  }
+
+  return res.status(400).json({ error: 'unsupported_grant_type', error_description: `grant_type '${grant_type}' is not supported` });
+});
+
+// ── 启动 ──
+app.listen(PORT, () => {
+  const base = BASE_URL;
+  console.log(`\n  🚀 企业自有品牌授权服务已启动\n`);
+  console.log(`  授权页面:    ${base}/cli-auth.html`);
+  console.log(`  授权回调页:  ${base}/cli-auth-callback.html`);
+  console.log(`  设备码 API:  POST ${base}/auth/device/code`);
+  console.log(`  验证 API:    POST ${base}/auth/verify-cloudbase`);
+  console.log(`  Token API:   POST ${base}/auth/token`);
+  console.log(`  配置 API:    GET  ${base}/auth/config`);
+  console.log(`\n  管理中心环境: ${CLOUDBASE_ENV_ID || '(未配置)'}`);
+  console.log(`  托管登录页:  ${CLOUDBASE_ENV_ID ? `https://tcb.cloud.tencent.com/dev?envId=${CLOUDBASE_ENV_ID}#/identity/login-manage` : '(未配置)'}\n`);
+});

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/server.ts
@@ -127,42 +127,58 @@ app.post('/auth/verify-cloudbase', verifyLimiter, async (req, res) => {
     });
   }
 
-  // 尝试校验 token 归属（非阻塞，仅获取 provider 信息）
-  // 注意：CloudBase Auth HTTP API 的 user/me 端点尚不稳定
-  // 因此 token 校验失败时不阻断流程，仅跳过 provider 信息
-  let verifiedUserInfo: CloudBaseUserInfo | null = null;
+  // 校验 access token 归属，并只信任已验证的用户身份。
+  let verifiedUserInfo: CloudBaseUserInfo;
   try {
     verifiedUserInfo = await verifyCloudBaseAccessToken(cloudbaseAccessToken);
   } catch (err) {
-    console.warn('verify-cloudbase token check (non-blocking):', (err as Error).message);
+    console.warn('verify-cloudbase token check failed:', (err as Error).message);
+    return res.status(401).json({
+      error: 'invalid_token',
+      error_description: 'cloudbase_access_token is invalid or expired',
+    });
+  }
+
+  const verifiedUid = verifiedUserInfo.user_id || verifiedUserInfo.sub;
+  if (!verifiedUid || verifiedUid !== cloudbaseUid) {
+    return res.status(401).json({
+      error: 'invalid_token',
+      error_description: 'cloudbase_uid does not match cloudbase_access_token',
+    });
   }
 
   // 查找设备码记录（CloudBase 数据库，跨容器共享）
-  let record: AuthorizationRecord | null = null;
+  let record: AuthorizationRecord | null;
   try {
     record = await findDeviceByUserCode(userCode);
   } catch (err) {
     console.error('find device record error:', err);
+    return res.status(500).json({
+      error: 'server_error',
+      error_description: 'Failed to query device authorization record',
+    });
   }
-  if (!record) {
-    console.warn('device code not found in DB, proceeding with cloudbaseUid');
+  if (!record || record.status !== 'pending' || Date.now() > record.expiresAt) {
+    return res.status(400).json(INVALID_GRANT_ERROR);
   }
+
+  const provider = verifiedUserInfo.providers?.[0];
 
   // 授权确认：记录 cloudbaseUid 到设备码记录
   // 环境和 API Key 在 POST /auth/token 轮询时按需创建
-  if (record) {
-    record.status = 'authorized';
-    record.cloudbaseUid = cloudbaseUid;
-    if (verifiedUserInfo?.providers?.length) {
-      record.providerId = verifiedUserInfo.providers[0].id;
-      record.providerUserId = verifiedUserInfo.providers[0].provider_user_id;
-    }
+  try {
     await updateDeviceRecord(record.deviceCode, {
       status: 'authorized',
-      cloudbaseUid,
-      providerId: record.providerId,
-      providerUserId: record.providerUserId,
-    }).catch(err => console.error('update device record error:', err));
+      cloudbaseUid: verifiedUid,
+      providerId: provider?.id,
+      providerUserId: provider?.provider_user_id,
+    });
+  } catch (err) {
+    console.error('update device record error:', err);
+    return res.status(500).json({
+      error: 'server_error',
+      error_description: 'Failed to update device authorization record',
+    });
   }
 
   res.json({ status: 'ok', env_id: '' });

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
@@ -1,0 +1,56 @@
+export interface AuthorizationRecord {
+  deviceCode: string;
+  userCode: string;
+  clientId: string;
+  status: 'pending' | 'authorized' | 'consumed' | 'expired';
+  uin: string;
+  ownerUin: string;
+  regionId: string;
+  expiresAt: number;
+  /** 当通过 CloudBase 托管登录页认证时，记录用户 uid */
+  cloudbaseUid?: string;
+  /** 为该用户创建的环境 ID */
+  envId?: string;
+  /** 为该环境签发的 API Key */
+  apiKey?: string;
+}
+
+export interface RefreshTokenRecord {
+  refreshToken: string;
+  clientId: string;
+  uin: string;
+  ownerUin: string;
+  regionId: string;
+  expiresAt: number;
+  cloudbaseUid?: string;
+  envId?: string;
+}
+
+export interface DeviceCodeRequest {
+  client_id?: string;
+  scope?: string;
+}
+
+export interface DeviceCodeResponse {
+  device_code: string;
+  user_code: string;
+  verification_uri: string;
+  expires_in: number;
+  interval: number;
+}
+
+export interface VerifyRequest {
+  user_code: string;
+}
+
+export interface TokenRequest {
+  grant_type: 'device_code' | 'refresh_token' | 'revoke_token';
+  device_code?: string;
+  refresh_token?: string;
+  client_id?: string;
+}
+
+export interface CloudBaseVerifyRequest {
+  user_code: string;
+  cloudbase_uid: string;
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
@@ -15,6 +15,10 @@ export interface AuthorizationRecord {
   apiKey?: string;
   /** API Key 的 ID */
   apiKeyId?: string;
+  /** 用户使用的身份源 ID（如 custom_oauth_feishu、email 等） */
+  providerId?: string;
+  /** 用户在身份源侧的原始 ID（如飞书 open_id） */
+  providerUserId?: string;
 }
 
 export interface RefreshTokenRecord {
@@ -28,6 +32,8 @@ export interface RefreshTokenRecord {
   envId?: string;
   apiKey?: string;
   apiKeyId?: string;
+  providerId?: string;
+  providerUserId?: string;
 }
 
 export interface DeviceCodeRequest {

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
@@ -11,8 +11,10 @@ export interface AuthorizationRecord {
   cloudbaseUid?: string;
   /** 为该用户创建的环境 ID */
   envId?: string;
-  /** 为该环境签发的 API Key */
+  /** 为该环境签发的 API Key Token（jwt 格式） */
   apiKey?: string;
+  /** API Key 的 ID */
+  apiKeyId?: string;
 }
 
 export interface RefreshTokenRecord {
@@ -24,6 +26,7 @@ export interface RefreshTokenRecord {
   expiresAt: number;
   cloudbaseUid?: string;
   envId?: string;
+  apiKey?: string;
 }
 
 export interface DeviceCodeRequest {

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/types.ts
@@ -27,6 +27,7 @@ export interface RefreshTokenRecord {
   cloudbaseUid?: string;
   envId?: string;
   apiKey?: string;
+  apiKeyId?: string;
 }
 
 export interface DeviceCodeRequest {
@@ -56,4 +57,5 @@ export interface TokenRequest {
 export interface CloudBaseVerifyRequest {
   user_code: string;
   cloudbase_uid: string;
+  cloudbase_access_token: string;
 }

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/auth.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/auth.ts
@@ -1,0 +1,55 @@
+import { CLOUDBASE_ENV_ID, CLOUDBASE_REGION } from '../config';
+
+/**
+ * CloudBase User Info HTTP API 返回结构
+ */
+export interface CloudBaseUserInfo {
+  sub?: string;
+  user_id?: string;
+  name?: string;
+  email?: string;
+  providers?: Array<{
+    id: string;
+    provider_user_id: string;
+    name?: string;
+  }>;
+  status?: string;
+}
+
+/**
+ * 使用 HTTP API 验证 cloudbase_access_token 并获取用户信息。
+ *
+ * 对应 API: GET /auth/v1/user/me
+ * 文档: https://docs.cloudbase.net/http-api/auth/user-me
+ *
+ * @param accessToken - 待验证的 CloudBase access_token
+ * @returns 用户信息，包含 user_id 和 providers
+ * @throws 如果 token 无效或 API 调用失败
+ */
+export async function verifyCloudBaseAccessToken(
+  accessToken: string,
+): Promise<CloudBaseUserInfo> {
+  const url = `https://tcb.cloud.tencent.com/auth/v1/user/me`;
+
+  const response = await fetch(url, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'X-CloudBase-EnvId': CLOUDBASE_ENV_ID,
+    },
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text().catch(() => '');
+    throw new Error(
+      `CloudBase token verification failed: ${response.status} ${errorBody}`,
+    );
+  }
+
+  const userInfo: CloudBaseUserInfo = await response.json() as CloudBaseUserInfo;
+
+  if (!userInfo.user_id && !userInfo.sub) {
+    throw new Error('CloudBase token verification: invalid response (missing user_id)');
+  }
+
+  return userInfo;
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
@@ -1,0 +1,34 @@
+import { AuthorizationRecord } from '../types';
+import { CONSUMED_TTL_MS } from '../config';
+
+export function cleanupExpired(
+  deviceStore: Map<string, AuthorizationRecord>,
+  userCodeIndex: Map<string, string>,
+): void {
+  const now = Date.now();
+  for (const [key, auth] of deviceStore.entries()) {
+    if (now > auth.expiresAt) {
+      deviceStore.delete(key);
+      userCodeIndex.delete(auth.userCode);
+    }
+  }
+}
+
+export function scheduleExpiry(
+  deviceStore: Map<string, AuthorizationRecord>,
+  userCodeIndex: Map<string, string>,
+  deviceCode: string,
+  userCode: string,
+  ttlMs: number,
+): void {
+  setTimeout(() => {
+    const auth = deviceStore.get(deviceCode);
+    if (auth && (auth.status === 'pending' || auth.status === 'authorized')) {
+      auth.status = 'expired';
+      setTimeout(() => {
+        deviceStore.delete(deviceCode);
+        userCodeIndex.delete(userCode);
+      }, CONSUMED_TTL_MS);
+    }
+  }, ttlMs);
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
@@ -1,34 +1,69 @@
-import { AuthorizationRecord } from '../types';
-import { CONSUMED_TTL_MS } from '../config';
+import cloudbase from '@cloudbase/node-sdk';
+import { AuthorizationRecord, RefreshTokenRecord } from '../types';
+import { CLOUDBASE_ENV_ID, CLOUDBASE_REGION, CONSUMED_TTL_MS } from '../config';
 
-export function cleanupExpired(
-  deviceStore: Map<string, AuthorizationRecord>,
-  userCodeIndex: Map<string, string>,
-): void {
-  const now = Date.now();
-  for (const [key, auth] of deviceStore.entries()) {
-    if (now > auth.expiresAt) {
-      deviceStore.delete(key);
-      userCodeIndex.delete(auth.userCode);
-    }
-  }
+const CB_SECRET_ID = process.env.CB_SECRET_ID || '';
+const CB_SECRET_KEY = process.env.CB_SECRET_KEY || '';
+
+const app = cloudbase.init({
+  env: CLOUDBASE_ENV_ID,
+  region: CLOUDBASE_REGION,
+  secretId: CB_SECRET_ID,
+  secretKey: CB_SECRET_KEY,
+});
+
+const db = app.database();
+const devices = db.collection('auth_devices');
+const refreshTokens = db.collection('auth_refresh_tokens');
+
+const _ = db.command;
+
+// ── 设备码 ──
+
+export async function getDeviceRecord(deviceCode: string): Promise<AuthorizationRecord | null> {
+  const res = await devices.where({ deviceCode }).get();
+  if (res.data.length === 0) return null;
+  return res.data[0] as unknown as AuthorizationRecord;
 }
 
-export function scheduleExpiry(
-  deviceStore: Map<string, AuthorizationRecord>,
-  userCodeIndex: Map<string, string>,
-  deviceCode: string,
-  userCode: string,
-  ttlMs: number,
-): void {
-  setTimeout(() => {
-    const auth = deviceStore.get(deviceCode);
-    if (auth && (auth.status === 'pending' || auth.status === 'authorized')) {
-      auth.status = 'expired';
-      setTimeout(() => {
-        deviceStore.delete(deviceCode);
-        userCodeIndex.delete(userCode);
-      }, CONSUMED_TTL_MS);
-    }
-  }, ttlMs);
+export async function findDeviceByUserCode(userCode: string): Promise<AuthorizationRecord | null> {
+  const res = await devices.where({ userCode }).get();
+  if (res.data.length === 0) return null;
+  return res.data[0] as unknown as AuthorizationRecord;
+}
+
+export async function saveDeviceRecord(record: AuthorizationRecord): Promise<void> {
+  await devices.add(record);
+}
+
+export async function updateDeviceRecord(deviceCode: string, updates: Partial<AuthorizationRecord>): Promise<void> {
+  await devices.where({ deviceCode }).update(updates as any);
+}
+
+export async function deleteDeviceRecord(deviceCode: string): Promise<void> {
+  await devices.where({ deviceCode }).remove();
+}
+
+// ── Refresh Token ──
+
+export async function getRefreshRecord(refreshToken: string): Promise<RefreshTokenRecord | null> {
+  const res = await refreshTokens.where({ refreshToken }).get();
+  if (res.data.length === 0) return null;
+  return res.data[0] as unknown as RefreshTokenRecord;
+}
+
+export async function saveRefreshRecord(record: RefreshTokenRecord): Promise<void> {
+  await refreshTokens.add(record);
+}
+
+export async function deleteRefreshRecord(refreshToken: string): Promise<void> {
+  await refreshTokens.where({ refreshToken }).remove();
+}
+
+// ── 清理过期记录（定时调用） ──
+
+export async function cleanupExpiredRecords(): Promise<void> {
+  const now = Date.now();
+  await devices.where({ expiresAt: _.lt(now) }).remove();
+  await refreshTokens.where({ expiresAt: _.lt(now) }).remove();
 }

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/device-store.ts
@@ -1,9 +1,9 @@
 import cloudbase from '@cloudbase/node-sdk';
 import { AuthorizationRecord, RefreshTokenRecord } from '../types';
-import { CLOUDBASE_ENV_ID, CLOUDBASE_REGION, CONSUMED_TTL_MS } from '../config';
+import { CLOUDBASE_ENV_ID, CLOUDBASE_REGION, TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY } from '../config';
 
-const CB_SECRET_ID = process.env.CB_SECRET_ID || '';
-const CB_SECRET_KEY = process.env.CB_SECRET_KEY || '';
+const CB_SECRET_ID = process.env.CB_SECRET_ID || TENCENTCLOUD_SECRET_ID;
+const CB_SECRET_KEY = process.env.CB_SECRET_KEY || TENCENTCLOUD_SECRET_KEY;
 
 const app = cloudbase.init({
   env: CLOUDBASE_ENV_ID,

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/oauth.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/oauth.ts
@@ -1,0 +1,27 @@
+import { randomBytes } from 'crypto';
+
+/**
+ * 生成设备码（device_code）—— 随机字符串，供客户端轮询用
+ */
+export function generateDeviceCode(): string {
+  return randomBytes(32).toString('hex');
+}
+
+/**
+ * 生成用户码（user_code）—— 简短易输入格式：XXXX-XXXX
+ */
+export function generateUserCode(): string {
+  const segment1 = randomBytes(2).readUInt16BE(0) % 10000;
+  const segment2 = randomBytes(2).readUInt16BE(0) % 10000;
+  return `${String(segment1).padStart(4, '0')}-${String(segment2).padStart(4, '0')}`;
+}
+
+export const INVALID_GRANT_ERROR = {
+  error: 'invalid_grant',
+  error_description: 'The authorization has been denied or expired.',
+};
+
+export const AUTHORIZATION_PENDING_ERROR = {
+  error: 'authorization_pending',
+  error_description: 'The user has not yet completed authorization.',
+};

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/public-dir.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/public-dir.ts
@@ -1,0 +1,6 @@
+import path from 'path';
+
+export function resolvePublicDir(): string {
+  const dir = path.resolve(__dirname, '../../public');
+  return dir;
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
@@ -1,7 +1,18 @@
+import { createHash } from 'crypto';
 import * as tencentcloud from 'tencentcloud-sdk-nodejs-tcb';
-import { TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY, CLOUDBASE_REGION } from '../config';
+import {
+  TENCENTCLOUD_SECRET_ID,
+  TENCENTCLOUD_SECRET_KEY,
+  CLOUDBASE_REGION,
+  CLOUDBASE_USER_ENV_AUTO_VOUCHER,
+  CLOUDBASE_USER_ENV_PACKAGE_ID,
+  CLOUDBASE_USER_ENV_PERIOD,
+  CLOUDBASE_USER_ENV_READY_TIMEOUT_MS,
+  CLOUDBASE_USER_ENV_RESOURCES,
+} from '../config';
 
 const TcbClient = tencentcloud.tcb.v20180608.Client;
+const ENV_READY_POLL_INTERVAL_MS = 5_000;
 
 function getClient(): InstanceType<typeof TcbClient> {
   return new TcbClient({
@@ -14,26 +25,64 @@ function getClient(): InstanceType<typeof TcbClient> {
 }
 
 /**
+ * 生成符合 CreateEnv Alias 契约的用户环境别名。
+ * CreateEnv 要求 Alias 仅包含小写字母、数字、减号，且长度不超过 20 位。
+ */
+function getUserEnvAlias(subject: string): string {
+  const digest = createHash('sha256').update(subject).digest('hex').slice(0, 18);
+  return `u-${digest}`;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
  * 查询主账号下的所有环境列表
  */
-export async function listEnvs(): Promise<Array<{ EnvId: string; Alias: string }>> {
+export async function listEnvs(): Promise<Array<{ EnvId: string; Alias: string; Status?: string }>> {
   const client = getClient();
   const result = await client.DescribeEnvs({});
-  return result.EnvList || [];
+  return (result.EnvList || [])
+    .filter(env => env.EnvId && env.Alias)
+    .map(env => ({ EnvId: env.EnvId!, Alias: env.Alias!, Status: env.Status }));
+}
+
+async function waitForEnvReady(envId: string): Promise<void> {
+  const client = getClient();
+  const deadline = Date.now() + CLOUDBASE_USER_ENV_READY_TIMEOUT_MS;
+
+  while (Date.now() < deadline) {
+    const result = await client.DescribeEnvs({ EnvId: envId });
+    const env = result.EnvList?.find(item => item.EnvId === envId) || result.EnvList?.[0];
+    if (env?.Status === 'NORMAL') return;
+    await sleep(ENV_READY_POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`CloudBase environment ${envId} is not ready before timeout`);
 }
 
 /**
  * 为用户创建一个新的 CloudBase 环境（1+N 中的"用户环境"）
  * 注意：此操作需要 TENCENTCLOUD_SECRET_ID 具备 tcb:CreateEnv 权限
- * @param alias 环境别名，建议使用用户标识
+ * @param subject 用户稳定身份标识
  * @returns 新环境 ID
  */
-export async function createEnv(alias: string): Promise<string> {
+export async function createEnv(subject: string): Promise<string> {
   const client = getClient();
   const result = await client.CreateEnv({
-    EnvType: 'MINI',
-    Alias: `user-${alias}`,
+    Alias: getUserEnvAlias(subject),
+    PackageId: CLOUDBASE_USER_ENV_PACKAGE_ID,
+    Resources: CLOUDBASE_USER_ENV_RESOURCES,
+    Period: CLOUDBASE_USER_ENV_PERIOD,
+    AutoVoucher: CLOUDBASE_USER_ENV_AUTO_VOUCHER,
   });
+
+  if (!result.EnvId) {
+    throw new Error('CreateEnv did not return EnvId');
+  }
+
+  await waitForEnvReady(result.EnvId);
   return result.EnvId;
 }
 
@@ -54,22 +103,29 @@ export async function createApiKey(
   expireIn?: number,
 ): Promise<{ apiKeyId: string; apiKey: string }> {
   const client = getClient();
-  const params: Record<string, unknown> = {
+  const params = {
     EnvId: envId,
     KeyType: 'api_key',
+    ...(keyName ? { KeyName: keyName } : {}),
+    ...(expireIn ? { ExpireIn: expireIn } : {}),
   };
-  if (keyName) params.KeyName = keyName;
-  if (expireIn) params.ExpireIn = expireIn;
 
   const result = await client.CreateApiKey(params);
-  return { apiKeyId: result.KeyId!, apiKey: result.ApiKey! };
+  if (!result.KeyId || !result.ApiKey) {
+    throw new Error('CreateApiKey did not return KeyId or ApiKey');
+  }
+
+  return { apiKeyId: result.KeyId, apiKey: result.ApiKey };
 }
 
 /**
- * 通过别名查找已有环境
+ * 通过用户稳定身份标识查找已有环境
  */
-export async function findEnvByAlias(alias: string): Promise<string | null> {
+export async function findEnvByAlias(subject: string): Promise<string | null> {
   const envs = await listEnvs();
-  const match = envs.find(e => e.Alias === `user-${alias}`);
+  const match = envs.find(e => e.Alias === getUserEnvAlias(subject));
+  if (match?.EnvId && match.Status !== 'NORMAL') {
+    await waitForEnvReady(match.EnvId);
+  }
   return match?.EnvId || null;
 }

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
@@ -1,0 +1,61 @@
+import * as tencentcloud from 'tencentcloud-sdk-nodejs-tcb';
+import { TENCENTCLOUD_SECRET_ID, TENCENTCLOUD_SECRET_KEY, CLOUDBASE_REGION } from '../config';
+
+const TcbClient = tencentcloud.tcb.v20180608.Client;
+
+function getClient(): InstanceType<typeof TcbClient> {
+  return new TcbClient({
+    credential: {
+      secretId: TENCENTCLOUD_SECRET_ID,
+      secretKey: TENCENTCLOUD_SECRET_KEY,
+    },
+    region: CLOUDBASE_REGION,
+  });
+}
+
+/**
+ * 查询主账号下的所有环境列表
+ */
+export async function listEnvs(): Promise<Array<{ EnvId: string; Alias: string }>> {
+  const client = getClient();
+  const result = await client.DescribeEnvs({});
+  return result.EnvList || [];
+}
+
+/**
+ * 为用户创建一个新的 CloudBase 环境（1+N 中的"用户环境"）
+ * 注意：此操作需要 TENCENTCLOUD_SECRET_ID 具备 tcb:CreateEnv 权限
+ * @param alias 环境别名，建议使用用户标识
+ * @returns 新环境 ID
+ */
+export async function createEnv(alias: string): Promise<string> {
+  const client = getClient();
+  const result = await client.CreateEnv({
+    EnvType: 'MINI',
+    Alias: `user-${alias}`,
+  });
+  return result.EnvId;
+}
+
+/**
+ * 为指定环境创建一个 API Key
+ * @param envId 目标环境 ID
+ * @param desc API Key 描述
+ */
+export async function createApiKey(envId: string, desc: string): Promise<{ apiKeyId: string; apiKey: string }> {
+  const client = getClient();
+  const result = await client.CreateApiKey({
+    EnvId: envId,
+    Remark: desc,
+  });
+  return { apiKeyId: result.ApiKeyId!, apiKey: result.ApiKey! };
+}
+
+/**
+ * 通过别名查找已有环境
+ */
+export async function findEnvByAlias(alias: string): Promise<string | null> {
+  const envs = await listEnvs();
+  const match = envs.find(e => e.Alias === `user-${alias}`);
+  return match?.EnvId || null;
+}

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
@@ -70,20 +70,31 @@ async function waitForEnvReady(envId: string): Promise<void> {
  */
 export async function createEnv(subject: string): Promise<string> {
   const client = getClient();
-  const result = await client.CreateEnv({
-    Alias: getUserEnvAlias(subject),
+  const alias = getUserEnvAlias(subject);
+  const params = {
+    Alias: alias,
     PackageId: CLOUDBASE_USER_ENV_PACKAGE_ID,
     Resources: CLOUDBASE_USER_ENV_RESOURCES,
     Period: CLOUDBASE_USER_ENV_PERIOD,
     AutoVoucher: CLOUDBASE_USER_ENV_AUTO_VOUCHER,
-  });
+  };
+  await client.CreateEnv(params);
 
-  if (!result.EnvId) {
-    throw new Error('CreateEnv did not return EnvId');
+  // CreateEnv 是异步发货，通过轮询 DescribeEnvs 按 Alias 查找
+  const deadline = Date.now() + CLOUDBASE_USER_ENV_READY_TIMEOUT_MS; // 默认 120 秒
+  while (Date.now() < deadline) {
+    const result = await client.DescribeEnvs({});
+    const env = (result.EnvList || []).find(e => e.Alias === alias);
+    if (env?.EnvId) {
+      if (env.Status === 'NORMAL') return env.EnvId;
+      // 等待环境就绪（创建中状态）
+      await sleep(ENV_READY_POLL_INTERVAL_MS);
+      continue;
+    }
+    await sleep(ENV_READY_POLL_INTERVAL_MS);
   }
 
-  await waitForEnvReady(result.EnvId);
-  return result.EnvId;
+  throw new Error(`CreateEnv timed out waiting for env with alias: ${alias}`);
 }
 
 /**

--- a/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
+++ b/examples/cloudbase-auth-endpoint-with-feishu/src/utils/tcb.ts
@@ -38,17 +38,31 @@ export async function createEnv(alias: string): Promise<string> {
 }
 
 /**
- * 为指定环境创建一个 API Key
+ * 为指定环境创建 API Key（服务端管理员凭证）
+ * 该 key 以管理员身份签发，拥有该环境完整数据流权限（数据库/云函数/存储/托管等）
+ * 支持设置有效期，不设置则永不过期；单环境最多创建 5 个 api_key
+ *
+ * @see https://cloud.tencent.com/document/api/876/129835
+ *
  * @param envId 目标环境 ID
- * @param desc API Key 描述
+ * @param keyName 密钥名称（可选）
+ * @param expireIn 有效期（秒），不传则永不过期。最短 7200 秒
  */
-export async function createApiKey(envId: string, desc: string): Promise<{ apiKeyId: string; apiKey: string }> {
+export async function createApiKey(
+  envId: string,
+  keyName?: string,
+  expireIn?: number,
+): Promise<{ apiKeyId: string; apiKey: string }> {
   const client = getClient();
-  const result = await client.CreateApiKey({
+  const params: Record<string, unknown> = {
     EnvId: envId,
-    Remark: desc,
-  });
-  return { apiKeyId: result.ApiKeyId!, apiKey: result.ApiKey! };
+    KeyType: 'api_key',
+  };
+  if (keyName) params.KeyName = keyName;
+  if (expireIn) params.ExpireIn = expireIn;
+
+  const result = await client.CreateApiKey(params);
+  return { apiKeyId: result.KeyId!, apiKey: result.ApiKey! };
 }
 
 /**

--- a/examples/cloudbase-auth-endpoint-with-feishu/tsconfig.json
+++ b/examples/cloudbase-auth-endpoint-with-feishu/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "lib": ["ES2020"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "declaration": true
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## 概述

基于 `cloudbase-cli-auth-endpoint` 参考实现改造，接入 CloudBase 托管登录页 + 自定义 OAuth 2.0 身份源（飞书/企微/Google 等），实现企业自有品牌下的免腾讯云账号授权流程。

## 变更内容

### 新增文件

| 文件 | 说明 |
|------|------|
| `examples/cloudbase-auth-endpoint-with-feishu/` | 完整示例代码（13 个文件） |
| `docs/enterprise-auth-with-feishu.md` | 集成文档（含 Mermaid 架构图/时序图） |
| `docs/research-codex-plugin-enterprise-auth.md` | 前期调研报告 |

### 核心变化（相对于原始 `cloudbase-cli-auth-endpoint`）

1. **新增 `POST /auth/verify-cloudbase` 端点** — 接收 `user_code` + `cloudbase_uid`，首次登录自动创建环境并签发 API Key
2. **新增 `GET /auth/config` 端点** — 向前端提供 CloudBase SDK 初始化参数（envId, publishableKey）
3. **重写 `cli-auth.html`** — 集成 CloudBase Web SDK，使用 `auth.toDefaultLoginPage()` 跳转托管登录页
4. **新增 `cli-auth-callback.html`** — 处理 OAuth 回调，通过 `pollSession()` 轮询 `getSession()` 避免事件竞态
5. **扩展 `tcb.ts`** — 新增 `createEnv()` / `createApiKey()`（类型 `api_key`，7 天有效期，管理员权限）
6. **去掉特定厂商绑定** — 身份源由 CloudBase 托管登录页统一管理，控制台配一次即可

### 关键 API 参考

- `CreateApiKey`：https://cloud.tencent.com/document/api/876/129835
- `CreateEnv`：https://cloud.tencent.com/document/api/876/128592

### 1+N 架构

- **1 个管理中心环境**：部署授权服务 + CloudBase 托管登录页（配自定义 OAuth 2.0 身份源）
- **N 个用户环境**：认证成功后通过 `CreateEnv` 自动创建，环境隔离 + `CreateApiKey` 签发凭证

## 修复记录

- `CreateApiKey` 是有效 API（文档已查实），回退错误的 STS 替换方案
- `cli-auth-callback.html` 的 `onAuthStateChange` 事件竞态修复，改用 `pollSession()` 轮询 + 30s 超时
- `protocol.md` 的 Mermaid 时序图箭头方向修复（CloudBase 重定向到浏览器，非授权服务）
- 删除未使用的 `sts.ts` 和 `STS_TOKEN_DURATION` 配置

## 使用方式

1. CloudBase 控制台配置飞书/企业微信等自定义 OAuth 2.0 身份源
2. 部署授权服务到 CloudRun
3. Codex 配置 `TCB_AUTH_OAUTH_ENDPOINT` 指向授权服务地址
4. 用户通过 `tcb login` 完成设备码授权

## 文档

完整流程参见 `docs/enterprise-auth-with-feishu.md`（含 3 张 Mermaid 图）