### PR TITLE
fix(mcp): 🐛 add postgresql to manageEnv resources enum and update docs

### DIFF
--- a/config/source/guideline/cloudbase/references/mcp-setup.md
+++ b/config/source/guideline/cloudbase/references/mcp-setup.md
@@ -85,3 +85,51 @@ When your IDE does not support native MCP, use **mcporter** as the CLI.
   `npx mcporter call cloudbase.manageAppAuth action=patchLoginStrategy patch='{"usernamePassword":true}' --output json`
 - Query publishable key:
   `npx mcporter call cloudbase.queryAppAuth action=getPublishableKey --output json`
+
+---
+
+## Environment Management Tools (manageEnv + auth + envQuery)
+
+Beyond authentication, CloudBase MCP provides several environment management tools.
+
+### manageEnv — Full environment lifecycle
+
+Query available plans, create environments, change plans, and renew:
+
+- **List available packages**:
+  `npx mcporter call cloudbase.manageEnv action=listPackages --output json`
+
+- **Create a new environment**:
+  ```
+  npx mcporter call cloudbase.manageEnv action=create alias=my-env packageId=baas_personal resources='["flexdb","storage","function","postgresql"]' duration=1 confirm=yes --output json
+  ```
+
+  Resources parameter values: `flexdb` (document database), `storage` (cloud storage), `function` (cloud functions), `postgresql` (PostgreSQL database).
+
+- **Change plan** (e.g. upgrade to standard):
+  `npx mcporter call cloudbase.manageEnv action=modifyPlan envId=<envId> packageId=baas_pf_standard confirm=yes --output json`
+
+- **Renew environment**:
+  `npx mcporter call cloudbase.manageEnv action=renew envId=<envId> duration=12 confirm=yes --output json`
+
+### Auth — Environment binding & logout
+
+- **Check status** (shows env candidates when multiple environments exist):
+  `npx mcporter call cloudbase.auth action=status --output json`
+
+- **Bind to a specific environment** (after login):
+  `npx mcporter call cloudbase.auth action=set_env envId=<full-env-id> --output json`
+
+- **Logout** (clears login state and cached env binding):
+  `npx mcporter call cloudbase.auth action=logout confirm=yes --output json`
+
+### envQuery — Query environment details
+
+- **List all environments**:
+  `npx mcporter call cloudbase.envQuery action=list --output json`
+
+- **Get environment info** (runtime backends, storage, status):
+  `npx mcporter call cloudbase.envQuery action=info envId=<envId> --output json`
+
+- **Resolve alias to EnvId**:
+  `npx mcporter call cloudbase.envQuery action=list alias=demo aliasExact=true fields='["EnvId","Alias","Status","IsDefault"]' --output json`

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -179,6 +179,45 @@ Example structure for operation recording:
      - Do **not** use dynamic imports like `import("@cloudbase/js-sdk")` or async wrappers such as `initCloudBase()` with internal `initPromise`
    - Then proceed with login using a verified method (username/password, phone, email, or WeChat)
 
+2. **Environment Management (via manageEnv)**:
+   The `manageEnv` tool provides full lifecycle management for CloudBase environments.
+
+   | Action | Description | Key Parameters |
+   |--------|-------------|----------------|
+   | `listPackages` | Query available plans | (none) |
+   | `create` | Create new environment (needs confirm) | `alias`, `packageId`, `resources`, `region`, `duration` |
+   | `modifyPlan` | Change plan (upgrade/downgrade, needs confirm) | `envId`, `packageId` |
+   | `renew` | Renew environment (needs confirm) | `envId`, `duration` |
+
+   **Creating an environment with specific resources:**
+   ```
+   manageEnv(action="create", alias="my-env", packageId="baas_personal",
+             resources=["flexdb","storage","function","postgresql"], confirm="yes")
+   ```
+
+   - **`resources`** (optional, create only): controls which CloudBase capabilities to enable:
+     - `flexdb` — Document database (NoSQL)
+     - `storage` — Cloud Storage
+     - `function` — Cloud Functions
+     - `postgresql` — PostgreSQL relational database (PG mode)
+   - Defaults to all enabled if omitted.
+   - ⚠️ **All paid operations** (create / modifyPlan / renew) require `confirm="yes"`.
+
+   **Querying available packages before creating:**
+   ```
+   manageEnv(action="listPackages")
+   ```
+
+   **Changing plan (e.g. personal → standard):**
+   ```
+   manageEnv(action="modifyPlan", envId="your-env-id", packageId="baas_pf_standard", confirm="yes")
+   ```
+
+   **Renewing an environment:**
+   ```
+   manageEnv(action="renew", envId="your-env-id", duration=1, confirm="yes")
+   ```
+
 ## Authentication Best Practices
 
 **Important: Authentication methods for different platforms are completely different, must strictly distinguish!**

