### PR TITLE
fix(ci): dispatch Push Plugin Repos after skill sync

### DIFF
--- a/.github/workflows/sync-cloudbase-plugin-skills.yml
+++ b/.github/workflows/sync-cloudbase-plugin-skills.yml
@@ -14,6 +14,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   sync-plugin-skills:
@@ -33,14 +34,28 @@ jobs:
       - name: Sync CloudBase plugin skills
         run: node scripts/sync-cloudbase-plugin-skills.mjs
 
+      # GITHUB_TOKEN pushes do not retrigger path-filtered workflows (e.g. Push Plugin Repos).
+      # After we land skill changes under plugin/cloudbase/, explicitly dispatch that workflow.
+      # workflow_dispatch is an exception to the GITHUB_TOKEN non-retrigger rule.
       - name: Commit and push changes
+        id: commit_skills
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add plugin/cloudbase/skills plugin/cloudbase/.sync-metadata.json
           if git diff --staged --quiet; then
             echo "No changes, skipping."
+            echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: sync cloudbase plugin skills from upstream"
             git push
+            echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Trigger Push Plugin Repos
+        if: steps.commit_skills.outputs.pushed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run "Push Plugin Repos" --ref main
+          echo "Dispatched Push Plugin Repos for dedicated plugin repo sync."


### PR DESCRIPTION
## Summary
- After `Sync CloudBase Plugin Skills` pushes updates under `plugin/cloudbase/`, explicitly `workflow_dispatch` **Push Plugin Repos**.
- Root cause: `GITHUB_TOKEN` commits do not retrigger path-filtered `push` workflows, so dedicated `cloudbase-plugin` / `cloudbase-sites-plugin` repos stayed stale after skill sync (e.g. post-v2.24.0).
- `workflow_dispatch` is an allowed exception to the GITHUB_TOKEN non-retrigger rule; also grant `actions: write` for `gh workflow run`.

## Test plan
- [x] Manually ran **Push Plugin Repos** on `main` to catch up dedicated repos now
- [ ] Merge this PR, then either wait for next skill sync or `workflow_dispatch` Sync CloudBase Plugin Skills with a skill change and confirm Push Plugin Repos is dispatched
- [ ] Confirm dedicated repos receive a new `chore: sync from CloudBase-MCP` commit when skills change


Made with [Cursor](https://cursor.com)