### PR TITLE
feat(plugins): mirror OPS plugin repos to CNB like skills

### DIFF
--- a/.github/workflows/push-plugin-repos.yaml
+++ b/.github/workflows/push-plugin-repos.yaml
@@ -76,6 +76,12 @@ jobs:
           node scripts/push-plugin-repos.mjs
           node scripts/push-plugin-repos.mjs --check
 
+      # Same topology as cloudbase-skills:
+      #   MCP → GitHub dedicated OPS repo (this job)
+      #   GitHub dedicated repo → CNB via .github/workflows/sync-to-cnb.yml (git-sync)
+      # Do NOT use [skip ci] — the dedicated repo's Sync to CNB must run on push.
+      # CNB empty repos + CNB_TOKEN on the dedicated GitHub repos are prerequisites
+      # (same as TencentCloudBase/cloudbase-skills).
       - name: Sync cloudbase-plugin repo
         env:
           PLUGINS_REPO_TOKEN: ${{ secrets.PLUGINS_REPO_TOKEN }}
@@ -86,6 +92,7 @@ jobs:
 
           # Clear target (keep .git). Use rsync so Open Plugin Spec dotdirs (.plugin) are included.
           # `cp -r src/* dest` silently drops hidden paths.
+          # Output includes .github/workflows/sync-to-cnb.yml (skills-style CNB mirror).
           rsync -a --delete --exclude='.git' \
             "${{ github.workspace }}/.plugin-repo-output/cloudbase/" \
             /tmp/cloudbase-plugin/
@@ -95,6 +102,7 @@ jobs:
           test -f /tmp/cloudbase-plugin/mcp.json
           test -f /tmp/cloudbase-plugin/generated/skill-manifest.json
           test -f /tmp/cloudbase-plugin/generated/synonyms.json
+          test -f /tmp/cloudbase-plugin/.github/workflows/sync-to-cnb.yml
           test ! -f /tmp/cloudbase-plugin/marketplace.json
           test ! -d /tmp/cloudbase-plugin/.claude-plugin
           test ! -d /tmp/cloudbase-plugin/.codex-plugin
@@ -106,7 +114,8 @@ jobs:
 
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
-            git commit -m "chore: sync from CloudBase-MCP [skip ci]"
+            # No [skip ci]: must trigger Sync to CNB on the dedicated repo (skills pattern).
+            git commit -m "chore: sync from CloudBase-MCP"
             git push
             echo "✓ Pushed to cloudbase-plugin"
           else
@@ -127,6 +136,7 @@ jobs:
 
           test -f /tmp/cloudbase-sites-plugin/.plugin/plugin.json
           test -f /tmp/cloudbase-sites-plugin/mcp.json
+          test -f /tmp/cloudbase-sites-plugin/.github/workflows/sync-to-cnb.yml
           test ! -f /tmp/cloudbase-sites-plugin/marketplace.json
           test ! -d /tmp/cloudbase-sites-plugin/.claude-plugin
           test ! -d /tmp/cloudbase-sites-plugin/.codex-plugin
@@ -138,7 +148,7 @@ jobs:
 
           if [ -n "$(git status --porcelain)" ]; then
             git add -A
-            git commit -m "chore: sync from CloudBase-MCP [skip ci]"
+            git commit -m "chore: sync from CloudBase-MCP"
             git push
             echo "✓ Pushed to cloudbase-sites-plugin"
           else

