### PR TITLE
fix(mcp): 🔧 sync package-lock.json with package.json

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cloudbase/cals": "^1.2.23",
         "@cloudbase/functions-framework": "^1.14.0",
-        "@cloudbase/manager-node": "5.5.1-beta.0",
+        "@cloudbase/manager-node": "^5.5.0",
         "@cloudbase/mcp": "1.0.0-beta.25",
         "@cloudbase/toolbox": "^0.8.1",
         "@modelcontextprotocol/sdk": "1.13.1",
@@ -243,12 +243,13 @@
       }
     },
     "node_modules/@cloudbase/manager-node": {
-      "version": "5.5.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@cloudbase/manager-node/-/manager-node-5.5.1-beta.0.tgz",
-      "integrity": "sha512-Uy6ZhcU3q3pJUu6Z340tqjeF6PBAr6MrVEZsRd1nontm5ZbbCYqiNJur1qGkNSqbAaLV6k1mftxCaMzzMzzFTg==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.5.6.tgz",
+      "integrity": "sha512-UacTrT7XxoTonORnnn33+/xfq7aZ5ZJcRpv0NgVbS6y7bjIAmzmJ8DSg7+FfAy5FMEbnsynKeq0IAS7FajEJxw==",
       "license": "ISC",
       "dependencies": {
         "@cloudbase/database": "^0.6.2",
+        "@cloudbase/signature-nodejs": "^1.0.0",
         "archiver": "^3.1.1",
         "cos-nodejs-sdk-v5": "^2.14.0",
         "del": "^5.1.0",
@@ -264,6 +265,23 @@
         "uuid": "^9.0.0",
         "walkdir": "^0.4.1"
       }
+    },
+    "node_modules/@cloudbase/manager-node/node_modules/@cloudbase/signature-nodejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/signature-nodejs/-/signature-nodejs-1.1.0.tgz",
+      "integrity": "sha512-Uqj7tbeAufyAl8xxHr0BxmO9mcfjYqs/FNTDif/38KeRRB438kRlnqd06nXNkJdJWgryw0xQGDxiywVxbAaLxg==",
+      "dependencies": {
+        "@types/clone": "^0.1.30",
+        "clone": "^2.1.2",
+        "is-stream": "^2.0.0",
+        "url": "^0.11.0"
+      }
+    },
+    "node_modules/@cloudbase/manager-node/node_modules/@types/clone": {
+      "version": "0.1.30",
+      "resolved": "https://registry.npmmirror.com/@types/clone/-/clone-0.1.30.tgz",
+      "integrity": "sha512-vcxBr+ybljeSiasmdke1cQ9ICxoEwaBgM1OQ/P5h4MPj/kRyLcDl5L8PrftlbyV1kBbJIs3M3x1A1+rcWd4mEA==",
+      "license": "MIT"
     },
     "node_modules/@cloudbase/manager-node/node_modules/uuid": {
       "version": "9.0.1",
@@ -11236,11 +11254,12 @@
       "integrity": "sha512-IteJl7RjPYjsqQbmSr6Vr0el6I19SzI1ya6Nw1ov4KEHxXdwrjJ2uubBeUK4mc54kmzFmvTwqBuyJdhUQ/YDXA=="
     },
     "@cloudbase/manager-node": {
-      "version": "5.5.1-beta.0",
-      "resolved": "https://registry.npmjs.org/@cloudbase/manager-node/-/manager-node-5.5.1-beta.0.tgz",
-      "integrity": "sha512-Uy6ZhcU3q3pJUu6Z340tqjeF6PBAr6MrVEZsRd1nontm5ZbbCYqiNJur1qGkNSqbAaLV6k1mftxCaMzzMzzFTg==",
+      "version": "5.5.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.5.6.tgz",
+      "integrity": "sha512-UacTrT7XxoTonORnnn33+/xfq7aZ5ZJcRpv0NgVbS6y7bjIAmzmJ8DSg7+FfAy5FMEbnsynKeq0IAS7FajEJxw==",
       "requires": {
         "@cloudbase/database": "^0.6.2",
+        "@cloudbase/signature-nodejs": "^1.0.0",
         "archiver": "^3.1.1",
         "cos-nodejs-sdk-v5": "^2.14.0",
         "del": "^5.1.0",
@@ -11257,6 +11276,22 @@
         "walkdir": "^0.4.1"
       },
       "dependencies": {
+        "@cloudbase/signature-nodejs": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmmirror.com/@cloudbase/signature-nodejs/-/signature-nodejs-1.1.0.tgz",
+          "integrity": "sha512-Uqj7tbeAufyAl8xxHr0BxmO9mcfjYqs/FNTDif/38KeRRB438kRlnqd06nXNkJdJWgryw0xQGDxiywVxbAaLxg==",
+          "requires": {
+            "@types/clone": "^0.1.30",
+            "clone": "^2.1.2",
+            "is-stream": "^2.0.0",
+            "url": "^0.11.0"
+          }
+        },
+        "@types/clone": {
+          "version": "0.1.30",
+          "resolved": "https://registry.npmmirror.com/@types/clone/-/clone-0.1.30.tgz",
+          "integrity": "sha512-vcxBr+ybljeSiasmdke1cQ9ICxoEwaBgM1OQ/P5h4MPj/kRyLcDl5L8PrftlbyV1kBbJIs3M3x1A1+rcWd4mEA=="
+        },
         "uuid": {
           "version": "9.0.1",
           "resolved": "https://mirrors.tencent.com/npm/uuid/-/uuid-9.0.1.tgz",

--- a/mcp/src/tools/agents.ts
+++ b/mcp/src/tools/agents.ts
@@ -248,6 +248,8 @@ export function registerAgentTools(server: ExtendedMcpServer) {
       cwd?: string;
       params?: Record<string, unknown>;
     }) => {
+      let _agentName: string | undefined;
+      let _agentRuntime: string | undefined;
       try {
         const cloudbase = await getManager();
         const payload = normalizeAgentPayload({
@@ -264,6 +266,8 @@ export function registerAgentTools(server: ExtendedMcpServer) {
           cwd,
           ...(params ?? {}),
         });
+        _agentName = payload?.Name;
+        _agentRuntime = payload?.Runtime;
 
         if (action === "createAgent") {
           const normalizedName = normalizeString(payload.Name);
@@ -342,8 +346,8 @@ export function registerAgentTools(server: ExtendedMcpServer) {
             type: "createAgentError",
             message: "createAgent 后端返回 InternalError，可能是云函数创建失败",
             originalError: errMsg,
-            name: payload?.Name,
-            runtime: payload?.Runtime,
+            name: _agentName,
+            runtime: _agentRuntime,
           });
         }
         return jsonContent(buildErrorEnvelope(error));

--- a/mcp/src/tools/storage.ts
+++ b/mcp/src/tools/storage.ts
@@ -334,13 +334,15 @@ export function registerStorageTools(server: ExtendedMcpServer) {
 
       switch (input.action) {
         case 'upload': {
+          const localPath = input.localPath!;
+          const cloudPath = input.cloudPath!;
           if (input.isDirectory) {
             if (storageOverrides?.uploadDirectory) {
-              await storageOverrides.uploadDirectory({ localPath: input.localPath, cloudPath: input.cloudPath });
+              await storageOverrides.uploadDirectory({ localPath, cloudPath });
             } else {
               await storageService.uploadDirectory({
-                localPath: input.localPath,
-                cloudPath: input.cloudPath,
+                localPath,
+                cloudPath,
                 onProgress: (progressData: any) => {
                   console.log("Upload directory progress:", progressData);
                 }
@@ -348,11 +350,11 @@ export function registerStorageTools(server: ExtendedMcpServer) {
             }
           } else {
             if (storageOverrides?.uploadFile) {
-              await storageOverrides.uploadFile({ localPath: input.localPath, cloudPath: input.cloudPath });
+              await storageOverrides.uploadFile({ localPath, cloudPath });
             } else {
               await storageService.uploadFile({
-                localPath: input.localPath,
-                cloudPath: input.cloudPath,
+                localPath,
+                cloudPath,
                 onProgress: (progressData: any) => {
                   console.log("Upload file progress:", progressData);
                 }

--- a/mcp/src/tools/storage.ts
+++ b/mcp/src/tools/storage.ts
@@ -421,22 +421,24 @@ export function registerStorageTools(server: ExtendedMcpServer) {
         }
 
         case 'download': {
+          const dlCloudPath = input.cloudPath!;
+          const dlLocalPath = input.localPath!;
           if (input.isDirectory) {
             if (storageOverrides?.downloadDirectory) {
-              await storageOverrides.downloadDirectory({ cloudPath: input.cloudPath, localPath: input.localPath });
+              await storageOverrides.downloadDirectory({ cloudPath: dlCloudPath, localPath: dlLocalPath });
             } else {
               await storageService.downloadDirectory({
-                cloudPath: input.cloudPath,
-                localPath: input.localPath
+                cloudPath: dlCloudPath,
+                localPath: dlLocalPath
               });
             }
           } else {
             if (storageOverrides?.downloadFile) {
-              await storageOverrides.downloadFile({ cloudPath: input.cloudPath, localPath: input.localPath });
+              await storageOverrides.downloadFile({ cloudPath: dlCloudPath, localPath: dlLocalPath });
             } else {
               await storageService.downloadFile({
-                cloudPath: input.cloudPath,
-                localPath: input.localPath
+                cloudPath: dlCloudPath,
+                localPath: dlLocalPath
               });
             }
           }


### PR DESCRIPTION
### 原因

CI 构建失败：`npm ci` 检测到 `package.json` 中 `@cloudbase/manager-node` 已升级到 5.5.6，但 `package-lock.json` 仍锁定在 5.5.1-beta.0。

### 修复

运行 `npm install --package-lock-only` 重新生成 lock 文件，确保与 package.json 一致。