### PR TITLE
fix(plugin): 📦 keep dedicated repos Open Plugin Spec only

### DIFF
--- a/.github/workflows/push-plugin-repos.yaml
+++ b/.github/workflows/push-plugin-repos.yaml
@@ -84,17 +84,20 @@ jobs:
 
           git clone --depth 1 "https://x-access-token:${PLUGINS_REPO_TOKEN}@github.com/TencentCloudBase/cloudbase-plugin.git" /tmp/cloudbase-plugin
 
-          # Clear target (keep .git). Use rsync so dotfiles (.plugin, .claude-plugin, …) are included.
+          # Clear target (keep .git). Use rsync so Open Plugin Spec dotdirs (.plugin) are included.
           # `cp -r src/* dest` silently drops hidden paths.
           rsync -a --delete --exclude='.git' \
             "${{ github.workspace }}/.plugin-repo-output/cloudbase/" \
             /tmp/cloudbase-plugin/
 
-          # Guardrail: Open Plugin Spec manifest must exist after sync
+          # Guardrail: OPS-only dedicated repo
           test -f /tmp/cloudbase-plugin/.plugin/plugin.json
+          test -f /tmp/cloudbase-plugin/mcp.json
           test -f /tmp/cloudbase-plugin/generated/skill-manifest.json
           test -f /tmp/cloudbase-plugin/generated/synonyms.json
           test ! -f /tmp/cloudbase-plugin/marketplace.json
+          test ! -d /tmp/cloudbase-plugin/.claude-plugin
+          test ! -d /tmp/cloudbase-plugin/.codex-plugin
 
           cd /tmp/cloudbase-plugin
           git config user.name "github-actions[bot]"
@@ -122,7 +125,10 @@ jobs:
             /tmp/cloudbase-sites-plugin/
 
           test -f /tmp/cloudbase-sites-plugin/.plugin/plugin.json
+          test -f /tmp/cloudbase-sites-plugin/mcp.json
           test ! -f /tmp/cloudbase-sites-plugin/marketplace.json
+          test ! -d /tmp/cloudbase-sites-plugin/.claude-plugin
+          test ! -d /tmp/cloudbase-sites-plugin/.codex-plugin
 
           cd /tmp/cloudbase-sites-plugin
           git config user.name "github-actions[bot]"

