### PR TITLE
feat(gateway): migrate manageGateway to Domain/Route APIs

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -327,9 +327,10 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 
 ### Gateway exposure
 
-- `queryGateway(action="getAccess")`
-- `manageGateway(action="createAccess")`
-- If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+- `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
+- `manageGateway(action="createRoute")` — for HTTP functions pass `type="HTTP"` (maps to `WEB_SCF`); for Event functions pass `type="Event"` (maps to `SCF`). Omit `domain` to use the environment default (`IsDefault`)
+- `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills
 

--- a/config/.claude/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create gateway access explicitly with `manageGateway(action="createAccess", type="HTTP")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", type="HTTP")` (maps to `WEB_SCF`) and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/config/.claude/skills/cloud-functions/references/http-functions.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions.md
@@ -348,7 +348,7 @@ Creating the function does not automatically create a browser-facing path. Add g
 
 ```javascript
 manageGateway({
-  action: "createAccess",
+  action: "createRoute",
   targetType: "function",
   targetName: "myHttpFunction",
   type: "HTTP",

--- a/config/.claude/skills/cloud-functions/references/operations-and-config.md
+++ b/config/.claude/skills/cloud-functions/references/operations-and-config.md
@@ -54,35 +54,25 @@ callCloudApi({
 
 ### Preferred path
 
-Use `manageGateway(action="createAccess")`.
-
-### Plan B: `callCloudApi`
-
-Use raw cloud API only after checking the documentation for `CreateCloudBaseGWAPI` and confirming the gateway parameter contract.
+Use Domain/Route via `manageGateway(action="createRoute")`. Omit `domain` to attach the route on the environment default HTTP domain (`IsDefault`).
 
 ```javascript
