### PR TITLE
docs(specs): 📝 add skill-effectiveness-eval and skill-slimming spec designs

### DIFF
--- a/specs/skill-effectiveness-eval/design.md
+++ b/specs/skill-effectiveness-eval/design.md
@@ -1,0 +1,416 @@
+# 技术方案设计：Skill Effectiveness 端到端评估
+
+## 架构
+
+```mermaid
+graph TD
+    A[评估数据集<br/>tests/skill-effectiveness/eval.jsonl] --> B[评估执行器<br/>scripts/eval-skill-effectiveness.mjs]
+    B --> C{三条件对照}
+    
+    C -->|Baseline| D1[fixture 项目<br/>无 skills + 无 MCP]
+    C -->|MCP only| D2[fixture 项目<br/>无 skills + 有 MCP]
+    C -->|MCP + Skill| D3[fixture 项目<br/>有 skills + 有 MCP]
+    
+    D1 --> E1[codebuddy -p --model hy3<br/>执行代理任务]
+    D2 --> E2[codebuddy -p --model hy3<br/>执行代理任务]
+    D3 --> E3[codebuddy -p --model hy3<br/>执行代理任务]
+    
+    E1 --> F1[收集: 转录 + 文件变更]
+    E2 --> F2[收集: 转录 + 文件变更]
+    E3 --> F3[收集: 转录 + 文件变更]
+    
+    F1 --> G[LLM Judge<br/>hy3 模型评分]
+    F2 --> G
+    F3 --> G
+    
+    G --> H[评估报告<br/>三条件对比表 + skill 净贡献]
+    H --> I[存档<br/>specs/skill-effectiveness-eval/results/]
+```
+
+## 技术栈
+
+| 组件 | 选型 | 理由 |
+|------|------|------|
+| 代理执行 | CodeBuddy CLI headless（`codebuddy -p --model hy3-ioa`） | CI 中已有，hy3 免费，`--output-format json` 可收集转录 |
+| LLM judge | 同一 hy3 模型，不同 prompt | 免费，无需额外平台 |
+| fixture 项目 | 最小可运行项目模板（package.json + 入口文件 + TODO） | 隔离三条件，可复现 |
+| 评估脚本 | Node.js（复用 eval-skill-inject.mjs 框架） | 与现有评估体系一致 |
+| CI | GitHub Actions workflow（cron + workflow_dispatch） | 不每 PR 跑，成本控制 |
+
+## 核心设计
+
+### 1. 评估数据集设计
+
+文件：`tests/skill-effectiveness/eval.jsonl`
+
+```json
+{
+  "id": "pg-rls",
+  "scenario": "PostgreSQL RLS",
+  "prompt": "创建一个 articles 表，包含 title、content、created_at 字段，并设置行级安全策略，让用户只能读写自己的数据。用户身份通过 JWT 的 sub 字段标识。",
+  "fixtureDir": "tests/skill-effectiveness/fixtures/pg-rls",
+  "primaryRequirements": [
+    "创建了 articles 表，包含 title、content、created_at 字段",
+    "表有 owner 列（DEFAULT auth.uid()），用于标识数据归属",
+    "启用了 RLS（ALTER TABLE articles ENABLE ROW LEVEL SECURITY）",
+    "创建了 SELECT 策略（USING (owner = auth.uid())）",
+    "创建了 INSERT 策略（WITH CHECK (owner = auth.uid())）"
+  ],
+  "secondaryRequirements": [
+    "使用了 managePgDatabase(action=\"applyMigration\") 而非 manageMysqlDatabase",
+    "owner 列用 DEFAULT auth.uid()，INSERT 时不手动传 owner",
+    "没有使用 _openid（这是 NoSQL 概念，PG 不适用）",
+    "没有使用 db.collection()（NoSQL API）"
+  ],
+  "skillsExpected": ["postgresql-development"],
+  "category": "database",
+  "differentiator": "baseline 会建表但不知道 PG 要用 auth.uid() + RLS；MCP only 可能用 MySQL API 或 _openid；只有 skill 知道 PG 的正确安全模式"
+}
+```
+
+### 2. Case 设计原则
+
+好的 case 必须满足三个条件：
+
+1. **baseline 能完成基础部分** — 代理训练数据中有足够的知识完成基本任务（如建表、写表单）。如果三条件都是 0 分，case 无法区分 skill 的贡献。
+2. **CloudBase 特有要求只有读 skill 才会知道** — 这是区分点。如 `security_invoker`、`auth.uid()`、`scf_bootstrap`、安全域名检查等，训练数据中不会有。
+3. **有客观证据可验证** — SQL 语句、工具调用记录、配置文件内容，LLM judge 能直接检查。
+
+### 3. 五个核心场景详细设计
+
+#### Case 1: `pg-rls` — PostgreSQL 行级安全
+
+| 维度 | 设计 |
+|------|------|
+| **Prompt** | "创建一个 articles 表，包含 title、content、created_at 字段，并设置行级安全策略，让用户只能读写自己的数据。用户身份通过 JWT 的 sub 字段标识。" |
+| **baseline 能做什么** | 建表 SQL（CREATE TABLE articles...），可能加个 user_id 列 |
+| **CloudBase 特有要求** | ① owner 列用 `DEFAULT auth.uid()` 而非手动传 ② 必须 `ENABLE ROW LEVEL SECURITY` ③ SELECT 策略用 `USING (owner = auth.uid())` ④ INSERT 策略用 `WITH CHECK` ⑤ 用 `managePgDatabase` 而非 `manageMysqlDatabase` |
+| **区分点** | baseline 不知道 `auth.uid()` 函数；MCP only 可能用 MySQL API 或 `_openid`；只有 skill 知道 PG 正确的安全模式 |
+| **Primary 验证** | 表结构 + owner 列 + RLS 启用 + SELECT/INSERT 策略 |
+| **Secondary 验证** | 用对 managePgDatabase + DEFAULT auth.uid() + 没用 _openid + 没用 db.collection |
+| **Fixture** | 空 Vite 项目 + `src/lib/db.js`（含 TODO） |
+
+#### Case 2: `web-auth` — Web 用户名密码登录
+
+| 维度 | 设计 |
+|------|------|
+| **Prompt** | "实现一个 Web 登录页面，用户名是 admin（非邮箱格式），密码是 admin123。用 CloudBase 认证。" |
+| **baseline 能做什么** | 写一个 HTML 登录表单 + 基本的提交逻辑 |
+| **CloudBase 特有要求** | ① 用户名非邮箱格式 → 必须用 `usernamePassword` 而非 `emailPassword` ② 必须先 `queryAppAuth(action="getLoginConfig")` 检查 provider 状态 ③ 如果未启用，先 `manageAppAuth(action="patchLoginStrategy", patch={usernamePassword: true})` ④ 登录用 `auth.signInWithPassword({username, password})` 而非 `signInWithEmailAndPassword` ⑤ 不能用 `signUpWithEmailAndPassword` |
+| **区分点** | baseline 会写表单但不知道 CloudBase 的 provider 配置流程；MCP only 有工具但不知道 usernamePassword 和 emailPassword 的区别；只有 skill 知道"非邮箱格式 → usernamePassword"这个判断 |
+| **Primary 验证** | 登录页面实现 + provider 启用 + 登录 API 调用正确 |
+| **Secondary 验证** | 先 query 再 patch 的顺序 + 用 signInWithPassword 而非 Email 方法 + 没用 signUpWithEmailAndPassword |
+| **Fixture** | Vite + React 项目 + `src/pages/Login.jsx`（含 TODO） |
+
+#### Case 3: `storage-upload` — 前端文件上传
+
+| 维度 | 设计 |
+|------|------|
+| **Prompt** | "实现一个前端图片上传功能，用户选择图片后上传到 CloudBase 云存储，上传成功后显示图片预览。" |
+| **baseline 能做什么** | 写一个 file input + 预览逻辑 |
+| **CloudBase 特有要求** | ① 必须先检查安全域名 `envQuery(action="domains")` ② 如果当前 host:port 不在白名单，必须 `envDomainManagement(action="create")` 添加 ③ 上传用 `app.uploadFile()` 或 `app.storage.from()` ④ 上传后要保存返回的 `fileID` ⑤ 上传失败不能静默跳过后续操作（如 DB 插入） |
+| **区分点** | baseline 会写 file input 但不知道安全域名检查；MCP only 有工具但不知道要先检查 domains；只有 skill 知道"本地 dev server 的 host:port 需要加入白名单" |
+| **Primary 验证** | 上传功能实现 + 安全域名检查 + fileID 保存 |
+| **Secondary 验证** | 用了 envQuery(action="domains") + 失败处理 + 没有静默跳过 |
+| **Fixture** | Vite 项目 + `src/components/Upload.jsx`（含 TODO） |
+
+#### Case 4: `http-function` — HTTP 云函数
+
+| 维度 | 设计 |
+|------|------|
+| **Prompt** | "创建一个 HTTP 云函数，接收 POST 请求，返回 JSON 格式的 {success: true, data: ...}。" |
+| **baseline 能做什么** | 写一个 Node.js HTTP 服务 |
+| **CloudBase 特有要求** | ① 必须有 `scf_bootstrap` 文件 ② 必须监听端口 `9000` ③ Node.js 用原生 `http.createServer((req, res) => {...})` 而非 `exports.main` ④ 必须手动解析 `req.url` 和请求体（流式） ⑤ 用 `manageFunctions(action="createFunction")` 部署 |
+| **区分点** | baseline 会写 HTTP 服务但不知道 scf_bootstrap 和端口 9000；MCP only 有工具但不知道 Event 函数和 HTTP 函数的区别；只有 skill 知道 HTTP 函数的正确结构 |
+| **Primary 验证** | scf_bootstrap 存在 + 端口 9000 + 返回 JSON |
+| **Secondary 验证** | 用 http.createServer 而非 exports.main + 手动解析请求体 + 用 manageFunctions 部署 |
+| **Fixture** | 空目录 + `cloudfunctions/api/`（含 TODO） |
+
+#### Case 5: `nosql-rules` — NoSQL 安全规则
+
+| 维度 | 设计 |
+|------|------|
+| **Prompt** | "创建一个 posts 集合，配置安全规则：所有登录用户可读，只有创建者可写。用 CloudBase 文档数据库。" |
+| **baseline 能做什么** | 可能写前端权限检查代码（如 if userId === post.author） |
+| **CloudBase 特有要求** | ① 安全规则是"验证器"不是"过滤器"——写入时验证，读取时不过滤 ② 用 `managePermissions(resourceType="noSqlDatabase")` 配置规则 ③ 规则中用 `auth.openid` 标识用户 ④ 不能在前端代码中硬编码权限检查（应由安全规则保障） ⑤ 集合创建用 `writeNoSqlDatabaseStructure` |
+| **区分点** | baseline 会在前端做权限检查（错误做法）；MCP only 可能用错的 resourceType；只有 skill 知道"验证器 vs 过滤器"的区别和安全规则的正确配置方式 |
+| **Primary 验证** | 集合创建 + 安全规则配置 + 规则逻辑正确（读放开、写限制创建者） |
+| **Secondary 验证** | 用了 managePermissions + 用 auth.openid + 没有前端硬编码权限 + 理解验证器模式 |
+| **Fixture** | Vite 项目 + `src/lib/db.js`（含 TODO） |
+
+### 4. Case 区分度预期
+
+每个 case 在三条件下的预期表现：
+
+| Case | Baseline 预期 | MCP only 预期 | MCP + Skill 预期 | 区分度 |
+|------|--------------|---------------|-----------------|--------|
+| pg-rls | 建表但无 RLS / 用 _openid | 可能用 MySQL API / 有 RLS 但策略错 | 正确用 auth.uid() + RLS + 策略 | **高** |
+| web-auth | 写表单但用 email 登录 | 有工具但不知 usernamePassword | 先 query → patch → signInWithPassword | **高** |
+| storage-upload | 写 file input 但无域名检查 | 有工具但不知先查 domains | 先 envQuery → envDomainManagement → uploadFile | **中** |
+| http-function | 写 HTTP 服务但无 scf_bootstrap | 有工具但用 exports.main | scf_bootstrap + 端口 9000 + http.createServer | **高** |
+| nosql-rules | 前端硬编码权限检查 | 可能用错的 resourceType | managePermissions + 验证器模式 | **中** |
+
+区分度为"中"的 case（storage-upload、nosql-rules）如果实际跑出来三条件差异不明显，可在后续迭代中调整 prompt 或验证标准。
+
+### 5. fixture 项目设计
+
+每个场景一个最小项目模板，目录结构：
+
+```
+tests/skill-effectiveness/fixtures/pg-rls/
+├── package.json          # 最小依赖
+├── src/
+│   └── lib/
+│       └── db.js         # 入口文件，含 TODO 标记
+├── README.md             # 场景说明
+└── .expected/            # 预期结果（供 judge 参考）
+    ├── schema.sql        # 预期的 SQL 结构
+    └── policy.sql        # 预期的 RLS 策略
+```
+
+fixture 设计原则：
+- **最小化**：只包含任务所需的最小文件，不干扰代理判断
+- **有 TODO 标记**：用 `// TODO: ...` 明确标记代理需要完成的位置
+- **有 .expected 目录**：存放预期结果（SQL、配置等），供 LLM judge 参考
+- **无 CloudBase 依赖**：fixture 项目本身不预装 @cloudbase/js-sdk，让代理决定如何安装
+
+### 4. 三条件对照实现
+
+通过 fixture 项目的不同配置实现条件隔离：
+
+```
+条件 1: Baseline（无 skills + 无 MCP）
+  fixture 项目/
+  ├── package.json
+  ├── src/index.js
+  └── （无 .mcp.json，无 .codebuddy/skills/）
+
+条件 2: MCP only（无 skills + 有 MCP）
+  fixture 项目/
+  ├── package.json
+  ├── src/index.js
+  └── .mcp.json           # 配置 cloudbase MCP server
+
+条件 3: MCP + Skill（有 skills + 有 MCP）
+  fixture 项目/
+  ├── package.json
+  ├── src/index.js
+  ├── .mcp.json           # 配置 cloudbase MCP server
+  └── .codebuddy/skills/  # 复制相关 SKILL.md 文件
+      └── postgresql-development/SKILL.md
+```
+
+**关键点**：
+- 条件 3 的 skills 通过复制 SKILL.md 到 `.codebuddy/skills/` 实现，不依赖 hooks
+- 这测试的是"skill 内容本身是否有用"，不是"hooks 注入是否有效"
+- hooks 注入效果已有 `eval:skill-inject` 评估（F1=0.93），不需要重复
+
+### 5. 代理执行流程
+
+每个场景每个条件执行一次：
+
+```bash
+# 复制 fixture 到临时目录
+cp -r tests/skill-effectiveness/fixtures/pg-rls /tmp/eval/pg-rls-baseline
+
+# 如果是 MCP + Skill 条件，复制 skills
+cp -r config/source/skills/postgresql-development /tmp/eval/pg-rls-skill/.codebuddy/skills/
+
+# 如果是 MCP only 或 MCP + Skill 条件，配置 MCP
+cat > /tmp/eval/pg-rls-mcp/.mcp.json << 'EOF'
+{
+  "mcpServers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["@cloudbase/cloudbase-mcp@latest"]
+    }
+  }
+}
+EOF
+
+# 执行代理
+cd /tmp/eval/pg-rls-baseline
+codebuddy -p "$(cat prompt.txt)" -y --output-format json --permission-mode acceptEdits --model hy3-ioa > result.json 2>&1
+
+# 收集结果
+# - result.json: 代理转录
+# - git diff: 文件变更（在执行前 git init && git add -A && git commit）
+```
+
+**超时控制**：单次执行 timeout 1200s（20 分钟），与 issue-auto-processor 一致。
+
+### 6. LLM Judge 设计
+
+用 hy3 模型作为 judge，输入代理的转录和文件变更，输出评分。
+
+**Judge prompt 模板**：
+
+```
+你是一个代码审查专家。请评估 AI 代理完成以下任务的质量。
+
+## 用户任务
+{prompt}
+
+## 评估标准
+
+### 主要需求（核心交付物）
+{primaryRequirements}
+
+### 次要需求（安全检查、工作流合规）
+{secondaryRequirements}
+
+## 代理输出
+### 代理转录
+{agentTranscript}
+
+### 文件变更
+{fileDiff}
+
+## 评估要求
+1. 检查具体证据（SQL 语句、工具调用、代码文件），不要只看代理说"我会做"
+2. 对每个需求判断"通过"或"未通过"，并引用具体证据
+3. 如果无法判断，标注"不确定"
+
+## 输出格式（JSON）
+{
+  "score": 0-100,
+  "primaryResults": [
+    { "requirement": "...", "passed": true/false, "evidence": "..." }
+  ],
+  "secondaryResults": [
+    { "requirement": "...", "passed": true/false, "evidence": "..." }
+  ],
+  "overallAssessment": "..."
+}
+```
+
+**Judge 执行**：
+
+```bash
+codebuddy -p "$(cat judge-prompt.txt)" -y --output-format json --model hy3-ioa > judge-result.json
+```
+
+### 7. 评估报告格式
+
+输出到 `specs/skill-effectiveness-eval/results/{date}.md`：
+
+```markdown
+# Skill Effectiveness 评估报告 - 2026-07-16
+
+## 总览
+
+| 场景 | Baseline | MCP only | MCP + Skill | Skill 净贡献 |
+|------|----------|----------|-------------|-------------|
+| PG RLS | 40% | 60% | 80% | +20% |
+| Web Auth | 30% | 50% | 70% | +20% |
+| Storage Upload | 35% | 55% | 75% | +20% |
+| HTTP Function | 45% | 65% | 85% | +20% |
+| NoSQL Rules | 40% | 60% | 80% | +20% |
+| **平均** | **38%** | **58%** | **78%** | **+20%** |
+
+## 详细结果
+
+### PG RLS
+#### Baseline
+- Score: 40/100
+- 主要需求: 1/3 通过
+- 次要需求: 0/3 通过
+- 问题: 未启用 RLS，使用了 NoSQL API
+
+#### MCP only
+- Score: 60/100
+...
+
+#### MCP + Skill
+- Score: 80/100
+...
+```
+
+### 8. CI Workflow 设计
+
+文件：`.github/workflows/skill-effectiveness-eval.yml`
+
+```yaml
+name: Skill Effectiveness Evaluation
+
+on:
+  schedule:
+    - cron: '0 3 */14 * *'  # 每 2 周凌晨 3 点
+  workflow_dispatch:         # 手动触发
+
+jobs:
+  evaluate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    env:
+      CODEBUDDY_AUTH_TOKEN: ${{ secrets.CODEBUDDY_AUTH_TOKEN }}
+      CODEBUDDY_API_KEY: ${{ secrets.CODEBUDDY_API_KEY }}
+      CODEBUDDY_INTERNET_ENVIRONMENT: ${{ vars.CODEBUDDY_INTERNET_ENVIRONMENT }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm ci
+      - run: npm install -g @tencent-ai/codebuddy-code@latest
+      - name: Run evaluation
+        run: node scripts/eval-skill-effectiveness.mjs
+      - name: Archive results
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ github.run_id }}
+          path: specs/skill-effectiveness-eval/results/
+```
+
+## 成本估算
+
+| 项目 | 数量 | 单次耗时 | 总耗时 |
+|------|------|---------|--------|
+| 代理执行 | 5 场景 × 3 条件 = 15 次 | ~10-20 分钟 | ~2.5-5 小时 |
+| LLM judge | 15 次 | ~2-5 分钟 | ~30-75 分钟 |
+| 总计 | 30 次调用 | | ~3-6 小时 |
+
+- hy3 模型免费，无 API 费用
+- CI 并行执行可缩短（3 个 job 并行 = ~1-2 小时）
+- timeout 设为 120 分钟（2 小时），并行模式下足够
+
+## 测试策略
+
+1. **单元测试**：评估脚本逻辑（数据集解析、结果对比、报告生成）
+2. **集成测试**：用 1 个场景跑完整流程，验证脚本不报错
+3. **冒烟测试**：CI 手动触发跑 1 个场景，确认端到端可用
+4. **首次 baseline**：5 个场景全跑，记录基线数据
+
+## 安全性
+
+1. **认证隔离**：CI 使用 `CODEBUDDY_AUTH_TOKEN`，不暴露到日志
+2. **fixture 隔离**：评估在临时目录执行，不污染项目源码
+3. **MCP 隔离**：评估用 MCP 连接的是测试环境，不是生产环境
+4. **结果脱敏**：报告中不包含敏感信息（token、envId 等）
+
+## 风险与缓解
+
+| 风险 | 缓解措施 |
+|------|---------|
+| codebuddy CLI 输出格式不稳定 | 复用 issue-auto-processor 的 `extract-result-text` 解析逻辑 |
+| hy3 模型 judge 评分不稳定 | 同一结果跑 2 次 judge 取平均；低置信度结果标注人工复查 |
+| 代理执行超时 | 单次 timeout 1200s；超时记为 0 分并标注 |
+| fixture 项目 MCP 连接失败 | 执行前验证 MCP 可用性，失败时跳过并标注 |
+| 三条件隔离不彻底 | fixture 目录完全独立，执行前 `git clean` |
+
+## 实施计划
+
+1. **Phase 1**：创建评估数据集 + fixture 项目模板（5 个场景）
+2. **Phase 2**：实现评估执行器脚本（`scripts/eval-skill-effectiveness.mjs`）
+3. **Phase 3**：实现 LLM judge 脚本
+4. **Phase 4**：手动跑 1 个场景验证端到端流程
+5. **Phase 5**：跑完整 5 个场景，记录 baseline
+6. **Phase 6**：CI workflow 接入
+
+## 参考
+
+- 需求文档：`specs/skill-effectiveness-eval/requirements.md`
+- 现有评估脚本：`scripts/eval-skill-inject.mjs`
+- CodeBuddy CLI headless 调用示例：`.github/workflows/issue-auto-processor-simple.yml:419`
+- Supabase 评估方法论：https://supabase.com/blog/supabase-agent-skills#how-we-test-it
+- OpenAI Agent Skills 评估框架：https://developers.openai.com/blog/eval-skills

