### PR TITLE
fix(ci): 🔁 sync Claude skills mirror and harden push race

### DIFF
--- a/.github/workflows/sync-claude-skills-mirror.yml
+++ b/.github/workflows/sync-claude-skills-mirror.yml
@@ -40,5 +40,16 @@ jobs:
             echo "No changes, skipping."
           else
             git commit -m "chore: sync claude skills mirror from source"
-            git push
+            # Release and other sync workflows often push main in parallel;
+            # rebase and retry to avoid non-fast-forward races.
+            for i in 1 2 3; do
+              if git push; then
+                exit 0
+              fi
+              echo "Push rejected (attempt $i); rebasing onto origin/main..."
+              git pull --rebase origin main
+              sleep $((i * 2))
+            done
+            echo "Failed to push after retries"
+            exit 1
           fi

--- a/config/.claude/skills/ai-model-nodejs/SKILL.md
+++ b/config/.claude/skills/ai-model-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-nodejs
 description: "Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express, Koa, NestJS, serverless APIs, scheduled jobs, LLM proxies. Only SDK supporting image generation (ai.createImageModel + generateImage). Text models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field of generateText/streamText. MUST run two-step preflight before code — see body. Keywords: backend, 云函数, 云托管, serverless, LLM proxy, agent orchestration, generateText, streamText, generateImage, createModel, hunyuan-image, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat)."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-web/SKILL.md
+++ b/config/.claude/skills/ai-model-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-web
 description: "Use this skill when a browser/Web app (React, Vue, Angular, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI) needs AI models via @cloudbase/js-sdk. Default routing for page/页面/Web/前端/frontend/网页/H5 AI — call directly from browser, do NOT propose a Node.js proxy. Covers generateText and streamText. Models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the model field. MUST run two-step preflight before code — see body. Keywords: 页面, Web, 前端, React, Vue, Next, Nuxt, SPA, AI chat UI, generateText, streamText, createModel, hunyuan-exp, Token Credits, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only)."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-wechat/SKILL.md
+++ b/config/.claude/skills/ai-model-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-wechat
 description: "Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, 企业微信小程序, wx.cloud apps). Features generateText and streamText with callbacks (onText, onEvent, onFinish). Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*. Model IDs (deepseek-v4-flash, deepseek-v3.2, hunyuan-2.0-instruct-20251111, glm-5, kimi-k2.6) go in the data wrapper model field. API differs from JS/Node SDK — streamText needs data wrapper, generateText returns raw response. MUST run two-step preflight before code — see body. Keywords: Mini Program AI, wx.cloud.extend.AI, 小程序成长计划, ai_miniprogram_inspire_plan, Token Credits 资源包, generateText, streamText, createModel, hunyuan-exp, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, MiniMax. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs)."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-nodejs-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-nodejs-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-nodejs-cloudbase
 description: CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-tool-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-tool-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-tool-cloudbase
 description: CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-web-cloudbase
 description: CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-wechat-miniprogram/SKILL.md
+++ b/config/.claude/skills/auth-wechat-miniprogram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-wechat-miniprogram
 description: CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-storage-web
 description: Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-agent/SKILL.md
+++ b/config/.claude/skills/cloudbase-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-agent
 description: Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-cli/SKILL.md
+++ b/config/.claude/skills/cloudbase-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-cli
 description: CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. This skill should be used when users need to deploy cloud functions, manage CloudRun apps, upload files to storage, query NoSQL/MySQL databases, deploy static hosting, set access permissions, or configure CORS/domains/routing via tcb commands. Also use for CI/CD pipeline scripting, batch operations, terminal-based CloudBase management, or when the user prefers CLI over SDK/MCP.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-code-review/SKILL.md
+++ b/config/.claude/skills/cloudbase-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-code-review
 description: "Code review and validation for CloudBase projects. After writing code for Web / miniprogram / CloudRun / cloud-function projects, call this skill to check for known pitfalls — auth guard misuse, missing database tables, RLS misconfiguration, storage domain setup, and SDK API misuse. Supports automated lint scripts (regex-based) + LLM semantic review."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-document-database-in-wechat-miniprogram/SKILL.md
