### PR TITLE
feat(gateway): prefer custom-domain access URLs after deploy

### DIFF
--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -334,6 +334,7 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 - `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
 - `manageGateway(action="createRoute")` — for HTTP functions pass `upstreamResourceType="WEB_SCF"`; for Event functions pass `upstreamResourceType="SCF"`. Omit `domain` to use the environment default (`IsDefault`)
 - `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- When tool results include `accessUrl` / `accessUrls`, prefer them directly (gateway custom-domain URLs are ranked before default domains)
 - Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills

--- a/config/.claude/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/config/.claude/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. If the tool result already contains `accessUrl` / `accessUrls`, prefer those links directly. If no URL is returned yet, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/config/.claude/skills/cloud-functions/references/operations-and-config.md
+++ b/config/.claude/skills/cloud-functions/references/operations-and-config.md
@@ -75,6 +75,7 @@ Upstream type:
 
 Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 Do **not** pass `manageFunctions` `type="HTTP"|"Event"` into `manageGateway`; gateway uses `upstreamResourceType` only.
+When a deploy/create tool returns `accessUrl` or `accessUrls`, prefer those values directly; they already rank gateway custom domains before default domains when routes exist.
 ## Environment variable updates
 
 Do not overwrite function environment variables blindly.

--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -334,6 +334,7 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 - `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
 - `manageGateway(action="createRoute")` — for HTTP functions pass `upstreamResourceType="WEB_SCF"`; for Event functions pass `upstreamResourceType="SCF"`. Omit `domain` to use the environment default (`IsDefault`)
 - `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- When tool results include `accessUrl` / `accessUrls`, prefer them directly (gateway custom-domain URLs are ranked before default domains)
 - Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills

--- a/config/source/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/config/source/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. If the tool result already contains `accessUrl` / `accessUrls`, prefer those links directly. If no URL is returned yet, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -75,6 +75,7 @@ Upstream type:
 
 Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 Do **not** pass `manageFunctions` `type="HTTP"|"Event"` into `manageGateway`; gateway uses `upstreamResourceType` only.
+When a deploy/create tool returns `accessUrl` or `accessUrls`, prefer those values directly; they already rank gateway custom domains before default domains when routes exist.
 ## Environment variable updates
 
 Do not overwrite function environment variables blindly.

--- a/mcp/src/tools/apps.ts
+++ b/mcp/src/tools/apps.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import { getCloudBaseManager, logCloudBaseResult } from "../cloudbase-manager.js";
+import { getCloudBaseManager, getEnvId, logCloudBaseResult } from "../cloudbase-manager.js";
 import type { ExtendedMcpServer } from "../server.js";
 import { jsonContent } from "../utils/json-content.js";
 import { isCloudMode } from "../utils/cloud-mode.js";
+import { preferGatewayOrFallback, resolveGatewayAccessUrls } from "../utils/gateway-access-urls.js";
 
 const QUERY_APP_ACTIONS = ["listApps", "getApp", "listAppVersions", "getAppVersion", "getBuildLog"] as const;
 const MANAGE_APP_ACTIONS = ["deployApp", "getUploadUrl", "deleteApp", "deleteAppVersion"] as const;
