### PR TITLE
feat(cloudrun): 🔧 preserve remote config on deploy and add updateConfig

### DIFF
--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -128,7 +128,8 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> deploy local project
+- `manageCloudRun(action="deploy")` -> deploy local project (existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes)
+- `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="delete")` -> delete service
 - `manageCloudRun(action="createAgent")` -> create Agent service
 

--- a/config/source/skills/cloudrun-development/references/vpc-and-database.md
+++ b/config/source/skills/cloudrun-development/references/vpc-and-database.md
@@ -27,8 +27,11 @@ Practical agent rules:
 
 1. Always pass `serverConfig.VpcConf` when the app needs TCP access to a VPC DB/cache.
 2. Prefer correct VPC on **first** create.
-3. If the service already exists: redeploy with `VpcConf`, then **verify** with `queryCloudRun(action="detail")` (`ServerConfig.VpcConf`).
-4. If detail still shows missing/wrong VPC after a successful update deploy, fall back to console network settings or delete + recreate — do not loop blind redeploys.
+3. If the service already exists:
+   - Prefer `manageCloudRun(action="updateConfig")` to change VPC / EnvParams / MinNum without re-uploading code (console-aligned `SubmitServerConfigChangeDiff`).
+   - Or redeploy with `VpcConf`. MCP **deploy** uses Read-Merge-Write: omitting `VpcConf` / partial `EnvParams` / omitting `OpenAccessTypes` **preserves** remote values (set `envParamsReplaceAll=true` only when you intend a full env replace).
+   - Then **verify** with `queryCloudRun(action="detail")` (`ServerConfig.VpcConf`).
+4. If detail still shows missing/wrong VPC after a successful update, fall back to console network settings or delete + recreate — do not loop blind redeploys.
 
 ## When VpcConf is mandatory
 
@@ -102,7 +105,8 @@ Missing `VpcConf` here commonly yields deploy **success** followed by runtime `E
 
 | Symptom | Likely cause | Fix |
 | --- | --- | --- |
-| Deploy OK, app cannot connect to DB | Missing/wrong VPC, or old SDK dropped `VpcConf` | Redeploy with `VpcConf` on SDK &gt;= 5.6.2; verify via `detail`; if still wrong, console network settings or recreate |
+| Deploy OK, app cannot connect to DB | Missing/wrong VPC, or old SDK dropped `VpcConf` | Use `updateConfig` or redeploy with `VpcConf` on SDK &gt;= 5.6.2; verify via `detail`; if still wrong, console or recreate |
+| Redeploy wiped console VPC / env keys | Partial deploy without merge (legacy) | Current MCP deploy RMW preserves remote `VpcConf` / EnvParams keys / `OpenAccessTypes`; prefer `updateConfig` for config-only changes |
 | Timeout to DB IP | Security group / ACL | Allow CloudRun subnet CIDR on DB port |
 | Works locally, fails on CloudRun | Using `localhost` / docker-compose hostname | Replace with VPC private address |
 | Connected VPC but lost outbound Internet | Public egress disabled without NAT | Keep platform public egress, or add NAT gateway in VPC |
@@ -115,5 +119,5 @@ Missing `VpcConf` here commonly yields deploy **success** followed by runtime `E
 - [ ] `VpcId` + `SubnetId` resolved (same region as DB)
 - [ ] Private connection string prepared
 - [ ] Security group / allowlist planned
-- [ ] `manageCloudRun` deploy includes `serverConfig.VpcConf`
+- [ ] `manageCloudRun` deploy includes `serverConfig.VpcConf`, **or** `updateConfig` set VPC after create
 - [ ] Post-deploy connectivity verified

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1799,7 +1799,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.0），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.1），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -2007,7 +2007,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 ---
 
 ### `manageCloudRun`
-管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、删除服务。部署可配置CPU、内存、实例数、访问类型等参数。删除操作需要确认，建议设置force=true。
+管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。
 
 #### 参数
 
@@ -2017,7 +2017,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
       name: "action",
       type: "string",
       required: true,
