### PR TITLE
feat(plugin): Vercel-style DAU telemetry via Beacon

### DIFF
--- a/plugin/cloudbase/README.md
+++ b/plugin/cloudbase/README.md
@@ -157,6 +157,32 @@ for everything else (auth, database, functions, AI models, storage).
 
 ## Updating skills
 
+## Telemetry
+
+Plugin telemetry is on by default and mirrors Vercel's lightweight DAU model,
+uploaded via the same Tencent Beacon (灯塔) endpoint used by `cloudbase-mcp`.
+
+What is collected:
+
+- `toolkit_plugin_dau`: at most once per UTC day when a SessionStart hook runs
+- `toolkit_plugin_first_use`: once per local user profile on first successful report
+- `pluginVersion`: included on each event so usage can be grouped by plugin version
+
+What is **not** collected: prompt text, file paths, project names, account IDs,
+tool-call contents, or skill-injection details.
+
+Disable:
+
+```bash
+export CLOUDBASE_PLUGIN_TELEMETRY=off
+```
+
+`CLOUDBASE_MCP_TELEMETRY_DISABLED=true` also disables plugin telemetry.
+Local throttle files live under `~/.config/cloudbase-plugin/` (`dau-stamp`,
+`first-use-stamp`) and are written only after a successful Beacon upload.
+
+## Skill sync
+
 Skills are auto-synced from `TencentCloudBase/skills@main`. To update
 manually:
 

