### PR TITLE
fix(publish): normalize ClawHub changelog

### DIFF
--- a/scripts/publish-to-clawhub.mjs
+++ b/scripts/publish-to-clawhub.mjs
@@ -102,7 +102,7 @@ function getRecentCommitLines(gitRoot) {
   }
 }
 
-function buildChangelogText(manualChangelog, gitRoot) {
+export function buildChangelogText(manualChangelog, gitRoot) {
   const normalizedManual = (manualChangelog || "").trim();
   const recentCommits = getRecentCommitLines(gitRoot);
 
@@ -121,7 +121,15 @@ function buildChangelogText(manualChangelog, gitRoot) {
   return "";
 }
 
-function buildSyncCommand(target, options) {
+export function normalizeClawhubChangelog(changelog) {
+  return String(changelog || "")
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .join(" | ");
+}
+
+export function buildSyncCommand(target, options) {
   return {
     command: "clawhub",
     args: [
@@ -134,7 +142,7 @@ function buildSyncCommand(target, options) {
       "--bump",
       options.bump,
       "--changelog",
-      options.changelog,
+      normalizeClawhubChangelog(options.changelog),
       "--tags",
       options.tags,
     ],

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, test } from 'vitest';
+import {
+  buildSyncCommand,
+  normalizeClawhubChangelog,
+} from '../scripts/publish-to-clawhub.mjs';
+
+describe('publish-to-clawhub command construction', () => {
+  test('normalizes multiline changelog for clawhub CLI arguments', () => {
+    const changelog = [
+      'Recent commits / 最近提交:',
+      '- Merge pull request #757 from TencentCloudBase/feature/pg-skill-guidance-hardening',
+      '- fix(tests): 🧪 restore PR verification',
+      '',
+      '- chore(deps): 🔒 refresh pnpm lockfile',
+    ].join('\n');
+
+    const normalized = normalizeClawhubChangelog(changelog);
+
+    expect(normalized).toBe(
+      'Recent commits / 最近提交: | - Merge pull request #757 from TencentCloudBase/feature/pg-skill-guidance-hardening | - fix(tests): 🧪 restore PR verification | - chore(deps): 🔒 refresh pnpm lockfile',
+    );
+    expect(normalized).not.toMatch(/[\r\n]/);
+  });
+
+  test('passes a single-line changelog to clawhub sync', () => {
+    const command = buildSyncCommand(
+      { artifactRootDir: '/tmp/artifact', targetKey: 'all-in-one' },
+      {
+        bump: 'minor',
+        tags: 'latest',
+        changelog: 'Recent commits / 最近提交:\n- first\n- second',
+      },
+    );
+
+    const changelogIndex = command.args.indexOf('--changelog') + 1;
+
+    expect(command.command).toBe('clawhub');
+    expect(command.args).toContain('--all');
+    expect(command.args[changelogIndex]).toBe('Recent commits / 最近提交: | - first | - second');
+    expect(command.args[changelogIndex]).not.toMatch(/[\r\n]/);
+  });
+});


### PR DESCRIPTION
## Summary
- Normalize multiline ClawHub changelog text into a single-line CLI argument
- Export command construction helpers for focused coverage
- Add tests for ClawHub changelog handling

## Verification
- pnpm -C worktrees/fix-clawhub-changelog exec vitest run tests/publish-to-clawhub.test.js tests/publish-to-skillhub.test.js
- npm run build (via pre-commit hook)