### PR TITLE
docs(pg-skill): 📝 refine PG auth skill with auth.users and cloud-function access patterns

### DIFF
--- a/config/.claude/skills/postgresql-development/references/auth-and-rls.md
+++ b/config/.claude/skills/postgresql-development/references/auth-and-rls.md
@@ -8,7 +8,22 @@ Use this reference before writing browser-side PG CRUD or database policies.
 | --- | --- | --- | --- |
 | Publishable Key | `anon` | Frontend-safe | Still constrained by GRANT/RLS. |
 | User access token | `authenticated` | SDK-managed frontend session | Represents a real logged-in user. |
-| API Key | `service_role` | Backend / trusted tooling only | Bypasses RLS; never expose to browser code. |
+| API Key | `service_role` | Backend / trusted tooling only | Bypasses RLS; never expose to browser code. Treat any leak as a serious credential compromise and rotate/revoke it via `manageAppAuth(action="deleteApiKey")` immediately. |
+
+## `auth.users` — the built-in account table
+
+CloudBase PG stores account data in `auth.users` (schema `auth`), not a business-defined table. Query it directly instead of creating a parallel `public.users` table for identity data:
+
+```sql
+select id, email, phone, app_metadata, user_metadata from auth.users;
+
+-- Join business tables against the built-in account table
+select o.*, u.user_metadata->>'name' as buyer_name
+from public.orders o
+join auth.users u on u.id = o.buyer_id;
+```
+
+Only create a separate `public.*` table (e.g. `user_roles`, `profiles`) when the app needs fields that do not belong in `auth.users`, such as an app-specific role or a denormalized display name for fast reads. Do not duplicate `email`/`phone` into a new table just to avoid a join.
 
 ## SQL identity helpers
 
@@ -83,6 +98,31 @@ CREATE POLICY todos_delete_own ON public.todos
   FOR DELETE TO authenticated
   USING (owner_id = auth.uid());
 ```
+
+## Accessing PG from a cloud function
+
+A cloud function has two distinct ways to reach PG, and they are NOT interchangeable. Choose based on whether the function should act as the logged-in caller or as an admin/backend task:
+
+1. **Act as the caller, stay RLS-constrained** — when a function wraps business logic but must still respect row ownership (e.g. an HTTP Function that a logged-in user calls to run a multi-step update). The caller's access token must reach the function and then be forwarded to the PG REST call:
+
+   ```js
+   const res = await fetch(`https://${envId}.api.tcloudbasegateway.com/v1/rdb/rest/orders?select=*`, {
+     headers: { Authorization: `Bearer ${callerAccessToken}` },
+   });
+   ```
+
+   Do not guess the exact field/property that carries `callerAccessToken` from `event`/`context` (or an HTTP Function's `req.headers`). Verify it against the installed `@cloudbase/node-sdk` version and the official cloud-functions docs before writing this code; if you cannot verify the field, treat this pattern as unavailable rather than inventing a shape.
+
+2. **Act as admin, bypass RLS with the API Key (`service_role`)** — use this only for admin/backend tasks such as batch imports, cross-user aggregation, or scheduled jobs, and only inside a cloud function / CloudRun service:
+
+   ```js
+   // Inject the API Key via function environment variables; never return it to the client.
+   const res = await fetch(`https://${envId}.api.tcloudbasegateway.com/v1/rdb/rest/orders?select=*`, {
+     headers: { Authorization: `Bearer ${process.env.CLOUDBASE_API_KEY}` },
+   });
+   ```
+
+Do not default to the API Key path just because it is simpler — if the task only needs "let the logged-in user read/write their own rows," forwarding the caller's access token keeps RLS as the enforcement layer and avoids re-implementing ownership checks in function code. Never let a function response leak the API Key back to the frontend.
 
 ## Pitfalls
 

--- a/config/.claude/skills/postgresql-development/references/storage-pg.md
+++ b/config/.claude/skills/postgresql-development/references/storage-pg.md
@@ -38,7 +38,38 @@ await app.storage.from().upload('covers/a.png', file);
 
 ## Bucket creation
 
-The browser SDK cannot create buckets. Create/select the PG storage bucket before writing upload code, through PG storage HTTP API / CLI / console / SQL on `storage.buckets` when appropriate.
+The browser SDK cannot create buckets. Create the PG storage bucket **before** writing upload code.
+
+### `storage.buckets` schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `text` | Bucket ID (primary key), e.g. `avatars` |
+| `name` | `text` | Bucket display name (≤ 100 chars) |
+| `public` | `boolean` | Whether public read is allowed (default `false`). Does **not** bypass RLS. |
+| `file_size_limit` | `bigint` | Max file size in bytes |
+| `allowed_mime_types` | `text[]` | Allowed MIME types whitelist |
+| `owner_id` | `text` | Creator user ID |
+
+### Via MCP tool (recommended for AI agents)
+
+```sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('avatars', 'avatars', false, 5 * 1024 * 1024, ARRAY['image/png', 'image/jpeg', 'image/webp']);
+```
+
+Call via `managePgDatabase(action="execute", confirm=true, sql="...")`.
+
+### Via CloudBase CLI
+
+```bash
+tcb db execute -e <envId> --sql "INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types) VALUES ('avatars', 'avatars', false, 5 * 1024 * 1024, ARRAY['image/png', 'image/jpeg', 'image/webp']);"
+```
+
+### Post-creation: configure RLS (mandatory)
+
+After creating the bucket, configure RLS on `storage.objects` — see "Storage RLS" section below.
+The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`.
 
 The legacy NoSQL bucket returned by `EnvInfo.Storages[]` is not a PG storage bucket.
 
