### PR TITLE
feat(telemetry): report MCP clientInfo from initialize

### DIFF
--- a/mcp/src/utils/telemetry.test.ts
+++ b/mcp/src/utils/telemetry.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  extractMcpClientInfo,
+  readMcpClientInfoFromServer,
   reportToolCall,
   reportToolkitLifecycle,
   telemetryReporter,
@@ -31,6 +33,31 @@ describe("telemetry payload serialization", () => {
     );
   });
 
+  it("should include MCP clientInfo fields when provided", async () => {
+    const reportSpy = vi
+      .spyOn(telemetryReporter, "report")
+      .mockResolvedValue(undefined);
+
+    await reportToolCall({
+      toolName: "queryEnv",
+      success: true,
+      mcpClientInfo: {
+        name: "cursor-vscode",
+        version: "1.2.3",
+        title: "Cursor",
+      },
+    });
+
+    expect(reportSpy).toHaveBeenCalledWith(
+      "toolkit_tool_call",
+      expect.objectContaining({
+        mcpClientName: "cursor-vscode",
+        mcpClientVersion: "1.2.3",
+        mcpClientTitle: "Cursor",
+      }),
+    );
+  });
+
   it("should stringify lifecycle duration and exitCode", async () => {
     const reportSpy = vi
       .spyOn(telemetryReporter, "report")
@@ -49,5 +76,46 @@ describe("telemetry payload serialization", () => {
         exitCode: "2",
       }),
     );
+  });
+});
+
+describe("MCP clientInfo helpers", () => {
+  it("extractMcpClientInfo should keep name/version/title and drop empties", () => {
+    expect(
+      extractMcpClientInfo({
+        name: " Claude Code ",
+        version: "2.0.0",
+        title: "Claude Code",
+        extra: "ignored",
+      }),
+    ).toEqual({
+      name: "Claude Code",
+      version: "2.0.0",
+      title: "Claude Code",
+    });
+
+    expect(extractMcpClientInfo({ name: "  ", version: "" })).toEqual({});
+    expect(extractMcpClientInfo(undefined)).toEqual({});
+  });
+
+  it("readMcpClientInfoFromServer should read getClientVersion safely", () => {
+    expect(
+      readMcpClientInfoFromServer({
+        server: {
+          getClientVersion: () => ({ name: "cursor", version: "1.0.0" }),
+        },
+      }),
+    ).toEqual({ name: "cursor", version: "1.0.0" });
+
+    expect(readMcpClientInfoFromServer({})).toEqual({});
+    expect(
+      readMcpClientInfoFromServer({
+        server: {
+          getClientVersion: () => {
+            throw new Error("not initialized");
+          },
+        },
+      }),
+    ).toEqual({});
   });
 });

--- a/mcp/src/utils/telemetry.ts
+++ b/mcp/src/utils/telemetry.ts
@@ -263,6 +263,65 @@ function resolveEnvId(cloudBaseOptions?: CloudBaseOptions): { envId: string; env
     return { envId, envIdSource };
 }
 
