### PR TITLE
fix(plugin): 🐛 sync dotfiles and generated assets to plugin repos

### DIFF
--- a/.github/workflows/push-plugin-repos.yaml
+++ b/.github/workflows/push-plugin-repos.yaml
@@ -28,6 +28,15 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Require PLUGINS_REPO_TOKEN
+        env:
+          PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
+        run: |
+          if [ -z "$PLUGINS_REPO_TOKEN" ]; then
+            echo "::error::PLUGINS_REPO_TOKEN is not configured. Dedicated plugin repos cannot be synced."
+            exit 1
+          fi
+
       - name: Build Open Plugin Spec artifacts
         run: |
           node scripts/build-open-plugin-spec.mjs
@@ -35,32 +44,34 @@ jobs:
       - name: Build plugin repo output
         run: |
           node scripts/push-plugin-repos.mjs
+          node scripts/push-plugin-repos.mjs --check
 
       - name: Sync cloudbase-plugin repo
         env:
           PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
         run: |
-          if [ -z "$PLUGINS_REPO_TOKEN" ]; then
-            echo "⚠ PLUGINS_REPO_TOKEN not configured, skipping cloudbase-plugin sync"
-            exit 0
-          fi
+          set -euo pipefail
 
-          # Checkout target repo
-          git clone --depth 1 https://x-access-token:${PLUGINS_REPO_TOKEN}@github.com/TencentCloudBase/cloudbase-plugin.git /tmp/cloudbase-plugin
+          git clone --depth 1 "https://x-access-token:${PLUGINS_REPO_TOKEN}@github.com/TencentCloudBase/cloudbase-plugin.git" /tmp/cloudbase-plugin
 
-          # Clear target (keep .git)
+          # Clear target (keep .git). Use rsync so dotfiles (.plugin, .claude-plugin, …) are included.
+          # `cp -r src/* dest` silently drops hidden paths.
+          rsync -a --delete --exclude='.git' \
+            "${{ github.workspace }}/.plugin-repo-output/cloudbase/" \
+            /tmp/cloudbase-plugin/
+
+          # Guardrail: Open Plugin Spec manifest must exist after sync
+          test -f /tmp/cloudbase-plugin/.plugin/plugin.json
+          test -f /tmp/cloudbase-plugin/generated/skill-manifest.json
+          test -f /tmp/cloudbase-plugin/generated/synonyms.json
+          test ! -f /tmp/cloudbase-plugin/marketplace.json
+
           cd /tmp/cloudbase-plugin
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-
-          # Copy output
-          cp -r "${{ github.workspace }}/.plugin-repo-output/cloudbase/"* .
-
-          # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ -n "$(git status --porcelain)" ]; then
-            git add .
+            git add -A
             git commit -m "chore: sync from CloudBase-MCP [skip ci]"
             git push
             echo "✓ Pushed to cloudbase-plugin"
@@ -72,27 +83,23 @@ jobs:
         env:
           PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
         run: |
-          if [ -z "$PLUGINS_REPO_TOKEN" ]; then
-            echo "⚠ PLUGINS_REPO_TOKEN not configured, skipping cloudbase-sites-plugin sync"
-            exit 0
-          fi
+          set -euo pipefail
 
-          # Checkout target repo
-          git clone --depth 1 https://x-access-token:${PLUGINS_REPO_TOKEN}@github.com/TencentCloudBase/cloudbase-sites-plugin.git /tmp/cloudbase-sites-plugin
+          git clone --depth 1 "https://x-access-token:${PLUGINS_REPO_TOKEN}@github.com/TencentCloudBase/cloudbase-sites-plugin.git" /tmp/cloudbase-sites-plugin
 