@@ -46,21 +77,41 @@ The legacy NoSQL bucket returned by `EnvInfo.Storages[]` is not a PG storage buc
 
 After bucket creation, configure RLS on `storage.objects` for the intended role and bucket.
 
-Example authenticated upload/read policy:
+The default RLS is deny all. Use `storage.foldername(name)` to extract the first path segment (usually the user ID) and compare with `auth.uid()`.
+
+Example: per-user isolation for bucket `avatars` (object path: `<uid>/filename.png`):
 
 ```sql
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY covers_upload ON storage.objects
-  FOR INSERT TO authenticated
-  WITH CHECK (bucket_id = 'covers' AND auth.role() = 'authenticated');
-
-CREATE POLICY covers_read ON storage.objects
+-- Allow each authenticated user to read their own files
+CREATE POLICY avatars_select_own ON storage.objects
   FOR SELECT TO authenticated
-  USING (bucket_id = 'covers' AND auth.role() = 'authenticated');
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to upload to their own directory
+CREATE POLICY avatars_insert_own ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to update their own files
+CREATE POLICY avatars_update_own ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid())
+  WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to delete their own files
+CREATE POLICY avatars_delete_own ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
 ```
 
-For owner-scoped files, use `owner_id = auth.uid()` or join against business tables only after verifying the schema columns.
+Key points:
+- `storage.foldername(name)` is a built-in helper that splits `'<uid>/avatar.png'` into `{'<uid>'}`.
+- `auth.uid()` returns the current JWT `sub`.
+- `storage.objects` does **not** need extra `GRANT` — `anon`/`authenticated`/`service_role` already have `ALL`; RLS is the only gate.
+- Do **not** `DELETE FROM storage.objects` directly — a `protect_delete` trigger blocks it. Use SDK / Storage API.
+- For simpler authenticated-only access (not per-user), replace `(storage.foldername(name))[1] = auth.uid()` with `auth.role() = 'authenticated'`.
 
 ## Failure signals
 

--- a/config/source/skills/postgresql-development/references/auth-and-rls.md
+++ b/config/source/skills/postgresql-development/references/auth-and-rls.md
@@ -8,7 +8,22 @@ Use this reference before writing browser-side PG CRUD or database policies.
 | --- | --- | --- | --- |
 | Publishable Key | `anon` | Frontend-safe | Still constrained by GRANT/RLS. |
 | User access token | `authenticated` | SDK-managed frontend session | Represents a real logged-in user. |
