### PR TITLE
feat(skills): update auth skills to match Web SDK v3 API

### DIFF
--- a/config/source/skills/ai-model-web/SKILL.md
+++ b/config/source/skills/ai-model-web/SKILL.md
@@ -239,7 +239,7 @@ const app = cloudbase.init({
   accessKey: "<YOUR_PUBLISHABLE_KEY>"  // Get it from the CloudBase console
 });
 
-const auth = app.auth();
+const auth = app.auth;
 
 // CRITICAL: Use auth.getSession() to check login — NOT the deprecated getLoginState().
 // getLoginState() returns uid even without real login (just accessKey), causing false positives.

--- a/config/source/skills/auth-nodejs/SKILL.md
+++ b/config/source/skills/auth-nodejs/SKILL.md
@@ -121,7 +121,7 @@ When you load this skill to work on a task:
 
 ## Node auth architecture – how Node fits into CloudBase Auth
 
-CloudBase Auth v2 separates **where users log in** from **where backend code runs**:
+CloudBase Auth separates **where users log in** from **where backend code runs**:
 
 - Users log in through the supported auth methods (username/password, SMS, email, WeChat, custom login, anonymous — disabled by default, etc.) using client SDKs or HTTP interfaces, as described in the official CloudBase Auth overview documentation.
 - Once logged in, CloudBase attaches the user identity and tokens to the environment.

--- a/config/source/skills/auth-web/SKILL.md
+++ b/config/source/skills/auth-web/SKILL.md
@@ -49,7 +49,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
 - **Writing `auth.signInWithPassword(...)` or `auth.signUp(...)` code without first confirming the provider is enabled via MCP.** Before writing any sign-in or sign-up code in the browser, call `queryAppAuth(action="listProviders")` to verify the target provider (e.g. `email`, `phone`, `usernamePassword`) has `On: "TRUE"`. For email-based sign-up (`auth.signUp({ email, password })`), additionally confirm SMTP is configured — otherwise the provider may throw `"provider email not found"` or similar errors. For username/password login, use `auth.signInWithPassword({ username, password })`; registration is best done through the management API (`manageAppAuth(action="createUser")`) or by confirming email provider readiness first.
 - **Treating `auth.getUser()` or deprecated `auth.getLoginState()` as proof of real login.** When the SDK is initialized with `accessKey`, the deprecated `getLoginState()` returns an object with a valid `uid` even without any login — causing route guards that check `!!loginState` or `!!uid` to incorrectly pass. The fix is to use `auth.getSession()` instead: it returns `data.session === undefined` when no real login has occurred. Only `!!data.session` from `getSession()` is a reliable authentication check.
-- **Copying old CloudBase auth snippets from training data.** Do not use `auth.getLoginState()`, `auth.hasLoginState()`, `auth.getCurrentUser()`, or `auth.toDefaultLoginPage()` as the default Web flow. Use the Supabase-like Web SDK v2 auth methods in this file and provider readiness from `auth-tool`.
+- **Copying old CloudBase auth snippets from training data.** Do not use `auth.getLoginState()`, `auth.hasLoginState()`, `auth.getCurrentUser()`, or `auth.toDefaultLoginPage()` as the default Web flow. Use the Web SDK v3 auth methods in this file and provider readiness from `auth-tool`.
   
   Note: anonymous login is now **disabled by default** for new environments and inactive existing environments. Always use `auth.getSession()` for auth guards.
 
@@ -62,10 +62,10 @@ Keep local `references/...` paths for files that ship with the current skill dir
 
 ## Core Capabilities
 
-**Use Case**: Web frontend projects using `@cloudbase/js-sdk@2.24.0+` for user authentication  
+**Use Case**: Web frontend projects using `@cloudbase/js-sdk@latest` for user authentication  
 **Key Benefits**: **Supabase-compatible Auth API** — all methods return `{ data, error }`, supports phone, email, anonymous (disabled by default), username/password, OAuth, and third-party login methods
 
