### PR TITLE
feat(pg-storage): 🗄️ improve PG storage skill, add createBucket action, add PG warning to COS tools

### DIFF
--- a/config/source/skills/postgresql-development/references/storage-pg.md
+++ b/config/source/skills/postgresql-development/references/storage-pg.md
@@ -2,6 +2,31 @@
 
 PG storage stores file metadata in PostgreSQL `storage` schema and enforces permissions through RLS.
 
+> ⚠️ **PG 存储 ≠ 旧 COS 存储**：PG 环境的存储使用 pgstore + HTTP API，与旧 NoSQL 环境的 COS 存储是两套独立系统。以下情况请改用 `manageStorage`：非 PG 环境。
+
+## Decision Tree: Which Storage to Use
+
+```mermaid
+flowchart TD
+    A[当前环境是 PG 模式？] -->|是| B[使用 pgstore]
+    A -->|否| C[使用旧 COS / NoSQL 存储]
+    
+    B --> B1{需要做什么？}
+    B1 -->|创建 bucket| B2[INSERT INTO storage.buckets<br>或 HTTP API POST /v1/storages/bucket/]
+    B1 -->|上传文件| B3[前端 SDK: app.storage.from().upload()<br>或 HTTP API]
+    B1 -->|下载/签名| B4[HTTP API POST /v1/storages/object/sign/]
+    B1 -->|查询文件| B5[HTTP API / storage.objects 表查询]
+    B1 -->|配置权限| B6[ALTER TABLE storage.objects ENABLE RLS<br>CREATE POLICY ...]
+    
+    C --> C1{需要做什么？}
+    C1 -->|上传/下载| C2[manageStorage / queryStorage 工具]
+    C1 -->|查询| C3[queryStorage 工具]
+```
+
+**核心规则：**
+- PG 环境 → 用 `queryPgStorage`（规划方案） +  HTTP API / 前端 SDK（执行）
+- 旧 COS 环境 → 用 `manageStorage` / `queryStorage`（直接执行）
+
 ## Model
 
 - `storage.buckets`: one row per bucket.
@@ -9,6 +34,132 @@ PG storage stores file metadata in PostgreSQL `storage` schema and enforces perm
 - File bytes live in object storage, but metadata and permissions are coordinated through Storage API + PostgreSQL.
 - `storage.buckets` / `storage.objects` are granted to `anon`, `authenticated`, and `service_role`; RLS is the effective permission gate.
 - Traditional storage permission labels (`READONLY` / `PRIVATE` / `CUSTOM`) and JSON storage safe rules do not apply to PG storage.