-          # Clear target (keep .git)
+          rsync -a --delete --exclude='.git' \
+            "${{ github.workspace }}/.plugin-repo-output/cloudbase-sites/" \
+            /tmp/cloudbase-sites-plugin/
+
+          test -f /tmp/cloudbase-sites-plugin/.plugin/plugin.json
+          test ! -f /tmp/cloudbase-sites-plugin/marketplace.json
+
           cd /tmp/cloudbase-sites-plugin
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-
-          # Copy output
-          cp -r "${{ github.workspace }}/.plugin-repo-output/cloudbase-sites/"* .
-
-          # Commit and push
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           if [ -n "$(git status --porcelain)" ]; then
-            git add .
+            git add -A
             git commit -m "chore: sync from CloudBase-MCP [skip ci]"
             git push
             echo "✓ Pushed to cloudbase-sites-plugin"

--- a/.github/workflows/push-skills-repo.yaml
+++ b/.github/workflows/push-skills-repo.yaml
@@ -62,8 +62,8 @@ jobs:
             esac
           done
       
-          # 2. 拷贝生成产物覆盖（如果有同名目录，会被上面的删除逻辑释放出来）
-          cp -r ../.skills-repo-output/* .
+          # 2. Copy generated output (rsync includes dotfiles; `cp src/*` drops them)
+          rsync -a ../.skills-repo-output/ .
       
       - name: Commit and push changes
         env:

--- a/plugin/cloudbase-sites/.claude-plugin/plugin.json
+++ b/plugin/cloudbase-sites/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-sites-plugin",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/plugin/cloudbase-sites/.codex-plugin/plugin.json
+++ b/plugin/cloudbase-sites/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
-  "repository": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-sites-plugin",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/plugin/cloudbase-sites/.plugin/plugin.json
+++ b/plugin/cloudbase-sites/.plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-sites-plugin",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/plugin/cloudbase/.claude-plugin/plugin.json
+++ b/plugin/cloudbase/.claude-plugin/plugin.json
@@ -6,7 +6,7 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-plugin",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/plugin/cloudbase/.codex-plugin/plugin.json
+++ b/plugin/cloudbase/.codex-plugin/plugin.json
@@ -6,8 +6,8 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
-  "repository": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-plugin",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/plugin/cloudbase/.plugin/plugin.json
+++ b/plugin/cloudbase/.plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "Tencent CloudBase",
     "url": "https://cloudbase.net"
   },
-  "homepage": "https://github.com/TencentCloudBase/cloudbase-mcp",
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-plugin",
   "license": "MIT",
   "keywords": [
     "cloudbase",

--- a/scripts/push-plugin-repos.mjs
+++ b/scripts/push-plugin-repos.mjs
@@ -30,24 +30,27 @@ const PLUGINS = [
     sourceDir: path.join(ROOT_DIR, "plugin", "cloudbase"),
     repoName: "TencentCloudBase/cloudbase-plugin",
     description: "CloudBase AI Plugin — MCP Server + Agent Skills for AI Coding Agents",
+    // Hooks load skill-manifest.json + synonyms.json at runtime.
+    requireGenerated: true,
   },
   {
     name: "cloudbase-sites",
     sourceDir: path.join(ROOT_DIR, "plugin", "cloudbase-sites"),
     repoName: "TencentCloudBase/cloudbase-sites-plugin",
     description: "CloudBase Sites Plugin — create, deploy, and manage Vite web apps on CloudBase",
+    requireGenerated: false,
   },
 ];
 
 /**
  * Files/dirs to EXCLUDE when copying to dedicated plugin repo.
  * marketplace.json causes `plugins` CLI to treat repo as marketplace, not single plugin.
+ * Keep generated/ — hooks need skill-manifest.json and synonyms.json at runtime.
  */
 const EXCLUDE_PATTERNS = [
   "marketplace.json",
   ".claude-plugin/marketplace.json",
   ".sync-metadata.json",
-  "generated",           // build artifacts, not needed in plugin repo
   ".DS_Store",
   ".gitkeep",
 ];
@@ -132,27 +135,42 @@ function checkPlugin(plugin) {
   }
 
   // Verify no marketplace.json in output