-callCloudApi({
-  service: "tcb",
-  action: "CreateCloudBaseGWAPI",
-  params: {
-    EnableUnion: true,
-    Path: "/api/users",
-    ServiceId: "{envId}",
-    Type: 6,
-    Name: "functionName",
-    AuthSwitch: 2,
-    PathTransmission: 2,
-    EnableRegion: true,
-    Domain: "*"
-  }
+manageGateway({
+  action: "createRoute",
+  targetType: "function",
+  targetName: "functionName",
+  type: "Event", // Event -> SCF; HTTP functions must pass type="HTTP" -> WEB_SCF
+  path: "/api/users",
+  auth: false
 });
 ```
 
-Key parameters:
+Type mapping:
 
-- `Type: 6` -> function gateway type.
-- `AuthSwitch: 2` -> no auth. Use an authenticated mode only when the requirement says so.
-- `Domain: "*"` -> default domain.
+- `type="Event"` -> `UpstreamResourceType=SCF`
+- `type="HTTP"` -> `UpstreamResourceType=WEB_SCF`
+
+Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 
 ## Environment variable updates
 
@@ -152,7 +142,7 @@ Prefer the converged entrances below, but translate historical names when they a
 | `manageFunctionTriggers` | `manageFunctions(action="createFunctionTrigger"|"deleteFunctionTrigger")` |
 | `readFunctionLayers` | `queryFunctions(action="listLayers"|"listLayerVersions"|"getLayerVersionDetail"|"listFunctionLayers")` |
 | `writeFunctionLayers` | `manageFunctions(action="createLayerVersion"|"deleteLayerVersion"|"attachLayer"|"detachLayer"|"updateFunctionLayers")` |
-| `createFunctionHTTPAccess` | `manageGateway(action="createAccess")` |
+| `createFunctionHTTPAccess` | `manageGateway(action="createRoute")` with `type="HTTP"` |
 
 ## CLI fallback
 

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -327,9 +327,10 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 
 ### Gateway exposure
 
-- `queryGateway(action="getAccess")`
-- `manageGateway(action="createAccess")`
-- If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+- `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
+- `manageGateway(action="createRoute")` — for HTTP functions pass `type="HTTP"` (maps to `WEB_SCF`); for Event functions pass `type="Event"` (maps to `SCF`). Omit `domain` to use the environment default (`IsDefault`)
+- `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills
 

--- a/config/source/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/config/source/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create gateway access explicitly with `manageGateway(action="createAccess", type="HTTP")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", type="HTTP")` (maps to `WEB_SCF`) and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/config/source/skills/cloud-functions/references/http-functions.md
+++ b/config/source/skills/cloud-functions/references/http-functions.md
@@ -348,7 +348,7 @@ Creating the function does not automatically create a browser-facing path. Add g
 
 ```javascript
 manageGateway({
-  action: "createAccess",
+  action: "createRoute",
   targetType: "function",
   targetName: "myHttpFunction",
   type: "HTTP",

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -54,35 +54,25 @@ callCloudApi({
 
 ### Preferred path
 
-Use `manageGateway(action="createAccess")`.
-
-### Plan B: `callCloudApi`
-
-Use raw cloud API only after checking the documentation for `CreateCloudBaseGWAPI` and confirming the gateway parameter contract.
+Use Domain/Route via `manageGateway(action="createRoute")`. Omit `domain` to attach the route on the environment default HTTP domain (`IsDefault`).
 
 ```javascript
-callCloudApi({
-  service: "tcb",
-  action: "CreateCloudBaseGWAPI",
-  params: {
-    EnableUnion: true,
-    Path: "/api/users",
-    ServiceId: "{envId}",
-    Type: 6,
-    Name: "functionName",
-    AuthSwitch: 2,
-    PathTransmission: 2,
-    EnableRegion: true,
-    Domain: "*"
-  }
+manageGateway({
+  action: "createRoute",
+  targetType: "function",
+  targetName: "functionName",
+  type: "Event", // Event -> SCF; HTTP functions must pass type="HTTP" -> WEB_SCF
+  path: "/api/users",
+  auth: false
 });
 ```
 
-Key parameters:
+Type mapping:
 
-- `Type: 6` -> function gateway type.
-- `AuthSwitch: 2` -> no auth. Use an authenticated mode only when the requirement says so.
-- `Domain: "*"` -> default domain.
+- `type="Event"` -> `UpstreamResourceType=SCF`
+- `type="HTTP"` -> `UpstreamResourceType=WEB_SCF`
+
+Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 
 ## Environment variable updates
 
@@ -152,7 +142,7 @@ Prefer the converged entrances below, but translate historical names when they a
 | `manageFunctionTriggers` | `manageFunctions(action="createFunctionTrigger"|"deleteFunctionTrigger")` |
 | `readFunctionLayers` | `queryFunctions(action="listLayers"|"listLayerVersions"|"getLayerVersionDetail"|"listFunctionLayers")` |
 | `writeFunctionLayers` | `manageFunctions(action="createLayerVersion"|"deleteLayerVersion"|"attachLayer"|"detachLayer"|"updateFunctionLayers")` |
-| `createFunctionHTTPAccess` | `manageGateway(action="createAccess")` |
+| `createFunctionHTTPAccess` | `manageGateway(action="createRoute")` with `type="HTTP"` |
 
 ## CLI fallback
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1801,7 +1801,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.24.0），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.24.1），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -1858,7 +1858,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 文档名：cloudrun-development 文档介绍：CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, or AI agent development.
 文档名：data-model-creation 文档介绍："[Deprecated] Optional advanced tool for complex data modeling. For simple MySQL table creation, use relational-database-tool directly; for PostgreSQL / CloudBase PG schema work, use postgresql-development. New environments should use PostgreSQL DDL via queryPgDatabase/managePgDatabase — see postgresql-development skill instead."
 文档名：http-api 文档介绍：CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.
-文档名：miniprogram-development 文档介绍：WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools workflows, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, or 云开发 in a mini program project.
+文档名：miniprogram-development 文档介绍：WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools Nightly workflows, `wechatide` CLI, WeChat IDE Skills/MCP, console/network debugging, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, 微信云开发, or 云开发 in a mini program project.
 文档名：no-sql-web-sdk 文档介绍：Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.
 文档名：no-sql-wx-mp-sdk 文档介绍：Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.
 文档名：ops-inspector 文档介绍：AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.
@@ -1870,12 +1870,12 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 文档名：web-development 文档介绍：Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
 
       OpenAPI 文档 (openapi) 查询只需要传 mode="openapi" 和 apiName，不要传 action；action 仅用于 mode="docs"。当前支持 7 个 API 文档，分别是：
-      API名：functions API介绍：Cloud Functions API - 云函数 HTTP API
-API名：nosql API介绍：NoSQL RESTful API - 文档型数据库 HTTP API
-API名：storage API介绍：Storage API - 云存储 HTTP API
-API名：mysqldb API介绍：关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API
-API名：cloudrun API介绍：CloudRun API - 云托管服务 HTTP API
+      API名：mysqldb API介绍：关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API
+API名：functions API介绍：Cloud Functions API - 云函数 HTTP API
 API名：auth API介绍：Authentication API - 身份认证 HTTP API
+API名：cloudrun API介绍：CloudRun API - 云托管服务 HTTP API
+API名：storage API介绍：Storage API - 云存储 HTTP API
+API名：nosql API介绍：NoSQL RESTful API - 文档型数据库 HTTP API
 API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 
 #### 参数
@@ -1896,7 +1896,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
     {
       name: "apiName",
       type: "string",
-      description: `mode=openapi 时指定。API 名称。 可填写的值: "functions", "nosql", "storage", "mysqldb", "cloudrun", "auth", "ai_model"`,
+      description: `mode=openapi 时指定。API 名称。 可填写的值: "mysqldb", "functions", "auth", "cloudrun", "storage", "nosql", "ai_model"`,
     },
     {
       name: "action",
@@ -2346,7 +2346,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 ---
 
 ### `queryGateway`
-CloudBase 网关统一只读入口。通过 action 查询网关域名、访问入口和目标暴露情况。
+CloudBase 网关统一只读入口（Domain/Route 模型）。通过 listRoutes / getRoute / listCustomDomains 查询域名与路由；主键为 Domain + Path，上游类型为 SCF / WEB_SCF / CBR / STATIC_STORE / LH。
 
 #### 参数
 
@@ -2356,22 +2356,32 @@ CloudBase 网关统一只读入口。通过 action 查询网关域名、访问�
       name: "action",
       type: "string",
       required: true,
-      description: `只读操作类型，例如 getAccess、listDomains 可填写的值: "getAccess", "listDomains", "listRoutes", "getRoute", "listCustomDomains"`,
+      description: `只读操作类型：listRoutes、getRoute、listCustomDomains 可填写的值: "listRoutes", "getRoute", "listCustomDomains"`,
     },
     {
       name: "targetType",
       type: "string",
-      description: `目标资源类型。当前支持 function，后续可扩展 可填写的值: "function"`,
+      description: `目标资源类型。当前支持 function 可填写的值: "function"`,
     },
     {
       name: "targetName",
       type: "string",
-      description: `目标资源名称。getAccess 时必填`,
+      description: `上游资源名称。getRoute 时可按云函数名过滤`,
     },
     {
       name: "routeId",
       type: "string",
       description: `路由 ID。getRoute 时可选`,
+    },
+    {
+      name: "path",
+      type: "string",
+      description: `路由路径。getRoute / listRoutes 过滤时可选`,
+    },
+    {
+      name: "domain",
+      type: "string",
+      description: `域名。getRoute / listRoutes 过滤时可选`,
     }
   ]}
 />
@@ -2379,7 +2389,7 @@ CloudBase 网关统一只读入口。通过 action 查询网关域名、访问�
 ---
 
 ### `manageGateway`
-CloudBase 网关统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType="function"、targetName、type="HTTP" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。⚠️ 如需绑定带 SSL 证书的自定义域名供公网 HTTPS 访问，使用 action="bindCustomDomain"（需要 domain 和 certificateId 参数）；如需配置 CORS/安全域名（无证书），请使用 envDomainManagement 工具。
+CloudBase 网关统一写入口（Domain/Route 模型）。为已存在的 HTTP 云函数补默认域名访问时，使用 createRoute，并提供 targetType="function"、targetName、type="HTTP"（映射 WEB_SCF）与期望 path；Event 函数传 type="Event"（映射 SCF）。未传 domain 时自动解析 IsDefault 默认域名。注意 createRoute 只创建网关入口，不会自动修改函数资源权限。更新鉴权用 updateRoute；删除用 deleteRoute（Domain+Path）。⚠️ 绑定带 SSL 证书的自定义域名用 bindCustomDomain；CORS/安全域名请使用 envDomainManagement。
 
 #### 参数
 
@@ -2389,17 +2399,17 @@ CloudBase 网关统一写入口。通过 action 创建目标访问入口，后�
       name: "action",
       type: "string",
       required: true,
-      description: `写操作类型，例如 createAccess。为已有函数补默认域名访问入口时使用 createAccess；若 action=createAccess 且 targetType=function，必须显式提供 type。 可填写的值: "createAccess", "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "deleteAccess", "updatePathAuth"`,
+      description: `写操作类型。为已有函数补默认域名访问入口时使用 createRoute；函数场景必须显式提供 type（HTTP→WEB_SCF，Event→SCF）或 route.upstreamResourceType。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain"`,
     },
     {
       name: "targetType",
       type: "string",
-      description: `目标资源类型。当前支持 function，后续可扩展 可填写的值: "function"`,
+      description: `目标资源类型。当前支持 function 可填写的值: "function"`,
     },
     {
       name: "targetName",
       type: "string",
-      description: `目标资源名称。createAccess 到云函数时填写函数名`,
+      description: `目标资源名称。createRoute 到云函数时填写函数名`,
     },
     {
       name: "path",
@@ -2409,33 +2419,30 @@ CloudBase 网关统一写入口。通过 action 创建目标访问入口，后�
     {
       name: "type",
       type: "string",
-      description: `目标函数的运行时类型，不是接入协议。createAccess 到已创建的 HTTP 云函数时传 HTTP；给 Event 函数补网关访问时传 Event 或省略。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。 可填写的值: "Event", "HTTP"`,
+      description: `目标函数运行时类型，不是接入协议。HTTP 云函数传 HTTP（UpstreamResourceType=WEB_SCF）；Event 函数传 Event（SCF）。误标会导致 FUNCTION_PARAM_INVALID 或网关错误。函数路由场景必须显式提供 type 或 route.upstreamResourceType。 可填写的值: "Event", "HTTP"`,
     },
     {
       name: "auth",
       type: "boolean",
-      description: `是否开启网关路径鉴权。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限，仍需检查并按需调整函数安全规则。`,
+      description: `是否开启网关路径鉴权（EnableAuth）。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限。`,
     },
     {
       name: "route",
       type: "object",
-      description: `HTTP 路由配置对象`,
+      description: `HTTP 路由配置。upstreamResourceType 可选 SCF / WEB_SCF / CBR / STATIC_STORE / LH`,
       children: [
-        {
-          name: "routeId",
-          type: "string",
-        },
         {
           name: "path",
           type: "string",
         },
         {
-          name: "serviceType",
+          name: "serviceName",
           type: "string",
         },
         {
-          name: "serviceName",
+          name: "upstreamResourceType",
           type: "string",
+          description: ` 可填写的值: "SCF", "WEB_SCF", "CBR", "STATIC_STORE", "LH"`,
         },
         {
           name: "auth",
@@ -2446,22 +2453,12 @@ CloudBase 网关统一写入口。通过 action 创建目标访问入口，后�
     {
       name: "domain",
       type: "string",
-      description: `自定义域名`,
+      description: `域名。省略时自动使用环境 IsDefault 默认 HTTP 域名；自定义域名场景请显式传入`,
     },
     {
       name: "certificateId",
       type: "string",
-      description: `证书 ID`,
-    },
-    {
-      name: "accessName",
-      type: "string",
-      description: `访问入口名称，保留字段`,
-    },
-    {
-      name: "accessId",
-      type: "string",
-      description: `访问入口 ID。deleteAccess 时可直接传入，避免参数歧义`,
+      description: `证书 ID。bindCustomDomain 时必填`,
     }
   ]}
 />

--- a/doc/prompts/cloud-functions.mdx
+++ b/doc/prompts/cloud-functions.mdx
@@ -365,9 +365,10 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 
 ### Gateway exposure
 
-- `queryGateway(action="getAccess")`
-- `manageGateway(action="createAccess")`
-- If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+- `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
+- `manageGateway(action="createRoute")` — for HTTP functions pass `type="HTTP"` (maps to `WEB_SCF`); for Event functions pass `type="Event"` (maps to `SCF`). Omit `domain` to use the environment default (`IsDefault`)
+- `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills
 

--- a/doc/prompts/web-development.mdx
+++ b/doc/prompts/web-development.mdx
@@ -202,8 +202,8 @@ Use this section only when the Web project needs CloudBase platform features.
 
 ### Web SDK rules
 
-- Prefer npm installation for React, Vue, Vite, and other bundler-based projects
-- Use the CDN only for static HTML pages, quick demos, embedded snippets, or README examples
+- Prefer npm installation for React, Vue, Vite, and other bundler-based projects: `npm install @cloudbase/js-sdk`
+- Use the CDN only for static HTML pages, quick demos, embedded snippets, or README examples: `https://static.cloudbase.net/cloudbase-js-sdk/latest/cloudbase.full.js`
 - Only use documented CloudBase Web SDK APIs; do not invent methods or options
 - Keep a shared `app` or `auth` instance instead of re-initializing on every call
 - If the user only provides an environment alias, nickname, or other shorthand, resolve it to the canonical full `EnvId` before writing SDK init code, console links, or config files. Do not pass alias-like short forms directly into `cloudbase.init({ env })`.

--- a/examples/cloudbase-auth-endpoint-with-feishu/README.md
+++ b/examples/cloudbase-auth-endpoint-with-feishu/README.md
@@ -99,7 +99,7 @@ curl -X POST http://localhost:9000/auth/device/code -H 'Content-Type: applicatio
 {
   "tool": "manageGateway",
   "params": {
-    "action": "createAccess",
+    "action": "createRoute",
     "targetType": "function",
     "targetName": "auth-service",
     "path": "/",
@@ -109,7 +109,7 @@ curl -X POST http://localhost:9000/auth/device/code -H 'Content-Type: applicatio
 }
 ```
 
-这会创建一个默认域名的网关入口。之后你的服务访问地址为：
+这会在环境默认 HTTP 域名（`IsDefault`）上创建 Domain/Route 入口。之后你的服务访问地址为：
 ```
 https://{envId}-{appId}.ap-shanghai.app.tcloudbase.com/cli-auth.html
 ```

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -182,15 +182,16 @@ describe("functions tool helpers", () => {
       force: false,
     });
     expect(mockCreateAccess).not.toHaveBeenCalled();
-    expect(payload.message).toContain("manageGateway(action=\"createAccess\")");
+    expect(payload.message).toContain("manageGateway(action=\"createRoute\")");
     expect(payload.message).toContain("type=\"HTTP\"");
+    expect(payload.message).toContain("WEB_SCF");
     expect(payload.message).toContain("匿名身份访问");
     expect(payload.message).toContain("EXCEED_AUTHORITY");
     expect(payload.nextActions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           tool: "manageGateway",
-          action: "createAccess",
+          action: "createRoute",
         }),
         expect.objectContaining({
           tool: "queryPermissions",

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -699,7 +699,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           },
           {
             tool: "queryGateway",
-            action: "getAccess",
+            action: "getRoute",
             reason: "查看该函数是否已暴露网关访问入口",
           },
         ],
@@ -1082,7 +1082,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           },
           `已基于镜像 ${createImageConfig.imageUri} 创建 HTTP 函数 ${functionName}。` +
             `请确认 TCR、SCF 与构建管道处于同一地域；如需通过 URL 访问，请显式调用 ` +
-            `manageGateway(action="createAccess", type="HTTP") 并按需调整函数安全规则。` +
+            `manageGateway(action="createRoute", type="HTTP") 并按需调整函数安全规则。` +
             `部署后可用 queryFunctions(action="getFunctionDetail") 确认函数已就绪。`,
           [
             {
@@ -1097,9 +1097,9 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
             },
             {
               tool: "manageGateway",
-              action: "createAccess",
+              action: "createRoute",
               reason:
-                "如需通过 URL 访问镜像 HTTP 函数，显式创建网关访问入口并传 type=\"HTTP\"",
+                "如需通过 URL 访问镜像 HTTP 函数，显式创建 Domain/Route 访问入口并传 type=\"HTTP\"（映射 WEB_SCF）",
             },
           ],
         );
@@ -1185,13 +1185,13 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       if (func.type === "HTTP") {
         nextActions.push({
           tool: "manageGateway",
-          action: "createAccess",
+          action: "createRoute",
           reason:
-            "如果需要通过 URL 访问 HTTP 函数，请调用 manageGateway(action=\"createAccess\") 并显式传 type=\"HTTP\"，再按实际路径和鉴权需求创建访问入口，不要默认假设 /函数名 已存在",
+            "如果需要通过 URL 访问 HTTP 函数，请调用 manageGateway(action=\"createRoute\") 并显式传 type=\"HTTP\"（映射 WEB_SCF），再按实际路径和鉴权需求创建访问入口，不要默认假设 /函数名 已存在",
         });
         nextActions.push({
           tool: "queryGateway",
-          action: "getAccess",
+          action: "getRoute",
           reason: "交付前确认 HTTP 访问路径是否已存在并已生效",
         });
         nextActions.push({
@@ -1210,7 +1210,7 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
 
       const message =
         func.type === "HTTP"
-          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createAccess")，并把 type="HTTP" 一起传入，再按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
+          ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createRoute")，并把 type="HTTP" 一起传入（映射 UpstreamResourceType=WEB_SCF），再按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
           : `已创建函数 ${functionName}`;
 
       return buildEnvelope(

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -3,10 +3,6 @@ import { registerGatewayTools } from "./gateway.js";
 import type { ExtendedMcpServer } from "../server.js";
 
 const {
-  mockGetAccessList,
-  mockGetDomainList,
-  mockCreateAccess,
-  mockDeleteAccess,
   mockDescribeHttpServiceRoute,
   mockCreateHttpServiceRoute,
   mockModifyHttpServiceRoute,
@@ -17,10 +13,6 @@ const {
   mockLogCloudBaseResult,
   mockGetEnvId,
 } = vi.hoisted(() => ({
-  mockGetAccessList: vi.fn(),
-  mockGetDomainList: vi.fn(),
-  mockCreateAccess: vi.fn(),
-  mockDeleteAccess: vi.fn(),
   mockDescribeHttpServiceRoute: vi.fn(),
   mockCreateHttpServiceRoute: vi.fn(),
   mockModifyHttpServiceRoute: vi.fn(),
@@ -72,53 +64,37 @@ describe("gateway tools", () => {
     vi.clearAllMocks();
 
     mockGetEnvId.mockResolvedValue("env-test");
-    mockGetAccessList.mockResolvedValue({
-      Total: 1,
-      EnableService: true,
-      APISet: [
-        {
-          APIId: "api-123",
-          Path: "api/hello",
-          Name: "helloFn",
-        },
-      ],
-    });
-    mockGetDomainList.mockResolvedValue({
-      DefaultDomain: "env-test.app.tcloudbase.com",
-      EnableService: true,
-      ServiceSet: [
-        {
-          Domain: "api.example.com",
-        },
-      ],
-    });
-    mockCreateAccess.mockResolvedValue({
-      RequestId: "req-create-access",
-      APIId: "api-123",
-    });
-    mockDeleteAccess.mockResolvedValue({
-      RequestId: "req-delete-access",
-    });
     mockDescribeHttpServiceRoute.mockResolvedValue({
-      OriginDomain: "env-test.service.tcloudbase.com",
+      OriginDomain: "origin.service.tcloudbase.com",
       TotalCount: 1,
       Domains: [
         {
           Domain: "env-test.service.tcloudbase.com",
+          IsDefault: true,
+          Enable: true,
+          Status: "SUCCESS",
           Routes: [
             {
               RouteId: "route-1",
               Path: "/api/hello",
-              UpstreamResourceType: "SCF",
+              UpstreamResourceType: "WEB_SCF",
               UpstreamResourceName: "helloFn",
+              EnableAuth: false,
             },
           ],
+        },
+        {
+          Domain: "api.example.com",
+          IsDefault: false,
+          Enable: true,
+          Status: "SUCCESS",
+          CertId: "cert-1",
+          Routes: [],
         },
       ],
       RequestId: "req-route-list",
     });
     mockCreateHttpServiceRoute.mockResolvedValue({
-      RouteId: "route-2",
       RequestId: "req-route-create",
     });
     mockModifyHttpServiceRoute.mockResolvedValue({
@@ -134,12 +110,6 @@ describe("gateway tools", () => {
       RequestId: "req-domain-delete",
     });
     mockGetCloudBaseManager.mockResolvedValue({
-      access: {
-        getAccessList: mockGetAccessList,
-        getDomainList: mockGetDomainList,
-        createAccess: mockCreateAccess,
-        deleteAccess: mockDeleteAccess,
-      },
       env: {
         describeHttpServiceRoute: mockDescribeHttpServiceRoute,
         createHttpServiceRoute: mockCreateHttpServiceRoute,
@@ -153,21 +123,41 @@ describe("gateway tools", () => {
     ({ tools } = createMockServer());
   });
 
-  it("manageGateway schema should explain how to expose an existing HTTP function", () => {
+  it("schema should expose Domain/Route actions only", () => {
+    const queryActions = tools.queryGateway.meta.inputSchema.action._def.values;
+    const manageActions = tools.manageGateway.meta.inputSchema.action._def.values;
+
+    expect(queryActions).toEqual(["listRoutes", "getRoute", "listCustomDomains"]);
+    expect(manageActions).toEqual([
+      "createRoute",
+      "updateRoute",
+      "deleteRoute",
+      "bindCustomDomain",
+      "deleteCustomDomain",
+    ]);
+    expect(queryActions).not.toContain("getAccess");
+    expect(queryActions).not.toContain("listDomains");
+    expect(manageActions).not.toContain("createAccess");
+    expect(manageActions).not.toContain("deleteAccess");
+    expect(manageActions).not.toContain("updatePathAuth");
+  });
+
+  it("manageGateway schema should explain createRoute for HTTP functions", () => {
     const schema = tools.manageGateway.meta.inputSchema;
 
-    expect(tools.manageGateway.meta.description).toContain("HTTP 云函数补默认域名访问");
-    expect(schema.action.description).toContain("createAccess");
-    expect(schema.action.description).toContain("默认域名访问入口");
+    expect(tools.manageGateway.meta.description).toContain("createRoute");
+    expect(tools.manageGateway.meta.description).toContain("WEB_SCF");
+    expect(schema.action.description).toContain("createRoute");
     expect(schema.targetName.description).toContain("填写函数名");
     expect(schema.path.description).toContain("/api/hello");
-    expect(schema.type.description).toContain("已创建的 HTTP 云函数时传 HTTP");
+    expect(schema.type.description).toContain("HTTP");
+    expect(schema.type.description).toContain("WEB_SCF");
     expect(schema.auth.description).toContain("通常设为 false");
   });
 
-  it("manageGateway(action=createAccess) should normalize path and return structured payload", async () => {
+  it("manageGateway(action=createRoute) should map HTTP to WEB_SCF on default domain", async () => {
     const result = await tools.manageGateway.handler({
-      action: "createAccess",
+      action: "createRoute",
       targetType: "function",
       targetName: "helloFn",
       path: "api/hello",
@@ -177,46 +167,52 @@ describe("gateway tools", () => {
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockCreateAccess).toHaveBeenCalledWith({
-      name: "helloFn",
-      path: "/api/hello",
-      type: 6,
-      auth: false,
+    expect(mockDescribeHttpServiceRoute).toHaveBeenCalled();
+    expect(mockCreateHttpServiceRoute).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: {
+        Domain: "env-test.service.tcloudbase.com",
+        Routes: [
+          {
+            Path: "/api/hello",
+            UpstreamResourceType: "WEB_SCF",
+            UpstreamResourceName: "helloFn",
+            EnableAuth: false,
+          },
+        ],
+      },
     });
     expect(payload).toMatchObject({
       success: true,
-      message:
-        "已为目标 helloFn 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开函数安全规则；若需要匿名或浏览器直接访问，请继续检查函数资源权限。",
       data: {
-        action: "createAccess",
-        targetType: "function",
-        targetName: "helloFn",
+        action: "createRoute",
+        model: "httpServiceRoute",
+        domain: "env-test.service.tcloudbase.com",
         path: "/api/hello",
+        upstreamResourceType: "WEB_SCF",
+        upstreamResourceName: "helloFn",
       },
       nextActions: [
         expect.objectContaining({
           tool: "queryGateway",
-          action: "getAccess",
-          reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
+          action: "getRoute",
         }),
         expect.objectContaining({
           tool: "queryPermissions",
           action: "getResourcePermission",
-          reason:
-            "确认函数安全规则是否允许预期访问方；网关 auth=false 不等于函数已允许匿名访问",
         }),
         expect.objectContaining({
           tool: "managePermissions",
           action: "updateResourcePermission",
-          reason: "只有在确认需要匿名或浏览器直连访问时，才按实际安全要求更新函数权限",
         }),
       ],
     });
+    expect(payload.message).toContain("30 秒到 3 分钟");
   });
 
-  it("manageGateway(action=createAccess) should default path to targetName when omitted", async () => {
+  it("manageGateway(action=createRoute) should map Event to SCF and default path", async () => {
     const result = await tools.manageGateway.handler({
-      action: "createAccess",
+      action: "createRoute",
       targetType: "function",
       targetName: "helloFn",
       type: "Event",
@@ -224,41 +220,39 @@ describe("gateway tools", () => {
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockCreateAccess).toHaveBeenCalledWith({
-      name: "helloFn",
-      path: "/helloFn",
-      type: 1,
-      auth: undefined,
+    expect(mockCreateHttpServiceRoute).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: {
+        Domain: "env-test.service.tcloudbase.com",
+        Routes: [
+          {
+            Path: "/helloFn",
+            UpstreamResourceType: "SCF",
+            UpstreamResourceName: "helloFn",
+            EnableAuth: undefined,
+          },
+        ],
+      },
     });
     expect(payload).toMatchObject({
       success: true,
       data: {
-        action: "createAccess",
-        targetType: "function",
-        targetName: "helloFn",
         path: "/helloFn",
+        upstreamResourceType: "SCF",
       },
     });
   });
 
-  it("manageGateway metadata should warn that createAccess requires explicit type", () => {
-    expect(tools.manageGateway.meta.description).toContain("createAccess");
-    expect(tools.manageGateway.meta.description).toContain("type");
-    expect(tools.manageGateway.meta.inputSchema.action.description).toContain("显式");
-    expect(tools.manageGateway.meta.inputSchema.type.description).toContain("createAccess");
-    expect(tools.manageGateway.meta.inputSchema.type.description).toContain("省略会默认按 Event 路由处理");
-  });
-
-  it("manageGateway(action=createAccess) should reject missing type with a clear message", async () => {
+  it("manageGateway(action=createRoute) should reject missing type for function routes", async () => {
     const result = await tools.manageGateway.handler({
-      action: "createAccess",
+      action: "createRoute",
       targetType: "function",
       targetName: "helloFn",
     });
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockCreateAccess).not.toHaveBeenCalled();
+    expect(mockCreateHttpServiceRoute).not.toHaveBeenCalled();
     expect(payload).toMatchObject({
       success: false,
       message: expect.stringContaining("必须显式提供 type"),
@@ -266,85 +260,118 @@ describe("gateway tools", () => {
     expect(payload.message).toContain("FUNCTION_PARAM_INVALID");
   });
 
-  it("manageGateway(action=deleteAccess) should delete by accessId directly", async () => {
+  it("manageGateway(action=createRoute) should not use OriginDomain as public domain", async () => {
+    mockDescribeHttpServiceRoute.mockResolvedValueOnce({
+      OriginDomain: "origin.service.tcloudbase.com",
+      TotalCount: 0,
+      Domains: [],
+      RequestId: "req-empty",
+    });
+
     const result = await tools.manageGateway.handler({
-      action: "deleteAccess",
-      accessId: "api-123",
+      action: "createRoute",
+      targetType: "function",
+      targetName: "helloFn",
+      type: "HTTP",
     });
 
     const payload = JSON.parse(result.content[0].text);
 
-    // 仅传 accessId 时，代码会先查询补全 name
-    expect(mockGetAccessList).toHaveBeenCalledWith({});
-    expect(mockDeleteAccess).toHaveBeenCalledWith({
-      name: "helloFn",
-      apiId: "api-123",
-    });
-    expect(payload).toMatchObject({
-      success: true,
-      data: {
-        action: "deleteAccess",
-        accessId: "api-123",
-      },
-    });
+    expect(mockCreateHttpServiceRoute).not.toHaveBeenCalled();
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("默认 HTTP 访问域名未就绪");
+    expect(payload.message).not.toContain("origin.service.tcloudbase.com");
   });
 
-  it("manageGateway(action=deleteAccess) should resolve accessId by targetName and path", async () => {
+  it("manageGateway(action=updateRoute) should modify route auth", async () => {
     const result = await tools.manageGateway.handler({
-      action: "deleteAccess",
+      action: "updateRoute",
+      domain: "api.example.com",
       targetName: "helloFn",
       path: "/api/hello",
+      type: "HTTP",
+      auth: true,
     });
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockGetAccessList).toHaveBeenCalledWith({
-      name: "helloFn",
-      path: "/api/hello",
-    });
-    expect(mockDeleteAccess).toHaveBeenCalledWith({
-      name: "helloFn",
-      apiId: "api-123",
+    expect(mockModifyHttpServiceRoute).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: {
+        Domain: "api.example.com",
+        Routes: [
+          {
+            Path: "/api/hello",
+            UpstreamResourceType: "WEB_SCF",
+            UpstreamResourceName: "helloFn",
+            EnableAuth: true,
+          },
+        ],
+      },
     });
     expect(payload).toMatchObject({
       success: true,
       data: {
-        action: "deleteAccess",
-        targetName: "helloFn",
-        path: "/api/hello",
-        accessId: "api-123",
+        action: "updateRoute",
+        domain: "api.example.com",
+        auth: true,
       },
     });
   });
 
-  it("queryGateway(action=getAccess) should aggregate access urls from domains", async () => {
+  it("manageGateway(action=deleteRoute) should delete by domain and path", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "deleteRoute",
+      domain: "env-test.service.tcloudbase.com",
+      path: "/api/hello",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDeleteHttpServiceRoute).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: "env-test.service.tcloudbase.com",
+      Paths: ["/api/hello"],
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "deleteRoute",
+        domain: "env-test.service.tcloudbase.com",
+        path: "/api/hello",
+      },
+    });
+  });
+
+  it("queryGateway(action=getRoute) should return urls for matching function", async () => {
     const result = await tools.queryGateway.handler({
-      action: "getAccess",
+      action: "getRoute",
       targetType: "function",
       targetName: "helloFn",
     });
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockGetAccessList).toHaveBeenCalledWith({ name: "helloFn" });
+    expect(mockDescribeHttpServiceRoute).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Limit: 1000,
+    });
     expect(payload).toMatchObject({
       success: true,
       data: {
-        action: "getAccess",
-        targetType: "function",
+        action: "getRoute",
         targetName: "helloFn",
         total: 1,
-        domains: ["env-test.app.tcloudbase.com", "api.example.com"],
-        urls: [
-          "https://env-test.app.tcloudbase.com/api/hello",
-          "https://api.example.com/api/hello",
-        ],
-        enableService: true,
+        urls: ["https://env-test.service.tcloudbase.com/api/hello"],
+        route: expect.objectContaining({
+          UpstreamResourceName: "helloFn",
+          UpstreamResourceType: "WEB_SCF",
+        }),
       },
       nextActions: [
         expect.objectContaining({
           tool: "manageGateway",
-          action: "createAccess",
+          action: "createRoute",
         }),
       ],
     });
@@ -357,9 +384,6 @@ describe("gateway tools", () => {
 
     const payload = JSON.parse(result.content[0].text);
 
-    expect(mockDescribeHttpServiceRoute).toHaveBeenCalledWith({
-      EnvId: "env-test",
-    });
     expect(payload).toMatchObject({
       success: true,
       data: {
@@ -370,14 +394,31 @@ describe("gateway tools", () => {
     });
   });
 
-  it("manageGateway(action=createRoute) should create http route", async () => {
+  it("queryGateway(action=listCustomDomains) should exclude default domain", async () => {
+    const result = await tools.queryGateway.handler({
+      action: "listCustomDomains",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "listCustomDomains",
+        total: 1,
+        domains: [expect.objectContaining({ Domain: "api.example.com" })],
+      },
+    });
+  });
+
+  it("manageGateway(action=createRoute) should accept explicit upstreamResourceType", async () => {
     const result = await tools.manageGateway.handler({
       action: "createRoute",
-      domain: "env-test.service.tcloudbase.com",
+      domain: "api.example.com",
       route: {
-        path: "/api/hello",
-        serviceType: "function",
-        serviceName: "helloFn",
+        path: "/api/run",
+        serviceName: "my-service",
+        upstreamResourceType: "CBR",
       },
     });
 
@@ -386,23 +427,18 @@ describe("gateway tools", () => {
     expect(mockCreateHttpServiceRoute).toHaveBeenCalledWith({
       EnvId: "env-test",
       Domain: {
-        Domain: "env-test.service.tcloudbase.com",
+        Domain: "api.example.com",
         Routes: [
           {
-            Path: "/api/hello",
-            UpstreamResourceType: "SCF",
-            UpstreamResourceName: "helloFn",
+            Path: "/api/run",
+            UpstreamResourceType: "CBR",
+            UpstreamResourceName: "my-service",
             EnableAuth: undefined,
           },
         ],
       },
     });
-    expect(payload).toMatchObject({
-      success: true,
-      data: {
-        action: "createRoute",
-      },
-    });
+    expect(payload.success).toBe(true);
   });
 
   it("manageGateway(action=bindCustomDomain) should bind custom domain", async () => {

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -8,27 +8,32 @@ import { ExtendedMcpServer } from "../server.js";
 import { jsonContent } from "../utils/json-content.js";
 
 const QUERY_GATEWAY_ACTIONS = [
-  "getAccess",
-  "listDomains",
   "listRoutes",
   "getRoute",
   "listCustomDomains",
 ] as const;
 
 const MANAGE_GATEWAY_ACTIONS = [
-  "createAccess",
   "createRoute",
   "updateRoute",
   "deleteRoute",
   "bindCustomDomain",
   "deleteCustomDomain",
-  "deleteAccess",
-  "updatePathAuth",
+] as const;
+
+const UPSTREAM_RESOURCE_TYPES = [
+  "SCF",
+  "WEB_SCF",
+  "CBR",
+  "STATIC_STORE",
+  "LH",
 ] as const;
 
 type QueryGatewayAction = (typeof QUERY_GATEWAY_ACTIONS)[number];
 type ManageGatewayAction = (typeof MANAGE_GATEWAY_ACTIONS)[number];
 type GatewayTargetType = "function";
+type UpstreamResourceType = (typeof UPSTREAM_RESOURCE_TYPES)[number];
+type FunctionRouteType = "Event" | "HTTP";
 
 type GatewayToolEnvelope = {
   success: boolean;
@@ -46,6 +51,8 @@ type QueryGatewayInput = {
   targetType?: GatewayTargetType;
   targetName?: string;
   routeId?: string;
+  path?: string;
+  domain?: string;
 };
 
 type ManageGatewayInput = {
@@ -53,19 +60,29 @@ type ManageGatewayInput = {
   targetType?: GatewayTargetType;
   targetName?: string;
   path?: string;
-  type?: "Event" | "HTTP";
+  type?: FunctionRouteType;
   auth?: boolean;
   route?: {
-    routeId?: string;
     path?: string;
-    serviceType?: string;
     serviceName?: string;
+    upstreamResourceType?: UpstreamResourceType;
     auth?: boolean;
   };
   domain?: string;
   certificateId?: string;
-  accessName?: string;
-  accessId?: string;
+};
+
+type FlatRoute = {
+  Domain: string;
+  DomainType?: string;
+  AccessType?: string;
+  IsDefault?: boolean;
+  Path?: string;
+  UpstreamResourceType?: string;
+  UpstreamResourceName?: string;
+  EnableAuth?: boolean;
+  RouteId?: string;
+  [key: string]: unknown;
 };
 
 function normalizeAccessPath(path: string | undefined): string {
@@ -106,27 +123,11 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     }
   };
 
-  const listGatewayDomains = async () => {
-    const cloudbase = await getManager();
-    const result = await cloudbase.access.getDomainList();
-    logCloudBaseResult(server.logger, result);
-
-    const domains = [
-      result.DefaultDomain,
-      ...(result.ServiceSet || []).map((item) => item.Domain),
-    ].filter(Boolean);
-
-    return {
-      domains,
-      enableService: result.EnableService,
-      raw: result,
-    };
-  };
-
   const listHttpServiceRoutes = async (domain?: string) => {
     const cloudbase = await getManager();
     const result = await cloudbase.env.describeHttpServiceRoute({
       EnvId: await resolveEnvId(),
+      Limit: 1000,
       ...(domain
         ? {
             Filters: [
@@ -142,178 +143,293 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     return result;
   };
 
-  const flattenRoutes = (result: any) =>
-    (result.Domains ?? []).flatMap((domainItem: any) =>
-      (domainItem.Routes ?? []).map((route: any) => ({
-        Domain: domainItem.Domain,
+  const flattenRoutes = (result: {
+    Domains?: Array<{
+      Domain?: string;
+      DomainType?: string;
+      AccessType?: string;
+      IsDefault?: boolean;
+      Routes?: Array<object>;
+    }>;
+  }): FlatRoute[] =>
+    (result.Domains ?? []).flatMap((domainItem) =>
+      (domainItem.Routes ?? []).map((route) => ({
+        Domain: domainItem.Domain ?? "",
         DomainType: domainItem.DomainType,
         AccessType: domainItem.AccessType,
-        ...route,
+        IsDefault: domainItem.IsDefault,
+        ...(route as Record<string, unknown>),
       })),
     );
+
+  const buildRouteUrls = (routes: FlatRoute[]) =>
+    Array.from(
+      new Set(
+        routes
+          .filter((route) => route.Domain && route.Path)
+          .map(
+            (route) =>
+              `https://${route.Domain}${normalizeAccessPath(String(route.Path))}`,
+          ),
+      ),
+    );
+
+  const resolveDefaultHttpDomain = async () => {
+    const routeInfo = await listHttpServiceRoutes();
+    const domains = routeInfo.Domains ?? [];
+    const defaultCandidates = domains.filter(
+      (item) => item.IsDefault === true && item.Domain,
+    );
+    const preferred =
+      defaultCandidates.find(
+        (item) => item.Enable !== false && item.Status === "SUCCESS",
+      ) ??
+      defaultCandidates.find((item) => item.Enable !== false) ??
+      defaultCandidates[0];
+
+    if (!preferred?.Domain) {
+      throw new Error(
+        "环境默认 HTTP 访问域名未就绪或未开通。请先在控制台开通 HTTP 访问服务，或用 queryGateway(action=\"listRoutes\") 确认 Domains 中是否存在 IsDefault=true 的域名；也可以显式传入 domain 后重试 createRoute/updateRoute/deleteRoute。",
+      );
+    }
+
+    return preferred.Domain;
+  };
 
   const resolveRouteDomain = async (preferredDomain?: string) => {
     if (preferredDomain) {
       return preferredDomain;
     }
-    const routeInfo = await listHttpServiceRoutes();
-    return routeInfo.OriginDomain;
+    return resolveDefaultHttpDomain();
+  };
+
+  const mapUpstreamResourceType = (input: {
+    type?: FunctionRouteType;
+    targetType?: GatewayTargetType;
+    upstreamResourceType?: UpstreamResourceType;
+    requiresFunctionType: boolean;
+  }): UpstreamResourceType => {
+    if (input.upstreamResourceType) {
+      return input.upstreamResourceType;
+    }
+
+    if (input.type === "HTTP") {
+      return "WEB_SCF";
+    }
+    if (input.type === "Event") {
+      return "SCF";
+    }
+
+    if (input.requiresFunctionType || input.targetType === "function") {
+      throw new Error(
+        "为云函数创建/更新路由时必须显式提供 type（HTTP→WEB_SCF，Event→SCF）或 route.upstreamResourceType。省略会导致 HTTP 与 Event 函数互相误标，访问时可能返回 FUNCTION_PARAM_INVALID 或网关内部错误。",
+      );
+    }
+
+    throw new Error(
+      "必须提供 route.upstreamResourceType（SCF / WEB_SCF / CBR / STATIC_STORE / LH），或在函数场景提供 type=\"HTTP\"|\"Event\"。",
+    );
   };
 
   const normalizeRoutePayload = async (
-    route: ManageGatewayInput["route"],
-    fallback: Pick<ManageGatewayInput, "path" | "targetName" | "targetType" | "auth">,
-    domain?: string,
-  ) => {
-    const path = normalizeAccessPath(route?.path ?? fallback.path);
-    const serviceType = route?.serviceType ?? fallback.targetType;
-    const serviceName = route?.serviceName ?? fallback.targetName;
-
-    if (!serviceType || !serviceName) {
-      throw new Error("route.serviceType 和 route.serviceName 为必填项");
+    input: ManageGatewayInput,
+  ): Promise<{
+    EnvId: string;
+    Domain: {
+      Domain: string;
+      Routes: Array<{
+        Path: string;
+        UpstreamResourceType: UpstreamResourceType;
+        UpstreamResourceName: string;
+        EnableAuth?: boolean;
+      }>;
+    };
+    resolved: {
+      domain: string;
+      path: string;
+      upstreamResourceType: UpstreamResourceType;
+      upstreamResourceName: string;
+      enableAuth?: boolean;
+    };
+  }> => {
+    const upstreamResourceName =
+      input.route?.serviceName ?? input.targetName;
+    if (!upstreamResourceName) {
+      throw new Error(
+        "必须提供 targetName 或 route.serviceName 作为上游资源名称（例如云函数名）",
+      );
     }
+
+    const isFunctionRoute =
+      input.targetType === "function" ||
+      input.type !== undefined ||
+      input.route?.upstreamResourceType === "SCF" ||
+      input.route?.upstreamResourceType === "WEB_SCF" ||
+      (!input.route?.upstreamResourceType && Boolean(input.targetName));
+
+    const upstreamResourceType = mapUpstreamResourceType({
+      type: input.type,
+      targetType: input.targetType,
+      upstreamResourceType: input.route?.upstreamResourceType,
+      requiresFunctionType: isFunctionRoute,
+    });
+
+    const path = normalizeAccessPath(
+      input.route?.path ?? input.path ?? `/${upstreamResourceName}`,
+    );
+    const domain = await resolveRouteDomain(input.domain);
+    const enableAuth =
+      input.route?.auth !== undefined
+        ? input.route.auth
+        : input.auth !== undefined
+          ? input.auth
+          : undefined;
 
     return {
       EnvId: await resolveEnvId(),
       Domain: {
-        Domain: await resolveRouteDomain(domain),
+        Domain: domain,
         Routes: [
           {
             Path: path,
-            UpstreamResourceType: serviceType === "function" ? "SCF" : "CBR",
-            UpstreamResourceName: serviceName,
-            EnableAuth:
-              route?.auth !== undefined
-                ? route.auth
-                : fallback.auth !== undefined
-                  ? fallback.auth
-                  : undefined,
+            UpstreamResourceType: upstreamResourceType,
+            UpstreamResourceName: upstreamResourceName,
+            EnableAuth: enableAuth,
           },
         ],
       },
+      resolved: {
+        domain,
+        path,
+        upstreamResourceType,
+        upstreamResourceName,
+        enableAuth,
+      },
     };
   };
+
+  const routeMutationNextActions = (
+    targetName: string,
+  ): GatewayToolEnvelope["nextActions"] => [
+    {
+      tool: "queryGateway",
+      action: "getRoute",
+      reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
+    },
+    {
+      tool: "queryPermissions",
+      action: "getResourcePermission",
+      reason:
+        "确认函数安全规则是否允许预期访问方；网关 EnableAuth/auth=false 不等于函数已允许匿名访问",
+    },
+    {
+      tool: "managePermissions",
+      action: "updateResourcePermission",
+      reason:
+        "只有在确认需要匿名或浏览器直连访问时，才按实际安全要求更新函数权限",
+    },
+  ];
 
   const handleQueryGateway = async (
     input: QueryGatewayInput,
   ): Promise<GatewayToolEnvelope> => {
     switch (input.action) {
-    case "listDomains": {
-      const result = await listGatewayDomains();
-      return buildEnvelope(
-        {
-          action: input.action,
-          domains: result.domains,
-          enableService: result.enableService,
-          raw: result.raw,
-        },
-        `已获取 ${result.domains.length} 个网关域名`,
-        [
+      case "listCustomDomains": {
+        const result = await listHttpServiceRoutes();
+        const customDomains = (result.Domains ?? []).filter(
+          (item) => item.IsDefault !== true,
+        );
+
+        return buildEnvelope(
           {
-            tool: "queryGateway",
-            action: "getAccess",
-            reason: "查看某个目标当前的访问入口",
+            action: input.action,
+            domains: customDomains,
+            total: customDomains.length,
+            raw: result,
           },
-        ],
-      );
-    }
-    case "listCustomDomains": {
-      const result = await listGatewayDomains();
-      return buildEnvelope(
-        {
-          action: input.action,
-          domains: result.raw.ServiceSet ?? [],
-          total: (result.raw.ServiceSet ?? []).length,
-          raw: result.raw,
-        },
-        `已获取 ${(result.raw.ServiceSet ?? []).length} 个自定义域名`,
-      );
-    }
-    case "listRoutes": {
-      const result = await listHttpServiceRoutes();
-      const routes = flattenRoutes(result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          routes,
-          total: result.TotalCount ?? routes.length,
-          raw: result,
-        },
-        `已获取 ${result.TotalCount ?? routes.length} 条 HTTP 路由`,
-      );
-    }
-    case "getRoute": {
-      const result = await listHttpServiceRoutes();
-      const route =
-        flattenRoutes(result).find(
-          (item: any) =>
-            (input.routeId && item.RouteId === input.routeId) ||
-            (input.targetName && item.UpstreamResourceName === input.targetName),
-        ) ?? null;
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          routeId: input.routeId ?? null,
-          route,
-          raw: result,
-        },
-        route ? "已获取路由详情" : "未找到对应路由",
-      );
-    }
-    case "getAccess": {
-      if (!input.targetName) {
-        throw new Error("getAccess 操作时，targetName 参数是必需的");
+          `已获取 ${customDomains.length} 个自定义域名`,
+        );
       }
+      case "listRoutes": {
+        const result = await listHttpServiceRoutes(input.domain);
+        const routes = flattenRoutes(result);
 
-      const cloudbase = await getManager();
-      const [accessList, domainInfo] = await Promise.all([
-        cloudbase.access.getAccessList({ name: input.targetName }),
-        listGatewayDomains(),
-      ]);
-
-      logCloudBaseResult(server.logger, accessList);
-
-      const urls = Array.from(
-        new Set(
-          (accessList.APISet || []).flatMap((api) =>
-            domainInfo.domains.map((domain) => {
-              const normalizedPath = normalizeAccessPath(api.Path);
-              return `https://${domain}${normalizedPath}`;
-            }),
-          ),
-        ),
-      );
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          targetType: input.targetType ?? "function",
-          targetName: input.targetName,
-          apis: accessList.APISet || [],
-          total: accessList.Total || 0,
-          domains: domainInfo.domains,
-          urls,
-          enableService:
-            accessList.EnableService ?? domainInfo.enableService ?? false,
-          raw: {
-            accessList,
-            domainList: domainInfo.raw,
-          },
-        },
-        `已获取目标 ${input.targetName} 的网关访问配置`,
-        [
+        return buildEnvelope(
           {
-            tool: "manageGateway",
-            action: "createAccess",
-            reason: "为该目标新增访问路径",
+            action: input.action,
+            routes,
+            urls: buildRouteUrls(routes),
+            total: result.TotalCount ?? routes.length,
+            raw: result,
           },
-        ],
-      );
-    }
-    default:
-      throw new Error(`不支持的操作类型: ${input.action}`);
+          `已获取 ${result.TotalCount ?? routes.length} 条 HTTP 路由`,
+        );
+      }
+      case "getRoute": {
+        if (!input.routeId && !input.targetName && !input.path) {
+          throw new Error(
+            "action=getRoute 时至少需要提供 routeId、targetName 或 path",
+          );
+        }
+
+        const result = await listHttpServiceRoutes(input.domain);
+        const normalizedPath = input.path
+          ? normalizeAccessPath(input.path)
+          : undefined;
+        const matches = flattenRoutes(result).filter((item) => {
+          if (input.routeId && item.RouteId !== input.routeId) {
+            return false;
+          }
+          if (input.domain && item.Domain !== input.domain) {
+            return false;
+          }
+          if (
+            normalizedPath &&
+            normalizeAccessPath(String(item.Path ?? "")) !== normalizedPath
+          ) {
+            return false;
+          }
+          if (
+            input.targetName &&
+            item.UpstreamResourceName !== input.targetName
+          ) {
+            return false;
+          }
+          return Boolean(input.routeId || input.targetName || normalizedPath);
+        });
+
+        const route = matches.length === 1 ? matches[0] : null;
+        const urls = buildRouteUrls(matches);
+
+        return buildEnvelope(
+          {
+            action: input.action,
+            routeId: input.routeId ?? null,
+            targetName: input.targetName ?? null,
+            path: normalizedPath ?? null,
+            domain: input.domain ?? null,
+            route,
+            routes: matches,
+            total: matches.length,
+            urls,
+            raw: result,
+          },
+          matches.length === 0
+            ? "未找到对应路由"
+            : matches.length === 1
+              ? "已获取路由详情"
+              : `匹配到 ${matches.length} 条路由，请补充 path 或 domain 精确定位`,
+          [
+            {
+              tool: "manageGateway",
+              action: "createRoute",
+              reason: "为该目标新增 Domain/Route 访问路径",
+            },
+          ],
+        );
+      }
+      default:
+        throw new Error(`不支持的操作类型: ${input.action}`);
     }
   };
 