+
+## How Supabase Does Storage (Reference)
+
+Supabase 和 CloudBase PG storage 的设计理念高度一致，可以对照理解：
+
+| Concept | Supabase | CloudBase PG |
+|---------|----------|-------------|
+| **Schema** | `storage.buckets` / `storage.objects` | 相同（内置 pgstore schema） |
+| **Anonymous access** | `anon` key (public, safe for client) | `anon` key（即 publishable key） |
+| **Server access** | `service_role` key (secret, bypass RLS) | API Key（`manageAppAuth(action="createApiKey")`） |
+| **User auth** | User JWT from `supabase.auth.signIn()` | User JWT from `auth.signInWithPassword()` 等 |
+| **RLS** | `CREATE POLICY ... ON storage.objects` | 相同 |
+| **Bucket creation** | `supabase.storage.createBucket()` | `INSERT INTO storage.buckets` 或 HTTP API |
+| **Upload** | `supabase.storage.from('b').upload()` | `app.storage.from('b').upload()` |
+| **Signed URL** | `createSignedUrl()` | HTTP API `POST /v1/storages/object/sign/` |
+
+## JWT Token Acquisition for PG Storage API
+
+PG Storage HTTP API 需要 Bearer JWT 认证。以下是三种角色对应的 token 获取方式：
+
+### 1. service_role（服务端、旁路 RLS）
+
+用于后端脚本、管理任务。对应 Supabase 的 `service_role` key。
+
+```mermaid
+flowchart LR
+    A[manageAppAuth<br>action=createApiKey] -->|返回| B[API Key (token)]
+    B --> C[Authorization: Bearer {token}]
+    C --> D[调用 PG Storage HTTP API<br>旁路 RLS, 全权限]
+```
+
+**获取方式：**
+```
+manageAppAuth(action="createApiKey", name="my-server-key", description="服务端存储用")
+```
+
+返回的 `token` 就是 `service_role` 级别的凭据。
+
+### 2. authenticated（已登录用户、受 RLS 约束）
+
+用户通过前端登录后获取 JWT，用于浏览器端上传。
+
+**前端登录：**
+```js
+// Web SDK
+import { CloudBase } from '@cloudbase/js-sdk';
+const app = CloudBase.init({ env: 'your-env-id' });
+await app.auth.signInWithPassword({ username, password });
+// 登录后 app 自动携带 JWT
+await app.storage.from('covers').upload('a.png', file);
+```
+
+**手动获取 JWT token：**
+```js
+const token = await app.auth.getAuthHeader();
+// token 形如 { 'x-cloudbase-uid': 'xxx', 'Authorization': 'Bearer xxx' }
+```
+
+### 3. anon（匿名、受 RLS 约束）
+
+不需要携带 Authorization 头，或使用 anon key。只能访问 `public` bucket 且 RLS 放行的资源。
+
+**获取 anon key（即 publishable key）：**
+```
+manageAppAuth(action="ensurePublishableKey")
+```
+
+返回的 `token` 即为 anon key，可安全暴露给客户端。
+
+### Supabase 对照
+
+```
+Supabase                              CloudBase PG
+────────────────────────────────────────────────────
+Dashboard > Settings > API            manageAppAuth(action="createApiKey")
+  → anon key (public)                   → publishable key (anon)
+  → service_role key (secret)           → API Key (service_role)
+supabase.auth.signIn()                 app.auth.signInWithPassword()
+  → user JWT                             → user JWT
+```
+
+## Full HTTP API Reference
+
+PG Storage 提供完整的 RESTful API，共 21 个端点，通过 OpenAPI 规范管理。
+
+**Base URL:** `https://{envId}.api.tcloudbasegateway.com`
+
+**Auth:** `Authorization: Bearer <token>` (service_role / user JWT / anon key)
+
+### How to Query the API Spec
+
+AI 助手可以通过以下方式获取完整 API 文档：
+
+```
+searchKnowledgeBase(mode="openapi", apiName="storage")
+```
+
+或直接查看文档：
+- OpenAPI YAML: `https://docs.cloudbase.net/openapi/storage.v1.postgres.openapi.yaml`
+- 文档首页: `https://docs.cloudbase.net/http-api/storage-pg/pg-storage-api`
+
+### Endpoint Summary
+
+| Category | Method | Endpoint | Description |
+|----------|--------|----------|-------------|
+| **Bucket** | POST | `/v1/storages/bucket/` | Create bucket |
+| | GET | `/v1/storages/bucket/` | List buckets |
+| | GET | `/v1/storages/bucket/{id}` | Get bucket info |
+| | PUT | `/v1/storages/bucket/{id}` | Update bucket |
+| | DELETE | `/v1/storages/bucket/{id}` | Delete bucket (must be empty) |
+| **Object** | POST | `/v1/storages/object/{bucket}/{name}` | Upload |
+| | PUT | `/v1/storages/object/{bucket}/{name}` | Upsert |
+| | GET | `/v1/storages/object/{bucket}/{name}` | Download |
+| | HEAD | `/v1/storages/object/{bucket}/{name}` | Object headers |
+| | DELETE | `/v1/storages/object/{bucket}/{name}` | Delete single |
+| | DELETE | `/v1/storages/object/{bucket}` | Delete batch (max 100) |
+| | POST | `/v1/storages/object/list/{bucket}` | List objects |
+| | POST | `/v1/storages/object/copy` | Copy object |
+| | POST | `/v1/storages/object/move` | Move object |
+| | GET | `/v1/storages/object/info/{bucket}/{name}` | Object metadata |
+| **Signed URL** | POST | `/v1/storages/object/sign/{bucket}/{name}` | Signed download URL (single) |
+| | POST | `/v1/storages/object/sign/{bucket}` | Signed download URL (batch, max 500) |
+| | POST | `/v1/storages/object/upload/sign/{bucket}/{name}` | Signed upload URL |
+| | GET | `/v1/storages/object/sign/{bucket}/{name}` | Download via signed URL |
+| | HEAD | `/v1/storages/object/sign/{bucket}/{name}` | Head via signed URL |
+| | PUT | `/v1/storages/object/upload/sign/{bucket}/{name}` | Upload via signed URL |
 
 ## Bucket and key semantics
 