@@ -497,6 +498,8 @@ export function registerAppTools(server: ExtendedMcpServer) {
           let appInfo: Record<string, unknown> | undefined;
           let domain: string | undefined;
           let accessUrl: string | undefined;
+          let accessUrls: string[] = [];
+          let accessUrlSource: string | undefined;
           let accessUrlLookupWarning: string | undefined;
           try {
             appInfo = await appService.describeAppInfo({
@@ -505,8 +508,33 @@ export function registerAppTools(server: ExtendedMcpServer) {
             });
             logCloudBaseResult(server.logger, appInfo);
             ({ domain, accessUrl } = normalizeAccessUrlFromDomain(appInfo?.Domain));
+            const envId = await getEnvId(cloudBaseOptions);
+            const gateway = await resolveGatewayAccessUrls({
+              envId,
+              upstreamResourceName: serviceName,
+              upstreamResourceTypes: ["STATIC_STORE"],
+              getManager: async () => {
+                const manager = await getManager();
+                if (!manager) {
+                  throw new Error("cloudbase manager unavailable");
+                }
+                return manager as any;
+              },
+            });
+            const preferred = preferGatewayOrFallback({
+              gateway,
+              fallbackUrl: accessUrl,
+              fallbackSource: "describeAppInfo.Domain",
+            });
+            accessUrl = preferred.accessUrl;
+            accessUrls = preferred.accessUrls;
+            accessUrlSource = preferred.accessUrlSource;
           } catch (error) {
             accessUrlLookupWarning = error instanceof Error ? error.message : String(error);
+            if (accessUrl) {
+              accessUrls = [accessUrl];
+              accessUrlSource = "describeAppInfo.Domain";
+            }
           }
 
           return jsonContent(
@@ -518,7 +546,8 @@ export function registerAppTools(server: ExtendedMcpServer) {
                 buildId: BuildId,
                 domain,
                 accessUrl,
-                accessUrlSource: accessUrl ? "describeAppInfo.Domain" : undefined,
+                accessUrls: accessUrls.length > 0 ? accessUrls : undefined,
+                accessUrlSource,
                 accessUrlLookupWarning,
                 app: appInfo,
                 upload: { cosTimestamp: cosTs },

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { getCloudBaseManager, getEnvId } from '../cloudbase-manager.js';
 import { ExtendedMcpServer } from '../server.js';
 import { debug } from '../utils/logger.js';
+import { preferGatewayOrFallback, resolveGatewayAccessUrls } from '../utils/gateway-access-urls.js';
 import { sendDeployNotification } from '../utils/notification.js';
 
 // CloudRun service types
@@ -341,6 +342,37 @@ function normalizeProcessLogText(logs: unknown[]): string {
       return String(log);
     })
     .join("\n");
+}
+
+function normalizeCloudRunDomainUrl(input: unknown): string | undefined {
+  if (typeof input !== "string" || !input.trim()) return undefined;
+  const raw = input.trim();
+  return raw.startsWith("http://") || raw.startsWith("https://")
+    ? raw
+    : `https://${raw}`;
+}
+
+function resolveCloudRunFallbackAccess(details: any): {
+  url?: string;
+  source?:
+    | "cloudrun.customDomain"
+    | "cloudrun.defaultDomain"
+    | "cloudrun.publicDomain"
+    | "cloudrun.internalDomain";
+} {
+  const custom = normalizeCloudRunDomainUrl(details?.BaseInfo?.CustomDomainName);
+  if (custom) return { url: custom, source: "cloudrun.customDomain" };
+  const defaultDomain = normalizeCloudRunDomainUrl(
+    details?.BaseInfo?.DefaultDomainName,
+  );
+  if (defaultDomain) return { url: defaultDomain, source: "cloudrun.defaultDomain" };
+  const publicDomain =
+    normalizeCloudRunDomainUrl(details?.BaseInfo?.PublicDomain) ??
+    normalizeCloudRunDomainUrl(details?.AccessInfo?.PublicDomain);
+  if (publicDomain) return { url: publicDomain, source: "cloudrun.publicDomain" };
+  const internal = normalizeCloudRunDomainUrl(details?.BaseInfo?.InternalDomain);
+  if (internal) return { url: internal, source: "cloudrun.internalDomain" };
+  return {};
 }
 
 /**
@@ -906,43 +938,44 @@ for await (let x of res.textStream) {
               debug('cloudbaserc.json creation skipped:', error instanceof Error ? error : new Error(String(error)));
             }
 
+            let preferredAccessUrl: string | undefined;
+            let preferredAccessUrls: string[] = [];
+            let preferredAccessSource: string | undefined;
+            try {
+              const serviceDetails = await cloudrunService.detail({
+                serverName: input.serverName,
+              });
+              const fallback = resolveCloudRunFallbackAccess(serviceDetails as any);
+              const gateway = await resolveGatewayAccessUrls({
+                envId: currentEnvId,
+                upstreamResourceName: input.serverName,
+                upstreamResourceTypes: ["CBR"],
+                getManager: async () => {
+                  const manager = await getManager();
+                  if (!manager) {
+                    throw new Error("cloudbase manager unavailable");
+                  }
+                  return manager as any;
+                },
+              });
+              const preferred = preferGatewayOrFallback({
+                gateway,
+                fallbackUrl: fallback.url,
+                fallbackSource: fallback.source,
+              });
+              preferredAccessUrl = preferred.accessUrl;
+              preferredAccessUrls = preferred.accessUrls;
+              preferredAccessSource = preferred.accessUrlSource;
+            } catch {
+              // best-effort URL enrichment only
+            }
+
             // Send deployment notification to CodeBuddy IDE
             try {
-              // Query service details to get access URL
-              let serviceUrl = "";
-              try {
-                const serviceDetails = await cloudrunService.detail({ serverName: input.serverName });
-                // Extract access URL from service details
-                // Priority: DefaultDomainName > CustomDomainName > PublicDomain > InternalDomain
-                const details = serviceDetails as any; // Use any to access dynamic properties
-                if (details?.BaseInfo?.DefaultDomainName) {
-                  // DefaultDomainName is already a complete URL (e.g., https://...)
-                  serviceUrl = details.BaseInfo.DefaultDomainName;
-                } else if (details?.BaseInfo?.CustomDomainName) {
-                  // CustomDomainName might be a domain without protocol
-                  const customDomain = details.BaseInfo.CustomDomainName;
-                  serviceUrl = customDomain.startsWith('http') ? customDomain : `https://${customDomain}`;
-                } else if (details?.BaseInfo?.PublicDomain) {
-                  serviceUrl = `https://${details.BaseInfo.PublicDomain}`;
-                } else if (details?.BaseInfo?.InternalDomain) {
-                  serviceUrl = `https://${details.BaseInfo.InternalDomain}`;
-                } else if (details?.AccessInfo?.PublicDomain) {
-                  serviceUrl = `https://${details.AccessInfo.PublicDomain}`;
-                } else {
-                  serviceUrl = ""; // URL not available
-                }
-              } catch (detailErr) {
-                // If query fails, continue with empty URL
-                serviceUrl = "";
-              }
-
-              // Extract project name from targetPath
               const projectName = path.basename(targetPath);
-
-              // Send notification
               await sendDeployNotification(server, {
                 deployType: 'cloudrun',
-                url: serviceUrl,
+                url: preferredAccessUrl ?? "",
                 projectId: currentEnvId,
                 projectName: projectName,
                 consoleUrl: consoleUrl
@@ -974,6 +1007,13 @@ for await (let x of res.textStream) {
                       serverType: serverType,
                       cloudbasercGenerated: true,
                       consoleUrl,
+                      ...(preferredAccessUrl ? { accessUrl: preferredAccessUrl } : {}),
+                      ...(preferredAccessUrls.length > 0
+                        ? { accessUrls: preferredAccessUrls }
+                        : {}),
+                      ...(preferredAccessSource
+                        ? { accessUrlSource: preferredAccessSource }
+                        : {}),
                       ...(warnings.length > 0 ? { warnings } : {}),
                     },
                     message: `Triggered deployment for ${serverType} service '${input.serverName}' from ${targetPath}. You can follow the progress in ${consoleUrl}.${warningSuffix}`

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -6,6 +6,7 @@ import {
 } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import { isCloudMode } from "../utils/cloud-mode.js";
+import { resolveGatewayAccessUrls } from "../utils/gateway-access-urls.js";
 import { jsonContent } from "../utils/json-content.js";
 import { debug } from "../utils/logger.js";
 
@@ -1228,10 +1229,35 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           ? `已创建 HTTP 函数 ${functionName}。如果后续需要通过 URL 访问，请显式调用 manageGateway(action="createRoute")，并把 upstreamResourceType="WEB_SCF" 一起传入，再按实际路径和鉴权需求创建访问入口。评测或其他外部调用方可能会以匿名身份访问，而且失败后不一定会把 EXCEED_AUTHORITY 再反馈给 AI；交付前请主动确认访问路径和函数安全规则，若已出现 EXCEED_AUTHORITY，请先调用 queryPermissions(action="getResourcePermission", resourceType="function", resourceId="${functionName}") 查看当前规则，再按需要使用 managePermissions(action="updateResourcePermission") 调整权限。`
           : `已创建函数 ${functionName}`;
 
+      let accessUrl: string | undefined;
+      let accessUrls: string[] = [];
+      let accessUrlSource: string | undefined;
+      if (func.type === "HTTP") {
+        const envId = cloudBaseOptions?.envId ?? await getEnvId(cloudBaseOptions);
+        const gateway = await resolveGatewayAccessUrls({
+          envId,
+          upstreamResourceName: functionName,
+          upstreamResourceTypes: ["WEB_SCF", "SCF"],
+          getManager: async () => {
+            const manager = await getManager();
+            if (!manager) {
+              throw new Error("cloudbase manager unavailable");
+            }
+            return manager as any;
+          },
+        });
+        accessUrl = gateway.accessUrl;
+        accessUrls = gateway.accessUrls;
+        accessUrlSource = gateway.accessUrlSource;
+      }
+
       return buildEnvelope(
         {
           action: input.action,
           functionName,
+          ...(accessUrl ? { accessUrl } : {}),
+          ...(accessUrls.length > 0 ? { accessUrls } : {}),
+          ...(accessUrlSource ? { accessUrlSource } : {}),
           raw: result as Record<string, unknown>,
         },
         message,
@@ -1281,12 +1307,34 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
           );
         }
         logCloudBaseResult(server.logger, imageResult);
+        const envId = cloudBaseOptions?.envId ?? await getEnvId(cloudBaseOptions);
+        const imageGatewayAccess = await resolveGatewayAccessUrls({
+          envId,
+          upstreamResourceName: input.functionName,
+          upstreamResourceTypes: ["WEB_SCF", "SCF"],
+          getManager: async () => {
+            const manager = await getManager();
+            if (!manager) {
+              throw new Error("cloudbase manager unavailable");
+            }
+            return manager as any;
+          },
+        });
         return buildEnvelope(
           {
             action: input.action,
             functionName: input.functionName,
             deployMode: "image",
             imageUri: updateImageConfig.imageUri,
+            ...(imageGatewayAccess.accessUrl
+              ? { accessUrl: imageGatewayAccess.accessUrl }
+              : {}),
+            ...(imageGatewayAccess.accessUrls.length > 0
+              ? { accessUrls: imageGatewayAccess.accessUrls }
+              : {}),
+            ...(imageGatewayAccess.accessUrlSource
+              ? { accessUrlSource: imageGatewayAccess.accessUrlSource }
+              : {}),
             raw: imageResult as Record<string, unknown>,
           },
           `已将函数 ${input.functionName} 的镜像更新为 ${updateImageConfig.imageUri}。` +
@@ -1331,10 +1379,30 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       }
 
       logCloudBaseResult(server.logger, result);
+      const envId = cloudBaseOptions?.envId ?? await getEnvId(cloudBaseOptions);
+      const gatewayAccess = await resolveGatewayAccessUrls({
+        envId,
+        upstreamResourceName: input.functionName,
+        upstreamResourceTypes: ["WEB_SCF", "SCF"],
+        getManager: async () => {
+          const manager = await getManager();
+          if (!manager) {
+            throw new Error("cloudbase manager unavailable");
+          }
+          return manager as any;
+        },
+      });
       return buildEnvelope(
         {
           action: input.action,
           functionName: input.functionName,
+          ...(gatewayAccess.accessUrl ? { accessUrl: gatewayAccess.accessUrl } : {}),
+          ...(gatewayAccess.accessUrls.length > 0
+            ? { accessUrls: gatewayAccess.accessUrls }
+            : {}),
+          ...(gatewayAccess.accessUrlSource
+            ? { accessUrlSource: gatewayAccess.accessUrlSource }
+            : {}),
           raw: result as Record<string, unknown>,
         },
         `已更新函数 ${input.functionName} 的代码`,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -5,6 +5,11 @@ import {
   logCloudBaseResult,
 } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
+import {
+  rankGatewayAccessUrls,
+  toAccessUrlEnvelope,
+  type GatewayRouteUrlCandidate,
+} from "../utils/gateway-access-urls.js";
 import { jsonContent } from "../utils/json-content.js";
 
 const QUERY_GATEWAY_ACTIONS = [
@@ -160,17 +165,34 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       })),
     );
 
-  const buildRouteUrls = (routes: FlatRoute[]) =>
-    Array.from(
-      new Set(
-        routes
-          .filter((route) => route.Domain && route.Path)
-          .map(
-            (route) =>
-              `https://${route.Domain}${normalizeAccessPath(String(route.Path))}`,
-          ),
-      ),
-    );
+  const buildRouteUrls = (routes: FlatRoute[]) => {
+    const candidates: GatewayRouteUrlCandidate[] = routes.map((route) => ({
+      Domain: route.Domain,
+      Path: route.Path,
+      IsDefault: route.IsDefault,
+      UpstreamResourceType: route.UpstreamResourceType,
+      UpstreamResourceName: route.UpstreamResourceName,
+    }));
+    return rankGatewayAccessUrls(candidates).map((item) => item.url);
+  };
+
+  const buildAccessUrlFields = (routes: FlatRoute[]) => {
+    const candidates: GatewayRouteUrlCandidate[] = routes.map((route) => ({
+      Domain: route.Domain,
+      Path: route.Path,
+      IsDefault: route.IsDefault,
+      UpstreamResourceType: route.UpstreamResourceType,
+      UpstreamResourceName: route.UpstreamResourceName,
+    }));
+    const envelope = toAccessUrlEnvelope(rankGatewayAccessUrls(candidates));
+    return {
+      ...(envelope.accessUrl ? { accessUrl: envelope.accessUrl } : {}),
+      accessUrls: envelope.accessUrls,
+      ...(envelope.accessUrlSource
+        ? { accessUrlSource: envelope.accessUrlSource }
+        : {}),
+    };
+  };
 
   const resolveDefaultHttpDomain = async () => {
     const routeInfo = await listHttpServiceRoutes();
@@ -356,6 +378,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             action: input.action,
             routes,
             urls: buildRouteUrls(routes),
+            ...buildAccessUrlFields(routes),
             total: result.TotalCount ?? routes.length,
             raw: result,
           },
@@ -409,6 +432,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             routes: matches,
             total: matches.length,
             urls,
+            ...buildAccessUrlFields(matches),
             raw: result,
           },
           matches.length === 0
@@ -473,6 +497,12 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             auth: payload.resolved.enableAuth ?? null,
             enablePathTransmission:
               payload.resolved.enablePathTransmission ?? null,
+            accessUrl: `https://${payload.resolved.domain}${payload.resolved.path}`,
+            accessUrls: [`https://${payload.resolved.domain}${payload.resolved.path}`],
+            accessUrlSource:
+              input.domain && input.domain === payload.resolved.domain
+                ? "gateway.custom"
+                : "gateway.default",
             raw: result,
           },
           `已为目标 ${payload.resolved.upstreamResourceName} 在域名 ${payload.resolved.domain} 创建路由 ${payload.resolved.path}（${payload.resolved.upstreamResourceType}）` +
@@ -505,6 +535,12 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             auth: payload.resolved.enableAuth ?? null,
             enablePathTransmission:
               payload.resolved.enablePathTransmission ?? null,
+            accessUrl: `https://${payload.resolved.domain}${payload.resolved.path}`,
+            accessUrls: [`https://${payload.resolved.domain}${payload.resolved.path}`],
+            accessUrlSource:
+              input.domain && input.domain === payload.resolved.domain
+                ? "gateway.custom"
+                : "gateway.default",
             raw: result,
           },
           `HTTP 路由更新成功（${payload.resolved.domain}${payload.resolved.path}` +

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -4,6 +4,7 @@ import { z } from 'zod';
 import { getCloudBaseManager, getEnvId, logCloudBaseResult } from '../cloudbase-manager.js';
 import { ExtendedMcpServer } from '../server.js';
 import { isCloudMode } from '../utils/cloud-mode.js';
+import { preferGatewayOrFallback, resolveGatewayAccessUrls } from '../utils/gateway-access-urls.js';
 import { sendDeployNotification } from '../utils/notification.js';
 import { buildJsonToolResult, toolPayloadErrorToResult } from '../utils/tool-result.js';
 
@@ -697,10 +698,53 @@ export function registerHostingTools(server: ExtendedMcpServer) {
             // StaticDomain there but not in DescribeStaticStore.
             const cdnFromStore = (store.CdnDomain ?? store.StaticDomain) as string | undefined;
             const staticDomain = cdnFromStore || await resolveHostingStaticDomain(cloudbase, server.logger);
-            const accessUrl = buildHostingAccessUrl(staticDomain, input.cloudPath, input.localPath);
+            const fallbackAccessUrl = buildHostingAccessUrl(staticDomain, input.cloudPath, input.localPath);
+            const envId = await getEnvId(cloudBaseOptions);
+            const gatewayCandidates = Array.from(
+              new Set(
+                [
+                  store.StaticStoreName,
+                  store.Name,
+                  store.StoreName,
+                  store.Bucket,
+                  "staticstore",
+                ]
+                  .map((item) => (typeof item === "string" ? item.trim() : ""))
+                  .filter(Boolean),
+              ),
+            );
+            let accessUrl = fallbackAccessUrl;
+            let accessUrls = accessUrl ? [accessUrl] : [];
+            let accessUrlSource: string | undefined = accessUrl
+              ? "hosting.staticDomain"
+              : undefined;
+            for (const upstreamName of gatewayCandidates) {
+              const gateway = await resolveGatewayAccessUrls({
+                envId,
+                upstreamResourceName: upstreamName,
+                upstreamResourceTypes: ["STATIC_STORE"],
+                getManager: async () => {
+                  const manager = await getManager();
+                  if (!manager) {
+                    throw new Error("cloudbase manager unavailable");
+                  }
+                  return manager as any;
+                },
+              });
+              const preferred = preferGatewayOrFallback({
+                gateway,
+                fallbackUrl: fallbackAccessUrl || undefined,
+                fallbackSource: "hosting.staticDomain",
+              });
+              if (preferred.accessUrl) {
+                accessUrl = preferred.accessUrl;
+                accessUrls = preferred.accessUrls;
+                accessUrlSource = preferred.accessUrlSource;
+                break;
+              }
+            }
 
             try {
-              const envId = await getEnvId(cloudBaseOptions);
               let projectName = 'unknown';
               if (input.localPath) {
                 try {
@@ -735,6 +779,8 @@ export function registerHostingTools(server: ExtendedMcpServer) {
                 ignore: input.ignore,
                 staticDomain,
                 accessUrl,
+                accessUrls,
+                accessUrlSource,
                 result,
                 nextActions: uploadPrefix ? [buildFindFilesNextStep(uploadPrefix.replace(/^\/+/, ''))] : undefined,
               },

--- a/mcp/src/utils/gateway-access-urls.test.ts
+++ b/mcp/src/utils/gateway-access-urls.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterRoutesByUpstream,
+  flattenHttpServiceRoutes,
+  preferGatewayOrFallback,
+  rankGatewayAccessUrls,
+  toAccessUrlEnvelope,
+} from "./gateway-access-urls.js";
+
+describe("gateway-access-urls", () => {
+  it("ranks custom domain URLs before default domain URLs", () => {
+    const ranked = rankGatewayAccessUrls([
+      {
+        Domain: "env-test.service.tcloudbase.com",
+        Path: "/api",
+        IsDefault: true,
+        UpstreamResourceName: "hello",
+        UpstreamResourceType: "WEB_SCF",
+      },
+      {
+        Domain: "api.example.com",
+        Path: "/api",
+        IsDefault: false,
+        UpstreamResourceName: "hello",
+        UpstreamResourceType: "WEB_SCF",
+      },
+    ]);
+
+    expect(ranked.map((item) => item.url)).toEqual([
+      "https://api.example.com/api",
+      "https://env-test.service.tcloudbase.com/api",
+    ]);
+    expect(ranked[0].source).toBe("gateway.custom");
+    expect(ranked[1].source).toBe("gateway.default");
+  });
+
+  it("dedupes identical URLs and normalizes paths", () => {
+    const ranked = rankGatewayAccessUrls([
+      {
+        Domain: "api.example.com",
+        Path: "api",
+        IsDefault: false,
+      },
+      {
+        Domain: "api.example.com",
+        Path: "/api",
+        IsDefault: false,
+      },
+    ]);
+
+    expect(ranked).toHaveLength(1);
+    expect(ranked[0].url).toBe("https://api.example.com/api");
+  });
+
+  it("returns empty envelope when no routes match", () => {
+    expect(toAccessUrlEnvelope([])).toEqual({
+      accessUrls: [],
+      routes: [],
+    });
+  });
+
+  it("flattens and filters routes by upstream type and name", () => {
+    const flattened = flattenHttpServiceRoutes({
+      Domains: [
+        {
+          Domain: "api.example.com",
+          IsDefault: false,
+          Routes: [
+            {
+              Path: "/run",
+              UpstreamResourceType: "CBR",
+              UpstreamResourceName: "my-service",
+            },
+            {
+              Path: "/fn",
+              UpstreamResourceType: "WEB_SCF",
+              UpstreamResourceName: "hello",
+            },
+          ],
+        },
+      ],
+    });
+
+    const matched = filterRoutesByUpstream(flattened, {
+      upstreamResourceName: "my-service",
+      upstreamResourceTypes: ["CBR"],
+    });
+
+    expect(matched).toHaveLength(1);
+    expect(matched[0].Path).toBe("/run");
+  });
+
+  it("prefers gateway URLs over resource-native fallback", () => {
+    const preferred = preferGatewayOrFallback({
+      gateway: {
+        accessUrl: "https://api.example.com/app",
+        accessUrls: ["https://api.example.com/app"],
+        accessUrlSource: "gateway.custom",
+        routes: [],
+      },
+      fallbackUrl: "https://env.tcloudbaseapp.com/app/",
+      fallbackSource: "hosting.staticDomain",
+    });
+
+    expect(preferred).toEqual({
+      accessUrl: "https://api.example.com/app",
+      accessUrls: [
+        "https://api.example.com/app",
+        "https://env.tcloudbaseapp.com/app/",
+      ],
+      accessUrlSource: "gateway.custom",
+    });
+  });
+
+  it("falls back to resource-native URL when gateway has no match", () => {
+    const preferred = preferGatewayOrFallback({
+      gateway: { accessUrls: [], routes: [] },
+      fallbackUrl: "https://svc.run.tcloudbase.com",
+      fallbackSource: "cloudrun.defaultDomain",
+    });
+
+    expect(preferred).toEqual({
+      accessUrl: "https://svc.run.tcloudbase.com",
+      accessUrls: ["https://svc.run.tcloudbase.com"],
+      accessUrlSource: "cloudrun.defaultDomain",
+    });
+  });
+});

--- a/mcp/src/utils/gateway-access-urls.ts
+++ b/mcp/src/utils/gateway-access-urls.ts
@@ -1,0 +1,229 @@
+export type GatewayUpstreamResourceType =
+  | "SCF"
+  | "WEB_SCF"
+  | "CBR"
+  | "STATIC_STORE"
+  | "LH"
+  | string;
+
+export type GatewayAccessUrlSource =
+  | "gateway.custom"
+  | "gateway.default";
+
+export type GatewayRouteUrlCandidate = {
+  Domain: string;
+  Path?: string;
+  IsDefault?: boolean;
+  UpstreamResourceType?: string;
+  UpstreamResourceName?: string;
+};
+
+export type RankedGatewayAccessUrl = {
+  url: string;
+  domain: string;
+  path: string;
+  isDefault: boolean;
+  source: GatewayAccessUrlSource;
+};
+
+export type ResolveGatewayAccessUrlsResult = {
+  accessUrl?: string;
+  accessUrls: string[];
+  accessUrlSource?: GatewayAccessUrlSource;
+  routes: RankedGatewayAccessUrl[];
+};
+
+function normalizeAccessPath(path: string | undefined): string {
+  if (!path) {
+    return "/";
+  }
+  return path.startsWith("/") ? path : `/${path}`;
+}
+
+function buildHttpsUrl(domain: string, path: string): string {
+  return `https://${domain}${normalizeAccessPath(path)}`;
+}
+
+/**
+ * Rank gateway route URLs: custom domains (IsDefault !== true) before default domain.
+ * Stable within each group; dedupe by full URL.
+ */
+export function rankGatewayAccessUrls(
+  routes: GatewayRouteUrlCandidate[],
+): RankedGatewayAccessUrl[] {
+  const mapped = routes
+    .filter((route) => Boolean(route.Domain))
+    .map((route) => {
+      const path = normalizeAccessPath(route.Path);
+      const isDefault = route.IsDefault === true;
+      return {
+        url: buildHttpsUrl(route.Domain, path),
+        domain: route.Domain,
+        path,
+        isDefault,
+        source: (isDefault
+          ? "gateway.default"
+          : "gateway.custom") as GatewayAccessUrlSource,
+      };
+    });
+
+  mapped.sort((a, b) => {
+    if (a.isDefault === b.isDefault) {
+      return 0;
+    }
+    return a.isDefault ? 1 : -1;
+  });
+
+  const seen = new Set<string>();
+  const deduped: RankedGatewayAccessUrl[] = [];
+  for (const item of mapped) {
+    if (seen.has(item.url)) {
+      continue;
+    }
+    seen.add(item.url);
+    deduped.push(item);
+  }
+  return deduped;
+}
+
+export function flattenHttpServiceRoutes(result: {
+  Domains?: Array<{
+    Domain?: string;
+    IsDefault?: boolean;
+    Routes?: Array<Record<string, unknown>>;
+  }>;
+}): GatewayRouteUrlCandidate[] {
+  return (result.Domains ?? []).flatMap((domainItem) =>
+    (domainItem.Routes ?? []).map((route) => ({
+      Domain: domainItem.Domain ?? "",
+      IsDefault: domainItem.IsDefault,
+      Path: typeof route.Path === "string" ? route.Path : undefined,
+      UpstreamResourceType:
+        typeof route.UpstreamResourceType === "string"
+          ? route.UpstreamResourceType
+          : undefined,
+      UpstreamResourceName:
+        typeof route.UpstreamResourceName === "string"
+          ? route.UpstreamResourceName
+          : undefined,
+    })),
+  );
+}
+
+export function filterRoutesByUpstream(
+  routes: GatewayRouteUrlCandidate[],
+  input: {
+    upstreamResourceName: string;
+    upstreamResourceTypes?: GatewayUpstreamResourceType[];
+  },
+): GatewayRouteUrlCandidate[] {
+  const name = input.upstreamResourceName;
+  const types = input.upstreamResourceTypes?.map((t) => String(t));
+  return routes.filter((route) => {
+    if (route.UpstreamResourceName !== name) {
+      return false;
+    }
+    if (!types || types.length === 0) {
+      return true;
+    }
+    return Boolean(
+      route.UpstreamResourceType &&
+        types.includes(String(route.UpstreamResourceType)),
+    );
+  });
+}
+
+export function toAccessUrlEnvelope(
+  ranked: RankedGatewayAccessUrl[],
+): ResolveGatewayAccessUrlsResult {
+  if (ranked.length === 0) {
+    return { accessUrls: [], routes: [] };
+  }
+  return {
+    accessUrl: ranked[0].url,
+    accessUrls: ranked.map((item) => item.url),
+    accessUrlSource: ranked[0].source,
+    routes: ranked,
+  };
+}
+
+type CloudBaseManagerLike = {
+  env: {
+    describeHttpServiceRoute: (params: {
+      EnvId: string;
+      Limit?: number;
+    }) => Promise<{
+      Domains?: Array<{
+        Domain?: string;
+        IsDefault?: boolean;
+        Routes?: Array<Record<string, unknown>>;
+      }>;
+    }>;
+  };
+};
+
+/**
+ * Best-effort lookup of gateway access URLs for an upstream resource.
+ * Never throws — returns empty lists on failure.
+ */
+export async function resolveGatewayAccessUrls(input: {
+  envId: string;
+  upstreamResourceName: string;
+  upstreamResourceTypes?: GatewayUpstreamResourceType[];
+  getManager: () => Promise<CloudBaseManagerLike>;
+}): Promise<ResolveGatewayAccessUrlsResult> {
+  try {
+    const manager = await input.getManager();
+    const result = await manager.env.describeHttpServiceRoute({
+      EnvId: input.envId,
+      Limit: 1000,
+    });
+    const flattened = flattenHttpServiceRoutes(result);
+    const matched = filterRoutesByUpstream(flattened, {
+      upstreamResourceName: input.upstreamResourceName,
+      upstreamResourceTypes: input.upstreamResourceTypes,
+    });
+    return toAccessUrlEnvelope(rankGatewayAccessUrls(matched));
+  } catch {
+    return { accessUrls: [], routes: [] };
+  }
+}
+
+/**
+ * Merge ranked gateway URLs with a resource-native fallback URL.
+ * Gateway custom/default always win over the fallback when present.
+ */
+export function preferGatewayOrFallback(input: {
+  gateway: ResolveGatewayAccessUrlsResult;
+  fallbackUrl?: string;
+  fallbackSource?: string;
+}): {
+  accessUrl?: string;
+  accessUrls: string[];
+  accessUrlSource?: string;
+} {
+  if (input.gateway.accessUrl) {
+    const urls = [...input.gateway.accessUrls];
+    if (
+      input.fallbackUrl &&
+      !urls.includes(input.fallbackUrl)
+    ) {
+      urls.push(input.fallbackUrl);
+    }
+    return {
+      accessUrl: input.gateway.accessUrl,
+      accessUrls: urls,
+      accessUrlSource: input.gateway.accessUrlSource,
+    };
+  }
+
+  if (input.fallbackUrl) {
+    return {
+      accessUrl: input.fallbackUrl,
+      accessUrls: [input.fallbackUrl],
+      accessUrlSource: input.fallbackSource,
+    };
+  }
+
+  return { accessUrls: [] };
+}

--- a/plugin/cloudbase/skills/cloud-functions/SKILL.md
+++ b/plugin/cloudbase/skills/cloud-functions/SKILL.md
@@ -334,6 +334,7 @@ If these are unavailable, read `./references/operations-and-config.md` before an
 - `queryGateway(action="getRoute")` / `listRoutes` / `listCustomDomains`
 - `manageGateway(action="createRoute")` — for HTTP functions pass `upstreamResourceType="WEB_SCF"`; for Event functions pass `upstreamResourceType="SCF"`. Omit `domain` to use the environment default (`IsDefault`)
 - `manageGateway(action="updateRoute")` / `deleteRoute` / `bindCustomDomain` / `deleteCustomDomain`
+- When tool results include `accessUrl` / `accessUrls`, prefer them directly (gateway custom-domain URLs are ranked before default domains)
 - Do **not** call deprecated GWAPI actions via `callCloudApi` (`CreateCloudBaseGWAPI`, etc.)
 
 ## Related skills

--- a/plugin/cloudbase/skills/cloud-functions/references/http-functions-custom-image.md
+++ b/plugin/cloudbase/skills/cloud-functions/references/http-functions-custom-image.md
@@ -99,7 +99,7 @@ manageFunctions({
 | `imagePort` | — | Web Server: `9000` (default). Job-style image: `-1`. |
 | `containerImageAccelerate` | — | Image acceleration; enable for large images to cut cold-start time. |
 
-After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. For public/browser access, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
+After deploy, confirm readiness with `queryFunctions(action="getFunctionDetail", functionName="my-scf-func")` and look for `Status=Active`. If the tool result already contains `accessUrl` / `accessUrls`, prefer those links directly. If no URL is returned yet, create a Domain/Route explicitly with `manageGateway(action="createRoute", upstreamResourceType="WEB_SCF")` and set the function security rule (anonymous login is disabled by default — see `http-functions.md`).
 
 ## Source packaging (Stage A input)
 

--- a/plugin/cloudbase/skills/cloud-functions/references/operations-and-config.md
+++ b/plugin/cloudbase/skills/cloud-functions/references/operations-and-config.md
@@ -75,6 +75,7 @@ Upstream type:
 
 Do **not** use deprecated GWAPI / `CreateCloudBaseGWAPI` via `callCloudApi` (blocked in evaluate mode and removed from MCP).
 Do **not** pass `manageFunctions` `type="HTTP"|"Event"` into `manageGateway`; gateway uses `upstreamResourceType` only.
+When a deploy/create tool returns `accessUrl` or `accessUrls`, prefer those values directly; they already rank gateway custom domains before default domains when routes exist.
 ## Environment variable updates
 
 Do not overwrite function environment variables blindly.

--- a/specs/prefer-gateway-custom-domain-urls/design.md
+++ b/specs/prefer-gateway-custom-domain-urls/design.md
@@ -1,0 +1,49 @@
+# 技术方案
+
+## 架构
+
+共享解析器 `mcp/src/utils/gateway-access-urls.ts`：
+
+1. 调用 `env.describeHttpServiceRoute`
+2. Flatten Domains × Routes
+3. 按 `UpstreamResourceType` + `UpstreamResourceName` 过滤
+4. 生成 `https://{Domain}{Path}`，自定义域名（`IsDefault !== true`）排在默认域名之前
+5. Soft-fail：异常返回空列表，由调用方回退
+
+## 调用面
+
+| 工具 | 行为 |
+|------|------|
+| `queryGateway` / `manageGateway` | URL 列表按上述规则排序；create/update 成功 envelope 增加 `accessUrl` / `accessUrls` / `accessUrlSource` |
+| `manageCloudRun` deploy | 优先网关 `CBR`；回退 CustomDomainName → DefaultDomainName → PublicDomain |
+| `manageHosting` upload | 优先网关 `STATIC_STORE`；回退 StaticDomain |
+| `manageApps` deployApp | 优先网关 `STATIC_STORE`（serviceName）；回退 app Domain |
+| `manageFunctions` HTTP create/update | 有 `WEB_SCF`/`SCF` 路由时附带 accessUrls |
+
+## Envelope
+
+```ts
+{
+  accessUrl?: string;
+  accessUrls?: string[];
+  accessUrlSource?:
+    | "gateway.custom"
+    | "gateway.default"
+    | "hosting.staticDomain"
+    | "apps.domain"
+    | "cloudrun.customDomain"
+    | "cloudrun.defaultDomain"
+    | "cloudrun.publicDomain"
+    | "cloudrun.internalDomain";
+}
+```
+
+## 测试策略
+
+- 纯函数排序单测（自定义优先、去重、空列表）
+- 工具单测 mock `describeHttpServiceRoute`
+- Soft-fail：网关抛错时部署仍成功且回退原生 URL
+
+## 安全性
+
+不发明域名/路径；不自动绑定证书或创建路由。

--- a/specs/prefer-gateway-custom-domain-urls/requirements.md
+++ b/specs/prefer-gateway-custom-domain-urls/requirements.md
@@ -1,0 +1,33 @@
+# 需求文档
+
+## 介绍
+
+云函数、静态托管、云托管部署成功后，工具常返回资源原生默认域名。若 HTTP 网关已将自定义域名路由到同一上游，应优先展示自定义域名访问地址，避免 Agent 继续分享默认域名。
+
+## 需求
+
+### 需求 1 - 网关 URL 排序偏好自定义域名
+
+**用户故事：** 作为查询或创建网关路由的开发者，我希望返回的访问链接优先是自定义域名，这样对外分享的链接与生产一致。
+
+#### 验收标准
+
+1. When `queryGateway` / `manageGateway` 返回某资源相关路由 URL 时，the MCP shall 将 `IsDefault !== true` 的域名 URL 排在 `IsDefault === true` 的默认 HTTP 域名之前。
+2. When 同一上游存在多条路由时，the MCP shall 去重后保留排序结果，且不得发明未出现在 `describeHttpServiceRoute` 中的域名或路径。
+
+### 需求 2 - 部署成功回包优先网关自定义域名
+
+**用户故事：** 作为部署应用的开发者，我希望部署成功后工具直接给出应优先使用的公网地址（若已配置网关自定义域名）。
+
+#### 验收标准
+
+1. When 云函数 HTTP / 静态托管上传 / 云托管部署 / Apps 部署成功且网关已有匹配上游路由时，the MCP shall 在成功 envelope 中提供 `accessUrl`、`accessUrls`、`accessUrlSource`，且优先使用网关自定义域名。
+2. When 网关查询失败或无匹配路由时，the MCP shall 回退到既有资源原生默认域名逻辑，且不得导致部署失败。
+
+### 需求 3 - 透明来源标记
+
+**用户故事：** 作为 Agent，我希望知道当前 `accessUrl` 来自网关自定义域名还是资源默认域名，以便正确提示用户。
+
+#### 验收标准
+
+1. When 返回 `accessUrl` 时，the MCP shall 同时返回可机读的 `accessUrlSource`（如 `gateway.custom` / `gateway.default` / 资源原生来源枚举值）。

--- a/specs/prefer-gateway-custom-domain-urls/tasks.md
+++ b/specs/prefer-gateway-custom-domain-urls/tasks.md
@@ -1,0 +1,19 @@
+# 实施计划
+
+- [ ] 1. Shared helper + unit tests
+  - Add `mcp/src/utils/gateway-access-urls.ts`
+  - Export `rankGatewayAccessUrls` and `resolveGatewayAccessUrls`
+  - _需求: 1, 2, 3_
+
+- [ ] 2. Gateway tools ranking + envelope fields
+  - Update `mcp/src/tools/gateway.ts` and `gateway.test.ts`
+  - _需求: 1, 3_
+
+- [ ] 3. Post-deploy enrichment
+  - CloudRun / Hosting / Apps / Functions soft-fail enrichment
+  - Matching tool tests
+  - _需求: 2, 3_
+
+- [ ] 4. Skills / docs touch-up
+  - Only where accessUrl guidance already exists
+  - _需求: 2_


### PR DESCRIPTION
## Summary
- Prefer HTTP gateway **custom domains** (`IsDefault !== true`) over default domains when returning public access URLs after deploy/create.
- Soft-fail gateway enrichment so CloudRun / hosting / apps / functions success paths stay intact if gateway lookup fails.
- Surface ranked `accessUrl` / `accessUrls` / `accessUrlSource` on gateway and deploy envelopes; update cloud-functions skills to prefer tool-returned URLs.

## Test plan
- [ ] Unit: `mcp/src/utils/gateway-access-urls.test.ts` (ranking + soft-fail)
- [ ] Unit: gateway / hosting / apps / functions suites still pass
- [ ] Manual: deploy CloudRun with a gateway custom domain → envelope prefers custom domain
- [ ] Manual: hosting/apps static deploy with `STATIC_STORE` gateway route → prefer gateway URL
- [ ] Manual: create HTTP function / updateFunctionCode → best-effort `WEB_SCF`/`SCF` gateway URLs without breaking deploy on gateway errors


Made with [Cursor](https://cursor.com)