--- a/plugin/cloudbase/hooks/hooks.json
+++ b/plugin/cloudbase/hooks/hooks.json
@@ -6,6 +6,10 @@
         "hooks": [
           {
             "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-telemetry.mjs\""
+          },
+          {
+            "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-start-seen-skills.mjs\""
           },
           {

--- a/plugin/cloudbase/hooks/plugin-telemetry.mjs
+++ b/plugin/cloudbase/hooks/plugin-telemetry.mjs
@@ -1,0 +1,285 @@
+// hooks/plugin-telemetry.mjs — Lightweight plugin DAU telemetry (Vercel-aligned, Beacon/灯塔 upload)
+//
+// Collects only:
+// - toolkit_plugin_dau: at most once per UTC day when SessionStart runs
+// - toolkit_plugin_first_use: once per local user profile
+// Always includes pluginVersion. No prompts, paths, tool args, or skill-injection details.
+//
+// Disable: CLOUDBASE_PLUGIN_TELEMETRY=off (or CLOUDBASE_MCP_TELEMETRY_DISABLED=true)
+import { createHash, randomBytes } from "crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "fs";
+import http from "http";
+import https from "https";
+import {
+  arch as osArch,
+  cpus,
+  hostname as osHostname,
+  homedir,
+  networkInterfaces,
+  release as osRelease,
+  type as osType,
+} from "os";
+import { dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { createLogger, logCaughtError } from "./logger.mjs";
+
+var log = createLogger();
+
+var BEACON_UPLOAD_URL = "https://otheve.beacon.qq.com/analytics/v2_upload";
+var BEACON_APP_KEY = "0WEB0AD0GM4PUUU1";
+var DEFAULT_TIMEOUT_MS = 1500;
+
+export var PLUGIN_DAU_EVENT = "toolkit_plugin_dau";
+export var PLUGIN_FIRST_USE_EVENT = "toolkit_plugin_first_use";
+
+function pluginPackageRoot(metaUrl = import.meta.url) {
+  return join(dirname(fileURLToPath(metaUrl)), "..");
+}
+
+export function isPluginTelemetryEnabled(env = process.env) {
+  const pluginFlag = String(env.CLOUDBASE_PLUGIN_TELEMETRY || "")
+    .trim()
+    .toLowerCase();
+  if (pluginFlag === "off" || pluginFlag === "0" || pluginFlag === "false") {
+    return false;
+  }
+  if (env.CLOUDBASE_MCP_TELEMETRY_DISABLED === "true") {
+    return false;
+  }
+  return true;
+}
+
+export function resolveStampDir(env = process.env, home = homedir()) {
+  const configured = env.CLOUDBASE_PLUGIN_TELEMETRY_DIR;
+  if (typeof configured === "string" && configured.trim()) {
+    return configured.trim();
+  }
+  return join(home, ".config", "cloudbase-plugin");
+}
+
+export function utcDateStamp(now = new Date()) {
+  return now.toISOString().slice(0, 10);
+}
+
+export function resolvePluginVersion(root = pluginPackageRoot()) {
+  const candidates = [
+    join(root, ".claude-plugin", "plugin.json"),
+    join(root, ".plugin", "plugin.json"),
+  ];
+  for (const filePath of candidates) {
+    try {
+      const pluginJson = JSON.parse(readFileSync(filePath, "utf-8"));
+      if (typeof pluginJson.version === "string" && pluginJson.version.trim()) {
+        return pluginJson.version.trim();
+      }
+    } catch {
+      // try next
+    }
+  }
+  return "unknown";
+}
+
+function buildDeviceId() {
+  try {
+    const nics = Object.values(networkInterfaces())
+      .flat()
+      .filter((nic) => nic && !nic.internal && nic.mac)
+      .map((nic) => nic.mac)
+      .join(",");
+    const deviceInfo = [
+      osHostname(),
+      cpus()
+        .map((cpu) => cpu.model)
+        .join(","),
+      nics,
+    ].join("|");
+    return createHash("sha256").update(deviceInfo).digest("hex").slice(0, 32);
+  } catch {
+    return randomBytes(16).toString("hex");
+  }
+}
+
+function buildUserAgent(pluginVersion) {
+  return `${osType()} ${osRelease()} ${osArch()} ${process.version} CloudBase-Plugin/${pluginVersion}`;
+}
+
+export function shouldSendDau(stampDir, now = new Date()) {
+  const stampPath = join(stampDir, "dau-stamp");
+  if (!existsSync(stampPath)) {
+    return true;
+  }
+  try {
+    const previous = readFileSync(stampPath, "utf-8").trim();
+    return previous !== utcDateStamp(now);
+  } catch {
+    return true;
+  }
+}
+
+export function shouldSendFirstUse(stampDir) {
+  return !existsSync(join(stampDir, "first-use-stamp"));
+}
+
+export function markDauSent(stampDir, now = new Date()) {
+  mkdirSync(stampDir, { recursive: true });
+  writeFileSync(join(stampDir, "dau-stamp"), `${utcDateStamp(now)}\n`, "utf-8");
+}
+
+export function markFirstUseSent(stampDir, now = new Date()) {
+  mkdirSync(stampDir, { recursive: true });
+  writeFileSync(
+    join(stampDir, "first-use-stamp"),
+    `${now.toISOString()}\n`,
+    "utf-8",
+  );
+}
+
+export function buildBeaconPayload({
+  eventCode,
+  eventData,
+  deviceId,
+  userAgent,
+  now = Date.now(),
+}) {
+  return {
+    appVersion: "",
+    sdkId: "js",
+    sdkVersion: "4.5.14-web",
+    mainAppKey: BEACON_APP_KEY,
+    platformId: 3,
+    common: {
+      A2: deviceId,
+      A101: userAgent,
+      from: "cloudbase-plugin",
+      xDeployEnv: process.env.NODE_ENV || "production",
+    },
+    events: [
+      {
+        eventCode,
+        eventTime: String(now),
+        mapValue: {
+          ...eventData,
+        },
+      },
+    ],
+  };
+}
+
+function postJson(url, data, timeoutMs = DEFAULT_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const postData = JSON.stringify(data);
+    const urlObj = new URL(url);
+    const client = urlObj.protocol === "https:" ? https : http;
+    const options = {
+      hostname: urlObj.hostname,
+      port: urlObj.port,
+      path: `${urlObj.pathname}${urlObj.search}`,
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "Content-Length": Buffer.byteLength(postData),
+        "User-Agent": data?.common?.A101 || "CloudBase-Plugin",
+      },
+      timeout: timeoutMs,
+    };
+    if (urlObj.protocol === "https:") {
+      options.minVersion = "TLSv1.2";
+      options.maxVersion = "TLSv1.2";
+    }
+
+    const req = client.request(options, (res) => {
+      let body = "";
+      res.on("data", (chunk) => {
+        body += chunk;
+      });
+      res.on("end", () => {
+        if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+          resolve({ statusCode: res.statusCode, body });
+        } else {
+          reject(new Error(`HTTP ${res.statusCode}: ${body}`));
+        }
+      });
+    });
+    req.on("error", reject);
+    req.on("timeout", () => {
+      req.destroy();
+      reject(new Error("Request timeout"));
+    });
+    req.write(postData);
+    req.end();
+  });
+}
+
+/**
+ * Report lightweight plugin session telemetry (DAU + first use).
+ * Stamps are written only after a successful Beacon upload (Vercel-aligned).
+ */
+export async function reportPluginSessionTelemetry(options = {}) {
+  const {
+    env = process.env,
+    pluginRoot = pluginPackageRoot(),
+    stampDir = resolveStampDir(env),
+    now = new Date(),
+    timeoutMs = DEFAULT_TIMEOUT_MS,
+    postFetch = postJson,
+  } = options;
+
+  if (!isPluginTelemetryEnabled(env)) {
+    return { enabled: false, sent: [] };
+  }
+
+  const pluginVersion = resolvePluginVersion(pluginRoot);
+  const deviceId = buildDeviceId();
+  const userAgent = buildUserAgent(pluginVersion);
+  const sent = [];
+
+  const sendEvent = async (eventCode, eventData, onSuccess) => {
+    const payload = buildBeaconPayload({
+      eventCode,
+      eventData: {
+        pluginVersion,
+        value: "1",
+        ...eventData,
+      },
+      deviceId,
+      userAgent,
+      now: now.getTime(),
+    });
+    await postFetch(BEACON_UPLOAD_URL, payload, timeoutMs);
+    onSuccess();
+    sent.push(eventCode);
+  };
+
+  try {
+    if (shouldSendFirstUse(stampDir)) {
+      await sendEvent(PLUGIN_FIRST_USE_EVENT, { event: "first_use" }, () =>
+        markFirstUseSent(stampDir, now),
+      );
+    }
+  } catch (error) {
+    logCaughtError(log, "plugin-telemetry:first-use-failed", error, {
+      pluginVersion,
+    });
+  }
+
+  try {
+    if (shouldSendDau(stampDir, now)) {
+      await sendEvent(PLUGIN_DAU_EVENT, { event: "dau_active_today" }, () =>
+        markDauSent(stampDir, now),
+      );
+    }
+  } catch (error) {
+    logCaughtError(log, "plugin-telemetry:dau-failed", error, { pluginVersion });
+  }
+
+  return {
+    enabled: true,
+    pluginVersion,
+    sent,
+  };
+}