-> 📌 **Supabase API Compatibility**: CloudBase Web SDK v2 auth module is designed with Supabase-like API ergonomics. If you are familiar with `supabase-js` auth patterns, the same mental model applies:
+> 📌 **Supabase API Compatibility**: CloudBase Web SDK v3 auth module is designed with Supabase-like API ergonomics. If you are familiar with `supabase-js` auth patterns, the same mental model applies:
 > - All methods return `Promise<{ data, error }>` — always check `error` first
 > - `signInWithPassword`, `signInWithOtp`, `signUp`, `signOut`, `getSession`, `getUser` follow the same naming as Supabase
 > - `onAuthStateChange(callback)` provides reactive auth state observation (events: `INITIAL_SESSION`, `SIGNED_IN`, `SIGNED_OUT`, `TOKEN_REFRESHED`, `USER_UPDATED`, `PASSWORD_RECOVERY`, `BIND_IDENTITY`)
@@ -108,14 +108,14 @@ import cloudbase from '@cloudbase/js-sdk'
 
 const app = cloudbase.init({
   env: 'your-full-env-id', // Canonical full CloudBase environment ID resolved from envQuery or the console, not an alias or shorthand
-  region: `region`,  // CloudBase environment Region, default 'ap-shanghai'
+  region: 'ap-shanghai',  // CloudBase environment Region, default 'ap-shanghai'
   accessKey: 'publishable key', // required, get from auth-tool-cloudbase
   // ⚠️ With accessKey, the deprecated getLoginState() returns misleading auth data (uid)
   // even without login. Always use auth.getSession() — returns undefined when not logged in.
   auth: { detectSessionInUrl: true }, // required
 })
 
-const auth = app.auth({ persistence: 'local' })
+const auth = app.auth
 ```
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
@@ -145,6 +145,7 @@ const { data: loginData, error: loginError } = await data.verifyOtp({ token: '65
 All auth methods return `{ data, error }`. Always check `error` first:
 ```js
 // Login — returns { data: { user, session }, error: null } on success
