### PR TITLE
fix(skills): link orphan references for vally lint

### DIFF
--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -212,3 +212,9 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [vpc-and-database.md](references/vpc-and-database.md)

--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -265,3 +265,16 @@ Avoid dynamic helper traps:
 - Editor permission is enforced outside the UI.
 - A pgstore bucket that matches the upload path (e.g. `covers`) exists BEFORE any browser upload runs. If it does not, create it via a management surface; the v3 SDK will not create one for you.
 - Storage upload returns a usable URL and that URL is persisted with the article. Upload errors must propagate — do not insert an article row with a placeholder cover URL.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [index.md](references/index.md)
+- [pg-mode-overview.md](references/pg-mode-overview.md)
+- [auth-and-rls.md](references/auth-and-rls.md)
+- [app-workflow.md](references/app-workflow.md)
+- [storage-pg.md](references/storage-pg.md)
+- [http-api.md](references/http-api.md)
+- [rls-patterns.md](references/rls-patterns.md)
+- [troubleshooting.md](references/troubleshooting.md)

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -212,3 +212,9 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [vpc-and-database.md](references/vpc-and-database.md)

--- a/config/source/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/source/skills/postgresql-development-cloudbase/SKILL.md
@@ -265,3 +265,16 @@ Avoid dynamic helper traps:
 - Editor permission is enforced outside the UI.
 - A pgstore bucket that matches the upload path (e.g. `covers`) exists BEFORE any browser upload runs. If it does not, create it via a management surface; the v3 SDK will not create one for you.
 - Storage upload returns a usable URL and that URL is persisted with the article. Upload errors must propagate — do not insert an article row with a placeholder cover URL.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [index.md](references/index.md)
+- [pg-mode-overview.md](references/pg-mode-overview.md)
+- [auth-and-rls.md](references/auth-and-rls.md)
+- [app-workflow.md](references/app-workflow.md)
+- [storage-pg.md](references/storage-pg.md)
+- [http-api.md](references/http-api.md)
+- [rls-patterns.md](references/rls-patterns.md)
+- [troubleshooting.md](references/troubleshooting.md)

--- a/plugin/cloudbase/skills/cloudrun-development/SKILL.md
+++ b/plugin/cloudbase/skills/cloudrun-development/SKILL.md
@@ -212,3 +212,9 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [vpc-and-database.md](references/vpc-and-database.md)

--- a/plugin/cloudbase/skills/postgresql-development-cloudbase/SKILL.md
+++ b/plugin/cloudbase/skills/postgresql-development-cloudbase/SKILL.md
@@ -265,3 +265,16 @@ Avoid dynamic helper traps:
 - Editor permission is enforced outside the UI.
 - A pgstore bucket that matches the upload path (e.g. `covers`) exists BEFORE any browser upload runs. If it does not, create it via a management surface; the v3 SDK will not create one for you.
 - Storage upload returns a usable URL and that URL is persisted with the article. Upload errors must propagate — do not insert an article row with a placeholder cover URL.
+
+## Reference index
+
+All packaged reference files (required for skill lint reachability):
+
+- [index.md](references/index.md)
+- [pg-mode-overview.md](references/pg-mode-overview.md)
+- [auth-and-rls.md](references/auth-and-rls.md)
+- [app-workflow.md](references/app-workflow.md)
+- [storage-pg.md](references/storage-pg.md)
+- [http-api.md](references/http-api.md)
+- [rls-patterns.md](references/rls-patterns.md)
+- [troubleshooting.md](references/troubleshooting.md)


### PR DESCRIPTION
## Summary
- Add explicit markdown links for `cloudrun-development` `references/vpc-and-database.md`
- Add Reference index links for all `postgresql-development-cloudbase` reference files
- Sync mirrors under `config/.claude/skills` and `plugin/cloudbase/skills`

## Context
Awesome Copilot intake on `b3835be…` still failed vally orphan-files for these two skills only. All name/length issues are already fixed.

## Test plan
- [ ] After merge + skills/plugin sync, update #2459 SHA and `/rerun-intake`
- [ ] Confirm vally passes for cloudrun-development and postgresql-development-cloudbase


Made with [Cursor](https://cursor.com)