### PR TITLE
feat(skillhub): 🎨 use curated displayName/summary/iconUrl for marketplace cards

### DIFF
--- a/scripts/build-clawhub-publish-artifacts.mjs
+++ b/scripts/build-clawhub-publish-artifacts.mjs
@@ -204,6 +204,7 @@ function buildTargetArtifact(target, outputDir) {
     targetKey: target.key,
     registrySlug: target.registrySlug,
     displayName: target.displayName || validation.metadata.name,
+    summary: target.summary || validation.metadata.description,
     iconUrl: target.iconUrl,
     artifactRootDir,
     artifactDir,

--- a/scripts/clawhub-publish-targets.mjs
+++ b/scripts/clawhub-publish-targets.mjs
@@ -7,14 +7,20 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "..");
 
-const CLOUDBASE_ICON_URL = "https://docs.cloudbase.net/en/img/favicon.png";
+// Pure-black-background CloudBase logo hosted in the dedicated plugin repo
+// (TencentCloudBase/cloudbase-plugin). Used as the SkillHub / ClawHub skill icon
+// so the marketplace cards match the CloudBase plugin branding.
+const CLOUDBASE_ICON_URL =
+  "https://raw.githubusercontent.com/TencentCloudBase/cloudbase-plugin/main/assets/logo-dark.png";
 
 export const CLAWHUB_PUBLISH_TARGETS = {
   "miniprogram-development": {
     key: "miniprogram-development",
     type: "local-skill",
     registrySlug: "miniprogram-development",
-    displayName: "微信小程序开发 / WeChat Mini Program Development",
+    displayName: "腾讯云 CloudBase 微信小程序开发 / Tencent CloudBase WeChat Mini Program Development",
+    summary:
+      "面向 AI 编码场景的腾讯云 CloudBase 微信小程序开发指南，覆盖项目脚手架、tabBar、路由、调试、预览、发布与 wx.cloud 集成。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDir: path.join(
       projectRoot,
@@ -29,7 +35,9 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     key: "cloudbase-wechat-integration",
     type: "local-skill",
     registrySlug: "cloudbase-wechat-integration",
-    displayName: "CloudBase 微信生态集成 / CloudBase WeChat Integration",
+    displayName: "腾讯云 CloudBase 微信生态集成 / Tencent CloudBase WeChat Integration",
+    summary:
+      "腾讯云 CloudBase 微信生态集成指南，覆盖小程序支付、公众号 JSAPI / Native 支付、公众号 OAuth、openid 处理与 Integration Center 云函数。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDir: path.join(
       projectRoot,
@@ -44,7 +52,9 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     key: "all-in-one",
     type: "generated-allinone",
     registrySlug: "cloudbase",
-    displayName: "CloudBase 云开发 / CloudBase",
+    displayName: "腾讯云 CloudBase / Tencent CloudBase",
+    summary:
+      "腾讯云 CloudBase 是面向 AI Coding 的后端一体化平台，内置数据库、存储、身份认证、云函数与云托管等服务，支持快速构建小程序、Web、移动 App、管理后台与 AI 应用。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDescription: "generated via scripts/build-allinone-skill.ts",
   },
@@ -53,7 +63,9 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     type: "local-skill",
     registrySlug: "ui-design-guide",
     publishName: "ui-design-guide",
-    displayName: "UI 设计 / UI Design",
+    displayName: "腾讯云 CloudBase UI 设计 / Tencent CloudBase UI Design",
+    summary:
+      "腾讯云 CloudBase UI 设计指南，提供 Web 与小程序前端的高保真原型、视觉规范与组件设计规范。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDir: path.join(projectRoot, "config", "source", "skills", "ui-design"),
     sourceDescription: "config/source/skills/ui-design",
@@ -62,7 +74,9 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     key: "web-development",
     type: "local-skill",
     registrySlug: "web-development",
-    displayName: "Web 开发 / Web Development",
+    displayName: "腾讯云 CloudBase Web 开发 / Tencent CloudBase Web Development",
+    summary:
+      "腾讯云 CloudBase Web 前端开发指南，覆盖 React / Vue / Vite 工程化、静态托管部署、@cloudbase/js-sdk 集成与内置认证。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDir: path.join(
       projectRoot,
@@ -78,7 +92,9 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     type: "local-skill",
     registrySlug: "spec-workflow-guide",
     publishName: "spec-workflow-guide",
-    displayName: "Spec 流程 / Spec Workflow",
+    displayName: "腾讯云 CloudBase Spec 流程 / Tencent CloudBase Spec Workflow",
+    summary:
+      "腾讯云 CloudBase 标准软件开发流程，统一需求 / 设计 / 任务文档与验收标准，适合中大型特性与多模块集成。",
     iconUrl: CLOUDBASE_ICON_URL,
     sourceDir: path.join(
       projectRoot,

--- a/scripts/publish-to-skillhub.mjs
+++ b/scripts/publish-to-skillhub.mjs
@@ -229,6 +229,24 @@ function parseFrontmatter(skillContent) {
   };
 }
 
+/**
+ * Pick SkillHub marketplace metadata for a target.
+ *
+ * SkillHub renders the displayName, summary, and iconUrl verbatim on the skill
+ * card. Curated values in `target` (e.g. set by clawhub-publish-targets.mjs)
+ * win over the raw SKILL.md frontmatter, which is English agent-trigger text
+ * not meant for human readers and uses the bare skill `name` slug.
+ */
+export function selectMarketplaceMetadata(target, frontmatter) {
+  const safeTarget = target || {};
+  const safeFrontmatter = frontmatter || {};
+  return {
+    displayName: safeTarget.displayName || safeFrontmatter.name || "",
+    summary: safeTarget.summary || safeFrontmatter.description || "",
+    iconUrl: safeTarget.iconUrl || "",
+  };
+}
+
 function collectFiles(dirPath, baseDir) {
   const files = [];
 
@@ -372,11 +390,20 @@ export async function publishToSkillhub({
     const metadata = parseFrontmatter(skillContent);
     const currentVersion = readCurrentVersion(skillFile);
 
+    // SkillHub marketplace metadata comes from the curated manifest target first
+    // (displayName / summary / iconUrl) so each skill can show a proper Chinese
+    // product name, a short Tencent-docs-style description and the black-bg
+    // CloudBase logo, instead of the raw English agent-trigger description and
+    // raw SKILL.md `name` slug.
+    const { displayName, summary, iconUrl } = selectMarketplaceMetadata(target, metadata);
+
     const files = collectFiles(artifactDir, artifactDir);
 
     console.log(`[SkillHub] 准备发布 / Preparing: ${target.targetKey} (${slug})`);
     console.log(`  Version: ${currentVersion || "(none)"}`);
-    console.log(`  DisplayName: ${metadata.name}`);
+    console.log(`  DisplayName: ${displayName}`);
+    console.log(`  Summary: ${summary ? summary.slice(0, 80) + (summary.length > 80 ? "..." : "") : "(none)"}`);
+    console.log(`  IconUrl: ${iconUrl || "(none)"}`);
     console.log(`  Files: ${files.length} file(s)`);
 
     if (dryRun) {
@@ -384,8 +411,9 @@ export async function publishToSkillhub({
         targetKey: target.targetKey,
         slug,
         version: currentVersion,
-        displayName: metadata.name,
-        summary: metadata.description,
+        displayName,
+        summary,
+        iconUrl,
         fileCount: files.length,
         status: "dry-run",
       });
@@ -419,8 +447,9 @@ export async function publishToSkillhub({
             targetKey: target.targetKey,
             slug,
             version: currentVersion,
-            displayName: metadata.name,
-            summary: metadata.description,
+            displayName,
+            summary,
+            iconUrl,
             fileCount: files.length,
             status: "skipped",
             reason: picked.reason,
@@ -447,9 +476,9 @@ export async function publishToSkillhub({
           slug,
           version,
           changelog: resolvedChangelog,
-          displayName: metadata.name,
-          summary: metadata.description,
-          iconUrl: target.iconUrl,
+          displayName,
+          summary,
+          iconUrl,
           files,
         });
 
@@ -459,8 +488,9 @@ export async function publishToSkillhub({
           targetKey: target.targetKey,
           slug,
           version,
-          displayName: metadata.name,
-          summary: metadata.description,
+          displayName,
+          summary,
+          iconUrl,
           fileCount: files.length,
           versionId: result.versionId,
           status: "published",

--- a/tests/build-clawhub-publish-artifacts.test.js
+++ b/tests/build-clawhub-publish-artifacts.test.js
@@ -168,3 +168,34 @@ test('buildClawhubPublishArtifacts rejects invalid targets', () => {
     }),
   ).toThrow(/Unknown publish targets/);
 });
+
+test('buildClawhubPublishArtifacts propagates curated displayName / summary / iconUrl to manifest', () => {
+  // The manifest is the single source of truth for SkillHub marketplace
+  // metadata. Each target entry must surface displayName, summary, and iconUrl
+  // so publish-to-skillhub.mjs can pass them to the SkillHub API instead of
+  // falling back to the raw SKILL.md `name` slug and English description.
+  const outputDir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawhub-meta-'));
+  tempDirs.push(outputDir);
+
+  const manifest = buildClawhubPublishArtifacts({
+    targets: 'all-in-one,miniprogram-development,web-development',
+    outputDir,
+  });
+
+  expect(manifest.targets).toHaveLength(3);
+
+  const allInOne = manifest.targets.find((t) => t.targetKey === 'all-in-one');
+  expect(allInOne.displayName).toBe('腾讯云 CloudBase / Tencent CloudBase');
+  expect(allInOne.summary).toMatch(/后端一体化平台/);
+  expect(allInOne.iconUrl).toMatch(/logo-dark\.png$/);
+
+  const miniprogram = manifest.targets.find((t) => t.targetKey === 'miniprogram-development');
+  expect(miniprogram.displayName).toMatch(/腾讯云 CloudBase 微信小程序开发/);
+  expect(miniprogram.summary).toMatch(/wx\.cloud/);
+  expect(miniprogram.iconUrl).toMatch(/logo-dark\.png$/);
+
+  const web = manifest.targets.find((t) => t.targetKey === 'web-development');
+  expect(web.displayName).toMatch(/腾讯云 CloudBase Web 开发/);
+  expect(web.summary).toMatch(/React|@cloudbase\/js-sdk/);
+  expect(web.iconUrl).toMatch(/logo-dark\.png$/);
+});

--- a/tests/publish-targets.test.js
+++ b/tests/publish-targets.test.js
@@ -53,3 +53,31 @@ test('resolvePublishTargets only returns whitelisted publish units', () => {
     targets.find((target) => target.key === 'spec-workflow')?.registrySlug,
   ).toBe('spec-workflow-guide');
 });
+
+test('every target exposes SkillHub marketplace metadata (displayName, summary, iconUrl)', () => {
+  // SkillHub / ClawHub marketplace cards need a Chinese product name
+  // (displayName), a short Tencent-docs-style summary, and the black-bg
+  // CloudBase logo. Without these the cards fall back to the raw SKILL.md
+  // `name` slug (e.g. "cloudbase") and the English agent-trigger description.
+  for (const target of Object.values(CLAWHUB_PUBLISH_TARGETS)) {
+    expect(target.displayName, `${target.key} missing displayName`).toBeTruthy();
+    expect(target.displayName, `${target.key} displayName should mention 腾讯云`).toMatch(
+      /腾讯云 CloudBase/,
+    );
+    expect(target.summary, `${target.key} missing summary`).toBeTruthy();
+    expect(target.iconUrl, `${target.key} missing iconUrl`).toBeTruthy();
+    expect(target.iconUrl, `${target.key} iconUrl should point to the black-bg logo`).toMatch(
+      /logo-dark\.png$/,
+    );
+  }
+});
+
+test('all-in-one displayName matches the official Tencent CloudBase product name', () => {
+  // SkillHub shows the displayName verbatim on the skill card. To match the
+  // product name on docs.cloudbase.net (腾讯云 CloudBase) instead of the raw
+  // `cloudbase` slug, all-in-one must use the bilingual product name.
+  const allInOne = CLAWHUB_PUBLISH_TARGETS['all-in-one'];
+  expect(allInOne.displayName).toBe('腾讯云 CloudBase / Tencent CloudBase');
+  expect(allInOne.summary).toMatch(/后端一体化平台/);
+  expect(allInOne.summary).toMatch(/数据库|云函数|云存储|身份认证/);
+});

--- a/tests/publish-to-skillhub.test.js
+++ b/tests/publish-to-skillhub.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from 'vitest';
+import { selectMarketplaceMetadata } from '../scripts/publish-to-skillhub.mjs';
+
+describe('selectMarketplaceMetadata', () => {
+  test('uses curated displayName / summary / iconUrl from manifest target', () => {
+    const result = selectMarketplaceMetadata(
+      {
+        displayName: '腾讯云 CloudBase / Tencent CloudBase',
+        summary: '腾讯云 CloudBase 是面向 AI Coding 的后端一体化平台。',
+        iconUrl: 'https://raw.githubusercontent.com/TencentCloudBase/cloudbase-plugin/main/assets/logo-dark.png',
+      },
+      {
+        name: 'cloudbase',
+        description:
+          'Use this skill when you develop, design, build, deploy, debug, migrate, or troubleshoot CloudBase (腾讯云开发)...',
+      },
+    );
+
+    expect(result).toEqual({
+      displayName: '腾讯云 CloudBase / Tencent CloudBase',
+      summary: '腾讯云 CloudBase 是面向 AI Coding 的后端一体化平台。',
+      iconUrl:
+        'https://raw.githubusercontent.com/TencentCloudBase/cloudbase-plugin/main/assets/logo-dark.png',
+    });
+  });
+
+  test('falls back to SKILL.md frontmatter when manifest target lacks curated values', () => {
+    // If a future target forgets to set curated values, we still publish
+    // something usable instead of dropping the skill from the marketplace.
+    const result = selectMarketplaceMetadata(
+      {},
+      { name: 'miniprogram-development', description: 'WeChat Mini Program skill' },
+    );
+
+    expect(result.displayName).toBe('miniprogram-development');
+    expect(result.summary).toBe('WeChat Mini Program skill');
+    expect(result.iconUrl).toBe('');
+  });
+
+  test('returns empty strings when both target and frontmatter are missing', () => {
+    const result = selectMarketplaceMetadata(undefined, undefined);
+
+    expect(result).toEqual({ displayName: '', summary: '', iconUrl: '' });
+  });
+
+  test('prefers target.displayName over the raw `cloudbase` slug in SKILL.md', () => {
+    // Regression: SkillHub previously rendered the raw SKILL.md `name` slug
+    // (e.g. "cloudbase") on the card. Curated displayName must win so the
+    // skill shows up as "腾讯云 CloudBase / Tencent CloudBase".
+    const result = selectMarketplaceMetadata(
+      { displayName: '腾讯云 CloudBase / Tencent CloudBase' },
+      { name: 'cloudbase', description: 'raw English trigger description' },
+    );
+
+    expect(result.displayName).toBe('腾讯云 CloudBase / Tencent CloudBase');
+    expect(result.displayName).not.toBe('cloudbase');
+  });
+
+  test('prefers target.summary over the long English SKILL.md description', () => {
+    // The SKILL.md description is a long English agent-trigger paragraph
+    // (full of keywords like "CloudBase", "腾讯云开发", "generateText"). The
+    // curated summary is the short Tencent-docs-style blurb that should show
+    // on the SkillHub card instead.
+    const longEnglish =
+      'Use this skill when you develop, design, build, deploy, debug, migrate, or troubleshoot CloudBase (腾讯云开发, 云开发, TCB, 微信云开发) projects. Covers Web, 微信小程序...';
+    const shortChinese = '腾讯云 CloudBase 是面向 AI Coding 的后端一体化平台。';
+
+    const result = selectMarketplaceMetadata(
+      { summary: shortChinese },
+      { name: 'cloudbase', description: longEnglish },
+    );
+
+    expect(result.summary).toBe(shortChinese);
+    expect(result.summary).not.toMatch(/Use this skill when/);
+  });
+});


### PR DESCRIPTION
## 问题

SkillHub（https://skillhub.cn/skills?sortBy=score）上我们的 skill 卡片显示有问题：

1. **显示名称是 `cloudbase`**，而不是「腾讯云 CloudBase」
2. **描述用的是 SKILL.md 的英文长 description**（agent-trigger 关键词文本），不是腾讯云官方文档风格的精炼描述
3. **logo 是 docs.cloudbase.net favicon**（透明底），不是插件目录的黑底 logo

## 根因

`scripts/publish-to-skillhub.mjs` 直接用 `metadata.name`（SKILL.md 的 `name` 字段，是 raw slug 如 `cloudbase`）作 displayName，用 `metadata.description`（英文长 agent-trigger 描述）作 summary，没有读 manifest.targets 的 `displayName` 和 `iconUrl`，尽管 `scripts/clawhub-publish-targets.mjs` 已经定义了这些字段。

## 修复

### 1. `scripts/clawhub-publish-targets.mjs`
- 每个 target 新增 `summary` 字段（精炼的腾讯云官方文档风格中文描述）
- `displayName` 改为「腾讯云 CloudBase ... / Tencent CloudBase ...」格式
  - all-in-one: `"腾讯云 CloudBase / Tencent CloudBase"`（与 docs.cloudbase.net 官方产品名一致）
  - miniprogram-development: `"腾讯云 CloudBase 微信小程序开发 / Tencent CloudBase WeChat Mini Program Development"`
  - 其他 target 同样格式
- `CLOUDBASE_ICON_URL` 改为 plugin 仓库的 logo-dark.png raw URL（`TencentCloudBase/cloudbase-plugin` 仓库的 512×512 黑底彩色 logo）

### 2. `scripts/build-clawhub-publish-artifacts.mjs`
- 让 manifest.targets 暴露 `summary` 字段（之前只暴露 `displayName` 和 `iconUrl`）

### 3. `scripts/publish-to-skillhub.mjs`
- 新增 `selectMarketplaceMetadata(target, frontmatter)` 工具函数
- 优先使用 manifest target 的 `displayName` / `summary` / `iconUrl`，fallback 到 SKILL.md frontmatter
- 在 dry-run 和 publish 日志中输出 displayName / summary / iconUrl，便于调试
- 上传 SkillHub 的 payload 三个字段都来自 curated metadata

### 4. 测试
- `tests/publish-to-skillhub.test.js`（新增 5 个测试）：覆盖 curated metadata 优先级、fallback、all-in-one 产品名回归
- `tests/publish-targets.test.js`（+2 个测试）：验证所有 target 暴露 displayName/summary/iconUrl，all-in-one displayName 是「腾讯云 CloudBase / Tencent CloudBase」
- `tests/build-clawhub-publish-artifacts.test.js`（+1 个测试）：验证 manifest 透传 curated metadata

## 验证

```
✓ tests/publish-to-skillhub.test.js (5 tests)
✓ tests/publish-targets.test.js (5 tests)
✓ tests/build-clawhub-publish-artifacts.test.js (8 tests)
✓ tests/publish-to-clawhub.test.js (2 tests)
Test Files  4 passed (4)
     Tests  20 passed (20)
```

dry-run 验证 manifest.json payload 已正确包含：

| target | displayName | summary | iconUrl |
|---|---|---|---|
| all-in-one | 腾讯云 CloudBase / Tencent CloudBase | 腾讯云 CloudBase 是面向 AI Coding 的后端一体化平台... | ...logo-dark.png |
| miniprogram-development | 腾讯云 CloudBase 微信小程序开发 / ... | 面向 AI 编码场景的腾讯云 CloudBase 微信小程序开发指南... | ...logo-dark.png |
| cloudbase-wechat-integration | 腾讯云 CloudBase 微信生态集成 / ... | 腾讯云 CloudBase 微信生态集成指南... | ...logo-dark.png |
| ui-design | 腾讯云 CloudBase UI 设计 / ... | 腾讯云 CloudBase UI 设计指南... | ...logo-dark.png |
| web-development | 腾讯云 CloudBase Web 开发 / ... | 腾讯云 CloudBase Web 前端开发指南... | ...logo-dark.png |
| spec-workflow | 腾讯云 CloudBase Spec 流程 / ... | 腾讯云 CloudBase 标准软件开发流程... | ...logo-dark.png |

## 后续

合并后下次 GitHub Actions `Publish ClawHub & SkillHub Registry` 工作流触发（手动 dispatch 或 push 到 main）时，SkillHub 卡片就会更新为新 displayName/summary/iconUrl。SkillHub 已发布的版本不会自动更新卡片，需要发布新版本才会刷新。