+// Supports optional is_encrypt for password encryption (default false)
 const { data, error } = await auth.signInWithPassword({ username: 'test_user', password: 'pass123' })
 if (error) {
   // Handle login failure (wrong password, user not found, provider not enabled)
@@ -157,6 +158,8 @@ const uid = data.user.id
 // Also works with email or phone:
 // await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123' })
 // await auth.signInWithPassword({ phone: '13800138000', password: 'pass123' })
+// Optional: encrypt password during transmission
+// await auth.signInWithPassword({ email: 'user@example.com', password: 'pass123', is_encrypt: true })
 ```
 
 **Checking login state (for route guards / auth checks):**
@@ -285,14 +288,39 @@ const handleRegister = async () => {
 ```js
 // Anonymous login is disabled by default — must be explicitly enabled via auth-tool
 const { data, error } = await auth.signInAnonymously()
+// Optional: pass provider_token to associate anonymous session with third-party identity
+// const { data, error } = await auth.signInAnonymously({ provider_token: 'xxx' })
 ```
 
-**6. OAuth (Google/WeChat)**
+**6. OAuth (Google/WeChat/GitHub)**
 - Automatically use `auth-tool-cloudbase` to turn on `Google Login` or `WeChat Login` through `manageAppAuth`
+- Supported providers: `google`, `wechat`, `github`, `facebook`, `apple`
+- By default, OAuth callback is auto-handled when `auth.detectSessionInUrl: true` is set in init
 ```js
 const { data, error } = await auth.signInWithOAuth({ provider: 'google' })
-window.location.href = data.url // Auto-complete after callback
+if (error) throw error
+// Auto-redirect to OAuth provider; after callback SDK auto-completes login
+window.location.href = data.url
+
+// For non-redirect flows (popup / custom UX), use skipBrowserRedirect + type:
+// await auth.signInWithOAuth({
+//   provider: 'github',
+//   options: { skipBrowserRedirect: true, type: 'sign_in' }
+// })
+// Then use data.url manually (e.g. window.open(data.url))
+
+// For binding additional identity to existing user: type: 'bind_identity'
 ```
+
+**Manual OAuth callback handling:**
+- If `detectSessionInUrl` is not set, call `verifyOAuth` manually after redirect:
+```js
+const urlParams = new URLSearchParams(window.location.search)
+const { data, error } = await auth.verifyOAuth({
+  provider: 'google',
+  code: urlParams.get('code'),
+  state: urlParams.get('state'),
+})
 
 **7. Custom Ticket**
 ```js
@@ -376,7 +404,7 @@ const unlinkIdentityResult = await auth.unlinkIdentity({
 })
 
 // Delete account
-const deleteMeResult = await auth.deleteMe({ password: 'current' })
+const deleteResult = await auth.deleteUser({ password: 'current' })
 
 // Listen to state changes
 const authStateSubscription = auth.onAuthStateChange((event, session, info) => {

--- a/config/source/skills/auth-wechat/SKILL.md
+++ b/config/source/skills/auth-wechat/SKILL.md
@@ -459,6 +459,62 @@ exports.main = async (event, context) => {
 
 ---
 
+## v3 Web SDK Mini Program methods
+
+If the Mini Program uses `@cloudbase/js-sdk` (Web SDK v3) instead of `wx-server-sdk`, the following auth methods are available:
+
+### signInWithOpenId
+
+WeChat OpenID silent login — automatically uses the current WeChat login state:
+
+```js
+import cloudbase from "@cloudbase/js-sdk"
+
+const app = cloudbase.init({
+  env: "your-env-id",
+  region: "ap-shanghai",
+})
+const auth = app.auth
+
+// OpenID silent login (default: use wx.cloud mode)
+const { data, error } = await auth.signInWithOpenId()
+if (error) {
+  console.error('OpenID login failed:', error.message)
+} else {
+  console.log('Logged in with OpenID:', data.user?.id)
+}
+
+// For non-wx.cloud mode, pass useWxCloud: false
+// const { data, error } = await auth.signInWithOpenId({ useWxCloud: false })
+```
+
+### signInWithPhoneAuth
+
+WeChat phone number authorization login — requires the user to authorize phone number via the Mini Program button:
+
+```js
+// Step 1: In Mini Program page, use <button open-type="getPhoneNumber">
+// to get the encrypted phone code
+
+// Step 2: Pass the phoneCode to signInWithPhoneAuth
+const { data, error } = await auth.signInWithPhoneAuth({
+  phoneCode: '<encrypted-phone-code-from-wechat>',
+})
+if (error) {
+  console.error('Phone auth failed:', error.message)
+} else {
+  console.log('Logged in with phone:', data.user)
+}
+```
+
+**Important:**
+- These methods are from `@cloudbase/js-sdk`, **not** `wx-server-sdk` or `wx.cloud`
+- They provide an alternative auth path for Mini Programs using the v3 Web SDK
+- For the standard `wx.cloud` + cloud function path, use the scenarios above instead
+- `signInWithPhoneAuth` requires the user to tap a `<button open-type="getPhoneNumber">` in the Mini Program
+
+---
+
 ## Summary
 
 WeChat Mini Program authentication with CloudBase is **simple and secure**:

--- a/config/source/skills/postgresql-development/SKILL.md
+++ b/config/source/skills/postgresql-development/SKILL.md
@@ -150,7 +150,7 @@ Use static imports and one shared `app.rdb()` client:
 ```ts
 import cloudbase from "@cloudbase/js-sdk";
 const app = cloudbase.init({ env: import.meta.env.VITE_CLOUDBASE_ENV_ID });
-export const auth = app.auth();
+export const auth = app.auth;
 export const db = app.rdb();
 ```
 

--- a/config/source/skills/postgresql-development/references/app-workflow.md
+++ b/config/source/skills/postgresql-development/references/app-workflow.md
@@ -77,7 +77,7 @@ Use one shared app:
 import cloudbase from "@cloudbase/js-sdk";
 
 export const app = cloudbase.init({ env: import.meta.env.VITE_ENV_ID });
-export const auth = app.auth();
+export const auth = app.auth;
 export const db = app.rdb();
 ```
 

--- a/config/source/skills/relational-database-web/SKILL.md
+++ b/config/source/skills/relational-database-web/SKILL.md
@@ -75,7 +75,7 @@ const app = cloudbase.init({
   env: "your-env-id"
 });
 
-const auth = app.auth();
+const auth = app.auth;
 // Handle login separately
 
 const db = app.rdb();

--- a/config/source/skills/web-development/SKILL.md
+++ b/config/source/skills/web-development/SKILL.md
@@ -205,5 +205,5 @@ const app = cloudbase.init({
   env: "your-full-env-id", // Canonical full CloudBase environment ID resolved from envQuery or the console
 });
 
-const auth = app.auth();
+const auth = app.auth
 ```

--- a/config/source/skills/web-development/frameworks.md
+++ b/config/source/skills/web-development/frameworks.md
@@ -7,11 +7,173 @@
 - Keep state close to where it is used unless the project already relies on shared state primitives.
 - For form, navigation, and async UI bugs, verify the behavior in browser after code changes.
 
+## Next.js
+
+### SDK boundary
+
+`@cloudbase/js-sdk` is a **browser-only** SDK. It must not be imported in Server Components, `getServerSideProps`, or API Routes.
+
+- Auth flows (sign in, sign up, session check) → **Client Component only** (`"use client"`)
+- API Routes / Route Handlers → use `@cloudbase/node-sdk` (Node.js SDK) for server-side token verification
+- Server Components → read tokens from cookies/headers, do NOT import `@cloudbase/js-sdk`
+
+### Auth pattern (App Router)
+
+```tsx
+// components/auth-guard.tsx — Client Component
+"use client"
+
+import { useEffect, useState } from "react"
+import cloudbase from "@cloudbase/js-sdk"
+
+const app = cloudbase.init({
+  env: process.env.NEXT_PUBLIC_CLOUDBASE_ENV_ID!,
+  region: process.env.NEXT_PUBLIC_CLOUDBASE_REGION || "ap-shanghai",
+  accessKey: process.env.NEXT_PUBLIC_CLOUDBASE_ACCESS_KEY!,
+  auth: { detectSessionInUrl: true },
+})
+const auth = app.auth
+
+export function AuthGuard({ children }: { children: React.ReactNode }) {
+  const [session, setSession] = useState<any>(null)
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    auth.getSession().then(({ data }) => {
+      if (data?.session) {
+        setSession(data.session)
+        // Store access_token in cookie for API route verification
+        document.cookie = `cloudbase_token=${data.session.access_token}; path=/; max-age=3600`
+      }
+      setLoading(false)
+    })
+  }, [])
+
+  if (loading) return <div>Loading...</div>
+  if (!session) return <div>Please sign in</div>
+  return <>{children}</>
+}
+```
+
+### Passing auth to API Routes
+
+```tsx
+// app/api/protected/route.ts — Server-side Route Handler
+import { NextRequest, NextResponse } from "next/server"
+
+export async function GET(request: NextRequest) {
+  const token = request.cookies.get("cloudbase_token")?.value
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+  }
+  // Verify token with Node SDK or forward to your backend
+  return NextResponse.json({ data: "protected resource" })
+}
+```
+
+### Deployment
+
+- Build output: `next build` → `.next` directory
+- CloudBase static hosting expects `package.json` with build scripts and the output directory configured; prefer `manageApps` for deployment
+- If deploying via `manageHosting`, set error document to `index.html` for client-side routing (even though Next.js defaults to file-based routing, fallback handling is needed for SPA-like paths)
+
 ## Vue
 
 - Respect the existing composition style in the repo, such as Composition API or Options API.
 - Keep template, script, and style responsibilities clear instead of mixing unrelated logic into one large SFC.
 - When changing reactive state or watchers, verify the actual rendered behavior rather than assuming the code path is enough.
+
+## NestJS
+
+### SDK choice
+
+Use `@cloudbase/node-sdk` (Node.js SDK), **not** `@cloudbase/js-sdk` (which is browser-only).
+
+### Module setup
+
+```ts
+// cloudbase.module.ts
+import { Module, Global } from "@nestjs/common"
+import tcb from "@cloudbase/node-sdk"
+
+export const CLOUDBASE = "CLOUDBASE"
+
+const cloudbaseProvider = {
+  provide: CLOUDBASE,
+  useFactory: () => {
+    const app = tcb.init({
+      env: process.env.CLOUDBASE_ENV_ID!,
+      // credentials: require("/path/to/tcb_custom_login.json"), // only for custom login
+    })
+    return {
+      app,
+      auth: app.auth(),
+      // db: app.database(), // for NoSQL
+    }
+  },
+}
+
+@Global()
+@Module({
+  providers: [cloudbaseProvider],
+  exports: [cloudbaseProvider],
+})
+export class CloudBaseModule {}
+```
+
+### AuthGuard for token verification
+
+```ts
+// auth.guard.ts
+import { Injectable, CanActivate, ExecutionContext, Inject } from "@nestjs/common"
+import { CLOUDBASE } from "./cloudbase.module"
+
+@Injectable()
+export class CloudBaseAuthGuard implements CanActivate {
+  constructor(@Inject(CLOUDBASE) private cloudbase: any) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest()
+    const token = request.headers.authorization?.replace("Bearer ", "")
+    if (!token) return false
+
+    try {
+      // Verify the session via Node SDK
+      // Note: Node SDK does not have a direct "verify token" method —
+      // forward the token to a cloud function or use the HTTP API for validation
+      request.user = { token }
+      return true
+    } catch {
+      return false
+    }
+  }
+}
+```
+
+### CORS (required for Web frontend calls)
+
+```ts
+// main.ts
+import { NestFactory } from "@nestjs/core"
+import { AppModule } from "./app.module"
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule)
+  app.enableCors({
+    origin: process.env.CORS_ORIGIN || "*",
+    methods: ["GET", "POST", "PUT", "DELETE", "OPTIONS"],
+    credentials: true,
+  })
+  await app.listen(9000) // CloudBase HTTP Functions expect port 9000
+}
+bootstrap()
+```
+
+### Deployment
+
+- Build to JavaScript output, include `package.json` with `start` script
+- Deploy via `manageCloudRun` (container) or `manageFunctions` (HTTP Function, default to native `http` module unless NestJS is explicitly required)
+- Set `MinNum` instances to 1 to reduce cold start
 
 ## Vite
 

--- a/tests/skill-quality-standards.test.js
+++ b/tests/skill-quality-standards.test.js
@@ -34,7 +34,7 @@ describe('skill quality standards', () => {
   test('auth-web stays web-only and fixes the known snippet issues', () => {
     const raw = readSourceSkill('auth-web');
 
-    expect(raw).toMatch(/const\s+auth\s*=\s*app\.auth\(/);
+    expect(raw).toMatch(/const\s+auth\s*=\s*app\.auth/);
     expect(raw).not.toContain('const { data, error } = const { data, error } =');
     expect(raw).not.toContain('## WeChat Mini Program');
     expect(raw).not.toContain('auth.signInWithOpenId');


### PR DESCRIPTION
## Summary

Updates the Skills content to match the actual CloudBase Web SDK v3 authentication API. Previously the Skills described v2 SDK methods and lacked coverage for v3 additions.

## Changes

### SDK version fixes (7 files)
- auth-web: app.auth() -> app.auth, v2->v3 labels, @2.24.0+ -> @latest, deleteMe() -> deleteUser()
- auth-nodejs: removed Auth v2 label
- web-development, postgresql-development, relational-database-web, ai-model-web: app.auth() -> app.auth

### Missing v3 API methods (2 files)
- auth-web: added is_encrypt param, options.type, more OAuth providers, verifyOAuth()
- auth-wechat: added signInWithOpenId() and signInWithPhoneAuth()

### Framework support (1 file)
- frameworks.md: added Next.js and NestJS integration guidance

All changes verified against official v3 docs at docs.cloudbase.net/api-reference/webv3/authentication