@@ -321,272 +437,145 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     input: ManageGatewayInput,
   ): Promise<GatewayToolEnvelope> => {
     switch (input.action) {
-    case "createAccess": {
-      if (!input.targetName || !input.targetType) {
-        throw new Error("action=createAccess 时必须提供 targetType 和 targetName");
-      }
-      if (!input.type) {
-        throw new Error(
-          "action=createAccess 且 targetType=function 时必须显式提供 type。HTTP 云函数传 HTTP；Event 函数传 Event。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。",
+      case "createRoute": {
+        const cloudbase = await getManager();
+        const payload = await normalizeRoutePayload(input);
+        let result;
+        try {
+          result = await cloudbase.env.createHttpServiceRoute({
+            EnvId: payload.EnvId,
+            Domain: payload.Domain,
+          } as any);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          if (message.includes("An error has occurred")) {
+            let hint =
+              "为目标资源配置访问路由失败（后端内部错误）。请确保：1) 目标云函数已成功创建并处于 Active 状态；2) 环境默认 HTTP 域名已完成初始化（IsDefault）；3) 该访问路径未被占用。";
+            if (input.type === "HTTP") {
+              hint +=
+                "此外注意：如果目标函数最初是作为 Event 函数创建的，这里 type 仍必须传 Event（UpstreamResourceType=SCF）；误传 HTTP/WEB_SCF 会导致此错误。";
+            }
+            throw new Error(`${hint} 原始错误：${message}`);
+          }
+          throw err;
+        }
+        logCloudBaseResult(server.logger, result);
+
+        return buildEnvelope(
+          {
+            action: input.action,
+            model: "httpServiceRoute",
+            targetType: input.targetType ?? null,
+            targetName: payload.resolved.upstreamResourceName,
+            domain: payload.resolved.domain,
+            path: payload.resolved.path,
+            upstreamResourceType: payload.resolved.upstreamResourceType,
+            upstreamResourceName: payload.resolved.upstreamResourceName,
+            auth: payload.resolved.enableAuth ?? null,
+            raw: result,
+          },
+          `已为目标 ${payload.resolved.upstreamResourceName} 在域名 ${payload.resolved.domain} 创建路由 ${payload.resolved.path}（${payload.resolved.upstreamResourceType}）。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开函数安全规则；若需要匿名或浏览器直接访问，请继续检查函数资源权限。`,
+          routeMutationNextActions(payload.resolved.upstreamResourceName),
         );
       }
-      const cloudbase = await getManager();
-      const accessPath = normalizeAccessPath(input.path || `/${input.targetName}`);
-      let result;
-      try {
-        result = await cloudbase.access.createAccess({
-          name: input.targetName,
-          path: accessPath,
-          type: (input.type === "HTTP" ? 6 : 1) as 1 | 2,
-          auth: input.auth,
-        });
-      } catch (err: any) {
-        if (err.message && err.message.includes("An error has occurred")) {
-          let hint = "为目标资源配置访问路由失败（后端内部错误）。请确保：1) 目标云函数已成功创建并处于 Active 状态；2) 环境默认 HTTP 域名已完成初始化；3) 该访问路径未被占用。";
-          if (input.type === "HTTP") {
-            hint += "此外注意：如果目标函数最初是作为 Event 函数创建的，这里 type 仍必须传 Event；误传 HTTP 会导致此错误。";
-          }
-          throw new Error(`${hint} 原始错误：${err.message}`);
-        }
-        throw err;
-      }
-      logCloudBaseResult(server.logger, result);
+      case "updateRoute": {
+        const cloudbase = await getManager();
+        const payload = await normalizeRoutePayload(input);
+        const result = await cloudbase.env.modifyHttpServiceRoute({
+          EnvId: payload.EnvId,
+          Domain: payload.Domain,
+        } as any);
+        logCloudBaseResult(server.logger, result);
 
-      return buildEnvelope(
-        {
-          action: input.action,
-          targetType: input.targetType,
-          targetName: input.targetName,
-          path: accessPath,
-          raw: result,
-        },
-        `已为目标 ${input.targetName} 创建网关访问路径。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开函数安全规则；若需要匿名或浏览器直接访问，请继续检查函数资源权限。`,
-        [
+        return buildEnvelope(
           {
-            tool: "queryGateway",
-            action: "getAccess",
-            reason: "等待 30 秒到 3 分钟后再确认访问入口是否已生效",
+            action: input.action,
+            model: "httpServiceRoute",
+            domain: payload.resolved.domain,
+            path: payload.resolved.path,
+            upstreamResourceType: payload.resolved.upstreamResourceType,
+            upstreamResourceName: payload.resolved.upstreamResourceName,
+            auth: payload.resolved.enableAuth ?? null,
+            raw: result,
           },
+          `HTTP 路由更新成功（${payload.resolved.domain}${payload.resolved.path}）`,
+          routeMutationNextActions(payload.resolved.upstreamResourceName),
+        );
+      }
+      case "deleteRoute": {
+        const routePath = input.route?.path ?? input.path;
+        if (!routePath) {
+          throw new Error("action=deleteRoute 时必须提供 route.path 或 path");
+        }
+        const cloudbase = await getManager();
+        const domain = await resolveRouteDomain(input.domain);
+        const normalizedPath = normalizeAccessPath(routePath);
+        const result = await cloudbase.env.deleteHttpServiceRoute({
+          EnvId: await resolveEnvId(),
+          Domain: domain,
+          Paths: [normalizedPath],
+        } as any);
+        logCloudBaseResult(server.logger, result);
+
+        return buildEnvelope(
           {
-            tool: "queryPermissions",
-            action: "getResourcePermission",
-            reason: "确认函数安全规则是否允许预期访问方；网关 auth=false 不等于函数已允许匿名访问",
+            action: input.action,
+            model: "httpServiceRoute",
+            domain,
+            path: normalizedPath,
+            raw: result,
           },
-          {
-            tool: "managePermissions",
-            action: "updateResourcePermission",
-            reason: "只有在确认需要匿名或浏览器直连访问时，才按实际安全要求更新函数权限",
-          },
-        ],
-      );
-    }
-    case "createRoute": {
-      const cloudbase = await getManager();
-      const result = await cloudbase.env.createHttpServiceRoute(
-        (await normalizeRoutePayload(input.route, input, input.domain)) as any,
-      );
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          route: input.route ?? null,
-          raw: result,
-        },
-        "HTTP 路由创建成功",
-      );
-    }
-    case "updateRoute": {
-      const cloudbase = await getManager();
-      const result = await cloudbase.env.modifyHttpServiceRoute(
-        (await normalizeRoutePayload(input.route, input, input.domain)) as any,
-      );
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          route: input.route ?? null,
-          raw: result,
-        },
-        "HTTP 路由更新成功",
-      );
-    }
-    case "deleteRoute": {
-      const routePath = input.route?.path ?? input.path;
-      if (!routePath) {
-        throw new Error("action=deleteRoute 时必须提供 route.path 或 path");
+          "HTTP 路由删除成功",
+        );
       }
-      const cloudbase = await getManager();
-      const domain = await resolveRouteDomain(input.domain);
-      const result = await cloudbase.env.deleteHttpServiceRoute({
-        EnvId: await resolveEnvId(),
-        Domain: domain,
-        Paths: [normalizeAccessPath(routePath)],
-      } as any);
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          domain,
-          path: normalizeAccessPath(routePath),
-          raw: result,
-        },
-        "HTTP 路由删除成功",
-      );
-    }
-    case "bindCustomDomain": {
-      if (!input.domain || !input.certificateId) {
-        throw new Error("action=bindCustomDomain 时必须提供 domain 和 certificateId");
-      }
-      const cloudbase = await getManager();
-      const result = await cloudbase.env.bindCustomDomain({
-        EnvId: await resolveEnvId(),
-        Domain: {
-          Domain: input.domain,
-          CertId: input.certificateId,
-        },
-      } as any);
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          domain: input.domain,
-          certificateId: input.certificateId,
-          raw: result,
-        },
-        "自定义域名绑定成功",
-      );
-    }
-    case "deleteCustomDomain": {
-      if (!input.domain) {
-        throw new Error("action=deleteCustomDomain 时必须提供 domain");
-      }
-      const cloudbase = await getManager();
-      const result = await cloudbase.env.deleteCustomDomain({
-        EnvId: await resolveEnvId(),
-        Domain: input.domain,
-      });
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          domain: input.domain,
-          raw: result,
-        },
-        "自定义域名删除成功",
-      );
-    }
-    case "deleteAccess": {
-      const cloudbase = await getManager();
-      const accessPath = input.path ? normalizeAccessPath(input.path) : undefined;
-      let resolvedAccessId = input.accessId;
-      let resolvedName: string | undefined;
-
-      if (!resolvedAccessId) {
-        if (!input.targetName && !accessPath) {
-          throw new Error("action=deleteAccess 时至少需要提供 accessId，或提供 targetName/path 用于定位入口");
-        }
-
-        const accessList = await cloudbase.access.getAccessList({
-          ...(input.targetName ? { name: input.targetName } : {}),
-          ...(accessPath ? { path: accessPath } : {}),
-        });
-        const candidates = (accessList.APISet ?? []).filter((item: any) => {
-          if (!accessPath) {
-            return true;
-          }
-          return normalizeAccessPath(item.Path) === accessPath;
-        });
-
-        if (candidates.length === 0) {
-          throw new Error("未找到可删除的访问入口，请确认 targetName/path 或直接传 accessId");
-        }
-
-        if (candidates.length > 1 && !accessPath) {
-          throw new Error("匹配到多个访问入口，请补充 path 或直接传 accessId");
-        }
-
-        resolvedAccessId = candidates[0]?.APIId;
-        resolvedName = candidates[0]?.Name;
-      } else {
-        // 仅传入 accessId 时，先查询获取 name 等信息，确保删除参数完整
-        try {
-          const accessList = await cloudbase.access.getAccessList({});
-          const match = (accessList.APISet ?? []).find(
-            (item: any) => item.APIId === resolvedAccessId,
+      case "bindCustomDomain": {
+        if (!input.domain || !input.certificateId) {
+          throw new Error(
+            "action=bindCustomDomain 时必须提供 domain 和 certificateId",
           );
-          if (match) {
-            resolvedName = match.Name;
-          }
-        } catch {
-          // 查询失败不影响主流程，继续用 accessId 删除
         }
+        const cloudbase = await getManager();
+        const result = await cloudbase.env.bindCustomDomain({
+          EnvId: await resolveEnvId(),
+          Domain: {
+            Domain: input.domain,
+            CertId: input.certificateId,
+          },
+        } as any);
+        logCloudBaseResult(server.logger, result);
+
+        return buildEnvelope(
+          {
+            action: input.action,
+            domain: input.domain,
+            certificateId: input.certificateId,
+            raw: result,
+          },
+          "自定义域名绑定成功",
+        );
       }
+      case "deleteCustomDomain": {
+        if (!input.domain) {
+          throw new Error("action=deleteCustomDomain 时必须提供 domain");
+        }
+        const cloudbase = await getManager();
+        const result = await cloudbase.env.deleteCustomDomain({
+          EnvId: await resolveEnvId(),
+          Domain: input.domain,
+        });
+        logCloudBaseResult(server.logger, result);
 
-      if (!resolvedAccessId) {
-        throw new Error("无法解析访问入口 accessId，请改为显式传入 accessId");
+        return buildEnvelope(
+          {
+            action: input.action,
+            domain: input.domain,
+            raw: result,
+          },
+          "自定义域名删除成功",
+        );
       }
-
-      const result = await cloudbase.access.deleteAccess({
-        ...(resolvedName ? { name: resolvedName } : {}),
-        apiId: resolvedAccessId,
-      });
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          targetName: resolvedName ?? input.targetName ?? null,
-          path: accessPath ?? null,
-          accessId: resolvedAccessId,
-          raw: result,
-        },
-        "网关访问入口删除成功",
-      );
-    }
-    case "updatePathAuth": {
-      if (!input.targetName && !input.path) {
-        throw new Error("action=updatePathAuth 时至少需要提供 targetName 或 path");
-      }
-      if (input.auth === undefined) {
-        throw new Error("action=updatePathAuth 时必须提供 auth");
-      }
-
-      const cloudbase = await getManager();
-      const accessPath = input.path ? normalizeAccessPath(input.path) : undefined;
-      const accessList = await cloudbase.access.getAccessList({
-        ...(input.targetName ? { name: input.targetName } : {}),
-        ...(accessPath ? { path: accessPath } : {}),
-      });
-      const apiIds = (accessList.APISet ?? []).map((item) => item.APIId).filter(Boolean);
-      if (apiIds.length === 0) {
-        throw new Error("未找到可更新鉴权状态的访问入口");
-      }
-
-      const result = await cloudbase.access.switchPathAuth({
-        apiIds,
-        auth: input.auth,
-      });
-      logCloudBaseResult(server.logger, result);
-
-      return buildEnvelope(
-        {
-          action: input.action,
-          targetName: input.targetName ?? null,
-          path: accessPath ?? null,
-          auth: input.auth,
-          apiIds,
-          raw: result,
-        },
-        "网关路径鉴权更新成功",
-      );
-    }
-    default:
-      throw new Error(`不支持的操作类型: ${input.action}`);
+      default:
+        throw new Error(`不支持的操作类型: ${input.action}`);
     }
   };
 
