### PR TITLE
fix(plugin): 🛡️ validate skill-manifest before sync + README one-click install

### DIFF
--- a/.github/workflows/push-plugin-repos.yaml
+++ b/.github/workflows/push-plugin-repos.yaml
@@ -8,7 +8,6 @@ on:
       - 'plugin/cloudbase/**'
       - 'plugin/cloudbase-sites/**'
       - 'scripts/build-open-plugin-spec.mjs'
-      - 'scripts/build-skill-manifest.mjs'
       - 'scripts/push-plugin-repos.mjs'
   workflow_dispatch:
 
@@ -38,16 +37,35 @@ jobs:
             exit 1
           fi
 
-      - name: Install dependencies
-        run: npm ci --ignore-scripts
-
-      - name: Rebuild skill-inject artifacts
+      - name: Validate skill-inject artifacts
         run: |
-          # Keep generated/skill-manifest.json in sync with skills before
-          # publishing to dedicated plugin repos (hooks load it at runtime).
-          node scripts/build-skill-manifest.mjs
-          test -f plugin/cloudbase/generated/skill-manifest.json
-          test -f plugin/cloudbase/generated/synonyms.json
+          # Do NOT run build-skill-manifest here: promptSignals/retrieval currently
+          # live only in generated/skill-manifest.json (not SKILL.md frontmatter).
+          # Rebuilding from skills would wipe matching data until skill-metadata
+          # persistence lands. Validate the committed artifact instead.
+          node -e "
+            const fs = require('fs');
+            const manifestPath = 'plugin/cloudbase/generated/skill-manifest.json';
+            const synonymsPath = 'plugin/cloudbase/generated/synonyms.json';
+            for (const p of [manifestPath, synonymsPath]) {
+              if (!fs.existsSync(p)) {
+                console.error('Missing required artifact:', p);
+                process.exit(1);
+              }
+            }
+            const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+            const skills = Object.values(manifest.skills || {});
+            if (skills.length === 0) {
+              console.error('skill-manifest.json has no skills');
+              process.exit(1);
+            }
+            const withSignals = skills.filter((s) => (s.promptSignals?.phrases || []).length > 0);
+            if (withSignals.length === 0) {
+              console.error('skill-manifest.json has empty promptSignals — refusing to sync broken hooks data');
+              process.exit(1);
+            }
+            console.log('✓ skill-manifest ok:', skills.length, 'skills,', withSignals.length, 'with promptSignals');
+          "
 
       - name: Build Open Plugin Spec artifacts
         run: |

--- a/.github/workflows/push-plugin-repos.yaml
+++ b/.github/workflows/push-plugin-repos.yaml
@@ -8,6 +8,7 @@ on:
       - 'plugin/cloudbase/**'
       - 'plugin/cloudbase-sites/**'
       - 'scripts/build-open-plugin-spec.mjs'
+      - 'scripts/build-skill-manifest.mjs'
       - 'scripts/push-plugin-repos.mjs'
   workflow_dispatch:
 
@@ -36,6 +37,17 @@ jobs:
             echo "::error::PLUGINS_REPO_TOKEN is not configured. Dedicated plugin repos cannot be synced."
             exit 1
           fi
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Rebuild skill-inject artifacts
+        run: |
+          # Keep generated/skill-manifest.json in sync with skills before
+          # publishing to dedicated plugin repos (hooks load it at runtime).
+          node scripts/build-skill-manifest.mjs
+          test -f plugin/cloudbase/generated/skill-manifest.json
+          test -f plugin/cloudbase/generated/synonyms.json
 
       - name: Build Open Plugin Spec artifacts
         run: |

--- a/plugin/cloudbase-sites/README.md
+++ b/plugin/cloudbase-sites/README.md
@@ -14,7 +14,22 @@ CodeBuddy, and Codex.
 - **Skills** — The `cloudbase-sites-runtime` skill orchestrates the full
   vibe-coding session.
 
+## One-click install (recommended)
+
+Install via the dedicated plugin repository (Open Plugin Spec):
+
+```bash
+npx plugins add TencentCloudBase/cloudbase-sites-plugin
+```
+
+This works with Claude Code, Cursor, Codex, and other hosts that support the
+[Open Plugin Specification](https://open-plugins.com/plugin-builders/specification).
+The dedicated repo is auto-synced from this directory (without `marketplace.json`).
+
 ## Quick start per host
+
+Use these host-native marketplace flows when you prefer IDE-specific install
+paths instead of `npx plugins add`.
 
 ### Codex
 

--- a/plugin/cloudbase/README.md
+++ b/plugin/cloudbase/README.md
@@ -18,7 +18,22 @@ The `skills/` directory is a **generated artifact** — do not edit files in it
 directly. They are synced from `TencentCloudBase/skills@main` via
 `scripts/sync-cloudbase-plugin-skills.mjs`.
 
+## One-click install (recommended)
+
+Install via the dedicated plugin repository (Open Plugin Spec):
+
+```bash
+npx plugins add TencentCloudBase/cloudbase-plugin
+```
+
+This works with Claude Code, Cursor, Codex, and other hosts that support the
+[Open Plugin Specification](https://open-plugins.com/plugin-builders/specification).
+The dedicated repo is auto-synced from this directory (without `marketplace.json`).
+
 ## Quick start per host
+
+Use these host-native marketplace flows when you prefer IDE-specific install
+paths instead of `npx plugins add`.
 
 ### Codex
 

--- a/scripts/push-plugin-repos.mjs
+++ b/scripts/push-plugin-repos.mjs
@@ -171,6 +171,27 @@ function checkPlugin(plugin) {
         return false;
       }
     }
+
+    // promptSignals currently survive only in committed skill-manifest.json.
+    // Refuse to publish an empty matching table (would disable skill-inject).
+    try {
+      const manifest = JSON.parse(
+        fs.readFileSync(path.join(outDir, "generated", "skill-manifest.json"), "utf-8"),
+      );
+      const skills = Object.values(manifest.skills || {});
+      const withSignals = skills.filter((s) => (s.promptSignals?.phrases || []).length > 0);
+      if (skills.length === 0 || withSignals.length === 0) {
+        console.error(
+          `✗ [${plugin.name}] generated/skill-manifest.json has empty promptSignals ` +
+            `(${withSignals.length}/${skills.length}). Do not rebuild from SKILL.md until ` +
+            `skill-metadata persistence is implemented.`,
+        );
+        return false;
+      }
+    } catch (err) {
+      console.error(`✗ [${plugin.name}] Failed to parse generated/skill-manifest.json: ${err.message}`);
+      return false;
+    }
   }
 
   console.log(`✓ [${plugin.name}] Output looks good`);


### PR DESCRIPTION
## Summary
- Add **pre-sync validation** that `plugin/cloudbase/generated/skill-manifest.json` has non-empty `promptSignals` (skill-inject depends on this)
- Document recommended one-click install in plugin READMEs:
  - `npx plugins add TencentCloudBase/cloudbase-plugin`
  - `npx plugins add TencentCloudBase/cloudbase-sites-plugin`

## Important finding
Blind `npm run build:skill-manifest` before sync is **unsafe** today: `promptSignals`/`retrieval` were removed from SKILL.md frontmatter, and independent skill-metadata persistence is not landed yet. Rebuilding would publish empty matching data and silently disable skill-inject.

Until that persistence work lands, CI validates the committed artifact instead of regenerating it.

## Test plan
- [ ] Push Plugin Repos validates skill-manifest and syncs successfully
- [ ] Plugin README tops show one-click install before marketplace sections