-| API Key | `service_role` | Backend / trusted tooling only | Bypasses RLS; never expose to browser code. |
+| API Key | `service_role` | Backend / trusted tooling only | Bypasses RLS; never expose to browser code. Treat any leak as a serious credential compromise and rotate/revoke it via `manageAppAuth(action="deleteApiKey")` immediately. |
+
+## `auth.users` — the built-in account table
+
+CloudBase PG stores account data in `auth.users` (schema `auth`), not a business-defined table. Query it directly instead of creating a parallel `public.users` table for identity data:
+
+```sql
+select id, email, phone, app_metadata, user_metadata from auth.users;
+
+-- Join business tables against the built-in account table
+select o.*, u.user_metadata->>'name' as buyer_name
+from public.orders o
+join auth.users u on u.id = o.buyer_id;
+```
+
+Only create a separate `public.*` table (e.g. `user_roles`, `profiles`) when the app needs fields that do not belong in `auth.users`, such as an app-specific role or a denormalized display name for fast reads. Do not duplicate `email`/`phone` into a new table just to avoid a join.
 
 ## SQL identity helpers
 
@@ -83,6 +98,31 @@ CREATE POLICY todos_delete_own ON public.todos
   FOR DELETE TO authenticated
   USING (owner_id = auth.uid());
 ```
+
+## Accessing PG from a cloud function
+
+A cloud function has two distinct ways to reach PG, and they are NOT interchangeable. Choose based on whether the function should act as the logged-in caller or as an admin/backend task:
+
+1. **Act as the caller, stay RLS-constrained** — when a function wraps business logic but must still respect row ownership (e.g. an HTTP Function that a logged-in user calls to run a multi-step update). The caller's access token must reach the function and then be forwarded to the PG REST call:
+
+   ```js
+   const res = await fetch(`https://${envId}.api.tcloudbasegateway.com/v1/rdb/rest/orders?select=*`, {
+     headers: { Authorization: `Bearer ${callerAccessToken}` },
+   });
+   ```
+
+   Do not guess the exact field/property that carries `callerAccessToken` from `event`/`context` (or an HTTP Function's `req.headers`). Verify it against the installed `@cloudbase/node-sdk` version and the official cloud-functions docs before writing this code; if you cannot verify the field, treat this pattern as unavailable rather than inventing a shape.
+
+2. **Act as admin, bypass RLS with the API Key (`service_role`)** — use this only for admin/backend tasks such as batch imports, cross-user aggregation, or scheduled jobs, and only inside a cloud function / CloudRun service:
+
+   ```js
+   // Inject the API Key via function environment variables; never return it to the client.
+   const res = await fetch(`https://${envId}.api.tcloudbasegateway.com/v1/rdb/rest/orders?select=*`, {
+     headers: { Authorization: `Bearer ${process.env.CLOUDBASE_API_KEY}` },
+   });
+   ```
+
+Do not default to the API Key path just because it is simpler — if the task only needs "let the logged-in user read/write their own rows," forwarding the caller's access token keeps RLS as the enforcement layer and avoids re-implementing ownership checks in function code. Never let a function response leak the API Key back to the frontend.
 
 ## Pitfalls
 

--- a/config/source/skills/postgresql-development/references/storage-pg.md
+++ b/config/source/skills/postgresql-development/references/storage-pg.md
@@ -38,7 +38,38 @@ await app.storage.from().upload('covers/a.png', file);
 
 ## Bucket creation
 
-The browser SDK cannot create buckets. Create/select the PG storage bucket before writing upload code, through PG storage HTTP API / CLI / console / SQL on `storage.buckets` when appropriate.
+The browser SDK cannot create buckets. Create the PG storage bucket **before** writing upload code.
+
+### `storage.buckets` schema
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | `text` | Bucket ID (primary key), e.g. `avatars` |
+| `name` | `text` | Bucket display name (≤ 100 chars) |
+| `public` | `boolean` | Whether public read is allowed (default `false`). Does **not** bypass RLS. |
+| `file_size_limit` | `bigint` | Max file size in bytes |
+| `allowed_mime_types` | `text[]` | Allowed MIME types whitelist |
+| `owner_id` | `text` | Creator user ID |
+
+### Via MCP tool (recommended for AI agents)
+
+```sql
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('avatars', 'avatars', false, 5 * 1024 * 1024, ARRAY['image/png', 'image/jpeg', 'image/webp']);
+```
+
+Call via `managePgDatabase(action="execute", confirm=true, sql="...")`.
+
+### Via CloudBase CLI
+
+```bash
+tcb db execute -e <envId> --sql "INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types) VALUES ('avatars', 'avatars', false, 5 * 1024 * 1024, ARRAY['image/png', 'image/jpeg', 'image/webp']);"
+```
+
+### Post-creation: configure RLS (mandatory)
+
+After creating the bucket, configure RLS on `storage.objects` — see "Storage RLS" section below.
+The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`.
 
 The legacy NoSQL bucket returned by `EnvInfo.Storages[]` is not a PG storage bucket.
 