@@ -59,6 +210,23 @@ VALUES ('avatars', 'avatars', false, 5 * 1024 * 1024, ARRAY['image/png', 'image/
 ```
 
 Call via `managePgDatabase(action="execute", confirm=true, sql="...")`.
+
+### Via HTTP API (service_role only)
+
+```bash
+curl -X POST "https://{envId}.api.tcloudbasegateway.com/v1/storages/bucket/" \
+  -H "Authorization: Bearer {service_role_token}" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "avatars", "public": false, "file_size_limit": 5242880, "allowed_mime_types": ["image/png", "image/jpeg"]}'
+```
+
+### Via queryPgStorage (get executable example)
+
+```
+queryPgStorage(action="createBucket", bucket="avatars")
+```
+
+Returns a complete plan with SQL, HTTP API curl, and SDK code examples.
 
 ### Via CloudBase CLI
 
@@ -112,6 +280,25 @@ Key points:
 - `storage.objects` does **not** need extra `GRANT` — `anon`/`authenticated`/`service_role` already have `ALL`; RLS is the only gate.
 - Do **not** `DELETE FROM storage.objects` directly — a `protect_delete` trigger blocks it. Use SDK / Storage API.
 - For simpler authenticated-only access (not per-user), replace `(storage.foldername(name))[1] = auth.uid()` with `auth.role() = 'authenticated'`.
+
+## Typical Pattern: Upload + Register Metadata
+
+这是你在 CRM 等业务中需要完整遵循的「三步走」模式（对应 Supabase 的 storage + 业务表分离模式）：
+
+```
+1. 创建 bucket（仅一次）
+   managePgDatabase(action="execute", confirm=true, sql="INSERT INTO storage.buckets ...")
+
+2. 前端或后端上传文件
+   // 前端 SDK
+   await app.storage.from('crm').upload('contracts/2026/renewal.pdf', file);
+   
+3. 在业务表中记录文件元信息
+   INSERT INTO crm_attachments (customer_id, file_name, file_size, mime_type, storage_path, category)
+   VALUES (1, 'renewal.pdf', 102400, 'application/pdf', 'contracts/2026/renewal.pdf', 'contract');
+```
+
+注意：Supabase 的 `storage.objects` 表自带元信息记录，CloudBase PG storage 也有 `storage.objects` 表。如果你的需求只是「上传文件 + 按 bucket 列表查询」，可以直接查 `storage.objects` 表。只有当需要自定义业务元信息（如 `customer_id`, `category`）时，才需要额外建业务关联表。
 
 ## Failure signals
 

--- a/mcp/src/tools/storage.ts
+++ b/mcp/src/tools/storage.ts
@@ -4,6 +4,7 @@ import * as path from "path";
 import { z } from "zod";
 import { getCloudBaseManager, getEnvId } from '../cloudbase-manager.js';
 import { ExtendedMcpServer } from '../server.js';
+import { buildJsonToolResult } from '../utils/tool-result.js';
 
 const MAX_INLINE_TEXT_BYTES = 256 * 1024;
 const STORAGE_READ_TEMP_PREFIX = 'cloudbase-mcp-storage-read-';
@@ -138,7 +139,7 @@ export function registerStorageTools(server: ExtendedMcpServer) {
     "queryStorage",
     {
       title: "查询 CloudBase 存储信息",
-      description: "查询 CloudBase 云存储信息，支持列出目录文件、获取文件信息、获取临时下载链接等只读操作。返回的文件信息包括文件名、大小、修改时间、下载链接等。注意：action=url 返回的 temporaryUrl 是临时签名链接，有效期由 maxAge 参数决定（默认1小时），不要当作永久公网地址使用。工具还会基于 DescribeEnvs 返回的 Storages[0].CdnDomain 推导 publicUrl，⚠️ 警告：publicUrl 仅在存储桶 ACL 为公有读（所有用户可读）时才能被匿名访问；默认私有读写存储桶返回的 publicUrl 会 403，此时请继续使用 temporaryUrl 或先通过控制台/SDK 将目标路径设置为公有读。\n\n💡 存储桶 ACL 权限管理请使用 permissions 工具：queryPermissions(action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\") 查询，managePermissions(action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"READONLY\") 设置。\n\n📦 CloudBase PG / pgstore 环境：`DescribeEnvs.Storages[]` 列出的 bucket 是旧 NoSQL 后端的，不等于 pgstore bucket。本工具用于查看常规存储；为 PG 浏览器上传准备 bucket 时，请确认目标 bucket 是 pgstore 后端可用的，否则浏览器 `app.storage.from().upload(...)` 会得到 `STORAGE_BUCKET_NOT_FOUND` 并出现 `PUT https://undefined/`。",
+      description: "⚠️ PG 模式环境请使用 queryPgStorage 而非本工具（pgstore 与旧 COS 是两套独立系统）。\n\n查询 CloudBase 云存储信息，支持列出目录文件、获取文件信息、获取临时下载链接等只读操作。返回的文件信息包括文件名、大小、修改时间、下载链接等。注意：action=url 返回的 temporaryUrl 是临时签名链接，有效期由 maxAge 参数决定（默认1小时），不要当作永久公网地址使用。工具还会基于 DescribeEnvs 返回的 Storages[0].CdnDomain 推导 publicUrl，⚠️ 警告：publicUrl 仅在存储桶 ACL 为公有读（所有用户可读）时才能被匿名访问；默认私有读写存储桶返回的 publicUrl 会 403，此时请继续使用 temporaryUrl 或先通过控制台/SDK 将目标路径设置为公有读。\n\n💡 存储桶 ACL 权限管理请使用 permissions 工具：queryPermissions(action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\") 查询，managePermissions(action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"READONLY\") 设置。\n\n📦 CloudBase PG / pgstore 环境：`DescribeEnvs.Storages[]` 列出的 bucket 是旧 NoSQL 后端的，不等于 pgstore bucket。本工具用于查看常规存储；为 PG 浏览器上传准备 bucket 时，请确认目标 bucket 是 pgstore 后端可用的，否则浏览器 `app.storage.from().upload(...)` 会得到 `STORAGE_BUCKET_NOT_FOUND` 并出现 `PUT https://undefined/`。",
       inputSchema: queryStorageInputSchema,
       annotations: {
         readOnlyHint: true,
@@ -148,13 +149,14 @@ export function registerStorageTools(server: ExtendedMcpServer) {
     },
     async (args: QueryStorageInput) => {
       const input = args;
-      const manager = await getManager();
+      try {
+        const manager = await getManager();
 
-      if (!manager) {
-        throw new Error("Failed to initialize CloudBase manager. Please check your credentials and environment configuration.");
-      }
+        if (!manager) {
+          throw new Error("Failed to initialize CloudBase manager. Please check your credentials and environment configuration.");
+        }
 
-      const storageService = manager.storage;
+        const storageService = manager.storage;
 
       switch (input.action) {
         case 'list': {
@@ -304,7 +306,16 @@ export function registerStorageTools(server: ExtendedMcpServer) {
         default:
           throw new Error(`Unsupported action: ${input.action}`);
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return buildJsonToolResult({
+        success: false,
+        message: `queryStorage 操作失败: ${message}`,
+        action: input.action,
+        cloudPath: input.cloudPath,
+      });
     }
+  }
   );
 
   // Tool 2: manageStorage - 管理存储文件（写操作）
@@ -312,7 +323,7 @@ export function registerStorageTools(server: ExtendedMcpServer) {
     "manageStorage",
     {
       title: "管理 CloudBase 存储文件",
-      description: "管理 CloudBase 云存储文件，仅用于 COS/Storage 对象，不用于静态网站托管。支持上传文件/目录、下载文件/目录、删除文件/目录等操作。删除操作需要设置force=true进行确认，防止误删除重要文件。注意：上传后返回的 temporaryUrl 是临时签名链接，1小时后过期，不要当作永久公网地址写入配置或持久化存储。工具还会基于 DescribeEnvs 返回的 Storages[0].CdnDomain 推导 publicUrl，⚠️ 警告：publicUrl 仅在存储桶 ACL 为公有读（所有用户可读）时才能被匿名访问；默认私有读写存储桶返回的 publicUrl 会 403，此时请继续使用 temporaryUrl 或先通过控制台/SDK 将目标路径设置为公有读。\n\n💡 存储桶 ACL 权限管理请使用 permissions 工具：queryPermissions(action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\") 查询，managePermissions(action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"READONLY\") 设置。\n\n📦 CloudBase PG / pgstore 桶必须先创建后使用（与 Supabase Storage 一致：upload 前 bucket 必须存在）。浏览器 SDK `app.storage.from().upload(path, file)` 不会自动建桶，且 `path` 的第一段就是 bucket 名（例如 `covers/foo.png` → bucket=`covers`）；`from('covers')` 这个参数当前不会被拼到 path 里。如果上传时浏览器看到 `STORAGE_BUCKET_NOT_FOUND` 或 `PUT https://undefined/`（DevTools 表现为 `net::ERR_NAME_NOT_RESOLVED`），先用本工具或控制台确认 / 创建对应的 pgstore bucket，再让前端重试上传，不要让前端把上传失败静默吞掉。`DescribeEnvs.Storages[]` 返回的旧 NoSQL bucket（形如 `<hash>-<envId>-<appId>`）不是可用的 pgstore bucket，切勿当作默认目标使用。",
+      description: "⚠️ PG 模式环境请使用 queryPgStorage 而非本工具（pgstore 与旧 COS 是两套独立系统）。\n\n管理 CloudBase 云存储文件，仅用于 COS/Storage 对象，不用于静态网站托管。支持上传文件/目录、下载文件/目录、删除文件/目录等操作。删除操作需要设置force=true进行确认，防止误删除重要文件。注意：上传后返回的 temporaryUrl 是临时签名链接，1小时后过期，不要当作永久公网地址写入配置或持久化存储。工具还会基于 DescribeEnvs 返回的 Storages[0].CdnDomain 推导 publicUrl，⚠️ 警告：publicUrl 仅在存储桶 ACL 为公有读（所有用户可读）时才能被匿名访问；默认私有读写存储桶返回的 publicUrl 会 403，此时请继续使用 temporaryUrl 或先通过控制台/SDK 将目标路径设置为公有读。\n\n💡 存储桶 ACL 权限管理请使用 permissions 工具：queryPermissions(action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\") 查询，managePermissions(action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"READONLY\") 设置。\n\n📦 CloudBase PG / pgstore 桶必须先创建后使用（与 Supabase Storage 一致：upload 前 bucket 必须存在）。浏览器 SDK `app.storage.from().upload(path, file)` 不会自动建桶，且 `path` 的第一段就是 bucket 名（例如 `covers/foo.png` → bucket=`covers`）；`from('covers')` 这个参数当前不会被拼到 path 里。如果上传时浏览器看到 `STORAGE_BUCKET_NOT_FOUND` 或 `PUT https://undefined/`（DevTools 表现为 `net::ERR_NAME_NOT_RESOLVED`），先用本工具或控制台确认 / 创建对应的 pgstore bucket，再让前端重试上传，不要让前端把上传失败静默吞掉。`DescribeEnvs.Storages[]` 返回的旧 NoSQL bucket（形如 `<hash>-<envId>-<appId>`）不是可用的 pgstore bucket，切勿当作默认目标使用。",
       inputSchema: manageStorageInputSchema,
       annotations: {
         readOnlyHint: false,
@@ -324,11 +335,12 @@ export function registerStorageTools(server: ExtendedMcpServer) {
     },
     async (args: ManageStorageInput) => {
       const input = args;
-      const manager = await getManager();
+      try {
+        const manager = await getManager();
 
-      if (!manager) {
-        throw new Error("Failed to initialize CloudBase manager. Please check your credentials and environment configuration.");
-      }
+        if (!manager) {
+          throw new Error("Failed to initialize CloudBase manager. Please check your credentials and environment configuration.");
+        }
 
       const storageService = manager.storage;
 
@@ -514,6 +526,15 @@ export function registerStorageTools(server: ExtendedMcpServer) {
         default:
           throw new Error(`Unsupported action: ${input.action}`);
       }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      return buildJsonToolResult({
+        success: false,
+        message: `manageStorage 操作失败: ${message}`,
+        action: input.action,
+        cloudPath: input.cloudPath,
+      });
     }
+  }
   );
-} 
+}

--- a/mcp/src/tools/storagePG.ts
+++ b/mcp/src/tools/storagePG.ts
@@ -12,6 +12,7 @@ const STORAGE_ACTIONS = [
   "objectInfo",
   "signUpload",
   "signDownload",
+  "createBucket",
 ] as const;
 
 type StorageAction = (typeof STORAGE_ACTIONS)[number];
@@ -102,12 +103,56 @@ async function handleBuckets(server: ExtendedMcpServer) {
     data: {
       capability: "storageManagerSdkOrHttpApi",
       envId: server.cloudBaseOptions?.envId ?? null,
-      supportedActions: ["buckets", "config", "uploadPlan", "objectInfo"],
+      supportedActions: ["buckets", "config", "uploadPlan", "objectInfo", "createBucket"],
       note:
         "PG environment storage is exposed as metadata and implementation plans in MCP. Application data-plane upload/download should use SDK or HTTP API code.",
     },
     message:
       "Resolved PostgreSQL storage capability summary. Use uploadPlan for application-side upload implementation.",
+  });
+}
+
+async function handleCreateBucket(args: QueryPgStorageArgs, server: ExtendedMcpServer) {
+  if (!args.bucket?.trim()) {
+    return buildPgStorageResult({
+      success: false,
+      errorCode: "BUCKET_REQUIRED",
+      message: "Provide bucket name to create a PG storage bucket.",
+    });
+  }
+
+  const bucket = args.bucket.trim();
+  const envId = server.cloudBaseOptions?.envId ?? "${envId}";
+
+  return buildPgStorageResult({
+    success: true,
+    data: {
+      action: "createBucket",
+      bucket,
+      description: `Creates PG storage bucket '${bucket}'`,
+      plans: {
+        sql: `INSERT INTO storage.buckets (id, name, public) VALUES ('${bucket}', '${bucket}', false);`,
+        httpApi: {
+          method: "POST",
+          url: `https://${envId}.api.tcloudbasegateway.com/v1/storages/bucket/`,
+          headers: {
+            "Authorization": "Bearer {service_role_token}",
+            "Content-Type": "application/json",
+          },
+          body: { name: bucket, public: false },
+        },
+        cli: `tcb db execute -e ${envId} --sql "INSERT INTO storage.buckets (id, name, public) VALUES ('${bucket}', '${bucket}', false);"`,
+      },
+      tokenRequired: "service_role",
+      tokenGuide: "Use manageAppAuth(action='createApiKey', name='storage-server-key') to get a service_role level API key token.",
+      nextSteps: [
+        "Option A: Run the SQL via managePgDatabase(action='execute', confirm=true)",
+        "Option B: Call the HTTP API with a service_role token",
+        "Option C: Use CloudBase CLI: tcb db execute",
+      ],
+    },
+    message:
+      `Generated bucket creation plan for '${bucket}'. Execute one of the provided plans to create the bucket, then configure RLS policies.`,
   });
 }
 
@@ -190,7 +235,7 @@ export function registerPGStorageTools(server: ExtendedMcpServer) {
       inputSchema: {
         action: z
           .enum(STORAGE_ACTIONS)
-          .describe("操作类型：buckets/config=查询存储能力摘要；uploadPlan=生成 HTTP API/SDK 上传方案；objectInfo=生成对象元信息查询方案；signUpload/signDownload=显式的一次性签名 URL 请求占位"),
+          .describe("操作类型：buckets/config=查询存储能力摘要；createBucket=生成 bucket 创建方案（SQL/HTTP API/CLI）；uploadPlan=生成 HTTP API/SDK 上传方案；objectInfo=生成对象元信息查询方案；signUpload/signDownload=显式的一次性签名 URL 请求占位"),
         bucket: z.string().optional().describe("云存储 bucket 名称"),
         objectKey: z.string().optional().describe("单个对象 key"),
         objectKeys: z.array(z.string()).optional().describe("多个对象 key，用于对象元信息查询规划"),
@@ -217,6 +262,8 @@ export function registerPGStorageTools(server: ExtendedMcpServer) {
         case "buckets":
         case "config":
           return handleBuckets(server);
+        case "createBucket":
+          return handleCreateBucket(args, server);
         case "uploadPlan":
           return handleUploadPlan(args, server);
         case "objectInfo":


### PR DESCRIPTION
## Summary

Improves PG storage documentation and tooling to prevent common mistakes like using old COS tools in PG environments.

## Changes

### Skill: `storage-pg.md`
- **Decision tree** flowchart: PG storage vs legacy COS (mermaid)
- **Supabase comparison table**: maps CloudBase concepts to Supabase equivalents
- **JWT token guide**: how to get service_role (manageAppAuth), user JWT (auth.signInWithPassword), anon key (ensurePublishableKey)
- **Full HTTP API endpoint table** (21 endpoints)
- **CRM pattern** example: create bucket → upload → register metadata
- Clarified `storage.objects` already tracks metadata (no extra table needed for basic cases)

### Tool: `queryPgStorage`
- Added `createBucket` action returning 3 executable plans:
  - SQL via managePgDatabase
  - HTTP API curl with placeholders
  - CloudBase CLI command
- Includes token acquisition guidance in response

### Tool descriptions: `queryStorage` / `manageStorage`
- Added leading `⚠️ PG 模式环境请使用 queryPgStorage 而非本工具` warning