-      description: `云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体） 可填写的值: "init", "download", "run", "deploy", "delete", "createAgent"`,
+      description: `云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体） 可填写的值: "init", "download", "run", "deploy", "delete", "createAgent", "updateConfig"`,
     },
     {
       name: "serverName",
@@ -2028,12 +2028,17 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
     {
       name: "targetPath",
       type: "string",
-      description: `本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun`,
+      description: `本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun`,
+    },
+    {
+      name: "envParamsReplaceAll",
+      type: "boolean",
+      description: `EnvParams 合并策略（deploy / updateConfig）：false（默认）= 与远程按 key 合并（输入覆盖同名 key，远程其余 key 保留）；true= 用输入 EnvParams 整包替换远程。仅当显式传入 EnvParams 时生效`,
     },
     {
       name: "serverConfig",
       type: "object",
-      description: `服务配置项，用于部署时设置服务的运行参数。包括资源规格、访问权限、环境变量、日志、网络等配置。不提供时使用默认配置`,
+      description: `服务配置项，用于 deploy / updateConfig。包括资源规格、访问权限、环境变量、日志、网络等。deploy 未提供时对已存在服务仍会从远程合并保留 VpcConf/EnvParams/OpenAccessTypes；updateConfig 至少需要一个配置字段`,
       children: [
         {
           name: "OpenAccessTypes",
@@ -2208,7 +2213,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
         {
           name: "VpcConf",
           type: "object",
-          description: `VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。MCP 在创建时会将 VpcConf 映射为 SDK vpcInfo(CreateType=2)；更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf，未生效再走控制台网络设置或删建兜底`,
+          description: `VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。创建时映射为 SDK vpcInfo(CreateType=2)；已存在服务可用 updateConfig 或 deploy（RMW 会保留未传入的远程 VpcConf）。部署/更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf`,
           children: [
             {
               name: "VpcId",

--- a/mcp/src/tools/cloudrun-config.test.ts
+++ b/mcp/src/tools/cloudrun-config.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertCpuMemPair,
+  listLikelyRedeployFields,
+  mergeCloudRunServerConfig,
+  parseServerConfigToDiffItems,
+  summarizeConfigSnapshot,
+} from "./cloudrun-config.js";
+
+describe("mergeCloudRunServerConfig", () => {
+  it("preserves remote VpcConf when input omits it", () => {
+    const { merged, mergedFromRemote } = mergeCloudRunServerConfig({
+      remote: {
+        VpcConf: { VpcId: "vpc-remote", SubnetId: "subnet-remote" },
+        OpenAccessTypes: ["PUBLIC"],
+      },
+      input: { MinNum: 1 },
+    });
+    expect(merged.VpcConf).toEqual({
+      VpcId: "vpc-remote",
+      SubnetId: "subnet-remote",
+    });
+    expect(mergedFromRemote).toContain("VpcConf");
+    expect(merged.OpenAccessTypes).toEqual(["PUBLIC"]);
+    expect(mergedFromRemote).toContain("OpenAccessTypes");
+  });
+
+  it("prefers complete input VpcConf over remote", () => {
+    const { merged, mergedFromRemote } = mergeCloudRunServerConfig({
+      remote: {
+        VpcConf: { VpcId: "vpc-old", SubnetId: "subnet-old" },
+      },
+      input: {
+        VpcConf: { VpcId: "vpc-new", SubnetId: "subnet-new" },
+      },
+    });
+    expect(merged.VpcConf).toEqual({
+      VpcId: "vpc-new",
+      SubnetId: "subnet-new",
+    });
+    expect(mergedFromRemote).not.toContain("VpcConf");
+  });
+
+  it("merges EnvParams by key and preserves remote-only keys", () => {
+    const { merged, mergedFromRemote } = mergeCloudRunServerConfig({
+      remote: {
+        EnvParams: JSON.stringify({ KEEP: "1", SHARED: "old" }),
+      },
+      input: {
+        EnvParams: JSON.stringify({ SHARED: "new", ADD: "2" }),
+      },
+    });
+    expect(JSON.parse(String(merged.EnvParams))).toEqual({
+      KEEP: "1",
+      SHARED: "new",
+      ADD: "2",
+    });
+    expect(mergedFromRemote).toContain("EnvParams");
+  });
+
+  it("replaces EnvParams entirely when envParamsReplaceAll is true", () => {
+    const { merged, mergedFromRemote } = mergeCloudRunServerConfig({
+      remote: {
+        EnvParams: JSON.stringify({ KEEP: "1", SHARED: "old" }),
+      },
+      input: {
+        EnvParams: JSON.stringify({ SHARED: "new" }),
+      },
+      envParamsReplaceAll: true,
+    });
+    expect(JSON.parse(String(merged.EnvParams))).toEqual({ SHARED: "new" });
+    expect(mergedFromRemote).not.toContain("EnvParams");
+  });
+
+  it("keeps input OpenAccessTypes when provided", () => {
+    const { merged, mergedFromRemote } = mergeCloudRunServerConfig({
+      remote: { OpenAccessTypes: ["OA", "PUBLIC", "MINIAPP"] },
+      input: { OpenAccessTypes: ["PUBLIC", "VPC"] },
+    });
+    expect(merged.OpenAccessTypes).toEqual(["PUBLIC", "VPC"]);
+    expect(mergedFromRemote).not.toContain("OpenAccessTypes");
+  });
+});
+
+describe("parseServerConfigToDiffItems", () => {
+  it("maps Cpu/Mem/OpenAccessTypes/EnvParams/VpcConf to Diff keys", () => {
+    const items = parseServerConfigToDiffItems({
+      Cpu: 0.5,
+      Mem: 1,
+      OpenAccessTypes: ["PUBLIC"],
+      EnvParams: '{"A":"1"}',
+      VpcConf: { VpcId: "vpc-1", SubnetId: "subnet-1" },
+      MinNum: 1,
+    });
+    const byKey = Object.fromEntries(items.map((i) => [i.Key, i]));
+    expect(byKey.CpuSpecs?.FloatValue).toBe(0.5);
+    expect(byKey.MemSpecs?.FloatValue).toBe(1);
+    expect(byKey.AccessTypes?.ArrayValue).toEqual(["PUBLIC"]);
+    expect(byKey.EnvParam?.Value).toBe('{"A":"1"}');
+    expect(byKey.VpcConf?.VpcConf).toEqual({
+      VpcId: "vpc-1",
+      SubnetId: "subnet-1",
+    });
+    expect(byKey.MinNum?.IntValue).toBe(1);
+  });
+
+  it("throws when Cpu is set without Mem", () => {
+    expect(() => parseServerConfigToDiffItems({ Cpu: 1 })).toThrow(/Cpu and Mem/);
+  });
+
+  it("assertCpuMemPair allows both unset", () => {
+    expect(() => assertCpuMemPair({})).not.toThrow();
+  });
+});
+
+describe("summarizeConfigSnapshot", () => {
+  it("returns env keys without values", () => {
+    const snap = summarizeConfigSnapshot({
+      VpcConf: { VpcId: "vpc-x", SubnetId: "subnet-y" },
+      EnvParams: JSON.stringify({ SECRET: "do-not-leak", NODE_ENV: "prod" }),
+      OpenAccessTypes: ["PUBLIC"],
+    });
+    expect(snap.hasVpcConf).toBe(true);
+    expect(snap.vpcId).toBe("vpc-x");
+    expect(snap.envParamKeys).toEqual(
+      expect.arrayContaining(["SECRET", "NODE_ENV"]),
+    );
+    expect(JSON.stringify(snap)).not.toContain("do-not-leak");
+  });
+});
+
+describe("listLikelyRedeployFields", () => {
+  it("lists VpcConf and EnvParams when present", () => {
+    expect(
+      listLikelyRedeployFields({
+        VpcConf: { VpcId: "vpc-1", SubnetId: "subnet-1" },
+        EnvParams: "{}",
+        MinNum: 1,
+      }),
+    ).toEqual(expect.arrayContaining(["VpcConf", "EnvParams"]));
+  });
+});

--- a/mcp/src/tools/cloudrun-config.ts
+++ b/mcp/src/tools/cloudrun-config.ts
@@ -1,0 +1,252 @@
+/**
+ * CloudRun serverConfig merge (RMW) and DiffConfigItem helpers.
+ * Aligns with console SubmitServerConfigChangeDiff field mapping.
+ */
+
+export type CloudRunVpcConf = {
+  VpcId?: string;
+  SubnetId?: string;
+  VpcCIDR?: string;
+  SubnetCIDR?: string;
+};
+
+export type CloudRunServerConfigLike = Record<string, unknown> & {
+  VpcConf?: CloudRunVpcConf | null;
+  EnvParams?: string;
+  OpenAccessTypes?: string[];
+  Cpu?: number;
+  Mem?: number;
+};
+
+export type DiffConfigItem = {
+  Key: string;
+  Value?: string;
+  IntValue?: number;
+  FloatValue?: number;
+  BoolValue?: boolean;
+  ArrayValue?: string[];
+  PolicyDetails?: unknown;
+  TimerScale?: unknown;
+  VpcConf?: CloudRunVpcConf;
+  VolumesConf?: unknown;
+  PublicNetConf?: unknown;
+};
+
+const SUBMIT_DIFF_MAP: Record<string, string> = {
+  Cpu: "CpuSpecs",
+  Mem: "MemSpecs",
+  OpenAccessTypes: "AccessTypes",
+  EnvParams: "EnvParam",
+  CustomLogs: "LogPath",
+};
+
+const STRING_KEYS = new Set([
+  "CustomLogs",
+  "EnvParams",
+  "CreateTime",
+  "Dockerfile",
+  "BuildDir",
+  "LogType",
+  "LogSetId",
+  "LogTopicId",
+  "LogParseType",
+  "Tag",
+  "InternalAccess",
+  "InternalDomain",
+  "OperationMode",
+  "SessionAffinity",
+]);
+
+const INT_KEYS = new Set(["MinNum", "MaxNum", "InitialDelaySeconds", "Port"]);
+const BOOL_KEYS = new Set(["HasDockerfile"]);
+const FLOAT_KEYS = new Set(["Cpu", "Mem"]);
+const ARRAY_KEYS = new Set(["OpenAccessTypes", "EntryPoint", "Cmd"]);
+
+function parseEnvParamsObject(raw?: string | null): Record<string, string> {
+  if (!raw || !String(raw).trim()) {
+    return {};
+  }
+  try {
+    const value = JSON.parse(String(raw));
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      return {};
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (v === undefined || v === null) continue;
+      out[k] = typeof v === "string" ? v : String(v);
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+function stringifyEnvParams(obj: Record<string, string>): string {
+  return JSON.stringify(obj);
+}
+
+function isCompleteVpcConf(vpc?: CloudRunVpcConf | null): boolean {
+  return Boolean(vpc?.VpcId?.trim() && vpc?.SubnetId?.trim());
+}
+
+/**
+ * Merge remote ServerConfig with deploy/update input.
+ * Explicit input wins for provided fields; EnvParams merges by key unless replaceAll.
+ */
+export function mergeCloudRunServerConfig(options: {
+  remote?: CloudRunServerConfigLike | null;
+  input?: CloudRunServerConfigLike | null;
+  envParamsReplaceAll?: boolean;
+}): {
+  merged: CloudRunServerConfigLike;
+  mergedFromRemote: string[];
+} {
+  const remote = options.remote || {};
+  const input = options.input || {};
+  const mergedFromRemote: string[] = [];
+  const merged: CloudRunServerConfigLike = { ...input };
+
+  if (isCompleteVpcConf(input.VpcConf)) {
+    merged.VpcConf = {
+      VpcId: input.VpcConf!.VpcId!.trim(),
+      SubnetId: input.VpcConf!.SubnetId!.trim(),
+      ...(input.VpcConf!.VpcCIDR ? { VpcCIDR: input.VpcConf!.VpcCIDR } : {}),
+      ...(input.VpcConf!.SubnetCIDR ? { SubnetCIDR: input.VpcConf!.SubnetCIDR } : {}),
+    };
+  } else if (isCompleteVpcConf(remote.VpcConf)) {
+    merged.VpcConf = {
+      VpcId: remote.VpcConf!.VpcId!.trim(),
+      SubnetId: remote.VpcConf!.SubnetId!.trim(),
+      ...(remote.VpcConf!.VpcCIDR ? { VpcCIDR: remote.VpcConf!.VpcCIDR } : {}),
+      ...(remote.VpcConf!.SubnetCIDR ? { SubnetCIDR: remote.VpcConf!.SubnetCIDR } : {}),
+    };
+    mergedFromRemote.push("VpcConf");
+  } else {
+    delete merged.VpcConf;
+  }
+
+  const inputHasEnv = Object.prototype.hasOwnProperty.call(input, "EnvParams");
+  const remoteEnv = parseEnvParamsObject(remote.EnvParams);
+  const inputEnv = parseEnvParamsObject(input.EnvParams);
+
+  if (options.envParamsReplaceAll && inputHasEnv) {
+    merged.EnvParams = stringifyEnvParams(inputEnv);
+  } else if (inputHasEnv || Object.keys(remoteEnv).length > 0) {
+    const combined = options.envParamsReplaceAll
+      ? { ...inputEnv }
+      : { ...remoteEnv, ...inputEnv };
+    if (Object.keys(remoteEnv).length > 0 && !options.envParamsReplaceAll) {
+      const preserved = Object.keys(remoteEnv).filter((k) => !(k in inputEnv));
+      if (preserved.length > 0) {
+        mergedFromRemote.push("EnvParams");
+      }
+    }
+    if (Object.keys(combined).length > 0 || inputHasEnv) {
+      merged.EnvParams = stringifyEnvParams(combined);
+    }
+  }
+
+  // Must be explicit so Manager SDK update path cannot wipe with OA/PUBLIC/MINIAPP defaults.
+  if (Array.isArray(input.OpenAccessTypes) && input.OpenAccessTypes.length > 0) {
+    merged.OpenAccessTypes = [...input.OpenAccessTypes];
+  } else if (Array.isArray(remote.OpenAccessTypes) && remote.OpenAccessTypes.length > 0) {
+    merged.OpenAccessTypes = [...remote.OpenAccessTypes];
+    mergedFromRemote.push("OpenAccessTypes");
+  }
+
+  return { merged, mergedFromRemote };
+}
+
+export function assertCpuMemPair(config: CloudRunServerConfigLike): void {
+  const hasCpu = config.Cpu !== undefined && config.Cpu !== null;
+  const hasMem = config.Mem !== undefined && config.Mem !== null;
+  if (hasCpu !== hasMem) {
+    throw new Error(
+      "Cpu and Mem must be provided together when updating CloudRun config (platform requires the pair).",
+    );
+  }
+}
+
+/**
+ * Convert serverConfig object to DiffConfigItem[] for SubmitServerConfigChangeDiff.
+ */
+export function parseServerConfigToDiffItems(
+  data: CloudRunServerConfigLike,
+): DiffConfigItem[] {
+  assertCpuMemPair(data);
+  const Items: DiffConfigItem[] = [];
+
+  for (const [k, v] of Object.entries(data)) {
+    if (v === undefined || v === null) continue;
+    const Key = SUBMIT_DIFF_MAP[k] || k;
+
+    if (STRING_KEYS.has(k)) {
+      if (v !== "") {
+        Items.push({ Key, Value: String(v) });
+      }
+    } else if (INT_KEYS.has(k)) {
+      Items.push({ Key, IntValue: Number(v) });
+    } else if (BOOL_KEYS.has(k)) {
+      Items.push({ Key, BoolValue: Boolean(v) });
+    } else if (FLOAT_KEYS.has(k)) {
+      Items.push({ Key, FloatValue: Number(v) });
+    } else if (ARRAY_KEYS.has(k)) {
+      Items.push({ Key, ArrayValue: v as string[] });
+    } else if (k === "PolicyDetails") {
+      Items.push({ Key, PolicyDetails: v });
+    } else if (k === "TimerScale") {
+      Items.push({ Key, TimerScale: v });
+    } else if (k === "VpcConf") {
+      Items.push({ Key, VpcConf: v as CloudRunVpcConf });
+    } else if (k === "VolumesConf") {
+      Items.push({ Key, VolumesConf: v });
+    } else if (k === "PublicNetConf") {
+      Items.push({ Key, PublicNetConf: v });
+    }
+  }
+
+  return Items;
+}
+
+export function summarizeConfigSnapshot(config?: CloudRunServerConfigLike | null): {
+  hasVpcConf: boolean;
+  vpcId?: string;
+  subnetId?: string;
+  openAccessTypes?: string[];
+  envParamKeys: string[];
+} {
+  const vpc = config?.VpcConf;
+  const envKeys = Object.keys(parseEnvParamsObject(config?.EnvParams));
+  return {
+    hasVpcConf: isCompleteVpcConf(vpc),
+    ...(vpc?.VpcId ? { vpcId: vpc.VpcId } : {}),
+    ...(vpc?.SubnetId ? { subnetId: vpc.SubnetId } : {}),
+    ...(Array.isArray(config?.OpenAccessTypes)
+      ? { openAccessTypes: config!.OpenAccessTypes }
+      : {}),
+    envParamKeys: envKeys,
+  };
+}
+
+export const CONFIG_FIELDS_LIKELY_REDEPLOY = [
+  "VpcConf",
+  "EnvParams",
+  "Cpu",
+  "Mem",
+  "Port",
+  "Dockerfile",
+  "BuildDir",
+  "VolumesConf",
+  "LogType",
+  "LogSetId",
+  "LogTopicId",
+] as const;
+
+export function listLikelyRedeployFields(
+  config: CloudRunServerConfigLike,
+): string[] {
+  return CONFIG_FIELDS_LIKELY_REDEPLOY.filter((k) =>
+    Object.prototype.hasOwnProperty.call(config, k),
+  );
+}

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -7,6 +7,13 @@ import { ExtendedMcpServer } from '../server.js';
 import { debug } from '../utils/logger.js';
 import { preferGatewayOrFallback, resolveGatewayAccessUrls } from '../utils/gateway-access-urls.js';
 import { sendDeployNotification } from '../utils/notification.js';
+import {
+  listLikelyRedeployFields,
+  mergeCloudRunServerConfig,
+  parseServerConfigToDiffItems,
+  summarizeConfigSnapshot,
+  type CloudRunServerConfigLike,
+} from './cloudrun-config.js';
 
 // CloudRun service types
 export const CLOUDRUN_SERVICE_TYPES = ['function', 'container'] as const;
@@ -33,11 +40,12 @@ const queryCloudRunInputSchema = {
 
 // Input schema for manageCloudRun tool
 const ManageCloudRunInputSchema = {
-  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体）'),
+  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent', 'updateConfig']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体）'),
   serverName: z.string().describe('云托管服务名称，用于标识和管理服务。命名规则：支持大小写字母、数字、连字符和下划线，必须以字母开头，长度3-45个字符。在init操作中会作为在targetPath下创建的子目录名，在其他操作中作为目标服务名'),
 
   // Deploy operation parameters
-  targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun'),
+  targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun'),
+  envParamsReplaceAll: z.boolean().optional().default(false).describe('EnvParams 合并策略（deploy / updateConfig）：false（默认）= 与远程按 key 合并（输入覆盖同名 key，远程其余 key 保留）；true= 用输入 EnvParams 整包替换远程。仅当显式传入 EnvParams 时生效'),
   serverConfig: z.object({
     OpenAccessTypes: z.array(z.enum(CLOUDRUN_ACCESS_TYPES)).optional().describe('公网访问类型配置，控制服务的访问权限：OA=办公网访问，PUBLIC=公网访问（默认，可通过HTTPS域名访问），MINIAPP=小程序访问，VPC=VPC访问（仅同VPC内可访问）。可配置多个类型'),
     Cpu: z.number().positive().optional().describe('CPU规格配置，单位为核。可选值：0.25、0.5、1、2、4、8等。注意：内存规格必须是CPU规格的2倍（如CPU=0.25时内存=0.5，CPU=1时内存=2）。影响服务性能和计费'),
@@ -76,7 +84,7 @@ const ManageCloudRunInputSchema = {
     VpcConf: z.object({
       VpcId: z.string().describe('VPC网络ID，格式如 vpc-xxxxxxxx。必须与目标数据库/Redis 处于同一地域，并优先选择同一 VPC。禁止猜测或使用占位符；须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。建议首次创建即配置；已存在服务也可在 deploy 时传入，部署后必须用 queryCloudRun detail 复核是否生效'),
       SubnetId: z.string().describe('子网ID，格式如 subnet-xxxxxxxx。云托管实例将占用该子网 IP，需确保有足够可用 IP'),
-    }).optional().describe('VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。MCP 在创建时会将 VpcConf 映射为 SDK vpcInfo(CreateType=2)；更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf，未生效再走控制台网络设置或删建兜底'),
+    }).optional().describe('VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。创建时映射为 SDK vpcInfo(CreateType=2)；已存在服务可用 updateConfig 或 deploy（RMW 会保留未传入的远程 VpcConf）。部署/更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf'),
     VolumesConf: z.array(z.object({
       VolumeName: z.string().describe('存储卷名称'),
       VolumeType: z.string().describe('存储卷类型，如CFS表示云文件存储'),
@@ -86,7 +94,7 @@ const ManageCloudRunInputSchema = {
       PublicAccess: z.boolean().optional().describe('是否开启公网访问，true=开启公网访问，false=关闭公网访问'),
       PublicAccessPath: z.string().optional().describe('公网访问路径配置')
     }).optional().describe('公网访问配置，用于控制服务的公网访问策略。可配置是否开启公网访问及访问路径'),
-  }).optional().describe('服务配置项，用于部署时设置服务的运行参数。包括资源规格、访问权限、环境变量、日志、网络等配置。不提供时使用默认配置'),
+  }).optional().describe('服务配置项，用于 deploy / updateConfig。包括资源规格、访问权限、环境变量、日志、网络等。deploy 未提供时对已存在服务仍会从远程合并保留 VpcConf/EnvParams/OpenAccessTypes；updateConfig 至少需要一个配置字段'),
 
   // Init operation parameters
   template: z.string().optional().default('helloworld').describe('项目模板标识符，用于指定初始化项目时使用的模板。可通过queryCloudRun的templates操作获取可用模板列表。常用模板：helloworld=Hello World示例，nodejs=Node.js项目模板，python=Python项目模板等'),
@@ -123,10 +131,11 @@ type queryCloudRunInput = {
 };
 
 type ManageCloudRunInput = {
-  action: 'init' | 'download' | 'run' | 'deploy' | 'delete' | 'createAgent';
+  action: 'init' | 'download' | 'run' | 'deploy' | 'delete' | 'createAgent' | 'updateConfig';
   serverName: string;
   targetPath?: string;
   serverConfig?: any;
+  envParamsReplaceAll?: boolean;
   template?: string;
   force?: boolean;
   serverType?: CloudRunServiceType;
@@ -642,7 +651,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
     "manageCloudRun",
     {
       title: "管理 CloudRun 服务",
-      description: "管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、删除服务。部署可配置CPU、内存、实例数、访问类型等参数。删除操作需要确认，建议设置force=true。",
+      description: "管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。",
       inputSchema: ManageCloudRunInputSchema,
       annotations: {
         readOnlyHint: false,
@@ -854,6 +863,8 @@ for await (let x of res.textStream) {
 
             // Determine service type - use input.serverType if provided, otherwise auto-detect
             let serverType: 'function' | 'container';
+            let remoteServerConfig: CloudRunServerConfigLike | null = null;
+            let existingService = false;
             if (input.serverType) {
               serverType = input.serverType;
             } else {
@@ -861,6 +872,8 @@ for await (let x of res.textStream) {
                 // First try to get existing service details
                 const details = await cloudrunService.detail({ serverName: input.serverName });
                 serverType = details.BaseInfo?.ServerType || 'container';
+                remoteServerConfig = (details.ServerConfig || null) as unknown as CloudRunServerConfigLike | null;
+                existingService = true;
               } catch (e) {
                 // If service doesn't exist, determine by project structure
                 const dockerfilePath = path.join(targetPath, 'Dockerfile');
@@ -890,6 +903,30 @@ for await (let x of res.textStream) {
               }
             }
 
+            // When serverType was provided explicitly, still try to load remote config for RMW.
+            if (!existingService) {
+              try {
+                const details = await cloudrunService.detail({ serverName: input.serverName });
+                remoteServerConfig = (details.ServerConfig || null) as unknown as CloudRunServerConfigLike | null;
+                existingService = true;
+              } catch {
+                // New service create path
+              }
+            }
+
+            let mergedFromRemote: string[] = [];
+            let effectiveServerConfig: CloudRunServerConfigLike | undefined = input.serverConfig;
+
+            if (existingService) {
+              const mergedResult = mergeCloudRunServerConfig({
+                remote: remoteServerConfig,
+                input: input.serverConfig || {},
+                envParamsReplaceAll: Boolean(input.envParamsReplaceAll),
+              });
+              effectiveServerConfig = mergedResult.merged;
+              mergedFromRemote = mergedResult.mergedFromRemote;
+            }
+
             const deployParams: any = {
               serverName: input.serverName,
               targetPath: targetPath,
@@ -897,15 +934,15 @@ for await (let x of res.textStream) {
               serverType: serverType,
             };
 
-            // Add server configuration if provided
-            if (input.serverConfig) {
-              deployParams.serverConfig = input.serverConfig;
+            if (effectiveServerConfig && Object.keys(effectiveServerConfig).length > 0) {
+              deployParams.serverConfig = effectiveServerConfig;
             }
 
             // Manager SDK create path prefers top-level vpcInfo (CreateCloudRunServer.VpcInfo).
             // Map serverConfig.VpcConf → vpcInfo so first-time create actually binds VPC.
-            // Update path still sends Items.VpcConf; platform may ignore VPC changes on existing services.
-            const vpcConf = input.serverConfig?.VpcConf;
+            const vpcConf = effectiveServerConfig?.VpcConf as
+              | { VpcId?: string; SubnetId?: string }
+              | undefined;
             if (vpcConf?.VpcId?.trim() && vpcConf?.SubnetId?.trim()) {
               deployParams.vpcInfo = {
                 VpcId: vpcConf.VpcId.trim(),
@@ -941,10 +978,14 @@ for await (let x of res.textStream) {
             let preferredAccessUrl: string | undefined;
             let preferredAccessUrls: string[] = [];
             let preferredAccessSource: string | undefined;
+            let verifiedConfigSnapshot: ReturnType<typeof summarizeConfigSnapshot> | undefined;
             try {
               const serviceDetails = await cloudrunService.detail({
                 serverName: input.serverName,
               });
+              verifiedConfigSnapshot = summarizeConfigSnapshot(
+                (serviceDetails as any)?.ServerConfig,
+              );
               const fallback = resolveCloudRunFallbackAccess(serviceDetails as any);
               const gateway = await resolveGatewayAccessUrls({
                 envId: currentEnvId,
@@ -986,8 +1027,10 @@ for await (let x of res.textStream) {
             }
 
             const dbNetworkRisk = detectCloudRunDbNetworkRisk({
-              envParams: input.serverConfig?.EnvParams,
-              vpcConf: input.serverConfig?.VpcConf,
+              envParams: effectiveServerConfig?.EnvParams as string | undefined,
+              vpcConf: effectiveServerConfig?.VpcConf as
+                | { VpcId?: string; SubnetId?: string }
+                | undefined,
             });
             const warnings = dbNetworkRisk ? [dbNetworkRisk] : [];
             const warningSuffix = dbNetworkRisk
@@ -1007,6 +1050,18 @@ for await (let x of res.textStream) {
                       serverType: serverType,
                       cloudbasercGenerated: true,
                       consoleUrl,
+                      ...(existingService
+                        ? {
+                            configMerge: {
+                              existingService: true,
+                              mergedFromRemote,
+                              appliedConfig: summarizeConfigSnapshot(effectiveServerConfig),
+                              ...(verifiedConfigSnapshot
+                                ? { verifiedAfterDeploy: verifiedConfigSnapshot }
+                                : {}),
+                            },
+                          }
+                        : {}),
                       ...(preferredAccessUrl ? { accessUrl: preferredAccessUrl } : {}),
                       ...(preferredAccessUrls.length > 0
                         ? { accessUrls: preferredAccessUrls }
@@ -1020,6 +1075,174 @@ for await (let x of res.textStream) {
                   }, null, 2)
                 }
               ]
+            };
+          }
+
+          case 'updateConfig': {
+            if (!input.serverConfig || Object.keys(input.serverConfig).length === 0) {
+              throw new Error(
+                "serverConfig with at least one field is required for updateConfig",
+              );
+            }
+
+            let remoteServerConfig: CloudRunServerConfigLike = {};
+            try {
+              const details = await cloudrunService.detail({
+                serverName: input.serverName,
+              });
+              remoteServerConfig = (details.ServerConfig ||
+                {}) as unknown as CloudRunServerConfigLike;
+            } catch (error) {
+              throw new Error(
+                buildManageCloudRunErrorMessage(
+                  "updateConfig",
+                  input.serverName,
+                  error,
+                ),
+              );
+            }
+
+            // EnvParams on Diff replaces the whole blob — merge keys unless replaceAll.
+            const dirty: CloudRunServerConfigLike = { ...input.serverConfig };
+            if (Object.prototype.hasOwnProperty.call(input.serverConfig, "EnvParams")) {
+              const { merged } = mergeCloudRunServerConfig({
+                remote: { EnvParams: remoteServerConfig.EnvParams },
+                input: { EnvParams: input.serverConfig.EnvParams },
+                envParamsReplaceAll: Boolean(input.envParamsReplaceAll),
+              });
+              if (merged.EnvParams !== undefined) {
+                dirty.EnvParams = merged.EnvParams;
+              }
+            }
+
+            let Items;
+            try {
+              Items = parseServerConfigToDiffItems(dirty);
+            } catch (error) {
+              throw new Error(
+                buildManageCloudRunErrorMessage(
+                  "updateConfig",
+                  input.serverName,
+                  error,
+                ),
+              );
+            }
+
+            if (Items.length === 0) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify(
+                      {
+                        success: true,
+                        data: {
+                          serviceName: input.serverName,
+                          status: "noop",
+                          itemsCount: 0,
+                          appliedConfig: summarizeConfigSnapshot(dirty),
+                          verifiedConfig: summarizeConfigSnapshot(remoteServerConfig),
+                        },
+                        message: `No effective config changes for '${input.serverName}'.`,
+                      },
+                      null,
+                      2,
+                    ),
+                  },
+                ],
+              };
+            }
+
+            const currentEnvId = await getEnvId(cloudBaseOptions);
+            if (!manager.commonService) {
+              throw new Error(
+                "Current CloudBase Manager does not support commonService; cannot call SubmitServerConfigChangeDiff.",
+              );
+            }
+
+            let diffResult: any;
+            try {
+              diffResult = await manager
+                .commonService("tcbr", "2022-02-17")
+                .call({
+                  Action: "SubmitServerConfigChangeDiff",
+                  Param: {
+                    EnvId: currentEnvId,
+                    ServerName: input.serverName,
+                    Items,
+                  },
+                });
+            } catch (error) {
+              const msg = error instanceof Error ? error.message : String(error);
+              if (/ResourceInUse|task|running|进行中/i.test(msg)) {
+                throw new Error(
+                  buildManageCloudRunErrorMessage(
+                    "updateConfig",
+                    input.serverName,
+                    new Error(
+                      `${msg} A deploy or config task may still be running. Wait, then retry; or use queryCloudRun(action="getDeployLog").`,
+                    ),
+                  ),
+                );
+              }
+              throw new Error(
+                buildManageCloudRunErrorMessage(
+                  "updateConfig",
+                  input.serverName,
+                  error,
+                ),
+              );
+            }
+
+            let verifiedConfig = summarizeConfigSnapshot(remoteServerConfig);
+            try {
+              const after = await cloudrunService.detail({
+                serverName: input.serverName,
+              });
+              verifiedConfig = summarizeConfigSnapshot(
+                (after as any)?.ServerConfig,
+              );
+            } catch {
+              // best-effort verify
+            }
+
+            const likelyRedeploy = listLikelyRedeployFields(dirty);
+            const consoleUrl = `https://tcb.cloud.tencent.com/dev?envId=${currentEnvId}#/platform-run/service/detail?serverName=${input.serverName}&tabId=overview&envId=${currentEnvId}`;
+            const taskId =
+              diffResult?.TaskId ??
+              diffResult?.Response?.TaskId ??
+              diffResult?.taskId;
+
+            const redeployHint =
+              likelyRedeploy.length > 0
+                ? ` Fields that often trigger redeploy-with-online-image: ${likelyRedeploy.join(", ")}.`
+                : " Change may apply as a hot update (e.g. MinNum/MaxNum/AccessTypes).";
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify(
+                    {
+                      success: true,
+                      data: {
+                        serviceName: input.serverName,
+                        status: "configUpdating",
+                        itemsCount: Items.length,
+                        itemsKeys: Items.map((i: { Key: string }) => i.Key),
+                        ...(taskId ? { taskId } : {}),
+                        appliedConfig: summarizeConfigSnapshot(dirty),
+                        verifiedConfig,
+                        likelyRedeployFields: likelyRedeploy,
+                        consoleUrl,
+                      },
+                      message: `Submitted config change for '${input.serverName}'.${redeployHint} Verify with queryCloudRun(action="detail"). Console: ${consoleUrl}`,
+                    },
+                    null,
+                    2,
+                  ),
+                },
+              ],
             };
           }
 

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1852,7 +1852,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.0），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.1），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2107,7 +2107,7 @@
     },
     {
       "name": "manageCloudRun",
-      "description": "管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、删除服务。部署可配置CPU、内存、实例数、访问类型等参数。删除操作需要确认，建议设置force=true。",
+      "description": "管理云托管服务，按开发顺序支持：初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2119,9 +2119,10 @@
               "run",
               "deploy",
               "delete",
-              "createAgent"
+              "createAgent",
+              "updateConfig"
             ],
-            "description": "云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体）"
+            "description": "云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体）"
           },
           "serverName": {
             "type": "string",
@@ -2129,7 +2130,12 @@
           },
           "targetPath": {
             "type": "string",
-            "description": "本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun"
+            "description": "本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun"
+          },
+          "envParamsReplaceAll": {
+            "type": "boolean",
+            "default": false,
+            "description": "EnvParams 合并策略（deploy / updateConfig）：false（默认）= 与远程按 key 合并（输入覆盖同名 key，远程其余 key 保留）；true= 用输入 EnvParams 整包替换远程。仅当显式传入 EnvParams 时生效"
           },
           "serverConfig": {
             "type": "object",
@@ -2337,7 +2343,7 @@
                   "SubnetId"
                 ],
                 "additionalProperties": false,
-                "description": "VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。MCP 在创建时会将 VpcConf 映射为 SDK vpcInfo(CreateType=2)；更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf，未生效再走控制台网络设置或删建兜底"
+                "description": "VPC网络配置（实例出网/私有网络）。用于让云托管实例接入指定 VPC，从而内网访问 MySQL/PostgreSQL/Redis/CVM 等资源。与 OpenAccessTypes（外部如何访问本服务）是不同概念。TCP 连库场景必须配置。禁止猜测 VpcId/SubnetId，须来自数据库控制台、已有资源详情、callCloudApi 或用户确认。创建时映射为 SDK vpcInfo(CreateType=2)；已存在服务可用 updateConfig 或 deploy（RMW 会保留未传入的远程 VpcConf）。部署/更新后必须用 queryCloudRun detail 复核 ServerConfig.VpcConf"
               },
               "VolumesConf": {
                 "type": "array",
@@ -2383,7 +2389,7 @@
               }
             },
             "additionalProperties": false,
-            "description": "服务配置项，用于部署时设置服务的运行参数。包括资源规格、访问权限、环境变量、日志、网络等配置。不提供时使用默认配置"
+            "description": "服务配置项，用于 deploy / updateConfig。包括资源规格、访问权限、环境变量、日志、网络等。deploy 未提供时对已存在服务仍会从远程合并保留 VpcConf/EnvParams/OpenAccessTypes；updateConfig 至少需要一个配置字段"
           },
           "template": {
             "type": "string",

--- a/specs/cloudrun-config-preserve/design.md
+++ b/specs/cloudrun-config-preserve/design.md
@@ -1,0 +1,93 @@
+# 技术方案
+
+## 概述
+
+在 MCP `manageCloudRun` 中增加两类能力：
+
+1. **deploy RMW**：对已存在服务，先 `detail` 再合并 `serverConfig`，再调用现有 Manager `cloudrun.deploy`。
+2. **updateConfig**：新增 action，经 `commonService('tcbr','2022-02-17')` 调用 `SubmitServerConfigChangeDiff`，对齐控制台服务设置页。
+
+不修改 `@cloudbase/manager-node` 包本身（SDK 仍无独立 updateConfig）；MCP 层补齐合并与 Diff 调用。长期可再回推 SDK。
+
+## 架构
+
+```mermaid
+flowchart TD
+  Agent[Agent / User] --> Manage[manageCloudRun]
+  Manage -->|deploy existing| RMW[detail then merge serverConfig]
+  RMW --> Deploy[manager.cloudrun.deploy]
+  Manage -->|updateConfig| Diff[SubmitServerConfigChangeDiff]
+  Diff --> Verify[detail verify]
+  Deploy --> Verify
+```
+
+## Merge 规则（deploy）
+
+优先级：`explicitInput` > `remote ServerConfig`（对未传入字段）。
+
+| 字段 | 策略 |
+|------|------|
+| `VpcConf` | 输入完整则用输入；否则保留远程 |
+| `EnvParams` | JSON 对象按 key merge；输入 key 覆盖远程；远程其余保留。`envParamsReplaceAll=true` 时用输入整包替换 |
+| `OpenAccessTypes` | 输入有则用输入；否则保留远程（抵消 SDK 更新路径强制默认三件套） |
+| 其他标量/对象 | 输入有则用输入；否则不写入 merged 对象（让 SDK Items 不带该 key） |
+
+实现为纯函数 `mergeCloudRunServerConfig({ remote, input, options })`，便于单测。
+
+注意：Manager SDK 更新路径会 `Object.assign({}, serverConfig, { OpenAccessTypes: ['OA','PUBLIC','MINIAPP'] })`。因此 **MCP 必须在合并结果中始终显式带上最终 `OpenAccessTypes`**（来自 input 或 remote），避免被 SDK 默认值覆盖。
+
+## updateConfig
+
+### 调用
+
+```ts
+await manager.commonService("tcbr", "2022-02-17").call({
+  Action: "SubmitServerConfigChangeDiff",
+  Param: {
+    EnvId,
+    ServerName,
+    Items: parseObjectToDiffConfigItem(dirtyServerConfig),
+  },
+});
+```
+
+### Diff 映射（与控制台 / Manager parseObjectToDiffConfigItem 对齐）
+
+| 输入字段 | Diff Key | 载荷形态 |
+|----------|----------|----------|
+| Cpu | CpuSpecs | FloatValue |
+| Mem | MemSpecs | FloatValue |
+| OpenAccessTypes | AccessTypes | ArrayValue |
+| EnvParams | EnvParam | Value (string) |
+| CustomLogs | LogPath | Value |
+| VpcConf | VpcConf | VpcConf |
+| 其他 | 同名 | 按类型 |
+
+校验：`Cpu`/`Mem` 成对；`Items` 为空则 no-op 成功。
+
+### 热更 vs 发版（文档化，不在 MCP 内重实现后端判定）
+
+响应文案说明：变更可能热更（MinNum/MaxNum/PolicyDetails/AccessTypes/TimerScale/InternalAccess/SessionAffinity 全为这类时），否则后端会用线上镜像发新版（含 VpcConf/EnvParams/Cpu/Mem 等）。
+
+## Schema 变更
+
+- `action` 枚举增加 `updateConfig`
+- 可选 `envParamsReplaceAll: z.boolean()`（仅 deploy / updateConfig 影响 EnvParams 合并）
+- `updateConfig` 不要求 `targetPath`；要求 `serverConfig` 至少一个字段
+
+## 测试
+
+- `cloudrun-config-merge.test.ts`：VpcConf / EnvParams key-merge / OpenAccessTypes / replaceAll
+- `cloudrun-diff-items.test.ts`：字段映射与 Cpu/Mem 成对校验
+- 现有 `cloudrun.db-network.test.ts` 保持不变
+
+## 安全性
+
+- 不在日志中打印完整 EnvParams 密钥值（复核快照可只返回 key 列表 + 是否含 VpcConf）
+- `updateConfig` 标为非 readOnly；破坏性低于 delete，高于纯查询
+
+## 非目标（本迭代）
+
+- 不改 Manager SDK 公开发布 API
+- 不改 CLI `tcb cloudrun`
+- 不做控制台级异步任务长轮询到终态（返回 taskId + 指引用 queryCloudRun/getDeployLog）

--- a/specs/cloudrun-config-preserve/requirements.md
+++ b/specs/cloudrun-config-preserve/requirements.md
@@ -1,0 +1,56 @@
+# 需求文档
+
+## 介绍
+
+云托管通过 MCP `manageCloudRun(action=deploy)` 更新服务时，若未传入控制台已配置的 `VpcConf` / `EnvParams` / `OpenAccessTypes` 等字段，可能覆盖或冲掉云端配置。需要：
+
+1. **deploy 路径**：对已存在服务做 Read-Merge-Write，避免少传即抹配置。
+2. **独立更新配置路径**：对齐控制台「服务设置」，支持不重新上传代码的配置变更（`SubmitServerConfigChangeDiff`）。
+
+调研交接见 AI-Workspace：`specs/cloudrun-config-only-update/doc/handover.md`。
+
+## 需求
+
+### 需求 1 - Deploy 时保留未传入的云端配置（RMW）
+
+**用户故事：** 作为在控制台配置过 VPC/环境变量后再用 MCP 发版的用户，我希望只更新代码时不会把已有网络与环境变量抹掉。
+
+#### 验收标准
+
+1. While 目标服务已存在, when `manageCloudRun(action=deploy)` 未传入 `serverConfig.VpcConf`, the MCP shall 在提交前合并远程 `ServerConfig.VpcConf`，不得以「缺省」清空或省略导致失去 VPC。
+2. While 目标服务已存在, when `manageCloudRun(action=deploy)` 未传入或仅传入部分 `EnvParams` keys, the MCP shall 按 key 合并远程与本地环境变量（本地显式 key 覆盖远程；未提及的远程 key 保留），除非调用方显式要求全量替换。
+3. While 目标服务已存在, when `manageCloudRun(action=deploy)` 未传入 `OpenAccessTypes`, the MCP shall 保留远程访问类型，不得无脑覆盖为默认 `OA/PUBLIC/MINIAPP`（若底层 SDK 强制覆盖，MCP 须在合并后显式回填远程值）。
+4. When deploy 合并完成后, the MCP shall 在响应中可观测地标明已合并的关键字段（例如 `mergedFromRemote: ["VpcConf","EnvParams"]`），便于排查。
+5. When 服务不存在（首次创建）, the MCP shall 不执行远程 merge，行为与现网创建路径一致。
+
+### 需求 2 - 独立 updateConfig 能力
+
+**用户故事：** 作为只想改 VPC、环境变量或扩缩容而不重新传代码的用户，我希望 MCP 提供与控制台「服务设置」同路径的更新配置操作。
+
+#### 验收标准
+
+1. When 调用 `manageCloudRun(action=updateConfig)` 并传入 `serverConfig` 脏字段时, the MCP shall 调用 `tcbr.SubmitServerConfigChangeDiff`（`EnvId` + `ServerName` + `Items`），不要求 `targetPath`，不上传代码包。
+2. When 提交 Diff 时, the MCP shall 使用与控制台一致的字段映射（如 `Cpu→CpuSpecs`、`Mem→MemSpecs`、`OpenAccessTypes→AccessTypes`、`EnvParams→EnvParam`）。
+3. When `Cpu` 与 `Mem` 仅传其一, the MCP shall 拒绝并提示必须成对提交。
+4. When API 返回 `TaskId > 0`, the MCP shall 在响应中返回 `taskId` 与「可能触发基于线上镜像的新版本发布」说明；当 `TaskId` 为 0 或缺失时, shall 标明可能为热更同步完成。
+5. When 发生 `ResourceInUse`, the MCP shall 返回可操作的重试建议（服务有进行中任务）。
+
+### 需求 3 - 写后复核
+
+**用户故事：** 作为 Agent，我希望更新后能确认关键配置是否真正生效，而不是只看到「接口成功」。
+
+#### 验收标准
+
+1. When `updateConfig` 成功后, the MCP shall 调用 detail 复核，并在响应中返回当前 `ServerConfig` 中与本次变更相关的字段快照（至少含 `VpcConf` / `EnvParams` 若本次涉及）。
+2. When `deploy` 合并了远程 `VpcConf` 后, the MCP shall 在成功响应中回传最终提交使用的 `VpcConf`（或 warning：若 detail 暂时读不到则以提交值为准并提示稍后复核）。
+3. When 复核发现本次显式要求的 `VpcConf` 与远程不一致, the MCP shall 给出 warning，而不是静默当作完全成功。
+
+### 需求 4 - Schema / 文档 / 测试
+
+**用户故事：** 作为工具维护者与 Agent，我希望 schema 与测试覆盖新行为，避免回归。
+
+#### 验收标准
+
+1. When schema 更新后, `manageCloudRun.action` shall 包含 `updateConfig` 枚举值，且 description 说明与 deploy 的差异。
+2. When 单元测试运行时, RMW 合并逻辑与 Diff 映射 shall 有 focused 测试覆盖。
+3. When 变更影响对外工具清单时, shall 更新生成产物（如 `scripts/tools.json`、相关 mcp-tools 文档）与 skill 中云托管配置指引（如有）。

--- a/specs/cloudrun-config-preserve/tasks.md
+++ b/specs/cloudrun-config-preserve/tasks.md
@@ -1,0 +1,22 @@
+# 实施计划
+
+- [x] 1. 抽取合并与 Diff 工具模块
+  - 新增 `mcp/src/tools/cloudrun-config.ts`：`mergeCloudRunServerConfig`、`parseServerConfigToDiffItems`、`assertCpuMemPair`
+  - 单测覆盖 VpcConf / EnvParams merge / replaceAll / OpenAccessTypes / Diff 映射
+  - _需求: 1, 2, 4_
+
+- [x] 2. deploy 路径接入 RMW
+  - 已存在服务：`detail` → merge → 写入 `deployParams.serverConfig`
+  - 响应增加 `mergedFromRemote` / 最终 `VpcConf` 摘要
+  - _需求: 1, 3_
+
+- [x] 3. 新增 `action=updateConfig`
+  - schema 枚举与描述
+  - `commonService('tcbr','2022-02-17')` 调 `SubmitServerConfigChangeDiff`
+  - 处理空 Items、ResourceInUse、TaskId；detail 复核
+  - _需求: 2, 3_
+
+- [x] 4. 文档与生成物
+  - 更新 skill `vpc-and-database.md` / cloudrun-development
+  - `npm run build:tools-json`（及 tools-doc 如适用）
+  - _需求: 4_


### PR DESCRIPTION
## Summary
- Deploy to an existing CloudRun service now Read-Merge-Writes remote `VpcConf` / EnvParams keys / `OpenAccessTypes`, so console network/env settings are not wiped by code-only deploys.
- Adds `manageCloudRun(action="updateConfig")` aligned with console `SubmitServerConfigChangeDiff` for config-only changes (no code upload).
- Documents the behavior in cloudrun skill / VPC reference; includes merge/Diff unit tests and regenerates tools schema docs.

## Spec
See `specs/cloudrun-config-preserve/`.

## Test plan
- [x] `vitest` `cloudrun-config.test.ts` + `cloudrun.db-network.test.ts`
- [ ] CI green on this PR
- [ ] Manual (optional): set VPC in console → MCP deploy without `VpcConf` → `queryCloudRun detail` still shows VPC
- [ ] Manual (optional): `updateConfig` with EnvParams key merge / `envParamsReplaceAll=true`


Made with [Cursor](https://cursor.com)