@@ -595,20 +584,28 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "查询 CloudBase 网关",
       description:
-        "CloudBase 网关统一只读入口。通过 action 查询网关域名、访问入口和目标暴露情况。",
+        "CloudBase 网关统一只读入口（Domain/Route 模型）。通过 listRoutes / getRoute / listCustomDomains 查询域名与路由；主键为 Domain + Path，上游类型为 SCF / WEB_SCF / CBR / STATIC_STORE / LH。",
       inputSchema: {
         action: z
           .enum(QUERY_GATEWAY_ACTIONS)
-          .describe("只读操作类型，例如 getAccess、listDomains"),
+          .describe("只读操作类型：listRoutes、getRoute、listCustomDomains"),
         targetType: z
           .enum(["function"])
           .optional()
-          .describe("目标资源类型。当前支持 function，后续可扩展"),
+          .describe("目标资源类型。当前支持 function"),
         targetName: z
           .string()
           .optional()
-          .describe("目标资源名称。getAccess 时必填"),
+          .describe("上游资源名称。getRoute 时可按云函数名过滤"),
         routeId: z.string().optional().describe("路由 ID。getRoute 时可选"),
+        path: z
+          .string()
+          .optional()
+          .describe("路由路径。getRoute / listRoutes 过滤时可选"),
+        domain: z
+          .string()
+          .optional()
+          .describe("域名。getRoute / listRoutes 过滤时可选"),
       },
       annotations: {
         readOnlyHint: true,
@@ -616,7 +613,8 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         category: "gateway",
       },
     },