--- a/doc/ai-agent-plugins.mdx
+++ b/doc/ai-agent-plugins.mdx
@@ -42,7 +42,7 @@ npx plugins add TencentCloudBase/cloudbase-sites-plugin
 npx plugins add TencentCloudBase/cloudbase-plugin --yes
 ```
 
-> 💡 专门插件仓库 `TencentCloudBase/cloudbase-plugin` 由主仓库 CI 自动同步，内容与 `plugin/cloudbase/` 一致，但不含 `marketplace.json`，确保 `plugins` CLI 能将其识别为单插件而非 marketplace。
+> 💡 专门插件仓库 `TencentCloudBase/cloudbase-plugin` 由主仓库 CI 自动同步，只包含 [Open Plugin Specification](https://open-plugins.com/plugin-builders/specification) 标准内容（`.plugin/`、`mcp.json`、skills/hooks 等），不含 `marketplace.json` / `.claude-plugin` / `.codex-plugin`。Claude Code / Codex 原生 marketplace 安装请继续使用主仓库 `TencentCloudBase/CloudBase-MCP`。
 
 **支持的 AI 编程助手**（自动检测，检测到几个就装几个）：
 

--- a/scripts/push-plugin-repos.mjs
+++ b/scripts/push-plugin-repos.mjs
@@ -3,9 +3,11 @@
 /**
  * Build plugin repository output for syncing to dedicated plugin repos.
  *
- * For each plugin, copies its contents to .plugin-repo-output/<name>/
- * while EXCLUDING marketplace.json files (which cause `npx plugins` CLI
- * to treat the repo as a marketplace instead of a single plugin).
+ * Dedicated repos are Open Plugin Spec only (`npx plugins add`).
+ * Vendor-native marketplace manifests stay in the main CloudBase-MCP repo:
+ *   - `.claude-plugin/`  → Claude Code marketplace
+ *   - `.codex-plugin/`   → Codex marketplace
+ *   - `marketplace.json` → would make plugins CLI treat the repo as a marketplace
  *
  * Output: .plugin-repo-output/cloudbase/ and .plugin-repo-output/cloudbase-sites/
  *
@@ -44,12 +46,13 @@ const PLUGINS = [
 
 /**
  * Files/dirs to EXCLUDE when copying to dedicated plugin repo.
- * marketplace.json causes `plugins` CLI to treat repo as marketplace, not single plugin.
  * Keep generated/ — hooks need skill-manifest.json and synonyms.json at runtime.
  */
 const EXCLUDE_PATTERNS = [
+  // Marketplace / vendor-native install paths stay in CloudBase-MCP only
   "marketplace.json",
-  ".claude-plugin/marketplace.json",
+  ".claude-plugin",
+  ".codex-plugin",
   ".sync-metadata.json",
   ".DS_Store",
   ".gitkeep",
@@ -90,7 +93,11 @@ function generateReadme(plugin) {
 
 ${plugin.description}
 
-This repository is automatically synced from [${plugin.repoName.split("/")[0]}/CloudBase-MCP](https://github.com/${plugin.repoName.split("/")[0]}/CloudBase-MCP).
+This repository is automatically synced from [${plugin.repoName.split("/")[0]}/CloudBase-MCP](https://github.com/${plugin.repoName.split("/")[0]}/CloudBase-MCP)
+(\`plugin/${plugin.name}/\`, Open Plugin Spec artifacts only).
+
+Claude Code / Codex native marketplace install continues to use the main
+[CloudBase-MCP](https://github.com/${plugin.repoName.split("/")[0]}/CloudBase-MCP) repository.
 
 ## Installation
 
@@ -134,24 +141,27 @@ function checkPlugin(plugin) {
     return false;
   }
 
-  // Verify no marketplace.json in output
+  // Vendor-native / marketplace files must NOT appear in dedicated OPS repos
   const forbidden = [
-    path.join(outDir, "marketplace.json"),
-    path.join(outDir, ".claude-plugin", "marketplace.json"),
+    "marketplace.json",
+    ".claude-plugin",
+    ".codex-plugin",
+    path.join(".claude-plugin", "marketplace.json"),
+    path.join(".claude-plugin", "plugin.json"),
+    path.join(".codex-plugin", "plugin.json"),
   ];
-  for (const p of forbidden) {
+  for (const rel of forbidden) {
+    const p = path.join(outDir, rel);
     if (fs.existsSync(p)) {
-      console.error(`✗ [${plugin.name}] Found forbidden file: ${path.relative(outDir, p)}`);
+      console.error(`✗ [${plugin.name}] Found forbidden path (vendor/marketplace): ${rel}`);
       return false;
     }
   }
 
-  // Required Open Plugin Spec / vendor manifests (dotdirs must survive sync)
+  // Required Open Plugin Spec artifacts
   const required = [
     [".plugin/plugin.json", path.join(outDir, ".plugin", "plugin.json")],
     ["mcp.json", path.join(outDir, "mcp.json")],
-    [".mcp.json", path.join(outDir, ".mcp.json")],
-    [".claude-plugin/plugin.json", path.join(outDir, ".claude-plugin", "plugin.json")],
   ];
   for (const [label, p] of required) {
     if (!fs.existsSync(p)) {


### PR DESCRIPTION
## Summary
Dedicated plugin repos should be **Open Plugin Spec only** (`npx plugins add`).

- Exclude `.claude-plugin/` and `.codex-plugin/` from `push-plugin-repos` sync
- Keep validating no `marketplace.json` / vendor dirs after sync
- Clarify docs: native Claude/Codex marketplace stays on `CloudBase-MCP`

## Already synced
- `TencentCloudBase/cloudbase-plugin`
- `TencentCloudBase/cloudbase-sites-plugin`

Both still discover with skills/cmds/agents/hooks/mcp via `.plugin/`.

## Test plan
- [ ] `npx plugins discover TencentCloudBase/cloudbase-plugin --remote` works
- [ ] Dedicated repos have no `.claude-plugin` / `.codex-plugin`
- [ ] Main repo still has vendor manifests for marketplace install

Made with [Cursor](https://cursor.com)