--- a/README.md
+++ b/README.md
@@ -55,9 +55,9 @@ Publishing and sync repos live under [TencentCloudBase](https://github.com/Tence
 | Repository | Contents | Typical entry |
 |------|------|----------|
 | [CloudBase-AI-Toolkit](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit) (this repo) | MCP Server source; marketplace source for Claude Code / Codex | `npx @cloudbase/cloudbase-mcp@latest` |
-| [cloudbase-plugin](https://github.com/TencentCloudBase/cloudbase-plugin) | Open Plugin Spec publish repo (CI-synced): MCP + Skills + Hooks | `npx plugins add TencentCloudBase/cloudbase-plugin` |
-| [cloudbase-sites-plugin](https://github.com/TencentCloudBase/cloudbase-sites-plugin) | Sites plugin: Vite Web create & deploy | `npx plugins add TencentCloudBase/cloudbase-sites-plugin` |
-| [cloudbase-skills](https://github.com/TencentCloudBase/cloudbase-skills) | Agent Skills collection | `npx skills add TencentCloudBase/cloudbase-skills` |
+| [cloudbase-plugin](https://github.com/TencentCloudBase/cloudbase-plugin) | Open Plugin Spec publish repo (CI-synced): MCP + Skills + Hooks | `npx plugins add TencentCloudBase/cloudbase-plugin` · CNB fallback: `npx plugins add https://cnb.cool/tencent/cloud/cloudbase/cloudbase-plugin.git` |
+| [cloudbase-sites-plugin](https://github.com/TencentCloudBase/cloudbase-sites-plugin) | Sites plugin: Vite Web create & deploy | `npx plugins add TencentCloudBase/cloudbase-sites-plugin` · CNB: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-sites-plugin.git` |
+| [cloudbase-skills](https://github.com/TencentCloudBase/cloudbase-skills) | Agent Skills collection | `npx skills add TencentCloudBase/cloudbase-skills` · CNB: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills.git` |
 | [skills](https://github.com/TencentCloudBase/skills) | Per-skill install catalog (also on [skills.sh](https://skills.sh)) | `npx skills add tencentcloudbase/skills --skill <name>` |
 | [awesome-cloudbase-examples](https://github.com/TencentCloudBase/awesome-cloudbase-examples) | CloudBase examples and case studies | Browse / clone examples |
 | [OpenVibeCoding](https://github.com/TencentCloudBase/OpenVibeCoding) | Vibecoding template on CloudBase | Use as a project starter |

--- a/doc/ai-agent-plugins.mdx
+++ b/doc/ai-agent-plugins.mdx
@@ -55,6 +55,21 @@ npx plugins add TencentCloudBase/cloudbase-plugin -y --scope user --target curso
 
 > ⚠️ 已通过方式 2（`claude plugin install` / `codex plugin add` 等）安装过时，**不要**再对同一 IDE 执行 `npx plugins add`，以免重复实例。二选一即可。
 
+### GitHub 不可达时（CNB 镜像）
+
+`owner/repo` 短名会固定解析到 GitHub。若 `git clone` GitHub 失败，改用 **完整 CNB URL**（由 CI 从 OPS 产物同步，不含 marketplace 元数据）：
+
+```bash
+npx plugins add https://cnb.cool/tencent/cloud/cloudbase/cloudbase-plugin.git -y --scope user
+
+# Sites 插件（可选）
+npx plugins add https://cnb.cool/tencent/cloud/cloudbase/cloudbase-sites-plugin.git -y --scope user
+```
+
+> 不要用 monorepo 镜像 `CloudBase-AI-ToolKit` 做 `npx plugins add`：其 marketplace 结构与 OPS 专用仓不同，CLI 可能装不上。
+
+若插件仍无法安装，可退回 Skills CNB 或 npm MCP，见 [skill.md](https://docs.cloudbase.net/skill.md)。
+
 ### 方式 2：按 IDE 手动安装
 
 适用于 CodeBuddy、WorkBuddy、ZCode，或希望走 IDE 原生插件机制的场景：

--- a/doc/prompts/how-to-use.mdx
+++ b/doc/prompts/how-to-use.mdx
@@ -26,6 +26,14 @@ npx skills add https://github.com/tencentcloudbase/skills --skill auth-tool
 
 在线预览示例：[cloudbase-platform](https://skills.sh/tencentcloudbase/skills/cloudbase-platform)
 
+### GitHub 不可达时（CNB 镜像）
+
+短名 `owner/repo` 会走 GitHub。clone 失败时用完整 CNB URL：
+
+```bash
+npx skills add https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills.git -y
+```
+
 ### 提升激活率
 
 单独安装 Skills 时，AI 是否自动选用取决于模型和工具，不一定稳定。若希望更稳定地生效，建议直接安装 [CloudBase AI 插件](/ai/cloudbase-ai-toolkit/ai-agent-plugins)：一次安装同时获得 MCP、Skills 与 Hooks。

--- a/scripts/push-plugin-repos.mjs
+++ b/scripts/push-plugin-repos.mjs
@@ -10,6 +10,9 @@
  *   - `.cursor-plugin/`  → Cursor Marketplace
  *   - `marketplace.json` → would make plugins CLI treat the repo as a marketplace
  *
+ * Also emits `.github/workflows/sync-to-cnb.yml` (same as cloudbase-skills) so the
+ * dedicated GitHub repo can mirror itself to CNB via tencentcom/git-sync.
+ *
  * Output: .plugin-repo-output/cloudbase/ and .plugin-repo-output/cloudbase-sites/
  *
  * Usage:
@@ -90,7 +93,42 @@ function copyDir(src, dest, base) {
   return count;
 }
 
+function generateCnbSyncWorkflow(plugin) {
+  const shortName = plugin.repoName.split("/")[1];
+  const cnbGitUrl = `https://cnb.cool/tencent/cloud/cloudbase/${shortName}.git`;
+  // Same shape as TencentCloudBase/cloudbase-skills/.github/workflows/sync-to-cnb.yml
+  return `name: Sync to CNB
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync to CNB Repository
+        run: |
+          docker run --rm \\
+            -v \${{ github.workspace }}:\${{ github.workspace }} \\
+            -w \${{ github.workspace }} \\
+            -e PLUGIN_TARGET_URL="${cnbGitUrl}" \\
+            -e PLUGIN_AUTH_TYPE="https" \\
+            -e PLUGIN_USERNAME="cnb" \\
+            -e PLUGIN_PASSWORD=\${{ secrets.CNB_TOKEN }} \\
+            -e PLUGIN_FORCE="true" \\
+            tencentcom/git-sync
+`;
+}
+
 function generateReadme(plugin) {
+  const shortName = plugin.repoName.split("/")[1];
+  const cnbUrl = `https://cnb.cool/tencent/cloud/cloudbase/${shortName}.git`;
   return `# ${plugin.name}
 
 ${plugin.description}
@@ -98,13 +136,21 @@ ${plugin.description}
 This repository is automatically synced from [${plugin.repoName.split("/")[0]}/CloudBase-MCP](https://github.com/${plugin.repoName.split("/")[0]}/CloudBase-MCP)
 (\`plugin/${plugin.name}/\`, Open Plugin Spec artifacts only).
 
+A CNB mirror is synced the same way as [cloudbase-skills](https://github.com/TencentCloudBase/cloudbase-skills):
+this repo's \`.github/workflows/sync-to-cnb.yml\` mirrors to
+[${cnbUrl.replace(/\.git$/, "")}](${cnbUrl.replace(/\.git$/, "")}).
+
 Claude Code / Codex native marketplace install continues to use the main
 [CloudBase-MCP](https://github.com/${plugin.repoName.split("/")[0]}/CloudBase-MCP) repository.
 
 ## Installation
 
 \`\`\`bash
-npx plugins add ${plugin.repoName}
+# Default (GitHub)
+npx plugins add ${plugin.repoName} -y --scope user
+
+# Fallback when GitHub clone fails (CNB mirror — use full URL; short owner/repo always hits GitHub)
+npx plugins add ${cnbUrl} -y --scope user
 \`\`\`
 
 ## Open Plugin Specification
@@ -132,8 +178,13 @@ function buildPlugin(plugin) {
   // Generate README
   fs.writeFileSync(path.join(outDir, "README.md"), generateReadme(plugin));
 
-  console.log(`✓ [${plugin.name}] ${count} files copied to ${path.relative(ROOT_DIR, outDir)}/`);
-  return count;
+  // Skills-style CNB mirror workflow (lives in dedicated OPS repo, not MCP monorepo)
+  const workflowDir = path.join(outDir, ".github", "workflows");
+  fs.mkdirSync(workflowDir, { recursive: true });
+  fs.writeFileSync(path.join(workflowDir, "sync-to-cnb.yml"), generateCnbSyncWorkflow(plugin));
+
+  console.log(`✓ [${plugin.name}] ${count} files copied to ${path.relative(ROOT_DIR, outDir)}/ (+ sync-to-cnb.yml)`);
+  return count + 1;
 }
 
 function checkPlugin(plugin) {
@@ -166,6 +217,7 @@ function checkPlugin(plugin) {
   const required = [
     [".plugin/plugin.json", path.join(outDir, ".plugin", "plugin.json")],
     ["mcp.json", path.join(outDir, "mcp.json")],
+    [".github/workflows/sync-to-cnb.yml", path.join(outDir, ".github", "workflows", "sync-to-cnb.yml")],
   ];
   for (const [label, p] of required) {
     if (!fs.existsSync(p)) {


### PR DESCRIPTION
## Summary
- Emit `.github/workflows/sync-to-cnb.yml` into dedicated `cloudbase-plugin` / `cloudbase-sites-plugin` repos (same `tencentcom/git-sync` pattern as `cloudbase-skills`).
- Drop `[skip ci]` on content sync commits so CNB mirror workflows can run.
- Document GitHub-unreachable install via full CNB git URLs.

## Prerequisites (done)
- CNB empty repos: `cloudbase-plugin`, `cloudbase-sites-plugin`
- `CNB_TOKEN` set on both dedicated GitHub repos + CloudBase-MCP

## Test plan
- [ ] Merge to `main`
- [ ] Run **Push Plugin Repos** (`workflow_dispatch`)
- [ ] Confirm dedicated repos gained `sync-to-cnb.yml` and **Sync to CNB** succeeded
- [ ] `npx plugins discover https://cnb.cool/tencent/cloud/cloudbase/cloudbase-plugin.git` finds local plugin


Made with [Cursor](https://cursor.com)