### PR TITLE
fix(publish): use supported ClawHub publish command

### DIFF
--- a/scripts/publish-to-clawhub.mjs
+++ b/scripts/publish-to-clawhub.mjs
@@ -129,18 +129,15 @@ export function normalizeClawhubChangelog(changelog) {
     .join(" | ");
 }
 
-export function buildSyncCommand(target, options) {
+export function buildPublishCommand(target, options) {
   return {
     command: "clawhub",
     args: [
-      "sync",
-      "--workdir",
-      target.artifactRootDir,
-      "--dir",
-      "skills",
-      "--all",
-      "--bump",
-      options.bump,
+      "skill",
+      "publish",
+      target.artifactDir,
+      "--slug",
+      target.registrySlug,
       "--changelog",
       normalizeClawhubChangelog(options.changelog),
       "--tags",
@@ -167,7 +164,7 @@ export function publishToClawhub({
   }
 
   for (const target of manifest.targets || []) {
-    const publishCommand = buildSyncCommand(target, {
+    const publishCommand = buildPublishCommand(target, {
       changelog: resolvedChangelog,
       tags,
       bump,

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import {
-  buildSyncCommand,
+  buildPublishCommand,
   normalizeClawhubChangelog,
 } from '../scripts/publish-to-clawhub.mjs';
 
@@ -22,9 +22,13 @@ describe('publish-to-clawhub command construction', () => {
     expect(normalized).not.toMatch(/[\r\n]/);
   });
 
-  test('passes a single-line changelog to clawhub sync', () => {
-    const command = buildSyncCommand(
-      { artifactRootDir: '/tmp/artifact', targetKey: 'all-in-one' },
+  test('publishes a single skill folder with a single-line changelog', () => {
+    const command = buildPublishCommand(
+      {
+        artifactDir: '/tmp/artifact/skills/cloudbase',
+        registrySlug: 'cloudbase',
+        targetKey: 'all-in-one',
+      },
       {
         bump: 'minor',
         tags: 'latest',
@@ -35,7 +39,11 @@ describe('publish-to-clawhub command construction', () => {
     const changelogIndex = command.args.indexOf('--changelog') + 1;
 
     expect(command.command).toBe('clawhub');
-    expect(command.args).toContain('--all');
+    expect(command.args.slice(0, 3)).toEqual(['skill', 'publish', '/tmp/artifact/skills/cloudbase']);
+    expect(command.args).toContain('--slug');
+    expect(command.args[command.args.indexOf('--slug') + 1]).toBe('cloudbase');
+    expect(command.args).not.toContain('sync');
+    expect(command.args).not.toContain('--all');
     expect(command.args[changelogIndex]).toBe('Recent commits / 最近提交: | - first | - second');
     expect(command.args[changelogIndex]).not.toMatch(/[\r\n]/);
   });


### PR DESCRIPTION
## Summary
- Replace removed `clawhub sync` invocation with `clawhub skill publish <artifactDir>`
- Keep ClawHub changelog normalized to one CLI argument
- Update focused tests to reject `sync`/`--all` command construction

## Verification
- pnpm -C worktrees/fix-clawhub-changelog exec vitest run tests/publish-to-clawhub.test.js tests/publish-to-skillhub.test.js