### PR TITLE
feat(doc): 📺 add BV1kXEJ6VEn2 video tutorial + fix add_video_tutorial skill

### DIFF
--- a/doc/components/TutorialsGrid.tsx
+++ b/doc/components/TutorialsGrid.tsx
@@ -389,6 +389,19 @@ const tutorials: Tutorial[] = [
   },
   // 视频
   {
+    id: 'video-ai-miniprogram-tutorial',
+    title: '如何用AI制作高质量小程序｜保姆级教程',
+    description: '是Skye学姐呀',
+    category: '视频教程',
+    url: 'https://www.bilibili.com/video/BV1ADJ56PEUH/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
+    type: 'video',
+    thumbnail: 'https://7463-tcb-advanced-a656fc-1257967285.tcb.qcloud.la/video-thumbnails/BV1ADJ56PEUH.jpg',
+    terminalTags: ['小程序'],
+    appTypeTags: ['教育/学习'],
+    devToolTags: ['CodeBuddy'],
+    techStackTags: ['CloudBase'],
+  },
+  {
     id: 'video-loop-miniprogram-membership',
     title: 'Loop 目标编程 实现商用小程序：Codex 从 0 到 1 开发会员小程序，接入微信支付，完整前后端。',
     description: 'MakerJackie',

--- a/doc/components/TutorialsGrid.tsx
+++ b/doc/components/TutorialsGrid.tsx
@@ -389,6 +389,19 @@ const tutorials: Tutorial[] = [
   },
   // 视频
   {
+    id: 'video-loop-miniprogram-membership',
+    title: 'Loop 目标编程 实现商用小程序：Codex 从 0 到 1 开发会员小程序，接入微信支付，完整前后端。',
+    description: 'MakerJackie',
+    category: '视频教程',
+    url: 'https://www.bilibili.com/video/BV1kXEJ6VEn2/?share_source=copy_web&vd_source=068decbd00a3d00ff8662b6a358e5e1e',
+    type: 'video',
+    thumbnail: 'https://7463-tcb-advanced-a656fc-1257967285.tcb.qcloud.la/video-thumbnails/BV1kXEJ6VEn2.jpg',
+    terminalTags: ['小程序'],
+    appTypeTags: ['电商/业务系统'],
+    devToolTags: ['Codex'],
+    techStackTags: ['微信支付', '云函数'],
+  },
+  {
     id: 'video-figma-codebuddy-miniprogram',
     title: 'Figma + CodeBuddy + CloudBase 实战：完整开发一个微信小程序',
     description: 'JavaPub',

--- a/skills/docs-workflows/references/add_video_tutorial.md
+++ b/skills/docs-workflows/references/add_video_tutorial.md
@@ -49,7 +49,9 @@ When user inputs `/add_video_tutorial` or provides a Bilibili video URL with req
   - **Tool**: `mcp_cloudbase_manageStorage` with `action=upload`
   - **Local Path**: `/tmp/bilibili-thumbnails/{BV号}.jpg`
 - Get permanent access URL from upload response
-  - Format: `https://{env-id}-{app-id}.tcb.qcloud.la/video-thumbnails/{BV号}.jpg`
+  - Format: `https://{appId}-{envId}-{uin}.tcb.qcloud.la/video-thumbnails/{BV号}.jpg`
+  - Example: `https://7463-tcb-advanced-a656fc-1257967285.tcb.qcloud.la/video-thumbnails/BV1bRBkBFE7x.jpg`
+  - `appId` and the numeric `uin` suffix are visible in the env's `CdnDomain` returned by `envQuery`
 
 ### 4. Determine Tags
 - **Terminal Tags** (终端/平台):
@@ -62,7 +64,8 @@ When user inputs `/add_video_tutorial` or provides a Bilibili video URL with req
   - Determine from video title/content or ask user
 
 - **Dev Tool Tags** (开发工具):
-  - Common values: `['CodeBuddy']`, `['Cursor']`, `['Claude Code']`, `['Figma']`
+  - Known values: `['CodeBuddy']`, `['Cursor']`, `['Claude Code']`, `['Figma']`, `['Codex']`, `['OpenClaw']`
+  - The list is open — when the video uses a tool not in this list, add it (and update the skill doc) rather than force-fitting a wrong tag
   - **Important**: Do NOT include "CloudBase AI Toolkit" or "MCP" - CloudBase MCP is the default backend service for all tutorials and doesn't need to be explicitly tagged
   - Determine from video title/content or ask user
 
@@ -140,9 +143,10 @@ https://www.bilibili.com/video/BV1bRBkBFE7x/?share_source=copy_web&vd_source=068
    - **Never include "CloudBase AI Toolkit" or "MCP" in devToolTags** - CloudBase MCP is the default backend service used by all tutorials
    - **Never include "CloudBase AI Toolkit" or "MCP" in techStackTags** - CloudBase MCP is the default backend service and doesn't need to be explicitly tagged
 
-3. **Thumbnail URL Format**: 
+3. **Thumbnail URL Format**:
    - Use permanent cloud storage URL, not temporary URL
-   - Format: `https://{env-id}-{app-id}.tcb.qcloud.la/video-thumbnails/{BV号}.jpg`
+   - Format: `https://{appId}-{envId}-{uin}.tcb.qcloud.la/video-thumbnails/{BV号}.jpg`
+   - `appId` and the numeric `uin` suffix are visible in the env's `CdnDomain` returned by `envQuery` (e.g. `7463-tcb-advanced-a656fc-1257967285.tcb.qcloud.la` → AppId `7463`, envId `tcb-advanced-a656fc`, uin `1257967285`)
 
 4. **ID Generation**: 
    - Use kebab-case format


### PR DESCRIPTION
## 概述

两件事：

1. **新增视频教程条目** (`doc/components/TutorialsGrid.tsx`)
   - BV1kXEJ6VEn2 — Loop 目标编程 实现商用小程序：Codex 从 0 到 1 开发会员小程序，接入微信支付，完整前后端（UP: MakerJackie，2026-06-06）
   - 封面已上传到 `tcb-advanced-a656fc` 环境的 `video-thumbnails/BV1kXEJ6VEn2.jpg`，publicUrl 已用 `curl` 裸跑 HTTP 200 验证
   - 插入到视频段顶部（按发布日期倒序）

2. **修复 skill 文档** (`skills/docs-workflows/references/add_video_tutorial.md`)
   - 缩略图 URL 格式从 `{env-id}-{app-id}` 改为 `{appId}-{envId}-{uin}`，跟 `DescribeEnvs` 真实返回的 CdnDomain 对齐
   - `Important Notes` 段同步修正
   - `devToolTags` 可选值从封闭列表（CodeBuddy/Cursor/Claude Code/Figma）改为开放列表 + 注明"用新值要顺手更新 skill"——`TutorialsGrid.tsx` 里实际已出现 OpenClaw 等未列出的值

## 拆分

两个 commit，按"先修流程再加数据"顺序：

- `docs(skills): 📝 fix add_video_tutorial URL format and devToolTags list`
- `feat(doc): 📺 add BV1kXEJ6VEn2 video tutorial ...`

## 验证

- [x] 本地 `git status` 干净（除这两个 commit 的变更）
- [x] 缩略图 publicUrl 匿名可访问（HTTP 200, 183KB，与本地 183473 字节匹配）
- [x] CdnDomain 与 TutorialsGrid.tsx 历史 30+ 条视频前缀完全一致
- [x] CloudBase 当前登录账号对 `tcb-advanced-a656fc` 有写权限
- [x] 不打 `CloudBase AI Toolkit` / `MCP` 标（默认后端，按 skill 规则）

## 注意事项

`add_video_tutorial` skill 流程在执行中暴露了几个真实产品/文档缺陷（不只是 BV1kXEJ6VEn2 的事）：

- 文档里 URL 格式和实际 bucket 不符 —— 之前没暴露是因为没人按 skill 跑过完整流程
- `devToolTags` 列表维护滞后 —— 实际代码里已经用 `OpenClaw` 等文档没列的值
- skill 没显式要求跑前先核 `auth status` 当前账号对目标 env 的权限 —— 这次差点因为换账号卡住

后续要不要单独开 issue / PR 把"跑前必做校验"也补进 skill？