@@ -46,21 +77,41 @@ The legacy NoSQL bucket returned by `EnvInfo.Storages[]` is not a PG storage buc
 
 After bucket creation, configure RLS on `storage.objects` for the intended role and bucket.
 
-Example authenticated upload/read policy:
+The default RLS is deny all. Use `storage.foldername(name)` to extract the first path segment (usually the user ID) and compare with `auth.uid()`.
+
+Example: per-user isolation for bucket `avatars` (object path: `<uid>/filename.png`):
 
 ```sql
 ALTER TABLE storage.objects ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY covers_upload ON storage.objects
-  FOR INSERT TO authenticated
-  WITH CHECK (bucket_id = 'covers' AND auth.role() = 'authenticated');
-
-CREATE POLICY covers_read ON storage.objects
+-- Allow each authenticated user to read their own files
+CREATE POLICY avatars_select_own ON storage.objects
   FOR SELECT TO authenticated
-  USING (bucket_id = 'covers' AND auth.role() = 'authenticated');
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to upload to their own directory
+CREATE POLICY avatars_insert_own ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to update their own files
+CREATE POLICY avatars_update_own ON storage.objects
+  FOR UPDATE TO authenticated
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid())
+  WITH CHECK (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
+
+-- Allow each authenticated user to delete their own files
+CREATE POLICY avatars_delete_own ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'avatars' AND (storage.foldername(name))[1] = auth.uid());
 ```
 
-For owner-scoped files, use `owner_id = auth.uid()` or join against business tables only after verifying the schema columns.
+Key points:
+- `storage.foldername(name)` is a built-in helper that splits `'<uid>/avatar.png'` into `{'<uid>'}`.
+- `auth.uid()` returns the current JWT `sub`.
+- `storage.objects` does **not** need extra `GRANT` — `anon`/`authenticated`/`service_role` already have `ALL`; RLS is the only gate.
+- Do **not** `DELETE FROM storage.objects` directly — a `protect_delete` trigger blocks it. Use SDK / Storage API.
+- For simpler authenticated-only access (not per-user), replace `(storage.foldername(name))[1] = auth.uid()` with `auth.role() = 'authenticated'`.
 
 ## Failure signals
 


### PR DESCRIPTION
## Summary
- Add `auth.users` built-in account table guidance to the `postgresql-development` auth skill, so AI doesn't invent a duplicate user table.
- Add two documented patterns for accessing PG from a cloud function: pass-through caller access token (RLS-constrained) vs API Key (`service_role`, bypasses RLS), with an explicit warning not to guess the exact `event`/`context` field name for the access token.
- Add an API Key leak-response note (rotate/revoke via `manageAppAuth(action="deleteApiKey")`) without asserting unverifiable claims about token expiry mechanics.
- Corresponding `storage-pg.md` clarifications, synced to `config/.claude/skills/` mirror.

## Why
Reviewed https://docs.cloudbase.net/authentication-v2/auth/auth-pg to see whether the skill's auth/RLS guidance needed updates. Initially drafted a token-expiry comparison table, but after cross-checking against the official doc and JWT payload samples found internal inconsistencies (e.g. access-token default expiry stated as 2h in one section vs a 1h `exp`-`iat` delta in a sample payload). Rather than encode a possibly-wrong mechanism-level claim into a long-lived skill doc, that content was dropped, keeping only conservative, verifiable guidance.

## Test plan
- [x] `node scripts/sync-claude-skills-mirror.mjs` run and diffed — mirror matches source exactly.