-    async (input: QueryGatewayInput) => withEnvelope(() => handleQueryGateway(input)),
+    async (input: QueryGatewayInput) =>
+      withEnvelope(() => handleQueryGateway(input)),
   );
 
   server.registerTool?.(
@@ -624,45 +622,60 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
     {
       title: "管理 CloudBase 网关",
       description:
-        "CloudBase 网关统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。⚠️ 如需绑定带 SSL 证书的自定义域名供公网 HTTPS 访问，使用 action=\"bindCustomDomain\"（需要 domain 和 certificateId 参数）；如需配置 CORS/安全域名（无证书），请使用 envDomainManagement 工具。",
+        "CloudBase 网关统一写入口（Domain/Route 模型）。为已存在的 HTTP 云函数补默认域名访问时，使用 createRoute，并提供 targetType=\"function\"、targetName、type=\"HTTP\"（映射 WEB_SCF）与期望 path；Event 函数传 type=\"Event\"（映射 SCF）。未传 domain 时自动解析 IsDefault 默认域名。注意 createRoute 只创建网关入口，不会自动修改函数资源权限。更新鉴权用 updateRoute；删除用 deleteRoute（Domain+Path）。⚠️ 绑定带 SSL 证书的自定义域名用 bindCustomDomain；CORS/安全域名请使用 envDomainManagement。",
       inputSchema: {
         action: z
           .enum(MANAGE_GATEWAY_ACTIONS)
-          .describe('写操作类型，例如 createAccess。为已有函数补默认域名访问入口时使用 createAccess；若 action=createAccess 且 targetType=function，必须显式提供 type。'),
+          .describe(
+            "写操作类型。为已有函数补默认域名访问入口时使用 createRoute；函数场景必须显式提供 type（HTTP→WEB_SCF，Event→SCF）或 route.upstreamResourceType。",
+          ),
         targetType: z
           .enum(["function"])
           .optional()
-          .describe("目标资源类型。当前支持 function，后续可扩展"),
+          .describe("目标资源类型。当前支持 function"),
         targetName: z
           .string()
           .optional()
-          .describe("目标资源名称。createAccess 到云函数时填写函数名"),
+          .describe("目标资源名称。createRoute 到云函数时填写函数名"),
         path: z
           .string()
           .optional()
-          .describe("访问路径，默认 /{targetName}。例如为 HTTP 函数暴露 /api/hello 时传 /api/hello。该参数只创建网关入口，不会自动放开函数资源权限。"),
+          .describe(
+            "访问路径，默认 /{targetName}。例如为 HTTP 函数暴露 /api/hello 时传 /api/hello。该参数只创建网关入口，不会自动放开函数资源权限。",
+          ),
         type: z
           .enum(["Event", "HTTP"])
           .optional()
-          .describe("目标函数的运行时类型，不是接入协议。createAccess 到已创建的 HTTP 云函数时传 HTTP；给 Event 函数补网关访问时传 Event 或省略。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。"),
+          .describe(
+            "目标函数运行时类型，不是接入协议。HTTP 云函数传 HTTP（UpstreamResourceType=WEB_SCF）；Event 函数传 Event（SCF）。误标会导致 FUNCTION_PARAM_INVALID 或网关错误。函数路由场景必须显式提供 type 或 route.upstreamResourceType。",
+          ),
         auth: z
           .boolean()
           .optional()
-          .describe("是否开启网关路径鉴权。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限，仍需检查并按需调整函数安全规则。"),
+          .describe(
+            "是否开启网关路径鉴权（EnableAuth）。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限。",
+          ),
         route: z
           .object({
-            routeId: z.string().optional(),
             path: z.string().optional(),
-            serviceType: z.string().optional(),
             serviceName: z.string().optional(),
+            upstreamResourceType: z.enum(UPSTREAM_RESOURCE_TYPES).optional(),
             auth: z.boolean().optional(),
           })
           .optional()
-          .describe("HTTP 路由配置对象"),
-        domain: z.string().optional().describe("自定义域名"),
-        certificateId: z.string().optional().describe("证书 ID"),
-        accessName: z.string().optional().describe("访问入口名称，保留字段"),
-        accessId: z.string().optional().describe("访问入口 ID。deleteAccess 时可直接传入，避免参数歧义"),
+          .describe(
+            "HTTP 路由配置。upstreamResourceType 可选 SCF / WEB_SCF / CBR / STATIC_STORE / LH",
+          ),
+        domain: z
+          .string()
+          .optional()
+          .describe(
+            "域名。省略时自动使用环境 IsDefault 默认 HTTP 域名；自定义域名场景请显式传入",
+          ),
+        certificateId: z
+          .string()
+          .optional()
+          .describe("证书 ID。bindCustomDomain 时必填"),
       },
       annotations: {
         readOnlyHint: false,

--- a/plugin/cloudbase/skills/cloud-functions/SKILL.md
+++ b/plugin/cloudbase/skills/cloud-functions/SKILL.md
@@ -327,9 +327,10 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 
 ### Gateway exposure
 
-- `queryGateway(action="getAccess")`
-- `manageGateway(action="createAccess")`
-- If gateway operations need raw cloud API fallback, read `./references/operations-and-config.md` first
+- `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
+- `manageGateway(action="createRoute")` — for HTTP functions pass `type="HTTP"` (maps to `WEB_SCF`); for Event functions pass `type="Event"` (maps to `SCF`). Omit `domain` to use the environment default (`IsDefault`)
+- `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills
 

--- a/plugin/cloudbase/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/plugin/cloudbase/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create gateway access explicitly with `manageGateway(action="createAccess", type="HTTP")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", type="HTTP")` (maps to `WEB_SCF`) and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/plugin/cloudbase/skills/cloud-functions/references/http-functions.md
+++ b/plugin/cloudbase/skills/cloud-functions/references/http-functions.md
@@ -348,7 +348,7 @@ Creating the function does not automatically create a browser-facing path. Add g
 
 ```javascript
 manageGateway({
-  action: "createAccess",
+  action: "createRoute",
   targetType: "function",
   targetName: "myHttpFunction",
   type: "HTTP",

--- a/plugin/cloudbase/skills/cloud-functions/references/operations-and-config.md
+++ b/plugin/cloudbase/skills/cloud-functions/references/operations-and-config.md
@@ -54,35 +54,25 @@ callCloudApi({
 
 ### Preferred path
 
-Use `manageGateway(action="createAccess")`.
-
-### Plan B: `callCloudApi`
-
-Use raw cloud API only after checking the documentation for `CreateCloudBaseGWAPI` and confirming the gateway parameter contract.
+Use Domain/Route via `manageGateway(action="createRoute")`. Omit `domain` to attach the route on the environment default HTTP domain (`IsDefault`).
 
 ```javascript
-callCloudApi({
-  service: "tcb",
-  action: "CreateCloudBaseGWAPI",
-  params: {
-    EnableUnion: true,
-    Path: "/api/users",
-    ServiceId: "{envId}",
-    Type: 6,
-    Name: "functionName",
-    AuthSwitch: 2,
-    PathTransmission: 2,
-    EnableRegion: true,
-    Domain: "*"
-  }
+manageGateway({
+  action: "createRoute",
+  targetType: "function",
+  targetName: "functionName",
+  type: "Event", // Event -> SCF; HTTP functions must pass type="HTTP" -> WEB_SCF
+  path: "/api/users",
+  auth: false
 });
 ```
 
-Key parameters:
+Type mapping:
 
-- `Type: 6` -> function gateway type.
-- `AuthSwitch: 2` -> no auth. Use an authenticated mode only when the requirement says so.
-- `Domain: "*"` -> default domain.
+- `type="Event"` -> `UpstreamResourceType=SCF`
+- `type="HTTP"` -> `UpstreamResourceType=WEB_SCF`
+
+Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 
 ## Environment variable updates
 
@@ -152,7 +142,7 @@ Prefer the converged entrances below, but translate historical names when they a
 | `manageFunctionTriggers` | `manageFunctions(action="createFunctionTrigger"|"deleteFunctionTrigger")` |
 | `readFunctionLayers` | `queryFunctions(action="listLayers"|"listLayerVersions"|"getLayerVersionDetail"|"listFunctionLayers")` |
 | `writeFunctionLayers` | `manageFunctions(action="createLayerVersion"|"deleteLayerVersion"|"attachLayer"|"detachLayer"|"updateFunctionLayers")` |
-| `createFunctionHTTPAccess` | `manageGateway(action="createAccess")` |
+| `createFunctionHTTPAccess` | `manageGateway(action="createRoute")` with `type="HTTP"` |
 
 ## CLI fallback
 

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1850,7 +1850,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.24.0），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.24.1），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1908,7 +1908,7 @@
     },
     {
       "name": "searchKnowledgeBase",
-      "description": "云开发知识库智能检索工具，支持向量查询 (vector)、固定技能文档 (skill)、OpenAPI 文档 (openapi) 和 CloudBase 官方文档 (docs) 查询。\n\n      强烈推荐始终优先使用固定技能文档 (skill)、OpenAPI 文档 (openapi) 或 CloudBase 官方文档 (docs) 模式进行检索，仅当固定文档无法覆盖你的问题时，再使用向量查询 (vector) 模式。\n\n      ⚠️ 重要：当 CloudBase skills 处于禁用状态或当前 IDE 不支持 skill 文件读取时，必须使用 searchKnowledgeBase(mode=skill, skillName=...) 来获取 CloudBase 技能文档内容，而不是尝试直接读取 skill 文件。直接读取可能返回 400 错误。示例：\n      - 需要 auth-tool 指南时：searchKnowledgeBase(mode=skill, skillName=auth-tool)\n      - 需要 auth-web 指南时：searchKnowledgeBase(mode=skill, skillName=auth-web)\n      - 需要 cloudbase-agent 指南时：searchKnowledgeBase(mode=skill, skillName=cloudbase-agent)\n\n      固定技能文档 (skill) 查询当前支持 27 个固定文档，分别是：\n      文档名：ai-model-nodejs 文档介绍：\"Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express, Koa, NestJS, serverless APIs, scheduled jobs, LLM proxies. Only SDK supporting image generation (ai.createImageModel + generateImage). Text models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field of generateText/streamText. MUST run two-step preflight before code — see body. Keywords: backend, 云函数, 云托管, serverless, LLM proxy, agent orchestration, generateText, streamText, generateImage, createModel, hunyuan-image, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat).\"\n文档名：ai-model-web 文档介绍：\"Use this skill when a browser/Web app (React, Vue, Angular, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI) needs AI models via @cloudbase/js-sdk. Default routing for page/页面/Web/前端/frontend/网页/H5 AI — call directly from browser, do NOT propose a Node.js proxy. Covers generateText and streamText. Models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field. MUST run two-step preflight before code — see body. Keywords: 页面, Web, 前端, React, Vue, Next, Nuxt, SPA, AI chat UI, generateText, streamText, createModel, hunyuan-exp, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only).\"\n文档名：ai-model-wechat 文档介绍：\"Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, 企业微信小程序, wx.cloud apps). Features generateText and streamText with callbacks (onText, onEvent, onFinish). Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the data wrapper model field. API differs from JS/Node SDK — streamText needs data wrapper, generateText returns raw response. MUST run two-step preflight before code — see body. Keywords: Mini Program AI, wx.cloud.extend.AI, 小程序成长计划, ai_miniprogram_inspire_plan, Token Credits 资源包, generateText, streamText, createModel, hunyuan-exp, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs).\"\n文档名：auth-nodejs 文档介绍：CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.\n文档名：auth-tool 文档介绍：CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.\n文档名：auth-web 文档介绍：CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.\n文档名：auth-wechat 文档介绍：CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.\n文档名：cloud-functions 文档介绍：CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.\n文档名：cloud-storage-web 文档介绍：Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.\n文档名：cloudbase-agent 文档介绍：Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).\n文档名：cloudbase-cli 文档介绍：CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. This skill should be used when users need to deploy cloud functions, manage CloudRun apps, upload files to storage, query NoSQL/MySQL databases, deploy static hosting, set access permissions, or configure CORS/domains/routing via tcb commands. Also use for CI/CD pipeline scripting, batch operations, terminal-based CloudBase management, or when the user prefers CLI over SDK/MCP.\n文档名：cloudbase-code-review 文档介绍：\"Code review and validation for CloudBase projects. After writing code for Web / miniprogram / CloudRun / cloud-function projects, call this skill to check for known pitfalls — auth guard misuse, missing database tables, RLS misconfiguration, storage domain setup, and SDK API misuse. Supports automated lint scripts (regex-based) + LLM semantic review.\"\n文档名：cloudbase-platform 文档介绍：CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.\n文档名：cloudbase-wechat-integration 文档介绍：CloudBase WeChat integration guide for Mini Program WeChat Pay, Official Account JSAPI Pay, Native QR-code Pay, Official Account OAuth, openid handling, payment callbacks, and CloudBase Integration Center generated functions. This skill should be used when users ask to add, debug, or extend WeChat payment or official-account flows on CloudBase.\n文档名：cloudrun-development 文档介绍：CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, or AI agent development.\n文档名：data-model-creation 文档介绍：\"[Deprecated] Optional advanced tool for complex data modeling. For simple MySQL table creation, use relational-database-tool directly; for PostgreSQL / CloudBase PG schema work, use postgresql-development. New environments should use PostgreSQL DDL via queryPgDatabase/managePgDatabase — see postgresql-development skill instead.\"\n文档名：http-api 文档介绍：CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.\n文档名：miniprogram-development 文档介绍：WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools workflows, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, or 云开发 in a mini program project.\n文档名：no-sql-web-sdk 文档介绍：Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.\n文档名：no-sql-wx-mp-sdk 文档介绍：Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.\n文档名：ops-inspector 文档介绍：AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.\n文档名：postgresql-development 文档介绍：\"Use when building, debugging, or evaluating CloudBase PostgreSQL / CloudBase PG / PG mode apps, including Postgres schema setup, queryPgDatabase/managePgDatabase, JS SDK v3 app.rdb() CRUD/RPC, PG HTTP API fallback, RLS-style permissions, username-password auth, and Web CMS/admin CRUD flows backed by CloudBase PG.\"\n文档名：relational-database-tool 文档介绍：\"[Deprecated] This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `queryMysqlDatabase`, `manageMysqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates. New environments should use PostgreSQL — see postgresql-development skill instead.\"\n文档名：relational-database-web 文档介绍：\"[Deprecated] Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser. New environments should use PostgreSQL with app.rdb() — see postgresql-development skill instead.\"\n文档名：spec-workflow 文档介绍：Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.\n文档名：ui-design 文档介绍：Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.\n文档名：web-development 文档介绍：Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.\n\n      OpenAPI 文档 (openapi) 查询只需要传 mode=\"openapi\" 和 apiName，不要传 action；action 仅用于 mode=\"docs\"。当前支持 7 个 API 文档，分别是：\n      API名：functions API介绍：Cloud Functions API - 云函数 HTTP API\nAPI名：nosql API介绍：NoSQL RESTful API - 文档型数据库 HTTP API\nAPI名：storage API介绍：Storage API - 云存储 HTTP API\nAPI名：mysqldb API介绍：关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API\nAPI名：cloudrun API介绍：CloudRun API - 云托管服务 HTTP API\nAPI名：auth API介绍：Authentication API - 身份认证 HTTP API\nAPI名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API",
+      "description": "云开发知识库智能检索工具，支持向量查询 (vector)、固定技能文档 (skill)、OpenAPI 文档 (openapi) 和 CloudBase 官方文档 (docs) 查询。\n\n      强烈推荐始终优先使用固定技能文档 (skill)、OpenAPI 文档 (openapi) 或 CloudBase 官方文档 (docs) 模式进行检索，仅当固定文档无法覆盖你的问题时，再使用向量查询 (vector) 模式。\n\n      ⚠️ 重要：当 CloudBase skills 处于禁用状态或当前 IDE 不支持 skill 文件读取时，必须使用 searchKnowledgeBase(mode=skill, skillName=...) 来获取 CloudBase 技能文档内容，而不是尝试直接读取 skill 文件。直接读取可能返回 400 错误。示例：\n      - 需要 auth-tool 指南时：searchKnowledgeBase(mode=skill, skillName=auth-tool)\n      - 需要 auth-web 指南时：searchKnowledgeBase(mode=skill, skillName=auth-web)\n      - 需要 cloudbase-agent 指南时：searchKnowledgeBase(mode=skill, skillName=cloudbase-agent)\n\n      固定技能文档 (skill) 查询当前支持 27 个固定文档，分别是：\n      文档名：ai-model-nodejs 文档介绍：\"Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express, Koa, NestJS, serverless APIs, scheduled jobs, LLM proxies. Only SDK supporting image generation (ai.createImageModel + generateImage). Text models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field of generateText/streamText. MUST run two-step preflight before code — see body. Keywords: backend, 云函数, 云托管, serverless, LLM proxy, agent orchestration, generateText, streamText, generateImage, createModel, hunyuan-image, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat).\"\n文档名：ai-model-web 文档介绍：\"Use this skill when a browser/Web app (React, Vue, Angular, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI) needs AI models via @cloudbase/js-sdk. Default routing for page/页面/Web/前端/frontend/网页/H5 AI — call directly from browser, do NOT propose a Node.js proxy. Covers generateText and streamText. Models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field. MUST run two-step preflight before code — see body. Keywords: 页面, Web, 前端, React, Vue, Next, Nuxt, SPA, AI chat UI, generateText, streamText, createModel, hunyuan-exp, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only).\"\n文档名：ai-model-wechat 文档介绍：\"Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, 企业微信小程序, wx.cloud apps). Features generateText and streamText with callbacks (onText, onEvent, onFinish). Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the data wrapper model field. API differs from JS/Node SDK — streamText needs data wrapper, generateText returns raw response. MUST run two-step preflight before code — see body. Keywords: Mini Program AI, wx.cloud.extend.AI, 小程序成长计划, ai_miniprogram_inspire_plan, Token Credits 资源包, generateText, streamText, createModel, hunyuan-exp, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs).\"\n文档名：auth-nodejs 文档介绍：CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.\n文档名：auth-tool 文档介绍：CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.\n文档名：auth-web 文档介绍：CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.\n文档名：auth-wechat 文档介绍：CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.\n文档名：cloud-functions 文档介绍：CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.\n文档名：cloud-storage-web 文档介绍：Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.\n文档名：cloudbase-agent 文档介绍：Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).\n文档名：cloudbase-cli 文档介绍：CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. This skill should be used when users need to deploy cloud functions, manage CloudRun apps, upload files to storage, query NoSQL/MySQL databases, deploy static hosting, set access permissions, or configure CORS/domains/routing via tcb commands. Also use for CI/CD pipeline scripting, batch operations, terminal-based CloudBase management, or when the user prefers CLI over SDK/MCP.\n文档名：cloudbase-code-review 文档介绍：\"Code review and validation for CloudBase projects. After writing code for Web / miniprogram / CloudRun / cloud-function projects, call this skill to check for known pitfalls — auth guard misuse, missing database tables, RLS misconfiguration, storage domain setup, and SDK API misuse. Supports automated lint scripts (regex-based) + LLM semantic review.\"\n文档名：cloudbase-platform 文档介绍：CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.\n文档名：cloudbase-wechat-integration 文档介绍：CloudBase WeChat integration guide for Mini Program WeChat Pay, Official Account JSAPI Pay, Native QR-code Pay, Official Account OAuth, openid handling, payment callbacks, and CloudBase Integration Center generated functions. This skill should be used when users ask to add, debug, or extend WeChat payment or official-account flows on CloudBase.\n文档名：cloudrun-development 文档介绍：CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, or AI agent development.\n文档名：data-model-creation 文档介绍：\"[Deprecated] Optional advanced tool for complex data modeling. For simple MySQL table creation, use relational-database-tool directly; for PostgreSQL / CloudBase PG schema work, use postgresql-development. New environments should use PostgreSQL DDL via queryPgDatabase/managePgDatabase — see postgresql-development skill instead.\"\n文档名：http-api 文档介绍：CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.\n文档名：miniprogram-development 文档介绍：WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects. This skill should be used when users ask to create, develop, modify, debug, preview, test, deploy, publish, launch, review, or optimize WeChat Mini Programs, mini program pages, components, `tabBar`, routing, navigation, icon assets, project structure, project configuration, `project.config.json`, `appid` setup, device preview, real-device validation, WeChat Developer Tools Nightly workflows, `wechatide` CLI, WeChat IDE Skills/MCP, console/network debugging, `miniprogram-ci` preview/upload flows, or mini program release processes. It should also be used when users explicitly mention CloudBase, `wx.cloud`, Tencent CloudBase, 腾讯云开发, 微信云开发, or 云开发 in a mini program project.\n文档名：no-sql-web-sdk 文档介绍：Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.\n文档名：no-sql-wx-mp-sdk 文档介绍：Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.\n文档名：ops-inspector 文档介绍：AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.\n文档名：postgresql-development 文档介绍：\"Use when building, debugging, or evaluating CloudBase PostgreSQL / CloudBase PG / PG mode apps, including Postgres schema setup, queryPgDatabase/managePgDatabase, JS SDK v3 app.rdb() CRUD/RPC, PG HTTP API fallback, RLS-style permissions, username-password auth, and Web CMS/admin CRUD flows backed by CloudBase PG.\"\n文档名：relational-database-tool 文档介绍：\"[Deprecated] This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `queryMysqlDatabase`, `manageMysqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates. New environments should use PostgreSQL — see postgresql-development skill instead.\"\n文档名：relational-database-web 文档介绍：\"[Deprecated] Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser. New environments should use PostgreSQL with app.rdb() — see postgresql-development skill instead.\"\n文档名：spec-workflow 文档介绍：Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.\n文档名：ui-design 文档介绍：Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.\n文档名：web-development 文档介绍：Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.\n\n      OpenAPI 文档 (openapi) 查询只需要传 mode=\"openapi\" 和 apiName，不要传 action；action 仅用于 mode=\"docs\"。当前支持 7 个 API 文档，分别是：\n      API名：mysqldb API介绍：关系型数据库 RESTful API (MySQL/PostgreSQL) - 云开发关系型数据库 HTTP API\nAPI名：functions API介绍：Cloud Functions API - 云函数 HTTP API\nAPI名：auth API介绍：Authentication API - 身份认证 HTTP API\nAPI名：cloudrun API介绍：CloudRun API - 云托管服务 HTTP API\nAPI名：storage API介绍：Storage API - 云存储 HTTP API\nAPI名：nosql API介绍：NoSQL RESTful API - 文档型数据库 HTTP API\nAPI名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -1957,12 +1957,12 @@
           "apiName": {
             "type": "string",
             "enum": [
-              "functions",
-              "nosql",
-              "storage",
               "mysqldb",
-              "cloudrun",
+              "functions",
               "auth",
+              "cloudrun",
+              "storage",
+              "nosql",
               "ai_model"
             ],
             "description": "mode=openapi 时指定。API 名称。"
@@ -2473,35 +2473,41 @@
     },
     {
       "name": "queryGateway",
-      "description": "CloudBase 网关统一只读入口。通过 action 查询网关域名、访问入口和目标暴露情况。",
+      "description": "CloudBase 网关统一只读入口（Domain/Route 模型）。通过 listRoutes / getRoute / listCustomDomains 查询域名与路由；主键为 Domain + Path，上游类型为 SCF / WEB_SCF / CBR / STATIC_STORE / LH。",
       "inputSchema": {
         "type": "object",
         "properties": {
           "action": {
             "type": "string",
             "enum": [
-              "getAccess",
-              "listDomains",
               "listRoutes",
               "getRoute",
               "listCustomDomains"
             ],
-            "description": "只读操作类型，例如 getAccess、listDomains"
+            "description": "只读操作类型：listRoutes、getRoute、listCustomDomains"
           },
           "targetType": {
             "type": "string",
             "enum": [
               "function"
             ],
-            "description": "目标资源类型。当前支持 function，后续可扩展"
+            "description": "目标资源类型。当前支持 function"
           },
           "targetName": {
             "type": "string",
-            "description": "目标资源名称。getAccess 时必填"
+            "description": "上游资源名称。getRoute 时可按云函数名过滤"
           },
           "routeId": {
             "type": "string",
             "description": "路由 ID。getRoute 时可选"
+          },
+          "path": {
+            "type": "string",
+            "description": "路由路径。getRoute / listRoutes 过滤时可选"
+          },
+          "domain": {
+            "type": "string",
+            "description": "域名。getRoute / listRoutes 过滤时可选"
           }
         },
         "required": [
@@ -2513,34 +2519,31 @@
     },
     {
       "name": "manageGateway",
-      "description": "CloudBase 网关统一写入口。通过 action 创建目标访问入口，后续承接更通用的网关配置能力。为已存在的 HTTP 云函数补默认域名访问时，通常使用 createAccess 并提供 targetType=\"function\"、targetName、type=\"HTTP\" 与期望 path。注意 createAccess 只创建网关入口，不会自动修改函数资源权限。⚠️ 如需绑定带 SSL 证书的自定义域名供公网 HTTPS 访问，使用 action=\"bindCustomDomain\"（需要 domain 和 certificateId 参数）；如需配置 CORS/安全域名（无证书），请使用 envDomainManagement 工具。",
+      "description": "CloudBase 网关统一写入口（Domain/Route 模型）。为已存在的 HTTP 云函数补默认域名访问时，使用 createRoute，并提供 targetType=\"function\"、targetName、type=\"HTTP\"（映射 WEB_SCF）与期望 path；Event 函数传 type=\"Event\"（映射 SCF）。未传 domain 时自动解析 IsDefault 默认域名。注意 createRoute 只创建网关入口，不会自动修改函数资源权限。更新鉴权用 updateRoute；删除用 deleteRoute（Domain+Path）。⚠️ 绑定带 SSL 证书的自定义域名用 bindCustomDomain；CORS/安全域名请使用 envDomainManagement。",
       "inputSchema": {
         "type": "object",
         "properties": {
           "action": {
             "type": "string",
             "enum": [
-              "createAccess",
               "createRoute",
               "updateRoute",
               "deleteRoute",
               "bindCustomDomain",
-              "deleteCustomDomain",
-              "deleteAccess",
-              "updatePathAuth"
+              "deleteCustomDomain"
             ],
-            "description": "写操作类型，例如 createAccess。为已有函数补默认域名访问入口时使用 createAccess；若 action=createAccess 且 targetType=function，必须显式提供 type。"
+            "description": "写操作类型。为已有函数补默认域名访问入口时使用 createRoute；函数场景必须显式提供 type（HTTP→WEB_SCF，Event→SCF）或 route.upstreamResourceType。"
           },
           "targetType": {
             "type": "string",
             "enum": [
               "function"
             ],
-            "description": "目标资源类型。当前支持 function，后续可扩展"
+            "description": "目标资源类型。当前支持 function"
           },
           "targetName": {
             "type": "string",
-            "description": "目标资源名称。createAccess 到云函数时填写函数名"
+            "description": "目标资源名称。createRoute 到云函数时填写函数名"
           },
           "path": {
             "type": "string",
@@ -2552,49 +2555,45 @@
               "Event",
               "HTTP"
             ],
-            "description": "目标函数的运行时类型，不是接入协议。createAccess 到已创建的 HTTP 云函数时传 HTTP；给 Event 函数补网关访问时传 Event 或省略。省略会默认按 Event 路由处理，可能让 HTTP 云函数访问后返回 FUNCTION_PARAM_INVALID。"
+            "description": "目标函数运行时类型，不是接入协议。HTTP 云函数传 HTTP（UpstreamResourceType=WEB_SCF）；Event 函数传 Event（SCF）。误标会导致 FUNCTION_PARAM_INVALID 或网关错误。函数路由场景必须显式提供 type 或 route.upstreamResourceType。"
           },
           "auth": {
             "type": "boolean",
-            "description": "是否开启网关路径鉴权。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限，仍需检查并按需调整函数安全规则。"
+            "description": "是否开启网关路径鉴权（EnableAuth）。若要走默认域名做匿名或浏览器访问，通常设为 false；该开关仅控制网关入口本身，不会修改函数资源权限。"
           },
           "route": {
             "type": "object",
             "properties": {
-              "routeId": {
-                "type": "string"
-              },
               "path": {
-                "type": "string"
-              },
-              "serviceType": {
                 "type": "string"
               },
               "serviceName": {
                 "type": "string"
+              },
+              "upstreamResourceType": {
+                "type": "string",
+                "enum": [
+                  "SCF",
+                  "WEB_SCF",
+                  "CBR",
+                  "STATIC_STORE",
+                  "LH"
+                ]
               },
               "auth": {
                 "type": "boolean"
               }
             },
             "additionalProperties": false,
-            "description": "HTTP 路由配置对象"
+            "description": "HTTP 路由配置。upstreamResourceType 可选 SCF / WEB_SCF / CBR / STATIC_STORE / LH"
           },
           "domain": {
             "type": "string",
-            "description": "自定义域名"
+            "description": "域名。省略时自动使用环境 IsDefault 默认 HTTP 域名；自定义域名场景请显式传入"
           },
           "certificateId": {
             "type": "string",
-            "description": "证书 ID"
-          },
-          "accessName": {
-            "type": "string",
-            "description": "访问入口名称，保留字段"
-          },
-          "accessId": {
-            "type": "string",
-            "description": "访问入口 ID。deleteAccess 时可直接传入，避免参数歧义"
+            "description": "证书 ID。bindCustomDomain 时必填"
           }
         },
         "required": [

--- a/specs/manage-gateway-domain-route-migration/design.md
+++ b/specs/manage-gateway-domain-route-migration/design.md
@@ -1,0 +1,271 @@
+# Technical Design
+
+## Overview
+
+彻底移除 MCP 网关旧 GWAPI 语义（`access.*` / `CreateCloudBaseGWAPI` 等），将 `queryGateway` / `manageGateway` 收敛为与 Manager SDK v5 Domain/Route 及 CLI（`tcb domains` / `tcb routes`）一致的单一数据面。
+
+MCP **直接调用** `cloudbase.env.*HttpServiceRoute` / `bindCustomDomain` / `deleteCustomDomain`，不封装、不回退到 `cloudbase.access.*`。
+
+## Architecture
+
+```mermaid
+flowchart LR
+  Agent["Agent / Skills"]
+  QG["queryGateway"]
+  MG["manageGateway"]
+  Env["Manager SDK env.*"]
+  API["Cloud API HTTPServiceRoute / CustomDomain"]
+
+  Agent --> QG
+  Agent --> MG
+  QG --> Env
+  MG --> Env
+  Env --> API
+
+  Access["Manager SDK access.* / GWAPI"]
+  Access -.->|"removed from MCP call graph"| X["X"]
+```
+
+### Tool surface (after)
+
+| Tool | Actions |
+|------|---------|
+| `queryGateway` | `listRoutes`, `getRoute`, `listCustomDomains` |
+| `manageGateway` | `createRoute`, `updateRoute`, `deleteRoute`, `bindCustomDomain`, `deleteCustomDomain` |
+
+### Removed from schema
+
+| Removed | Replacement |
+|---------|-------------|
+| `getAccess` | `getRoute`（按 `targetName` / `path` / `domain` / `routeId`） |
+| `listDomains` | `listRoutes`（含 Domain 元数据）或 `listCustomDomains` |
+| `createAccess` | `createRoute`（可省略 `domain` → 解析默认域名；`type` 映射上游类型） |
+| `deleteAccess` | `deleteRoute`（`Domain + Path`） |
+| `updatePathAuth` | `updateRoute`（`EnableAuth` / `auth`） |
+
+## Module design
+
+Primary file: `mcp/src/tools/gateway.ts`（+ `gateway.test.ts`）。
+
+### Helpers
+
+1. **`listHttpServiceRoutes(filters?)`**  
+   封装 `env.describeHttpServiceRoute({ EnvId, Filters?, Limit })`。  
+   默认 `Limit` 取足够大（如 1000）以免漏默认域名。
+
+2. **`resolveDefaultHttpDomain()`**  
+   - 从 `Domains` 选 `IsDefault === true` 且可用（优先 `Enable !== false`，可选 `Status === "SUCCESS"`）。  
+   - **禁止**使用 `OriginDomain` 作为公网落点。  
+   - 失败：抛出明确中文错误（开通 HTTP 访问 / 显式传 `domain`）。
+
+3. **`resolveRouteDomain(preferred?)`**  
+   - 有 `preferred` → 直接用。  
+   - 否则 → `resolveDefaultHttpDomain()`。
+
+4. **`mapUpstreamResourceType(input)`**  
+   优先级：
+   1. 显式 `route.upstreamResourceType` / `route.serviceType`（若已是枚举值）
+   2. 顶层 `type`: `Event` → `SCF`，`HTTP` → `WEB_SCF`
+   3. 兼容：`targetType === "function"` **不能**单独决定类型；缺 `type` / 显式枚举则拒绝
+   4. `CBR` / `STATIC_STORE` / `LH` 仅通过显式枚举传入
+
+5. **`normalizeRoutePayload(...)`**  
+   产出 `CreateHttpServiceRoute` / `ModifyHttpServiceRoute` 所需结构：
+   ```ts
+   {
+     EnvId,
+     Domain: {
+       Domain: string,
+       Routes: [{
+         Path,
+         UpstreamResourceType,
+         UpstreamResourceName,
+         EnableAuth?,
+         Enable?
+       }]
+     }
+   }
+   ```
+   - `Path`：规范化为以 `/` 开头；默认 `/${targetName}`（与旧 createAccess 默认一致）。
+   - `UpstreamResourceName`：`route.serviceName ?? targetName`。
+
+6. **`flattenRoutes(describeResult)`**  
+   保留现有扁平化；补充拼装 `urls: https://${Domain}${Path}`。
+
+### Action handlers
+
+#### queryGateway
+
+| Action | Behavior |
+|--------|----------|
+| `listRoutes` | `describeHttpServiceRoute` → flatten；返回 `routes`、`total`、可选按 Domain 分组摘要 |
+| `getRoute` | 过滤：`routeId` **或** `targetName`（= UpstreamResourceName）**或** `path`（+ 可选 `domain`）。返回匹配路由列表或单条 + `urls` |
+| `listCustomDomains` | 从 `Domains` 过滤 `IsDefault !== true`（自定义域名）；返回 Domain 元数据（CertId、Status、DNSStatus、AccessType 等） |
+
+不再提供 `listDomains` / `getAccess`。若需要“所有域名含默认”，调用方可从 `listRoutes` 的 Domain 字段去重，或后续若有强需求再加 `listDomains` **基于新接口**的只读别名——**本需求不恢复旧 listDomains**。
+
+`getRoute` 建议支持可选 `domain` / `path` 输入（扩展现有 schema），以便精确定位；`targetName` 多匹配时返回列表并提示补充 `path`/`domain`。
+
+#### manageGateway
+
+| Action | Behavior |
+|--------|----------|
+| `createRoute` | resolve domain → map type → `createHttpServiceRoute`；成功 envelope 含 `domain`、`path`、`upstreamResourceType`、`upstreamResourceName`；nextActions：`getRoute` + permissions |
+| `updateRoute` | 同 payload 形态 → `modifyHttpServiceRoute`（鉴权更新走此路径） |
+| `deleteRoute` | resolve domain → `deleteHttpServiceRoute({ Domain, Paths })`；要求 `path` / `route.path` |
+| `bindCustomDomain` / `deleteCustomDomain` | 保持现有 `env.*` 调用 |
+
+### Schema changes
+
+**`manageGateway`**
+
+- `action`: 仅新枚举。
+- 保留便捷字段（降低 Agent 迁移成本，但仍属新 action）：
+  - `targetType`: `function`（可选，主要用于描述）
+  - `targetName`: 函数名 / 上游名
+  - `path`
+  - `type`: `Event` \| `HTTP`（函数场景必填其一，或改用 `route.upstreamResourceType`）
+  - `auth`: → `EnableAuth`
+  - `domain`
+  - `route`: 对象字段收紧：
+    - `path`, `serviceName`
+    - `upstreamResourceType`: `z.enum(["SCF","WEB_SCF","CBR","STATIC_STORE","LH"])`
+    - 可保留 `serviceType` 作为 **deprecated alias** 仅当值已是上述枚举；**不再**接受 `"function"` 并默认 SCF。为减少歧义，本设计建议 **删除 `serviceType: "function"` 映射**，统一用 `upstreamResourceType` + 顶层 `type`/`targetName`。
+  - 移除：`accessId`、`accessName`（旧主键）
+
+**`queryGateway`**
+
+- `action`: `listRoutes` \| `getRoute` \| `listCustomDomains`
+- 增加可选：`path`、`domain`（配合 `getRoute`）
+- 保留：`targetName`、`routeId`、`targetType`
+
+### Type mapping table
+
+| Agent input | UpstreamResourceType |
+|-------------|----------------------|
+| `type="Event"` | `SCF` |
+| `type="HTTP"` | `WEB_SCF` |
+| `upstreamResourceType="SCF"` | `SCF` |
+| `upstreamResourceType="WEB_SCF"` | `WEB_SCF` |
+| `upstreamResourceType="CBR"` | `CBR` |
+| `upstreamResourceType="STATIC_STORE"` | `STATIC_STORE` |
+| `upstreamResourceType="LH"` | `LH` |
+
+| 误用 | 风险 |
+|------|------|
+| HTTP 函数 + `SCF` | `FUNCTION_PARAM_INVALID` / 网关内部错误 |
+| Event 函数 + `WEB_SCF` | 调用形态不匹配 |
+
+### Default domain resolution
+
+```text
+describeHttpServiceRoute(EnvId, Limit=1000)
+→ candidates = Domains.filter(d => d.IsDefault === true)
+→ pick first with Enable !== false (prefer Status SUCCESS if present)
+→ else throw actionable error
+```
+
+不使用 `OriginDomain`。
+
+### Error message guidelines
+
+- 默认域名缺失：说明未开通 HTTP 访问 / 无 IsDefault；建议控制台开通或显式 `domain` + `createRoute`。
+- 缺类型：明确要求 `type="HTTP"|"Event"` 或 `route.upstreamResourceType`。
+- 删除缺 path：要求 `path` 或 `route.path`。
+- 多匹配 getRoute：提示补充 `path`/`domain`。
+
+## Downstream call sites (repo)
+
+| Location | Change |
+|----------|--------|
+| `mcp/src/tools/gateway.ts` | 重写 action 集与 helpers |
+| `mcp/src/tools/gateway.test.ts` | 全部改 mock `env.*`；删 access 断言 |
+| `mcp/src/tools/functions.ts` | nextActions / message → `createRoute` + `getRoute` |
+| `mcp/src/tools/functions.test.ts` | 同步期望文案 |
+| `config/source/skills/cloud-functions/**` | 推荐路径与删 Plan B |
+| `doc/mcp-tools.md` / prompts | 生成脚本刷新 |
+| `tests/sts-resource-level-validation.test.js` 等 | 新 action |
+| `examples/**`（若含 createAccess） | 更新示例 |
+| `mcp/src/tools/capi.ts` | **保持**旧 GWAPI 黑名单；不改开放 |
+
+`config/.claude/skills`、`plugin/`、`doc/prompts` 等为生成/镜像产物：改 source 后按项目脚本生成，不手改镜像。
+
+## Compatibility / migration note (for PR)
+
+破坏性：非法 enum，无运行时别名。
+
+```text
+createAccess  → createRoute   (+ type=HTTP|Event, 可省略 domain)
+getAccess     → getRoute      (targetName / path / domain)
+deleteAccess  → deleteRoute   (domain? + path)
+updatePathAuth→ updateRoute   (auth / EnableAuth)
+listDomains   → listRoutes 或 listCustomDomains
+Type 1 / 6    → SCF / WEB_SCF
+APIId         → Domain + Path
+```
+
+示例（HTTP 函数补默认域名入口）：
+
+```js
+manageGateway({
+  action: "createRoute",
+  targetType: "function",
+  targetName: "myHttpFunction",
+  type: "HTTP",
+  path: "/api/hello",
+  auth: false
+})
+```
+
+## Testing strategy
+
+1. **Unit**（`gateway.test.ts`）  
+   - 默认域名：`IsDefault` 被选中；`OriginDomain` 不被单独当作 Domain  
+   - 映射：Event→SCF、HTTP→WEB_SCF  
+   - 缺 type 拒绝  
+   - create/update/delete/get/list 调用参数形状  
+   - 默认域名缺失错误文案  
+   - schema enum 不含旧 action  
+
+2. **Functions tool**  
+   - 创建 HTTP 函数后的引导不含 `createAccess`/`getAccess`  
+
+3. **Repo integration / STS**  
+   - 网关步骤改新 action  
+
+4. **Manual / 验收**（任务阶段）  
+   - 默认域名补入口、自定义域名绑路由、HTTP vs Event、传播延迟、权限边界  
+
+不引入为过评测的特殊分支。
+
+## Security
+
+- 仅改网关配置面；不自动改函数安全规则。  
+- `auth` / `EnableAuth` 仅网关层。  
+- 成功后 nextActions 继续指向 permissions。  
+- CORS 安全域名 vs 自定义域名边界不变。  
+- AI 不得通过 `callCloudApi` 使用旧 GWAPI（黑名单保持）。
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| 存量 Agent 仍调旧 action | schema 直接拒绝；PR/spec 迁移表；skill 全切 |
+| 新旧数据面残留不一致 | MCP 只读新面；文档说明以 Domain/Route 为准；控制台/CLI 同模型 |
+| `IsDefault` 在部分环境缺失 | 明确错误；允许显式 `domain` |
+| `createRoute` 曾错误一律 SCF | 本设计强制类型映射与校验 |
+| SDK `access` / `function.createAccessPath` 仍旧 | 范围外；总结记后续；MCP 不调用 |
+
+## Non-goals
+
+- Manager SDK `access` 模块改造或 `@deprecated`  
+- 恢复旧 action 的成功兼容层或“仅报错别名”  
+- 开放 `callCloudApi` 旧 GWAPI  
+- 双写旧+新 API  
+
+## Implementation notes
+
+- 注释与 commit 信息使用英文（项目规范）。  
+- MCP 工具 description / 用户可见 message 可继续中文。  
+- 修改 schema 后跑既有 tools doc / prompts 生成脚本。  
+- `route.serviceType`：建议移除对 `"function"`→SCF 的隐式映射，避免与 HTTP 冲突；以 `type` + `upstreamResourceType` 为准。

--- a/specs/manage-gateway-domain-route-migration/requirements.md
+++ b/specs/manage-gateway-domain-route-migration/requirements.md
@@ -1,0 +1,118 @@
+# Requirements Document
+
+## Introduction
+
+CloudBase MCP 的网关能力当前是双轨：`createAccess` / `getAccess` / `deleteAccess` / `updatePathAuth` / 旧域名列表仍走 Manager SDK `access.*`（底层 `CreateCloudBaseGWAPI` 等已废弃云 API），而 `createRoute` / `updateRoute` / `deleteRoute` / `bindCustomDomain` 等已走 `env.*HttpServiceRoute` 新 Domain/Route 模型。
+
+本需求将 MCP 网关读写路径 **彻底切到新 Domain/Route 模型**：从 schema 移除旧 action，统一以 Domain + Path 为主键，上游类型使用字符串枚举（`SCF` / `WEB_SCF` / `CBR` / `STATIC_STORE` / `LH`）。MCP 直接调用 Manager SDK 的 `env.describeHttpServiceRoute` / `createHttpServiceRoute` / `modifyHttpServiceRoute` / `deleteHttpServiceRoute` / `bindCustomDomain` / `deleteCustomDomain`，**不依赖** 也不封装已废弃的 `access.*` 模块。
+
+破坏性变更需配套完整迁移说明，并同步清理 skill、函数创建引导、工具文档与仓库内测试中的旧 API / Plan B 写法。
+
+### Confirmed decisions
+
+1. **旧 action**：从 MCP schema **直接移除**（选项 A），不再作为成功路径，也不做“仅返回迁移错误”的兼容接收。
+2. **对外主入口**：以 Domain/Route action 为准（见需求 2）。
+3. **影响面**：MCP 实现 + 单测、`functions.ts` 引导、`config/source/skills/**`、`doc/mcp-tools.md` / prompts 生成、仓库内集成/STS 用例一并切换；仓外评测只提供迁移说明。
+4. **SDK**：不等待 / 不依赖 Manager SDK 对 `access` 的 facade 或 `@deprecated` 改造；MCP 只调 `env.*` 新接口。
+
+### Out of scope
+
+- 向 `@cloudbase/manager-node` 提交废弃 `access` 的 PR（仅在设计/任务总结中记录为后续事项）。
+- 修改仓外评测 runner / grader。
+- 通过 `callCloudApi` 重新开放旧 GWAPI（评测黑名单保持禁止）。
+
+---
+
+## Requirements
+
+### Requirement 1 - 移除旧网关 action（破坏性切换）
+
+**用户故事：** 作为 MCP 维护者，我希望工具 schema 不再暴露已废弃 GWAPI 语义的 action，避免 Agent 继续走旧数据面。
+
+#### 验收标准
+
+1. When 调用方检查 `manageGateway` 的 `action` 枚举时，the MCP shall 仅包含：`createRoute`、`updateRoute`、`deleteRoute`、`bindCustomDomain`、`deleteCustomDomain`（及本需求明确保留/新增且属于新模型的写 action，若有）。
+2. When 调用方检查 `queryGateway` 的 `action` 枚举时，the MCP shall 仅包含新模型只读 action：至少包括 `listRoutes`、`getRoute`、`listCustomDomains`；shall **不** 再包含 `getAccess`。
+3. When Agent 仍传入已移除的 `createAccess` / `deleteAccess` / `getAccess` / `updatePathAuth`（以及若移除的旧 `listDomains`）时，the MCP / 宿主 schema 校验 shall 拒绝该调用（非法 enum），而不是静默落到旧 `access.*` 实现。
+4. While 本需求落地后，when MCP 执行任一保留的网关读写 action 时，the 实现 shall **不** 调用 `cloudbase.access.*`（含 `createAccess`、`getAccessList`、`deleteAccess`、`switchPathAuth`、`getDomainList`、`addCustomDomain`、`deleteCustomDomain`）。
+
+### Requirement 2 - 统一 Domain/Route 对外语义
+
+**用户故事：** 作为使用 CloudBase MCP 的 Agent，我希望用一套与 CLI（`tcb domains` / `tcb routes`）和 Manager 文档一致的 Domain/Route 语义完成查询与配置。
+
+#### 验收标准
+
+1. When 需要在环境默认 HTTP 域名上为云函数补访问入口时，the Agent shall 使用 `manageGateway(action="createRoute")`；while 未显式传 `domain` 时，the MCP shall 通过 `describeHttpServiceRoute` 解析 `IsDefault === true` 的域名并在其上创建路由。
+2. When 需要在指定自定义域名上创建/修改/删除路由时，the Agent shall 使用 `createRoute` / `updateRoute` / `deleteRoute` 并显式提供 `domain`（或等价 route 载荷中的 Domain）。
+3. When 查询某函数或某路径的访问入口时，the Agent shall 使用 `queryGateway(action="getRoute")`（可按 `targetName` / `path` / `domain` / `routeId` 定位），而不是 `getAccess`。
+4. When 列出路由或自定义域名时，the Agent shall 使用 `listRoutes` / `listCustomDomains`（域名信息来自 `describeHttpServiceRoute` 结果，而不是 `DescribeCloudBaseGWService`）。
+5. When 更新路径鉴权时，the Agent shall 使用 `updateRoute` 并设置与 `EnableAuth` 对应的参数，而不是 `updatePathAuth`。
+6. When 删除访问入口时，the Agent shall 使用 `deleteRoute`，主键为 `Domain + Path`，而不是 `accessId` / `APIId`。
+7. When 绑定或删除自定义域名时，the MCP shall 继续通过 `bindCustomDomain` / `deleteCustomDomain` 调用 `env.bindCustomDomain` / `env.deleteCustomDomain`。
+
+### Requirement 3 - 默认域名解析与错误提示
+
+**用户故事：** 作为 Agent，我在不传 Domain 时仍能稳定落到环境默认 HTTP 域名；失败时能看到可执行的修复指引。
+
+#### 验收标准
+
+1. When `createRoute` / `updateRoute` / `deleteRoute` / `getRoute` 需要默认域名且调用方未提供 `domain` 时，the MCP shall 使用 `describeHttpServiceRoute` 返回的 `Domains` 中满足 `IsDefault === true`（且可用，例如已启用）的 `Domain` 字段。
+2. When 解析默认域名时，the MCP shall **不** 将 `OriginDomain`（回源域名）作为公网默认落点域名。
+3. When 环境无可用默认域名（未开通、列表为空、无 `IsDefault`、或默认域名不可用）时，the MCP shall 返回明确错误，说明需开通 HTTP 访问服务 / 在控制台确认默认域名，或改为显式传入 `domain` 后重试。
+4. When 默认域名解析成功并创建路由后，the 成功响应 shall 包含实际使用的 `domain`，便于 Agent 组装访问 URL。
+
+### Requirement 4 - 上游类型映射（Event / HTTP / 扩展类型）
+
+**用户故事：** 作为 Agent，我希望用清晰的函数类型或上游枚举创建正确路由，避免 HTTP 与 Event 函数互相误标。
+
+#### 验收标准
+
+1. When 为 Event 云函数创建路由且使用兼容快捷字段 `type="Event"`（或等价显式 `UpstreamResourceType=SCF`）时，the MCP shall 将上游类型设为 `SCF`。
+2. When 为 HTTP / Web 云函数创建路由且使用 `type="HTTP"`（或等价显式 `UpstreamResourceType=WEB_SCF`）时，the MCP shall 将上游类型设为 `WEB_SCF`。
+3. When `createRoute` 的 schema 描述固定可选上游类型时，the MCP shall 使用枚举（如 `SCF` / `WEB_SCF` / `CBR` / `STATIC_STORE` / `LH`），而不是仅用自由字符串 + 文字说明。
+4. When HTTP 函数被错误标为 `SCF`，或 Event 函数被错误标为 `WEB_SCF` 时，the 文档与工具描述 shall 明确警示该误用会导致访问失败（例如 `FUNCTION_PARAM_INVALID` 或网关内部错误）。
+5. While `targetType="function"` 且未提供可解析的 `type` / `UpstreamResourceType` 时，when 创建函数路由，the MCP shall 拒绝请求并提示必须显式区分 Event（`SCF`）与 HTTP（`WEB_SCF`），不得默认当成 Event/`SCF` 静默成功。
+
+### Requirement 5 - 查询与写路径全部走新接口
+
+**用户故事：** 作为平台用户，我希望查询到的入口与写入的路由来自同一 Domain/Route 数据面，避免新旧列表不一致。
+
+#### 验收标准
+
+1. When 执行 `listRoutes` / `getRoute` / `listCustomDomains` 时，the MCP shall 仅基于 `env.describeHttpServiceRoute`（及新模型字段）组装结果。
+2. When 执行 `createRoute` / `updateRoute` / `deleteRoute` 时，the MCP shall 分别调用 `env.createHttpServiceRoute` / `modifyHttpServiceRoute` / `deleteHttpServiceRoute`。
+3. When `getRoute` 按函数名查询时，the MCP shall 返回匹配的 Domain、Path、UpstreamResourceType、UpstreamResourceName、EnableAuth 及可拼装的访问 URL（基于实际 Domain + Path）。
+4. When 路由创建成功时，the 响应 message shall 继续提示路由传播可能需要等待（例如 30 秒到 3 分钟），且 shall 说明网关鉴权不等于函数安全规则，必要时引导 `queryPermissions` / `managePermissions`。
+
+### Requirement 6 - Skill、引导文案与文档迁移
+
+**用户故事：** 作为 Agent 作者 / 终端用户，我希望公开 skill 与 MCP 文档只推荐新 Domain/Route 路径，不再把旧 GWAPI 当作 Plan B。
+
+#### 验收标准
+
+1. When 更新 `config/source/skills/cloud-functions`（及由其生成/镜像的兼容产物源）时，the 文档 shall 将补默认域名入口的推荐写法改为 `manageGateway(action="createRoute", ...)`，并给出 `type` / `UpstreamResourceType` 映射说明。
+2. When 扫描 skill / references 时，the 仓库源文档 shall **不** 再将 `CreateCloudBaseGWAPI` / `DescribeCloudBaseGWAPI` / `callCloudApi` 旧 GWAPI 写为推荐路径或 Plan B。
+3. When `manageFunctions` 创建 HTTP 函数后的 `nextActions` / message 引导访问入口时，the 文案 shall 指向 `createRoute`（含显式 HTTP → `WEB_SCF` / `type="HTTP"` 要求），而不是 `createAccess`。
+4. When 本需求合并前，the 维护者 shall 重新生成受影响的对外 prompts / `doc/mcp-tools.md`（按项目既有生成脚本），使公开文档与 schema 一致。
+5. When CLI skill 已描述 `tcb routes` / `tcb domains` 时，the MCP 文档语义 shall 与之对齐（Domain 一等公民、上游字符串枚举、主键 Domain + Path）。
+
+### Requirement 7 - 测试、回归与迁移说明
+
+**用户故事：** 作为维护者，我希望破坏性变更有单测与回归覆盖，并向依赖方提供明确迁移说明。
+
+#### 验收标准
+
+1. When 网关单测运行时，the 测试 shall 覆盖：默认域名解析（`IsDefault`）、`Event→SCF`、`HTTP→WEB_SCF`、缺少类型时拒绝、`createRoute`/`updateRoute`/`deleteRoute`/`getRoute` 的 SDK 调用参数、默认域名缺失时的错误文案；shall **不** 再断言 `access.createAccess` 等旧调用。
+2. When 仓库内集成 / STS 等用例仍覆盖网关时，the 用例 shall 改用新 action 与参数。
+3. When 本需求交付时，the spec 或 PR 说明 shall 包含面向 Agent/skill 作者的迁移表：旧 action → 新 action、旧 `type` → 新 `UpstreamResourceType`、旧 `accessId` → `Domain+Path`。
+4. When 评测模式仍启用 `callCloudApi` 黑名单时，the 旧 GWAPI Action 屏蔽列表 shall 保持禁止（不回退）。
+
+### Requirement 8 - 安全与权限边界保持
+
+**用户故事：** 作为终端用户，我不希望网关迁移误放开或混淆函数资源权限。
+
+#### 验收标准
+
+1. When 创建或更新路由时，the MCP shall 仅配置网关侧 `EnableAuth`（若调用方提供），shall **不** 自动修改函数资源安全规则。
+2. When 成功创建面向浏览器/匿名访问的路由后，the nextActions shall 仍引导检查/按需更新函数权限（`queryPermissions` / `managePermissions`）。
+3. When 文档区分安全域名（CORS）与自定义域名（HTTPS + 证书）时，the 既有边界 shall 保持：`envDomainManagement` ≠ `manageGateway(bindCustomDomain)`。

--- a/specs/manage-gateway-domain-route-migration/tasks.md
+++ b/specs/manage-gateway-domain-route-migration/tasks.md
@@ -1,0 +1,60 @@
+# Implementation Plan
+
+- [x] 1. Rewrite gateway tool surface to Domain/Route only
+  - Update `QUERY_GATEWAY_ACTIONS` / `MANAGE_GATEWAY_ACTIONS` to remove `getAccess`, `listDomains`, `createAccess`, `deleteAccess`, `updatePathAuth`
+  - Keep: `listRoutes`, `getRoute`, `listCustomDomains`, `createRoute`, `updateRoute`, `deleteRoute`, `bindCustomDomain`, `deleteCustomDomain`
+  - Extend query input with optional `path` / `domain` for `getRoute`
+  - Tighten manage schema: `type` enum `Event|HTTP`, `route.upstreamResourceType` as `z.enum(["SCF","WEB_SCF","CBR","STATIC_STORE","LH"])`, remove `accessId` / `accessName`
+  - Update tool descriptions to recommend `createRoute` for default-domain function entry and warn HTTP vs Event mapping
+  - _需求: 1, 2, 4_
+
+- [x] 2. Implement Domain/Route helpers and handlers (no `access.*`)
+  - Replace `resolveRouteDomain` to use `IsDefault` (never `OriginDomain` alone)
+  - Implement `mapUpstreamResourceType` + reject missing type for function routes
+  - Fix `normalizeRoutePayload` to emit correct `UpstreamResourceType` / `UpstreamResourceName` / `EnableAuth`
+  - Rewrite `getRoute` / `listRoutes` / `listCustomDomains` on `describeHttpServiceRoute` only
+  - Wire create/update/delete to `env.createHttpServiceRoute` / `modifyHttpServiceRoute` / `deleteHttpServiceRoute`
+  - Ensure success envelopes include `domain`, path, upstream fields, propagation + permissions `nextActions`
+  - Remove all `cloudbase.access.*` call sites from `gateway.ts`
+  - _需求: 2, 3, 4, 5, 8_
+
+- [x] 3. Update gateway unit tests
+  - Retarget mocks to `env.*` only; drop `access.createAccess` / `getAccessList` / etc. assertions
+  - Cover: IsDefault resolution, OriginDomain not used as public domain, Event→SCF, HTTP→WEB_SCF, missing type rejection, CRUD param shapes, missing default-domain error, schema excludes removed actions
+  - _需求: 7_
+
+- [x] 4. Update function creation guidance
+  - Change `functions.ts` messages / `nextActions` from `createAccess`/`getAccess` to `createRoute`/`getRoute` (explicit HTTP type)
+  - Update `functions.test.ts` expectations
+  - _需求: 6, 8_
+
+- [x] 5. Migrate skills and remove old GWAPI Plan B
+  - Update `config/source/skills/cloud-functions/SKILL.md` and references (`http-functions.md`, `http-functions-custom-image.md`, `operations-and-config.md`)
+  - Delete `CreateCloudBaseGWAPI` / `callCloudApi` Plan B guidance
+  - Align wording with CLI Domain/Route semantics
+  - Sync `config/.claude/skills` mirror; align `plugin/cloudbase/skills/cloud-functions`
+  - _需求: 6_
+
+- [x] 6. Refresh generated docs and in-repo callers
+  - Run prompts / mcp-tools generation scripts as required by project rules
+  - Update `tests/sts-resource-level-validation.test.js` and any examples still using old actions
+  - Confirm `capi.ts` GWAPI blacklist unchanged
+  - _需求: 6, 7_
+
+- [x] 7. Verification and migration notes
+  - Run gateway + functions unit tests / relevant build checks
+  - Migration table (for PR): see below
+  - Note follow-up: Manager SDK `access` still not deprecated (out of scope)
+  - _需求: 7_
+
+## Migration table
+
+| Old | New |
+|-----|-----|
+| `createAccess` | `createRoute` (+ `type=HTTP\|Event`, optional `domain`) |
+| `getAccess` | `getRoute` (`targetName` / `path` / `domain`) |
+| `deleteAccess` | `deleteRoute` (`domain?` + `path`) |
+| `updatePathAuth` | `updateRoute` (`auth` / `EnableAuth`) |
+| `listDomains` | `listRoutes` or `listCustomDomains` |
+| Type `1` / `6` | `SCF` / `WEB_SCF` |
+| `APIId` | `Domain + Path` |

--- a/tests/function-layer-tools.test.js
+++ b/tests/function-layer-tools.test.js
@@ -193,15 +193,19 @@ describe("Function and gateway tool schemas", () => {
     const manageTool = toolsResult.tools.find((item) => item.name === "manageGateway");
 
     expect(queryTool).toBeDefined();
-    expect(queryTool.inputSchema.properties.action.enum).toContain("getAccess");
-    expect(queryTool.inputSchema.properties.action.enum).toContain("listDomains");
+    expect(queryTool.inputSchema.properties.action.enum).toContain("getRoute");
+    expect(queryTool.inputSchema.properties.action.enum).toContain("listRoutes");
+    expect(queryTool.inputSchema.properties.action.enum).toContain("listCustomDomains");
+    expect(queryTool.inputSchema.properties.action.enum).not.toContain("getAccess");
+    expect(queryTool.inputSchema.properties.action.enum).not.toContain("listDomains");
     expect(queryTool.inputSchema.properties.targetType).toBeDefined();
     expect(queryTool.inputSchema.properties.targetName).toBeDefined();
     expect(queryTool.annotations.category).toBe("gateway");
     expect(queryTool.annotations.readOnlyHint).toBe(true);
 
     expect(manageTool).toBeDefined();
-    expect(manageTool.inputSchema.properties.action.enum).toContain("createAccess");
+    expect(manageTool.inputSchema.properties.action.enum).toContain("createRoute");
+    expect(manageTool.inputSchema.properties.action.enum).not.toContain("createAccess");
     expect(manageTool.inputSchema.properties.targetType).toBeDefined();
     expect(manageTool.inputSchema.properties.targetName).toBeDefined();
     expect(manageTool.inputSchema.properties.path).toBeDefined();
@@ -240,11 +244,11 @@ describe("Function and gateway tool schemas", () => {
     const gatewayAccessResult = await testClient.callTool({
       name: "queryGateway",
       arguments: {
-        action: "getAccess",
+        action: "getRoute",
         targetType: "function",
       },
     });
-    expectToolFailure(gatewayAccessResult, /targetName 参数是必需的/);
+    expectToolFailure(gatewayAccessResult, /routeId、targetName 或 path/);
   });
 
   test.skipIf(!testClient)("queryFunctions can call listLayers when credentials are available", async () => {

--- a/tests/sts-resource-level-validation.test.js
+++ b/tests/sts-resource-level-validation.test.js
@@ -248,9 +248,11 @@ describe("STS 资源级临时密钥 - MCP 全资源验证", () => {
         console.log("🧹 删除测试云函数...");
         // 先删网关入口
         await safeTool(client, "manageGateway", {
-          action: "deleteAccess",
+          action: "deleteRoute",
           targetName: `${TEST_PREFIX}func`,
           targetType: "function",
+          path: `/${TEST_PREFIX}func`,
+          type: "Event",
         });
         await delay(1000);
         // 删函数本体 - 通过 callCloudApi
@@ -554,11 +556,11 @@ describe("STS 资源级临时密钥 - MCP 全资源验证", () => {
 
   // ═══ 3.7 网关 ═══════════════════════════════════════════════════════════
   test.skipIf(!hasCredentials())("3.7 网关 - 路由验证", async () => {
-    // 列出域名
+    // 列出自定义域名
     const domainsRes = await safeTool(client, "queryGateway", {
-      action: "listDomains",
+      action: "listCustomDomains",
     });
-    recordResult("网关", "列出域名", domainsRes.success, "");
+    recordResult("网关", "列出自定义域名", domainsRes.success, "");
 
     // 列出路由
     const routesRes = await safeTool(client, "queryGateway", {
@@ -568,21 +570,21 @@ describe("STS 资源级临时密钥 - MCP 全资源验证", () => {
 
     // 如果函数已创建，创建访问入口
     if (testFuncCreated) {
-      const createAccessRes = await safeTool(client, "manageGateway", {
-        action: "createAccess",
+      const createRouteRes = await safeTool(client, "manageGateway", {
+        action: "createRoute",
         targetName: `${TEST_PREFIX}func`,
         targetType: "function",
         type: "Event",
       });
-      recordResult("网关", "创建入口", createAccessRes.success, createAccessRes.text.slice(0, 100));
+      recordResult("网关", "创建入口", createRouteRes.success, createRouteRes.text.slice(0, 100));
 
-      if (createAccessRes.success) {
-        const getAccessRes = await safeTool(client, "queryGateway", {
-          action: "getAccess",
+      if (createRouteRes.success) {
+        const getRouteRes = await safeTool(client, "queryGateway", {
+          action: "getRoute",
           targetName: `${TEST_PREFIX}func`,
           targetType: "function",
         });
-        recordResult("网关", "查询入口", getAccessRes.success, "");
+        recordResult("网关", "查询入口", getRouteRes.success, "");
       }
     }
   }, 30000);


### PR DESCRIPTION
## Summary
- Breakingly migrate `queryGateway` / `manageGateway` to the Domain/Route model only: remove `createAccess`, `getAccess`, `deleteAccess`, `updatePathAuth`, and `listDomains`.
- Implement all gateway reads/writes via Manager SDK `env.*HttpServiceRoute` / custom-domain APIs (no `access.*` / GWAPI). Resolve default domains with `IsDefault`; map `Event→SCF` and `HTTP→WEB_SCF`.
- Update cloud-functions skills, function-creation guidance, examples, generated tool docs/prompts, and in-repo tests; keep deprecated GWAPI blocked in `callCloudApi` evaluate mode.

## Migration (breaking)
| Old | New |
|-----|-----|
| `createAccess` | `createRoute` (+ `type=HTTP\|Event`, optional `domain`) |
| `getAccess` | `getRoute` |
| `deleteAccess` | `deleteRoute` (`Domain` + `Path`) |
| `updatePathAuth` | `updateRoute` (`auth` / `EnableAuth`) |
| `listDomains` | `listRoutes` / `listCustomDomains` |
| Type `1` / `6` | `SCF` / `WEB_SCF` |

Spec: `specs/manage-gateway-domain-route-migration/`

## Test plan
- [x] `npx vitest run src/tools/gateway.test.ts src/tools/functions.test.ts` (27 passed)
- [x] `npm run build:tools-json` / tools-doc / prompts-data
- [ ] CI green on this PR
- [ ] Optional: STS gateway section with credentials (`createRoute` / `getRoute` / `deleteRoute`)


Made with [Cursor](https://cursor.com)