+/** MCP initialize clientInfo fields available after handshake via Server.getClientVersion(). */
+export type McpClientInfo = {
+    name?: string;
+    version?: string;
+    title?: string;
+};
+
+/**
+ * Normalize SDK Implementation / clientInfo into telemetry-safe fields.
+ */
+export function extractMcpClientInfo(clientVersion: unknown): McpClientInfo {
+    if (!clientVersion || typeof clientVersion !== "object") {
+        return {};
+    }
+
+    const info = clientVersion as Record<string, unknown>;
+    const name = typeof info.name === "string" ? info.name.trim() : "";
+    const version = typeof info.version === "string" ? info.version.trim() : "";
+    const title = typeof info.title === "string" ? info.title.trim() : "";
+
+    return {
+        ...(name ? { name } : {}),
+        ...(version ? { version } : {}),
+        ...(title ? { title } : {}),
+    };
+}
+
+/**
+ * Read MCP clientInfo from an McpServer after initialize.
+ * Returns empty object when handshake has not completed or the accessor is unavailable.
+ */
+export function readMcpClientInfoFromServer(server: {
+    server?: { getClientVersion?: () => unknown };
+}): McpClientInfo {
+    try {
+        return extractMcpClientInfo(server?.server?.getClientVersion?.());
+    } catch {
+        return {};
+    }
+}
+
+function appendMcpClientInfoFields(
+    eventData: { [key: string]: any },
+    clientInfo?: McpClientInfo,
+) {
+    if (!clientInfo) {
+        return;
+    }
+    if (clientInfo.name) {
+        eventData.mcpClientName = clientInfo.name;
+    }
+    if (clientInfo.version) {
+        eventData.mcpClientVersion = clientInfo.version;
+    }
+    if (clientInfo.title) {
+        eventData.mcpClientTitle = clientInfo.title;
+    }
+}
+
 // 便捷方法
 export const reportToolCall =  async (params: {
     toolName: string;
@@ -273,6 +332,7 @@ export const reportToolCall =  async (params: {
     inputParams?: any; // 入参上报
     cloudBaseOptions?: CloudBaseOptions; // 新增：CloudBase 配置选项
     ide?: string; // 新增：集成IDE信息
+    mcpClientInfo?: McpClientInfo; // MCP initialize clientInfo
 }) => {
     const {
         nodeVersion,
@@ -326,6 +386,8 @@ export const reportToolCall =  async (params: {
         eventData.ide = params.ide;
     }
 
+    appendMcpClientInfoFields(eventData, params.mcpClientInfo);
+
     // Debug: 打印最终上报参数
     debug('[telemetry] 工具调用上报参数', {
         toolName: params.toolName,
@@ -348,6 +410,7 @@ export const reportToolkitLifecycle = async (params: {
     error?: string; // 对于异常退出
     cloudBaseOptions?: CloudBaseOptions; // 新增：CloudBase 配置选项
     ide?: string; // 新增：集成IDE信息
+    mcpClientInfo?: McpClientInfo; // MCP initialize clientInfo (usually unavailable at start)
 }) => {
     const {
         nodeVersion,
@@ -385,6 +448,8 @@ export const reportToolkitLifecycle = async (params: {
     if (params.ide) {
         eventData.ide = params.ide;
     }
+
+    appendMcpClientInfoFields(eventData, params.mcpClientInfo);
 
     // Debug: 打印最终上报参数
     debug('[telemetry] 生命周期事件上报参数', {

--- a/mcp/src/utils/tool-wrapper.test.ts
+++ b/mcp/src/utils/tool-wrapper.test.ts
@@ -13,6 +13,10 @@ vi.mock("./cloud-mode.js", async (importOriginal) => {
 
 vi.mock("./telemetry.js", () => ({
   reportToolCall: vi.fn(() => Promise.resolve()),
+  readMcpClientInfoFromServer: vi.fn(() => ({
+    name: "test-client",
+    version: "0.0.1",
+  })),
 }));
 
 function withTelemetryEnabled<T>(run: () => Promise<T>) {
@@ -105,6 +109,10 @@ describe("wrapServerWithTelemetry", () => {
       expect(reportToolCall).toHaveBeenCalledWith(
         expect.objectContaining({
           requestId: "req-success",
+          mcpClientInfo: {
+            name: "test-client",
+            version: "0.0.1",
+          },
         }),
       );
     });

--- a/mcp/src/utils/tool-wrapper.ts
+++ b/mcp/src/utils/tool-wrapper.ts
@@ -5,7 +5,7 @@ import { ExtendedMcpServer } from "../server.js";
 import { CloudBaseOptions } from '../types.js';
 import { shouldRegisterTool } from './cloud-mode.js';
 import { debug } from './logger.js';
-import { reportToolCall } from './telemetry.js';
+import { reportToolCall, readMcpClientInfoFromServer } from './telemetry.js';
 import { isToolPayloadError } from "./tool-result.js";
 
 
@@ -208,7 +208,8 @@ function createWrappedHandler(name: string, handler: any, server: ExtendedMcpSer
                     error: errorMessage,
                     inputParams: sanitizeArgs(args), // 添加入参上报
                     cloudBaseOptions: cloudBaseOptions, // 传递 CloudBase 配置（可能已更新）
-                    ide: server.ide || process.env.INTEGRATION_IDE // 传递集成IDE信息
+                    ide: server.ide || process.env.INTEGRATION_IDE, // 传递集成IDE信息
+                    mcpClientInfo: readMcpClientInfoFromServer(server),
                 }).catch(err => {
                     // 静默处理上报错误，不影响主要功能
                     debug('遥测上报失败', { toolName: name, error: err instanceof Error ? err.message : String(err) });


### PR DESCRIPTION
## Summary
- Read MCP `initialize` `clientInfo` via `server.server.getClientVersion()`
- Attach `mcpClientName` / `mcpClientVersion` / `mcpClientTitle` to `toolkit_tool_call` telemetry (alongside existing `ide`)

## Notes
- This is the MCP **client/host** identity (Cursor, Claude Code, etc.), not the LLM model name
- Fields are omitted when handshake has not completed

## Test plan
- [x] `vitest` telemetry + tool-wrapper tests
- [ ] Optional: run against a real MCP host and confirm telemetry payload includes client name/version


Made with [Cursor](https://cursor.com)