### PR TITLE
fix(skillhub): 🔧 resolve SkillHub version conflict when nextPatch beta already exists

### DIFF
--- a/scripts/publish-to-skillhub.mjs
+++ b/scripts/publish-to-skillhub.mjs
@@ -360,9 +360,18 @@ export async function publishToSkillhub({
           // 例如最新版 2.24.1，则使用 2.24.2-beta.1（beta 版本低于正式版）
           const semver = parseSemver(latestRelease);
           const nextPatch = semver ? `${semver.major}.${semver.minor}.${semver.patch + 1}` : latestRelease;
-          version = `${nextPatch}-beta.${maxBeta + 1}`;
-          retryCount = maxBeta + 1;
-          console.log(`  → 使用版本 / Using version: ${version} (latest release: ${latestRelease}, next patch: ${nextPatch}, max beta: ${maxBeta})`);
+          // 用 nextPatch 搜索已有 beta 版本（之前可能已发布过 nextPatch-beta.X）
+          const nextBetaPrefix = `${nextPatch}-beta.`;
+          let nextMaxBeta = 0;
+          for (const v of versions) {
+            if (v.version && v.version.startsWith(nextBetaPrefix)) {
+              const num = parseInt(v.version.slice(nextBetaPrefix.length), 10);
+              if (!isNaN(num) && num > nextMaxBeta) nextMaxBeta = num;
+            }
+          }
+          version = `${nextPatch}-beta.${nextMaxBeta + 1}`;
+          retryCount = nextMaxBeta + 1;
+          console.log(`  → 使用版本 / Using version: ${version} (latest release: ${latestRelease}, next patch: ${nextPatch}, next max beta: ${nextMaxBeta})`);
         } else if (versions.some((v) => v.version === currentVersion)) {
           // SKILL.md 版本已存在，加 beta
           version = `${currentVersion}-beta.${maxBeta + 1}`;
@@ -405,7 +414,7 @@ export async function publishToSkillhub({
         });
         break;
       } catch (error) {
-        if (error.message.includes("409")) {
+        if (error.message.includes("409") || error.message.includes("400")) {
           retryCount++;
           if (retryCount > maxRetries) {
             console.warn(`  ⚠ 重试耗尽 / Max retries reached for ${target.targetKey} (${slug})`);
@@ -416,8 +425,16 @@ export async function publishToSkillhub({
             });
             break;
           }
-          version = `${currentVersion}-beta.${retryCount}`;
-          console.log(`  ↻ 版本冲突 / Version conflict (409), retrying with ${version} (attempt ${retryCount}/${maxRetries})`);
+          // 重试时优先基于 nextPatch 递增 beta（如果 latestRelease 可用），
+          // 避免在 currentVersion 远低于 SkillHub 最新版时产生过低版本号
+          if (latestRelease && latestRelease !== currentVersion) {
+            const semver = parseSemver(latestRelease);
+            const nextPatch = semver ? `${semver.major}.${semver.minor}.${semver.patch + 1}` : latestRelease;
+            version = `${nextPatch}-beta.${retryCount}`;
+          } else {
+            version = `${currentVersion}-beta.${retryCount}`;
+          }
+          console.log(`  ↻ 版本冲突 / Version conflict (${error.message.includes("409") ? "409" : "400"}), retrying with ${version} (attempt ${retryCount}/${maxRetries})`);
         } else {
           failures.push({
             targetKey: target.targetKey,


### PR DESCRIPTION
## 问题

`Publish ClawHub & SkillHub Registry` CI 运行失败，原因是 `publish-to-skillhub.mjs` 的版本计算逻辑存在两个 bug：

### Bug 1: Beta 前缀搜索错误

当 SkillHub 上已有 `latestRelease`（如 `2.24.1`）且高于当前 `SKILL.md` 版本（`2.23.9`）时，脚本计算 `nextPatch = 2.24.2`。但搜索已有 beta 版本时用的是 `2.24.1-beta.` 前缀（`latestRelease`），而不是 `2.24.2-beta.`（`nextPatch`），导致已有的 `2.24.2-beta.1` 没被发现，重复发布 409 冲突。

### Bug 2: 重试未处理 400 "版本过低" 错误

重试逻辑只检查 409（版本冲突），当 retry 使用 `2.23.9-beta.2`（低于 SkillHub 的 `2.24.2-beta.1`）时，API 返回 400 "版本号必须高于当前最新版本" 未被捕获，直接失败。

## 修复

1. 当 `latestRelease !== currentVersion` 时，用 `nextPatch-beta.` 前缀搜索已有 beta 版本并递增
2. 重试条件从仅 `409` 扩展为 `409 || 400`
3. 重试时优先基于 `nextPatch` 递增 beta，避免产生过低版本号

## 验证

修复后，在当前场景下版本计算流程应为：
- `nextPatch = 2.24.2`
- `nextMaxBeta = 1`（发现已有的 `2.24.2-beta.1`）
- 实际发布版本：`2.24.2-beta.2`