--- a/specs/skill-effectiveness-eval/requirements.md
+++ b/specs/skill-effectiveness-eval/requirements.md
@@ -1,0 +1,97 @@
+# 需求文档：Skill Effectiveness 端到端评估
+
+## 介绍
+
+当前 CloudBase-MCP 项目已有 skill-inject 命中率评估体系（P/R/F1=0.93），能量化检测"skill 是否被正确注入到代理上下文"。但**缺少对 skill 注入后实际效果的评估**——不知道 skill 内容是否真正帮助代理写出更好的代码。
+
+对标 Supabase Agent Skills 的三条件对照 + LLM judge 方法论，建立端到端 skill-effectiveness 评估能力，回答"我们的 skill 到底有没有用"这个根本问题。
+
+利用项目 CI 中已有的 CodeBuddy CLI headless 模式（`codebuddy -p --model hy3-preview-ioa`）和 hunyuan 免费模型，在项目内完成评估，不依赖 Braintrust 等外部平台。
+
+## 现状与差距
+
+| 维度 | 现状 | 目标 |
+|------|------|------|
+| 评估对象 | skill 是否被正确注入（命中率） | skill 是否真正改善代码质量（效果） |
+| 评估方法 | 规则匹配（P/R/F1） | LLM judge 评分 + 三条件对照 |
+| 对照组 | 无 | baseline / MCP only / MCP+Skill |
+| 评估平台 | 自研脚本 | CodeBuddy CLI + hy3 模型（项目内） |
+| CI 接入 | `npm run test:hooks`（每 PR） | 定期跑 + 手动触发（非每 PR） |
+
+## 需求
+
+### 需求 1 - 三条件对照评估框架
+
+**用户故事：** 作为 skill 维护者，我希望能在三种条件下对照评估代理完成 CloudBase 任务的质量，以便量化 skill 的真实贡献，而不是只看注入命中率。
+
+#### 验收标准
+
+1. While 评估框架已搭建, when 运行评估脚本时, the system shall 在三种条件下分别执行代理任务：Baseline（无 cloudbase plugin + 无 MCP）、MCP only（无 cloudbase plugin + 有 MCP）、MCP + Skill（有 cloudbase plugin + 有 MCP）。
+2. While 三条件任务已执行完成, when 收集结果时, the system shall 保存每个条件的完整代理转录和生成的文件。
+3. While 三条件结果已收集, when 输出报告时, the system shall 生成对比表展示每个场景在三条件下的得分，并计算 skill 净贡献值（MCP+Skill 得分 - MCP only 得分）。
+4. While 评估框架已搭建, when 控制条件时, the system shall 通过不同的 fixture 项目配置（`.claude/` 目录、MCP 配置）实现条件隔离，不依赖环境变量单独禁用 hooks。
+
+### 需求 2 - 核心场景覆盖
+
+**用户故事：** 作为 skill 维护者，我希望评估覆盖 CloudBase 核心开发场景，以便发现哪些 skill 内容有效、哪些需要改进。
+
+#### 验收标准
+
+1. While 评估场景已定义, when 选择场景时, the system shall 至少覆盖以下 5 个核心场景：PostgreSQL RLS（建表 + 安全策略）、Web 用户名密码认证、Storage 前端上传（安全域名配置）、HTTP 云函数部署、NoSQL 安全规则配置。
+2. While 场景已选定, when 执行评估时, the system shall 为每个场景提供一个最小可运行的 fixture 项目模板（包含必要的 `package.json`、入口文件、TODO 标记）。
+3. While 场景已执行, when 评分时, the system shall 将需求分为主要需求（核心交付物）和次要需求（安全检查、工作流合规），分别评分。
+
+### 需求 3 - LLM judge 自动评分
+
+**用户故事：** 作为 skill 维护者，我希望用 LLM 自动评分代理的输出质量，以便无需人工审查每个评估结果。
+
+#### 验收标准
+
+1. While 代理任务已执行完成, when 触发评分时, the system shall 调用 hunyuan 模型（`hy3-preview-ioa`）作为 LLM judge，审查完整转录和生成的文件。
+2. While LLM judge 审查时, when 评估主要需求时, the system shall 检查具体证据（工具调用记录、SQL 语句、代码文件、有效输出），而非仅依赖代理的自我陈述。
+3. While LLM judge 评分完成, when 输出结果时, the system shall 为每个场景每个条件生成 0-100 分的得分，并列出通过/未通过的具体需求项。
+4. While 评分结果已生成, when 评估可靠性不足时, the system shall 标注低置信度结果（如 judge 模型无法判断时），提示人工复查。
+
+### 需求 4 - CI 接入与定期执行
+
+**用户故事：** 作为团队，我们希望评估能定期自动运行，以便监控 skill 质量趋势，同时在 skill 内容变更时可手动触发验证。
+
+#### 验收标准
+
+1. While CI workflow 已配置, when 到达定期触发时间时, the system shall 每 2 周自动运行一次完整评估（cron 触发）。
+2. While PR 修改了 skill 内容, when 开发者需要验证时, the system shall 支持通过 `workflow_dispatch` 手动触发评估。
+3. While 评估不在每 PR 都跑, when PR 仅修改非 skill 内容时, the system shall 不触发评估（成本控制）。
+4. While 评估完成, when 结果已生成时, the system shall 将结果存档到 `specs/skill-effectiveness-eval/baseline-results/` 目录，按日期命名，便于趋势对比。
+
+## 范围
+
+### 在范围内
+
+- 三条件对照评估框架设计与实现
+- 5 个核心场景的 fixture 项目模板
+- LLM judge 评分脚本（用 hy3 模型）
+- CI workflow 配置（定期 + 手动触发）
+- 评估结果存档与对比
+
+### 不在范围内
+
+- Braintrust 等外部评估平台接入（用项目内 hy3 模型）
+- 跨代理评估（先在 CodeBuddy 上跑通，跨代理是后续 P2）
+- 评估所有 28 个 skill（先覆盖 5 个核心场景）
+- 实时评估反馈（先做离线定期评估）
+- skill 内容优化实施（评估方案先行，优化是后续任务）
+
+## 技术约束
+
+1. **复用现有基础设施**：CodeBuddy CLI headless 模式、`CODEBUDDY_AUTH_TOKEN` 认证、`hy3-preview-ioa` 模型
+2. **不依赖外部平台**：不引入 Braintrust，评估脚本和 judge 都在项目内完成
+3. **成本控制**：每场景 3 条件 = 3 次代理执行 + 3 次 judge 评分，5 场景共 30 次调用，需控制单次执行时间
+4. **fixture 项目隔离**：三条件通过不同的项目配置实现，不修改 hooks 运行时代码
+
+## 参考
+
+- Supabase Agent Skills 博文：https://supabase.com/blog/supabase-agent-skills#how-we-test-it
+- OpenAI Agent Skills 评估框架：https://developers.openai.com/blog/eval-skills
+- 现有 skill-inject 评估：`specs/plugin-review/evaluation-design.md`
+- CodeBuddy CLI headless 调用示例：`.github/workflows/issue-auto-processor-simple.yml:419`
+- 对标分析报告：`/Users/bookerzhao/Projects/AI-Workspace/output/reviews/2026-07-16-cloudbase-mcp-vs-supabase-agent-skills-review.md`