--- a/config/source/skills/postgresql-development/SKILL.md
+++ b/config/source/skills/postgresql-development/SKILL.md
@@ -66,6 +66,15 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
    - If both `postgresql` and `nosql` are `true` (the common case in a PG environment), they coexist. Apply this skill to NEW business data the task asks you to put in PG (e.g. articles / role tables explicitly described as PG). Existing NoSQL collections, the bucket reported in `EnvInfo.Storages[]`, and any `managePermissions(resourceType="noSqlDatabase")` rules continue to govern the legacy NoSQL data — do NOT migrate or rewrite them unless the task explicitly asks.
    - `RuntimeBackends.mysql === false` is the only hard "do not use" signal: when MySQL is absent, do not use `manageSqlDatabase` / `querySqlDatabase` and do not consult the `relational-database-tool` skill; those are MySQL-specific and have nothing to do with CloudBase PG.
    - Note: in a PG env, `EnvInfo.Storages[]` is the legacy NoSQL bucket. It still works for legacy `app.uploadFile()` flows but is NOT a usable pgstore bucket — never reuse it as the `<bucket>` segment in `app.storage.from('<bucket>').upload('<key>', file)`.
+
+> **Creating a PG-mode environment**
+>
+> If step 0 shows `RuntimeBackends.postgresql === false` and you need PostgreSQL, create a new environment with PG enabled:
+>
+> - **Via MCP**: `manageEnv(action="create", alias="my-env", packageId="baas_personal", resources=["flexdb","storage","function","postgresql"], confirm="yes")`
+> - **Via CLI**: `tcb env create --alias my-env --package baas_personal --postgresql --yes`
+> - **Via Console**: [Create environment](https://console.cloud.tencent.com/tcb/env/create)
+
 1. Inspect the existing app surfaces first: `src/lib/backend.*`, `src/lib/auth.*`, `src/lib/*service.*`, route guards, and the handlers bound to existing forms.
 2. Check PG state through MCP: use `queryPgDatabase` for schema/read-only inspection and `managePgDatabase` for DDL/DML. Do not switch to MySQL tools. For the complete route map, read `references/index.md`.
 3. **Understand PG roles before writing code:** Publishable Key maps to `anon`; a logged-in user's access token maps to `authenticated`; API Key maps to `service_role` and bypasses RLS. Never expose API Key / `service_role` credentials in frontend code. See `references/auth-and-rls.md`.

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -345,7 +345,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "resources",
       type: "array of string",
-      description: `启用的资源类型（action=create 时可选）。默认启用全部三项：flexdb(文档数据库)、storage(存储)、function(云函数)`,
+      description: `启用的资源类型（action=create 时可选）。默认启用全部四项：flexdb(文档数据库)、storage(存储)、function(云函数)、postgresql(PostgreSQL 数据库)`,
     },
     {
       name: "duration",

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1323,7 +1323,7 @@ describe("manageEnv", () => {
           alias: "my-env",
           packageId: "baas_personal",
           region: "ap-shanghai",
-          resources: ["flexdb", "storage", "function"],
+          resources: ["flexdb", "storage", "function", "postgresql"],
           duration: 1,
           confirm: "yes",
         })
@@ -1335,7 +1335,7 @@ describe("manageEnv", () => {
       PackageId: "baas_personal",
       Region: "ap-shanghai",
       Period: 1,
-      Resources: ["flexdb", "storage", "function"],
+      Resources: ["flexdb", "storage", "function", "postgresql"],
     });
     expect(payload).toMatchObject({
       ok: true,

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -1890,9 +1890,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
           .optional()
           .describe("环境地域（action=create 时可选）。默认 ap-shanghai，可选 ap-guangzhou、ap-beijing 等"),
         resources: z
-          .array(z.enum(["flexdb", "storage", "function"]))
+          .array(z.enum(["flexdb", "storage", "function", "postgresql"]))
           .optional()
-          .describe("启用的资源类型（action=create 时可选）。默认启用全部三项：flexdb(文档数据库)、storage(存储)、function(云函数)"),
+          .describe("启用的资源类型（action=create 时可选）。默认启用全部四项：flexdb(文档数据库)、storage(存储)、function(云函数)、postgresql(PostgreSQL 数据库)"),
         duration: z
           .number()
           .int()
@@ -1958,7 +1958,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               return buildJsonToolResult({
                 ok: false,
                 code: "CONFIRM_REQUIRED",
-                message: `创建环境需要您确认。请确认以下配置信息后传入 confirm="yes"：\n别名: ${alias}\n套餐: ${packageId}\n地域: ${region}\n资源类型: ${resources?.join(", ") ?? "flexdb, storage, function"}\n时长: ${duration} 个月`,
+                message: `创建环境需要您确认。请确认以下配置信息后传入 confirm="yes"：\n别名: ${alias}\n套餐: ${packageId}\n地域: ${region}\n资源类型: ${resources?.join(", ") ?? "flexdb, storage, function, postgresql"}\n时长: ${duration} 个月`,
                 next_step: {
                   tool: "manageEnv",
                   action: "create",


### PR DESCRIPTION
## Summary

Fix manageEnv resources enum missing postgresql and complement skill documentation gaps.

## Changes

### P0 — MCP tool fix
- Add `"postgresql"` to `manageEnv` `resources` z.enum so AI can create PG environments via MCP
- Update test case to include `"postgresql"` in resources test
- Sync doc/mcp-tools.md description

### P1 — Skill documentation
- **postgresql-development/SKILL.md**: Add `Creating a PG-mode environment` section with MCP/CLI/Console approaches
- **cloudbase-platform/SKILL.md**: Add complete manageEnv examples with resources enum documentation
- **mcp-setup.md**: Expand with manageEnv/auth/envQuery environment management tools