--- a/plugin/cloudbase/hooks/session-start-telemetry.mjs
+++ b/plugin/cloudbase/hooks/session-start-telemetry.mjs
@@ -1,0 +1,36 @@
+// hooks/session-start-telemetry.mjs — SessionStart entry for lightweight plugin DAU
+// Fire-and-forget style with a short timeout; never blocks or breaks the session hook chain.
+import { readFileSync } from "fs";
+import { createLogger, logCaughtError } from "./logger.mjs";
+import { normalizeInput, formatOutput } from "./compat.mjs";
+import { reportPluginSessionTelemetry } from "./plugin-telemetry.mjs";
+
+var log = createLogger();
+
+async function main() {
+  const raw = readFileSync(0, "utf-8");
+  let input;
+  try {
+    input = JSON.parse(raw || "{}");
+  } catch {
+    input = {};
+  }
+  const normalized = normalizeInput(input);
+  const platform = normalized.platform;
+
+  try {
+    const result = await reportPluginSessionTelemetry({ timeoutMs: 1500 });
+    log.debug("session-start-telemetry", {
+      enabled: result.enabled,
+      sent: result.sent,
+      pluginVersion: result.pluginVersion,
+      source: normalized.source || "",
+    });
+  } catch (error) {
+    logCaughtError(log, "session-start-telemetry:failed", error);
+  }
+
+  process.stdout.write(JSON.stringify(formatOutput(platform, {})));
+}
+
+main();