--- a/specs/skill-effectiveness-eval/tasks.md
+++ b/specs/skill-effectiveness-eval/tasks.md
@@ -1,0 +1,65 @@
+# 实施计划
+
+- [ ] 1. 创建评估数据集
+  - 创建 `tests/skill-effectiveness/eval.jsonl`，包含 5 个 case 的完整定义
+  - 每个 case 包含：id、scenario、prompt、fixtureDir、primaryRequirements、secondaryRequirements、skillsExpected、category、differentiator
+  - 参照 design.md 中 5 个场景的详细设计
+  - _需求: 需求 2（核心场景覆盖）
+
+- [ ] 2. 创建 fixture 项目模板（5 个）
+  - 创建 `tests/skill-effectiveness/fixtures/` 目录
+  - 每个 case 一个子目录：`pg-rls/`、`web-auth/`、`storage-upload/`、`http-function/`、`nosql-rules/`
+  - 每个目录包含：`package.json`（最小依赖）、`src/`（入口文件含 TODO）、`README.md`（场景说明）、`.expected/`（预期结果）
+  - fixture 项目不预装 @cloudbase/js-sdk，让代理自行决定
+  - _需求: 需求 2（核心场景覆盖）
+
+- [ ] 3. 实现评估执行器脚本
+  - 创建 `scripts/eval-skill-effectiveness.mjs`
+  - 核心流程：读取 eval.jsonl → 对每个 case 准备三条件 fixture → 调用 codebuddy CLI → 收集结果
+  - 三条件隔离：通过 fixture 项目配置实现（无 .mcp.json / 有 .mcp.json / 有 .mcp.json + .codebuddy/skills/）
+  - 复用 `issue-auto-processor-simple.yml` 中的 codebuddy 调用模式：`codebuddy -p "..." -y --output-format json --permission-mode acceptEdits --model hy3-ioa`
+  - 超时控制：单次 1200s
+  - 结果收集：代理 JSON 输出 + git diff（执行前 git init && commit）
+  - 支持单场景运行：`node scripts/eval-skill-effectiveness.mjs --case pg-rls`
+  - _需求: 需求 1（三条件对照评估框架）
+
+- [ ] 4. 实现 LLM judge 脚本
+  - 在评估执行器中集成 judge 逻辑（或独立脚本 `scripts/eval-skill-judge.mjs`）
+  - 输入：用户 prompt + primaryRequirements + secondaryRequirements + 代理转录 + 文件变更
+  - 用 hy3-ioa 模型作为 judge，输出 JSON：{ score, primaryResults, secondaryResults, overallAssessment }
+  - judge prompt 模板参照 design.md 中的设计
+  - 低置信度结果标注"不确定"，提示人工复查
+  - _需求: 需求 3（LLM judge 自动评分）
+
+- [ ] 5. 实现评估报告生成
+  - 生成 Markdown 报告到 `specs/skill-effectiveness-eval/results/{date}.md`
+  - 包含：总览对比表（三条件 × 5 场景 + skill 净贡献值）、每个场景的详细评分、judge 证据引用
+  - 报告格式参照 design.md 中的设计
+  - _需求: 需求 1（三条件对照评估框架）
+
+- [ ] 6. 手动跑 1 个场景验证端到端流程
+  - 用 `pg-rls` 场景跑完整流程（三条件 × 1 场景 = 3 次代理执行 + 3 次 judge）
+  - 验证：脚本不报错、结果可收集、judge 输出合理、报告可读
+  - 如果 codebuddy CLI 输出格式不稳定，调整解析逻辑
+  - _需求: 需求 1、3（验证框架可用性）
+
+- [ ] 7. 跑完整 5 个场景，记录 baseline
+  - 运行 `node scripts/eval-skill-effectiveness.mjs`（5 场景 × 3 条件 = 15 次代理 + 15 次 judge）
+  - 将结果存档到 `specs/skill-effectiveness-eval/results/`
+  - 分析 baseline 数据：skill 净贡献值是否为正、哪些 case 区分度高/低
+  - 如果区分度为"中"的 case 差异不明显，调整 prompt 或验证标准
+  - _需求: 需求 2、3（全场景 baseline）
+
+- [ ] 8. CI workflow 接入
+  - 创建 `.github/workflows/skill-effectiveness-eval.yml`
+  - 触发：每 2 周 cron + workflow_dispatch（手动）
+  - 复用 issue-auto-processor 的认证配置（CODEBUDDY_AUTH_TOKEN / CODEBUDDY_API_KEY）
+  - 执行评估脚本，上传结果 artifact
+  - 不每 PR 触发（成本控制）
+  - _需求: 需求 4（CI 接入与定期执行）
+
+- [ ] 9. 文档与测试
+  - 在 `specs/skill-effectiveness-eval/` 补充运行说明（如何手动跑、如何新增 case）
+  - 为评估脚本添加单元测试（数据集解析、报告生成逻辑）
+  - 更新 `package.json` scripts：`"eval:skill-effectiveness": "node scripts/eval-skill-effectiveness.mjs"`
+  - _需求: 需求 1、4

