### PR TITLE
fix: 🐛 resolve deleteAccess failure when only accessId is provided

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -79,6 +79,7 @@ describe("gateway tools", () => {
         {
           APIId: "api-123",
           Path: "api/hello",
+          Name: "helloFn",
         },
       ],
     });
@@ -273,7 +274,10 @@ describe("gateway tools", () => {
 
     const payload = JSON.parse(result.content[0].text);
 
+    // 仅传 accessId 时，代码会先查询补全 name
+    expect(mockGetAccessList).toHaveBeenCalledWith({});
     expect(mockDeleteAccess).toHaveBeenCalledWith({
+      name: "helloFn",
       apiId: "api-123",
     });
     expect(payload).toMatchObject({

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -484,6 +484,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       const cloudbase = await getManager();
       const accessPath = input.path ? normalizeAccessPath(input.path) : undefined;
       let resolvedAccessId = input.accessId;
+      let resolvedName: string | undefined;
 
       if (!resolvedAccessId) {
         if (!input.targetName && !accessPath) {
@@ -510,6 +511,20 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         }
 
         resolvedAccessId = candidates[0]?.APIId;
+        resolvedName = candidates[0]?.Name;
+      } else {
+        // 仅传入 accessId 时，先查询获取 name 等信息，确保删除参数完整
+        try {
+          const accessList = await cloudbase.access.getAccessList({});
+          const match = (accessList.APISet ?? []).find(
+            (item: any) => item.APIId === resolvedAccessId,
+          );
+          if (match) {
+            resolvedName = match.Name;
+          }
+        } catch {
+          // 查询失败不影响主流程，继续用 accessId 删除
+        }
       }
 
       if (!resolvedAccessId) {
@@ -517,7 +532,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       }
 
       const result = await cloudbase.access.deleteAccess({
-        ...(input.targetName ? { name: input.targetName } : {}),
+        ...(resolvedName ? { name: resolvedName } : {}),
         apiId: resolvedAccessId,
       });
       logCloudBaseResult(server.logger, result);
@@ -525,7 +540,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       return buildEnvelope(
         {
           action: input.action,
-          targetName: input.targetName ?? null,
+          targetName: resolvedName ?? input.targetName ?? null,
           path: accessPath ?? null,
           accessId: resolvedAccessId,
           raw: result,


### PR DESCRIPTION
仅传 accessId 删除网关访问路径时，先查询获取 name 再执行删除，避免因缺少 name 参数导致删除失败。

**改动量：** 2 个文件，+21/-2

改动：
- gateway.ts: 仅传 accessId 时先查询补全 name；通过 targetName 查到时也从结果中提取 name
- gateway.test.ts: mock 数据补全 Name 字段；更新 'delete by accessId directly' 测试断言

参见 #783 (Bug #3)