--- a/tests/hooks/plugin-telemetry.test.mjs
+++ b/tests/hooks/plugin-telemetry.test.mjs
@@ -1,0 +1,184 @@
+// tests/hooks/plugin-telemetry.test.mjs
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  PLUGIN_DAU_EVENT,
+  PLUGIN_FIRST_USE_EVENT,
+  buildBeaconPayload,
+  isPluginTelemetryEnabled,
+  markDauSent,
+  reportPluginSessionTelemetry,
+  resolvePluginVersion,
+  shouldSendDau,
+  shouldSendFirstUse,
+  utcDateStamp,
+} from "../../plugin/cloudbase/hooks/plugin-telemetry.mjs";
+
+const tempDirs = [];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function makeTempDir() {
+  const dir = mkdtempSync(join(tmpdir(), "cloudbase-plugin-telemetry-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe("plugin telemetry gating", () => {
+  it("is disabled by CLOUDBASE_PLUGIN_TELEMETRY=off", () => {
+    expect(isPluginTelemetryEnabled({ CLOUDBASE_PLUGIN_TELEMETRY: "off" })).toBe(
+      false,
+    );
+    expect(
+      isPluginTelemetryEnabled({ CLOUDBASE_MCP_TELEMETRY_DISABLED: "true" }),
+    ).toBe(false);
+    expect(isPluginTelemetryEnabled({})).toBe(true);
+  });
+
+  it("shouldSendDau is once per UTC day", () => {
+    const stampDir = makeTempDir();
+    const day = new Date("2026-07-21T12:00:00.000Z");
+    expect(shouldSendDau(stampDir, day)).toBe(true);
+    markDauSent(stampDir, day);
+    expect(shouldSendDau(stampDir, day)).toBe(false);
+    expect(shouldSendDau(stampDir, new Date("2026-07-22T01:00:00.000Z"))).toBe(
+      true,
+    );
+    expect(utcDateStamp(day)).toBe("2026-07-21");
+  });
+
+  it("shouldSendFirstUse is once forever", () => {
+    const stampDir = makeTempDir();
+    expect(shouldSendFirstUse(stampDir)).toBe(true);
+    writeFileSync(join(stampDir, "first-use-stamp"), "done\n");
+    expect(shouldSendFirstUse(stampDir)).toBe(false);
+  });
+
+  it("resolvePluginVersion reads .claude-plugin/plugin.json", () => {
+    const root = makeTempDir();
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ name: "cloudbase", version: "0.2.0" }),
+    );
+    expect(resolvePluginVersion(root)).toBe("0.2.0");
+  });
+});
+
+describe("reportPluginSessionTelemetry", () => {
+  it("sends first_use and dau, then stamps only after success", async () => {
+    const stampDir = makeTempDir();
+    const root = makeTempDir();
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ version: "9.9.9" }),
+    );
+
+    const posts = [];
+    const postFetch = vi.fn(async (_url, payload) => {
+      posts.push(payload);
+      return { statusCode: 200, body: "ok" };
+    });
+
+    const first = await reportPluginSessionTelemetry({
+      env: {},
+      pluginRoot: root,
+      stampDir,
+      now: new Date("2026-07-21T08:00:00.000Z"),
+      postFetch,
+    });
+
+    expect(first.enabled).toBe(true);
+    expect(first.sent).toEqual([PLUGIN_FIRST_USE_EVENT, PLUGIN_DAU_EVENT]);
+    expect(posts).toHaveLength(2);
+    expect(posts[0].common.from).toBe("cloudbase-plugin");
+    expect(posts[0].events[0].eventCode).toBe(PLUGIN_FIRST_USE_EVENT);
+    expect(posts[0].events[0].mapValue).toMatchObject({
+      pluginVersion: "9.9.9",
+      event: "first_use",
+      value: "1",
+    });
+    expect(posts[1].events[0].eventCode).toBe(PLUGIN_DAU_EVENT);
+    expect(readFileSync(join(stampDir, "dau-stamp"), "utf-8").trim()).toBe(
+      "2026-07-21",
+    );
+    expect(existsFirstUse(stampDir)).toBe(true);
+
+    const second = await reportPluginSessionTelemetry({
+      env: {},
+      pluginRoot: root,
+      stampDir,
+      now: new Date("2026-07-21T18:00:00.000Z"),
+      postFetch,
+    });
+    expect(second.sent).toEqual([]);
+    expect(posts).toHaveLength(2);
+  });
+
+  it("does not stamp when upload fails", async () => {
+    const stampDir = makeTempDir();
+    const root = makeTempDir();
+    mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+    writeFileSync(
+      join(root, ".claude-plugin", "plugin.json"),
+      JSON.stringify({ version: "1.0.0" }),
+    );
+
+    const result = await reportPluginSessionTelemetry({
+      env: {},
+      pluginRoot: root,
+      stampDir,
+      postFetch: async () => {
+        throw new Error("network down");
+      },
+    });
+
+    expect(result.sent).toEqual([]);
+    expect(shouldSendFirstUse(stampDir)).toBe(true);
+    expect(shouldSendDau(stampDir)).toBe(true);
+  });
+
+  it("skips entirely when telemetry is off", async () => {
+    const postFetch = vi.fn();
+    const result = await reportPluginSessionTelemetry({
+      env: { CLOUDBASE_PLUGIN_TELEMETRY: "off" },
+      stampDir: makeTempDir(),
+      postFetch,
+    });
+    expect(result).toEqual({ enabled: false, sent: [] });
+    expect(postFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe("buildBeaconPayload", () => {
+  it("matches MCP beacon envelope shape", () => {
+    const payload = buildBeaconPayload({
+      eventCode: PLUGIN_DAU_EVENT,
+      eventData: { pluginVersion: "0.2.0", value: "1" },
+      deviceId: "abc",
+      userAgent: "ua",
+      now: 1000,
+    });
+    expect(payload.mainAppKey).toBe("0WEB0AD0GM4PUUU1");
+    expect(payload.common.from).toBe("cloudbase-plugin");
+    expect(payload.events[0].eventTime).toBe("1000");
+  });
+});
+
+function existsFirstUse(stampDir) {
+  try {
+    readFileSync(join(stampDir, "first-use-stamp"), "utf-8");
+    return true;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- Align CloudBase plugin telemetry with Vercel’s lightweight DAU model
- Upload via the same Tencent Beacon (灯塔) path as \`cloudbase-mcp\`
- Events: \`toolkit_plugin_dau\` (once/UTC day), \`toolkit_plugin_first_use\` (once/profile), always with \`pluginVersion\`
- Opt-out: \`CLOUDBASE_PLUGIN_TELEMETRY=off\` (also respects \`CLOUDBASE_MCP_TELEMETRY_DISABLED=true\`)
- No prompt/path/tool/skill-injection content collected

## Beacon field notes (for console registration)
| Event | Field | 中文描述 | Type |
|-------|-------|----------|------|
| \`toolkit_plugin_dau\` | \`pluginVersion\` | 插件版本号 | string |
| \`toolkit_plugin_dau\` | \`event\` | 事件类型（dau_active_today） | string |
| \`toolkit_plugin_dau\` | \`value\` | 计数占位（固定 \"1\"） | string |
| \`toolkit_plugin_first_use\` | same fields | 首次使用 | string |

## Test plan
- [x] \`vitest run tests/hooks/plugin-telemetry.test.mjs\`
- [ ] Optional: SessionStart once, confirm stamps under \`~/.config/cloudbase-plugin/\`


Made with [Cursor](https://cursor.com)