--- a/specs/skill-slimming/requirements.md
+++ b/specs/skill-slimming/requirements.md
@@ -1,0 +1,207 @@
+# 需求文档：SKILL.md 瘦身与内联安全清单
+
+## 介绍
+
+当前 CloudBase-MCP 项目 28 个 skill 中 25 个超过 100 行（最长 585 行），大量内容是 API 参数文档的复制。Supabase 的实践表明"代理懒于读取参考文件"，过长的 SKILL.md 会导致关键安全信息被跳过。
+
+同时，安全规则集中在 `cloudbase-code-review/references/RULES_INDEX.md`（58 条），开发阶段看不到，只有 close-out 阶段才检查，增加返工成本。
+
+此外，`config/source/guideline/cloudbase/SKILL.md`（262 行）作为总入口指南，`alwaysApply: true`，**每次对话都加载到上下文**。过长的总入口会持续消耗 context budget，瘦身优先级最高。
+
+本需求旨在：
+1. 瘦身 guideline 总入口（alwaysApply，优先级最高），将部署流程、控制台链接等移到 `references/`
+2. 瘦身 top 5 最长 skill，将 API 细节移到 `references/`，SKILL.md 只保留核心信息
+3. 在开发类 skill 中内联安全检查清单，加载即获得
+4. 建立瘦身模板，指导后续 skill 维护
+
+## 现状与差距
+
+| 维度 | 现状 | 目标 |
+|------|------|------|
+| guideline 总入口长度 | 262 行，alwaysApply: true，每次加载 | ≤120 行，只保留路由 + 宪章 |
+| skill 平均长度 | 25/28 超过 100 行，最长 585 行 | top 5 瘦身到 ≤200 行 |
+| 安全清单位置 | 集中在 code-review 的 RULES_INDEX | 内联到各开发 skill 顶部 |
+| 内容策略 | 混合模式（查找 + 复制大量文档） | "教如何查找"为主，SKILL.md 不复制 API 细节 |
+| 重复内容 | http-api 中 searchKnowledgeBase 引导重复 3 次 | 去重，关键引导只保留 1 次 |
+
+## 需求
+
+### 需求 1 - Guideline 总入口瘦身（最高优先级）
+
+**用户故事：** 作为 skill 维护者，我希望 guideline 总入口（`alwaysApply: true`）能瘦身到合理长度，以便每次对话不消耗过多 context budget，代理能快速获取路由信息和工程宪章。
+
+#### 验收标准
+
+1. While 瘦身已完成, when 检查 guideline SKILL.md 长度时, the system shall 确保行数不超过 120 行（当前 262 行）。
+2. While 瘦身时, when 保留核心内容时, the system shall 在 SKILL.md 中保留：三阶段工作流、Activation Contract、Engineering constitution、High-priority routing 路由表、Routing reminders。
+3. While 瘦身时, when 移动非核心内容时, the system shall 将以下内容移到 `references/` 子目录：
+   - 部署流程（当前第 195-234 行）→ `references/deployment-workflow.md`
+   - 控制台链接列表（当前第 239-262 行）→ `references/console-links.md`
+   - CloudBase scenarios 表格（当前第 161-179 行）→ `references/scenarios.md`
+   - MCP Prerequisite 的 mcporter 配置细节（当前第 111-153 行）→ 合并到已有的 `references/mcp-setup.md`
+4. While 瘦身时, when 处理重复内容时, the system shall 消除 Core Behavior Rules（当前第 183-193 行）与 Activation Contract 的重复段落，保留更精确的版本。
+5. While 瘦身时, when 处理非核心内容时, the system shall 删除 Pricing & Free Trial 段落（保留链接即可）和 "What to add to AGENTS.md" 段落（元信息，不属于 skill 加载内容）。
+6. While 瘦身时, when 处理 Web SDK quick reminder 时, the system shall 将其移到 `web-development` skill，不在总入口保留。
+7. While 瘦身已完成, when 代理需要部署流程或控制台链接时, the system shall 通过 SKILL.md 中的 `references/` 链接按需加载，不丢失任何原有信息。
+
+### 需求 2 - Top 5 最长 skill 瘦身
+
+**用户故事：** 作为 skill 维护者，我希望 top 5 最长的 SKILL.md 能瘦身到合理长度，以便代理在加载时能快速获取关键信息，不被冗长内容淹没。
+
+#### 验收标准
+
+1. While 瘦身已完成, when 检查 SKILL.md 长度时, the system shall 确保 top 5 最长 skill 的 SKILL.md 行数不超过 200 行：http-api（当前 585 行）、auth-wechat（当前 535 行）、auth-web（当前 515 行）、auth-tool（当前 508 行）、cloudbase-platform（当前 484 行）。
+2. While 瘦身时, when 移动 API 细节时, the system shall 将完整的 API 参数表、curl 示例、错误码表移到 `references/` 子目录下的独立文件，SKILL.md 只保留工作流 + 查找指引 + 常见错误。
+3. While 瘦身时, when 处理重复内容时, the system shall 消除 SKILL.md 内的重复段落（如 searchKnowledgeBase 引导多次出现的合并为 1 次）。
+4. While 瘦身已完成, when 代理需要 API 细节时, the system shall 通过 SKILL.md 中的 `references/` 链接按需加载，不丢失任何原有信息。
+5. While 瘦身已完成, when 运行 skill 质量标准测试时, the system shall 通过 `tests/skill-quality-standards.test.js` 中所有断言。
+
+### 需求 3 - 内联安全检查清单
+
+**用户故事：** 作为使用 CloudBase 的开发者，我希望 AI 代理在开发阶段就能看到安全检查清单，而不是等到 code review 阶段才发现安全问题，以便减少返工。
+
+#### 验收标准
+
+1. While 内联安全清单已添加, when 代理加载开发类 skill 时, the system shall 在 SKILL.md 顶部（Activation Contract 之后）展示该领域的安全检查清单。
+2. While 安全清单已内联, when 选择清单内容时, the system shall 从 `cloudbase-code-review/references/RULES_INDEX.md` 提取每个领域 top 5 高频安全问题，不复制全部 58 条规则。
+3. While 安全清单已内联, when 格式化清单时, the system shall 使用 Supabase 风格的简洁格式（❌ 禁止 / ⚠️ 警告），每条不超过 2 行。
+4. While 内联清单已添加, when 代理开发时, the system shall 在以下 skill 中包含安全清单：postgresql-development、auth-web、auth-wechat、no-sql-web-sdk、cloud-storage-web。
+5. While 内联清单已添加, when code-review skill 运行时, the system shall 保留完整 RULES_INDEX.md 作为 close-out 兜底，不删除原有规则。
+
+### 需求 4 - 瘦身模板与规范
+
+**用户故事：** 作为 skill 维护者，我希望有统一的瘦身模板和规范，以便后续新增或修改 skill 时有标准可循，避免重新膨胀。
+
+#### 验收标准
+
+1. While 瘦身模板已定义, when 新建或修改 skill 时, the system shall 遵循以下 SKILL.md 结构规范：
+   - frontmatter（name / description / version / alwaysApply）
+   - Standalone Install Note
+   - Activation Contract（Use this first / Do NOT / Common mistakes）
+   - 安全检查清单（内联，仅开发类 skill）
+   - 工作流（何时用 / 如何用）
+   - 查找指引（searchKnowledgeBase，只 1 次）
+   - 详细参考链接（references/ 目录）
+2. While 瘦身模板已定义, when SKILL.md 超过 200 行时, the system shall 触发维护者审查，判断是否需要将部分内容移到 references/。
+3. While 瘦身规范已定义, when 内容属于 API 参数表、完整代码示例、错误码表时, the system shall 将其移到 references/ 而非保留在 SKILL.md 中。
+4. While 瘦身规范已定义, when 内容属于激活契约、安全清单、工作流、查找指引时, the system shall 将其保留在 SKILL.md 中，不移到 references/。
+
+### 需求 5 - promptSignals/retrieval 字段持久化（前置依赖）
+
+**用户故事：** 作为 skill 维护者，我希望 skill-inject 的匹配数据（promptSignals/retrieval）不会因 SKILL.md 同步覆盖而丢失，以便瘦身过程中安全重建 manifest，不会导致 skill-inject 失效。
+
+**背景**：调研发现当前 SKILL.md frontmatter 已丢失 `promptSignals` 和 `retrieval` 字段（被上游同步覆盖），manifest 中的匹配数据是"幸存的旧数据"。一旦运行 `npm run build:skill-manifest`，所有匹配数据会变空，skill-inject 完全失效（F1 从 0.93 → 0）。此问题必须在瘦身前优先解决。
+
+#### 验收标准
+
+1. While 字段持久化方案已实施, when 从 `config/source/skills/` 构建 manifest 时, the system shall 优先从独立的元数据配置文件（如 `skill-metadata.json`）读取 `promptSignals` 和 `retrieval` 字段，而非从 SKILL.md frontmatter 读取。
+2. While 独立配置已建立, when 同步脚本（`sync-claude-skills-mirror.mjs` 或 `sync-cloudbase-plugin-skills.mjs`）覆盖 SKILL.md 时, the system shall 不影响 `promptSignals` 和 `retrieval` 数据，因为这些数据已不在 SKILL.md 中。
+3. While 字段已迁移, when 运行 `npm run build:skill-manifest` 时, the system shall 生成与当前 manifest 中 `promptSignals`/`retrieval` 完全一致的数据，不丢失任何 phrases/allOf/anyOf/aliases/intents/entities/examples。
+4. While 字段已迁移, when 验证匹配效果时, the system shall 通过 `npm run eval:skill-inject` 保持 F1 ≥ 0.90（当前基线 0.93）。
+5. While 迁移已完成, when 新增 skill 时, the system shall 在独立配置文件中为新 skill 添加 `promptSignals` 和 `retrieval` 字段，并在 `tests/hooks/build-skill-manifest.test.mjs` 中断言所有 skill 都有非空 promptSignals。
+
+## 范围
+
+### 在范围内
+
+- **promptSignals/retrieval 字段持久化（前置依赖）**：迁移到独立配置文件，防止同步覆盖丢失
+- guideline 总入口瘦身（`config/source/guideline/cloudbase/SKILL.md`，262→≤120 行）
+- top 5 最长 skill 瘦身（http-api、auth-wechat、auth-web、auth-tool、cloudbase-platform）
+- 5 个开发类 skill 内联安全清单（postgresql-development、auth-web、auth-wechat、no-sql-web-sdk、cloud-storage-web）
+- 瘦身模板与规范文档
+- 更新 `tests/skill-quality-standards.test.js` 断言
+
+### 不在范围内
+
+- 全部 28 个 skill 瘦身（先 guideline + top 5，验证效果后再推广）
+- RULES_INDEX.md 重构（保留作为 close-out 兜底）
+- skill-inject hooks 匹配逻辑修改（不改 exact/lexical 匹配算法本身）
+- 评估瘦身效果（属于 skill-effectiveness-eval 的范畴）
+
+## 技术约束
+
+1. **不丢失信息**：移到 references/ 的内容必须完整保留，SKILL.md 中提供链接
+2. **description 字段不可精简**：cloudbase plugin（hooks）不是默认安装的，无插件场景下 skill 发现完全依赖 frontmatter 的 `description` 字段（IDE 原生 Skill tool 和 `searchKnowledgeBase` 都靠它匹配）。瘦身时只能精简正文，**不能缩短 description**
+3. **不破坏注入**：有插件场景下瘦身后 `npm run eval:skill-inject` 的 F1 必须 ≥ 0.90（当前基线 0.93）
+4. **不破坏兼容**：Standalone Install Note 保留，独立安装时仍可访问 references/
+5. **安全清单精简**：每个 skill 最多 5 条安全规则，不复制全部 RULES_INDEX
+6. **前置依赖**：promptSignals/retrieval 字段持久化（需求 5）必须先于瘦身（需求 1-2）完成，否则 manifest 重建会导致有插件场景的 skill-inject 失效
+7. **瘦身安全验证**：每完成一个 skill 瘦身后，运行 `npm run eval:skill-inject` 确认命中率不回归（验证有插件场景）；同时检查 description 字段未被修改（验证无插件场景）
+
+## 三种使用场景与 skill 发现机制
+
+| 场景 | plugin（hooks） | skill 发现方式 | 瘦身注意事项 |
+|------|----------------|---------------|-------------|
+| A：安装了 cloudbase plugin | ✅ 有 hooks | promptSignals/retrieval 自动匹配注入 | 正文可精简，不影响匹配 |
+| B：只有 MCP server | ❌ 无 hooks | `searchKnowledgeBase(mode=skill)` + IDE 原生 Skill tool（靠 description） | description 不可精简 |
+| C：通过 `npx skills add` 安装 | ❌ 无 hooks | IDE 原生 Skill tool（靠 description） | description 不可精简 |
+
+**关键结论**：description 字段是场景 B/C 的唯一匹配依据。瘦身只精简正文（移 API 细节到 references/），**不动 description**。
+
+## guideline 瘦身示范（参考）
+
+### 瘦身前（262 行）
+
+| 段落 | 行数 | 处理 |
+|------|------|------|
+| frontmatter | 1-7 | 保留（description 关键词可精简） |
+| Workflow（三阶段） | 9-29 | **保留** |
+| Activation Contract | 31-63 | **保留** |
+| Engineering constitution | 64-73 | **保留** |
+| High-priority routing（路由表） | 75-94 | **保留** |
+| Routing reminders | 96-102 | **精简**（与路由表去重） |
+| Web SDK quick reminder | 104-109 | **移到** web-development skill |
+| MCP Prerequisite（mcporter 配置） | 111-153 | **移到** references/mcp-setup.md |
+| Pricing & Free Trial | 155-158 | **删除**（保留链接） |
+| CloudBase scenarios 表格 | 161-179 | **移到** references/scenarios.md |
+| What to add to AGENTS.md | 177-179 | **删除**（元信息） |
+| Core Behavior Rules | 183-193 | **精简**（与 Activation Contract 去重） |
+| Deployment Workflow | 195-234 | **移到** references/deployment-workflow.md |
+| Console Entry Points | 239-262 | **移到** references/console-links.md |
+
+### 瘦身后（~120 行）
+
+- frontmatter
+- Workflow（三阶段）
+- Activation Contract（Global rules + Universal guardrails）
+- Engineering constitution（工程宪章）
+- High-priority routing（路由表）
+- Routing reminders（精简后）
+- MCP 必要性声明（1 段，细节链接到 references/mcp-setup.md）
+- 详细参考链接（references/ 目录）
+
+## http-api 瘦身示范（参考）
+
+### 瘦身前（585 行）
+
+| 段落 | 行数 | 问题 |
+|------|------|------|
+| frontmatter + Standalone | 1-16 | 保留 |
+| Activation Contract | 17-50 | 保留 |
+| When to use / How to use | 51-97 | 精简（searchKnowledgeBase 引导去重） |
+| OpenAPI Swagger Documentation | 99-132 | **删除**（与 85-97 重复） |
+| Authentication and Authorization | 134-220 | **精简**（移细节到 references） |
+| 关系型数据库 RESTful API | 235-357 | **移到** references/relational-database-api.md |
+| NoSQL RESTful API | 383-428 | **移到** references/nosql-api.md |
+| AI 大模型接入 API | 432-460 | **移到** references/ai-model-api.md |
+| Online Debugging Tool | 464-471 | **删除**（非核心） |
+| API Documentation References | 473-513 | **删除**（与 85-97 重复） |
+| Common Authentication Flows | 527-585 | **移到** references/auth-flows.md |
+
+### 瘦身后（~130 行）
+
+- frontmatter + Standalone Install Note
+- Activation Contract
+- 安全检查清单（新增内联）
+- How to use（精简）
+- 认证方式简表（3 种方式 + 安全 gotcha）
+- Base URL 规则
+- API 查找指引（searchKnowledgeBase，只 1 次）
+- 详细参考链接（references/ 目录）
+
+## 参考
+
+- Supabase Agent Skills 博文：https://supabase.com/blog/supabase-agent-skills#how-we-test-it
+- 现有安全规则矩阵：`config/source/skills/cloudbase-code-review/references/RULES_INDEX.md`
+- skill 质量标准测试：`tests/skill-quality-standards.test.js`
+- 对标分析报告：`/Users/bookerzhao/Projects/AI-Workspace/output/reviews/2026-07-16-cloudbase-mcp-vs-supabase-agent-skills-review.md`


