### PR TITLE
docs(marketplace): record awesome-copilot vally re-run SHA

### DIFF
--- a/specs/plugin-marketplace-listing/awesome-copilot-submission-packet.md
+++ b/specs/plugin-marketplace-listing/awesome-copilot-submission-packet.md
@@ -15,7 +15,7 @@ Prepared: 2026-07-28
 | GitHub repository | `TencentCloudBase/cloudbase-plugin` |
 | Plugin path | _(leave empty — plugin is at repo root)_ |
 | Ref to review | _(optional if SHA provided)_ |
-| Commit SHA | `93b747b3287787b8c3ad0811ef4f9b51e2479ec9` |
+| Commit SHA | `b3835bea5cb8e10f57c1e0a584f645eea2cbc127` |
 | Version | `0.2.0` |
 | License | `MIT` |
 | Author name | `Tencent CloudBase` |

--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -80,11 +80,12 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 
 | Field | Value |
 |-------|-------|
-| Status | **Issue opened** — awaiting maintainer review |
+| Status | **Intake re-run requested** — vally fixes synced; awaiting gate recheck |
 | Issue | https://github.com/github/awesome-copilot/issues/2459 |
 | Packet | `specs/plugin-marketplace-listing/awesome-copilot-submission-packet.md` |
-| Source | `TencentCloudBase/cloudbase-plugin` @ `93b747b3287787b8c3ad0811ef4f9b51e2479ec9` |
+| Source | `TencentCloudBase/cloudbase-plugin` @ `b3835bea5cb8e10f57c1e0a584f645eea2cbc127` |
 | Submitted at | 2026-07-28 |
+| Re-run at | 2026-07-28 (`/rerun-intake` after skill dir rename for vally) |
 
 ### How to check progress (Awesome Copilot)
 


### PR DESCRIPTION
## Summary
- Update Awesome Copilot #2459 pinned SHA to `b3835bea…` after vally skill-dir fix sync
- Mark intake as re-run requested in submission log

## Test plan
- [x] Issue body SHA matches packet / log


Made with [Cursor](https://cursor.com)