+++ b/config/.claude/skills/cloudbase-document-database-in-wechat-miniprogram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-in-wechat-miniprogram
 description: Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-document-database-web-sdk/SKILL.md
+++ b/config/.claude/skills/cloudbase-document-database-web-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-web-sdk
 description: Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-platform/SKILL.md
+++ b/config/.claude/skills/cloudbase-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-platform
 description: CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-wechat-integration/SKILL.md
+++ b/config/.claude/skills/cloudbase-wechat-integration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-wechat-integration
 description: CloudBase WeChat integration guide for Mini Program WeChat Pay, Official Account JSAPI Pay, Native QR-code Pay, Official Account OAuth, openid handling, payment callbacks, and CloudBase Integration Center generated functions. This skill should be used when users ask to add, debug, or extend WeChat payment or official-account flows on CloudBase.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudrun-development
 description: CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, AI agent development, or migrating existing/GitHub apps that need VPC access to MySQL/PostgreSQL/Redis.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/data-model-creation/SKILL.md
+++ b/config/.claude/skills/data-model-creation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-model-creation
 description: "[Deprecated] Optional advanced tool for complex data modeling. For simple MySQL table creation, use relational-database-tool directly; for PostgreSQL / CloudBase PG schema work, use postgresql-development. New environments should use PostgreSQL DDL via queryPgDatabase/managePgDatabase — see postgresql-development skill instead."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/http-api-cloudbase/SKILL.md
+++ b/config/.claude/skills/http-api-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: http-api-cloudbase
 description: CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ops-inspector/SKILL.md
+++ b/config/.claude/skills/ops-inspector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inspector
 description: AIOps-style one-click inspection skill for CloudBase resources. Use this skill when users need to diagnose errors, check resource health, inspect logs, or run a comprehensive health check across cloud functions, CloudRun services, databases, and other CloudBase resources.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: postgresql-development-cloudbase
 description: "Use when building, debugging, or evaluating CloudBase PostgreSQL / CloudBase PG / PG mode apps, including Postgres schema setup, queryPgDatabase/managePgDatabase, JS SDK v3 app.rdb() CRUD/RPC, PG HTTP API fallback, RLS-style permissions, username-password auth, and Web CMS/admin CRUD flows backed by CloudBase PG."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/relational-database-mcp-cloudbase/SKILL.md
+++ b/config/.claude/skills/relational-database-mcp-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-mcp-cloudbase
 description: "[Deprecated] This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `queryMysqlDatabase`, `manageMysqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates. New environments should use PostgreSQL — see postgresql-development skill instead."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/relational-database-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/relational-database-web-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-web-cloudbase
 description: "[Deprecated] Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser. New environments should use PostgreSQL with app.rdb() — see postgresql-development skill instead."
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/spec-workflow/SKILL.md
+++ b/config/.claude/skills/spec-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-workflow
 description: Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ui-design/SKILL.md
+++ b/config/.claude/skills/ui-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-design
 description: Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/web-development/SKILL.md
+++ b/config/.claude/skills/web-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-development
 description: Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
-version: 2.24.1
+version: 2.25.0
 alwaysApply: false
 ---
 


### PR DESCRIPTION
## Summary
- Root cause: Sync Claude Skills Mirror failed on `v2.25.0` bump because `git push` lost a race with other main pushes (`! [rejected] main -> main (fetch first)`).
- Sync `config/.claude/skills` to match source skill versions (2.25.0).
- Harden workflow: rebase onto `origin/main` and retry push up to 3 times.

## Failed run
- https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/actions/runs/30343470533

## Test plan
- [x] `node scripts/sync-claude-skills-mirror.mjs --check` (no diff)
- [ ] CI green on this PR
- [ ] After merge, Sync Claude Skills Mirror either skips (no changes) or succeeds


Made with [Cursor](https://cursor.com)