### PR DESCRIPTION
## 背景

对标 [Supabase Agent Skills](https://supabase.com/blog/supabase-agent-skills#how-we-test-it) 的做法，审查 CloudBase-MCP 项目的 skills 体系，识别差距并提出改进方案。

## 改动内容

### 1. `specs/skill-effectiveness-eval/` — 端到端 skill 效果评估方案（P0）

三件套：requirements.md + design.md + tasks.md

**核心设计**：
- 三条件对照：Baseline（无 skill 无 MCP）/ MCP only（有 MCP 无 skill）/ MCP + Skill（完整体验）
- 用 CodeBuddy CLI（`codebuddy -p --model hy3-ioa`）作为代理执行器 + LLM judge，免费
- 5 个精巧设计的 case：PG RLS、Web Auth、Storage Upload、HTTP Function、NoSQL Rules
- 每个 case 区分三条件：baseline 能做基础部分，CloudBase 特有安全要求只有读 skill 才会知道
- CI 每 2 周定期跑 + 手动触发

### 2. `specs/skill-slimming/` — SKILL.md 瘦身需求文档（P1，暂停在 requirements 阶段）

**核心需求**：
- Guideline 总入口瘦身（262→≤120 行，`alwaysApply: true`，每次加载消耗 context）
- Top 5 最长 skill 瘦身（http-api 585 行 → ~130 行等）
- 内联安全检查清单（从 RULES_INDEX 提取 top 5 到各开发 skill）
- **promptSignals/retrieval 字段持久化**（前置依赖，修复已发现的同步覆盖问题）

**关键发现**：
- skill-inject 匹配只用 frontmatter 的 promptSignals/retrieval，不用正文 → 正文瘦身对有插件用户安全
- cloudbase plugin **不是默认安装的** → 无插件场景靠 description 匹配，description 不可精简
- promptSignals/retrieval 已从 SKILL.md frontmatter 丢失（上游同步覆盖），manifest 中是幸存的旧数据

### 3. 执行顺序调整

```
先评估（建立 baseline）→ 再瘦身（基于数据决策）
```

skill-slimming 暂停在 requirements 阶段，等 skill-effectiveness-eval 跑出 baseline 后再推进 design。

## 不在本次范围

- 实际实施评估脚本（tasks.md 中的 9 个任务）
- SKILL.md 瘦身实施
- promptSignals/retrieval 字段持久化实施

## 检查清单

- [x] 需求文档遵循 EARS 语法
- [x] 技术方案包含架构图
- [x] Case 设计满足区分度要求（baseline 能做基础，CloudBase 特有要求只有 skill 知道）
- [x] 不包含代码改动，纯 spec 文档