-  const checks = [
+  const forbidden = [
     path.join(outDir, "marketplace.json"),
     path.join(outDir, ".claude-plugin", "marketplace.json"),
   ];
-  for (const p of checks) {
+  for (const p of forbidden) {
     if (fs.existsSync(p)) {
       console.error(`✗ [${plugin.name}] Found forbidden file: ${path.relative(outDir, p)}`);
       return false;
     }
   }
 
-  // Verify .plugin/plugin.json exists
-  if (!fs.existsSync(path.join(outDir, ".plugin", "plugin.json"))) {
-    console.error(`✗ [${plugin.name}] Missing .plugin/plugin.json`);
-    return false;
+  // Required Open Plugin Spec / vendor manifests (dotdirs must survive sync)
+  const required = [
+    [".plugin/plugin.json", path.join(outDir, ".plugin", "plugin.json")],
+    ["mcp.json", path.join(outDir, "mcp.json")],
+    [".mcp.json", path.join(outDir, ".mcp.json")],
+    [".claude-plugin/plugin.json", path.join(outDir, ".claude-plugin", "plugin.json")],
+  ];
+  for (const [label, p] of required) {
+    if (!fs.existsSync(p)) {
+      console.error(`✗ [${plugin.name}] Missing required file: ${label}`);
+      return false;
+    }
   }
 
-  // Verify mcp.json exists
-  if (!fs.existsSync(path.join(outDir, "mcp.json"))) {
-    console.error(`✗ [${plugin.name}] Missing mcp.json`);
-    return false;
+  if (plugin.requireGenerated) {
+    const generatedRequired = [
+      "generated/skill-manifest.json",
+      "generated/synonyms.json",
+    ];
+    for (const rel of generatedRequired) {
+      if (!fs.existsSync(path.join(outDir, rel))) {
+        console.error(`✗ [${plugin.name}] Missing required runtime artifact: ${rel}`);
+        return false;
+      }
+    }
   }
 
   console.log(`✓ [${plugin.name}] Output looks good`);
@@ -181,6 +199,13 @@ function main() {
   for (const plugin of PLUGINS) {
     totalFiles += buildPlugin(plugin);
   }
+
+  // Always validate after generate so CI catches incomplete output early
+  let allGood = true;
+  for (const plugin of PLUGINS) {
+    if (!checkPlugin(plugin)) allGood = false;
+  }
+  if (!allGood) process.exit(1);
 
   console.log(`\nDone. ${totalFiles} total files in ${path.relative(ROOT_DIR, OUTPUT_DIR)}/`);
 }


### PR DESCRIPTION
## Summary
- Fix `cp .../*` dropping hidden paths (`.plugin/`, `.claude-plugin/`, `.codex-plugin/`, `.mcp.json`) by switching to `rsync -a`
- Keep `generated/` (`skill-manifest.json`, `synonyms.json`) so skill-inject hooks work after install
- Fail CI when `PLUGINS_REPO_TOKEN` is missing (was soft-skip / false green)
- Apply the same rsync fix to `push-skills-repo.yaml`
- Update plugin homepage URLs to dedicated repos

## Already done outside this PR
- Manually re-synced `TencentCloudBase/cloudbase-plugin` and `cloudbase-sites-plugin`
- Configured `PLUGINS_REPO_TOKEN` GitHub Secret

## Verification
- `npx plugins discover TencentCloudBase/cloudbase-plugin --remote` → Found `cloudbase` with skills + cmds + agents + hooks + **mcp**
- `npx plugins discover TencentCloudBase/cloudbase-sites-plugin --remote` → Found `cloudbase-sites` with skill + hooks + **mcp**
- Remote trees now include `.plugin/plugin.json` and `generated/*`

## Test plan
- [ ] CI Push Plugin Repos succeeds on merge (token present)
- [ ] After merge, a plugin path change triggers auto-sync with dotfiles intact

Made with [Cursor](https://cursor.com)