### PR TITLE
docs(marketplace): 📝 map Qoder/Kimi/MiniMax CN listing paths

### DIFF
--- a/specs/plugin-marketplace-listing/followup-research.md
+++ b/specs/plugin-marketplace-listing/followup-research.md
@@ -55,9 +55,11 @@ They accept `.claude-plugin/plugin.json` for Claude-ecosystem plugins; our repo 
 |--------|---------|-------------|
 | Trae MCP | Community list: [trae-community/trae-mcp](https://github.com/trae-community/trae-mcp) — PRs add rows to README MCP table. Official IDE also has in-app MCP marketplace (publisher onboarding unclear). | Open PR to `trae-mcp` listing `@cloudbase/cloudbase-mcp` / docs; separately ask Trae for curated marketplace inclusion. |
 | Trae Skills | Separate from MCP (`README-skills.md` / Trae skills docs). | Confirm whether CloudBase skills map to Trae Agent Skills format; may need a thin adapter + second PR. |
-| Qoder / QoderWork | No public third-party plugin submit docs found in this pass. | Keep `needs_partner_outreach`; monitor Qoder docs / BD. |
-| CodeBuddy | CloudBase already deep-integrated; may already be listed/native. | Confirm with CodeBuddy PM whether catalog entry is needed vs built-in. |
-| Kimi Code | No clear public third-party listing path. | Outreach / watch docs. |
+| Qoder IDE | In-product plugin market + CN community hub https://qoder.com.cn/marketplace ; packaging `.qoder-plugin/plugin.json`. | Package adapter + submit via AppHub publications; Featured may need BD. |
+| QoderWork | **Self-serve** Skill/Plugin/Connector/Workbench marketplace. Guidelines: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines | **Do next:** submit CloudBase as Plugin (skills + optional MCP). Defer Connector (needs HTTPS+OAuth). |
+| CodeBuddy | CNB marketplace sync PR open; sync script on Toolkit. | Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 ; use `npm run sync:codebuddy-marketplace` for later refreshes. |
+| Kimi Code | `/plugins` Official/Third-party/Custom; GitHub/zip/custom marketplace JSON supported. Curated tab process undocumented. | Verify GitHub install; ask Moonshot for Official/Third-party listing. |
+| MiniMax Agent | Custom MCP + MCP Builder; marketplace reuse mentioned in changelog; no public publisher URL found (2026-07-30). | Manual MCP smoke-test; monitor docs; partner outreach if catalog opens. |
 | Claude Official curated | No application; Anthropic discretion only. | Do not treat as submittable. |
 
 ## 3. Lightweight dedicated marketplace repo (optional)

--- a/specs/plugin-marketplace-listing/markets.yaml
+++ b/specs/plugin-marketplace-listing/markets.yaml
@@ -226,26 +226,34 @@ markets:
     listing_statuses:
       official_curated: unknown
       community_directory: unknown
-      self_marketplace: not_applicable
+      self_marketplace: listed
       native_connector_or_builtin: not_applicable
       open_plugin_spec: listed
       mcp_or_skill_registry: not_applicable
-      docs_only: unknown
+      docs_only: listed
     submit_url_or_process: |
-      Official / third-party marketplace tabs plus custom marketplace JSON URL (KIMI_CODE_PLUGIN_MARKETPLACE_URL). Public third-party listing path needs verification.
-    eligibility: unknown_or_partner
+      Kimi Code CLI `/plugins` has Official / Third-party / Custom tabs.
+      Users can already install via GitHub URL or `npx plugins add TencentCloudBase/cloudbase-plugin` (kimi target).
+      Custom catalog: set KIMI_CODE_PLUGIN_MARKETPLACE_URL or `/plugins marketplace <json-url>`.
+      How to land in Official/Third-party curated tabs is not publicly documented (2026-07-30) — needs Moonshot outreach.
+      Docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+    eligibility: marketplace_add_or_catalog_pr
     blockers:
-      - Official third-party listing process not fully documented
+      - Official / Third-party curated listing process not publicly documented
     evidence_links:
       - https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+      - https://www.kimi.com/code/docs/en/kimi-code/whats-new.html
     local_evidence:
       - open_plugin_spec_cloudbase
+      - plugin/cloudbase
     submit_checklist:
-      - Confirm Kimi official vs third-party submission path
-      - Plugin zip or GitHub URL installable via /plugins
+      - Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)
+      - Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin
+      - Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab
+      - Keep docs install path updated
     recommended_install_path: null
     priority_hint: needs_partner_outreach
-    last_reviewed_at: "2026-07-27"
+    last_reviewed_at: "2026-07-30"
     owner: cloudbase-ai-toolkit
 
   - id: vscode-agent-plugins
@@ -434,27 +442,73 @@ markets:
     channel_type: community_plugin_directory
     listing_statuses:
       official_curated: unknown
-      community_directory: unknown
+      community_directory: submittable
       self_marketplace: not_applicable
       native_connector_or_builtin: not_applicable
       open_plugin_spec: not_applicable
       mcp_or_skill_registry: not_applicable
       docs_only: listed
     submit_url_or_process: |
-      Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).
-    eligibility: partner_outreach_required
+      Qoder IDE has an in-product plugin marketplace (Featured/Coding/DataBase/…).
+      CN community skill hub: https://qoder.com.cn/marketplace (submit via https://qoder.com.cn/account/apphub-publications).
+      Plugin packaging uses `.qoder-plugin/plugin.json` (+ skills/MCP/hooks). See https://docs.qoder.com/zh/extensions/plugins
+      CloudBase already has ide-setup docs; Featured/curated placement may still need partner outreach.
+    eligibility: marketplace_add_or_catalog_pr
     blockers:
-      - Self-serve listing docs incomplete for third parties
+      - Need to map CloudBase package to `.qoder-plugin` layout and try community submit
+      - Featured / official curated placement process unclear
     evidence_links:
-      - https://help.aliyun.com/zh/lingma/plugin-hidden-release
+      - https://docs.qoder.com/zh/extensions/plugins
+      - https://qoder.com.cn/marketplace
+      - https://qoder.com.cn/account/apphub-publications
       - doc/ide-setup/qoder.mdx
-    local_evidence: []
+    local_evidence:
+      - doc/ide-setup/qoder.mdx
     submit_checklist:
-      - Confirm Qoder CN plugin publish channel
-      - Package plugin.json compatible layout
+      - Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout
+      - Submit Skill or Plugin via Qoder CN community / AppHub publications
+      - Verify install from Qoder plugin marketplace UI
+      - Ask Qoder for Featured category if needed
     recommended_install_path: doc/ide-setup/qoder.mdx
-    priority_hint: needs_partner_outreach
-    last_reviewed_at: "2026-07-27"
+    priority_hint: ready_to_submit
+    last_reviewed_at: "2026-07-30"
+    owner: cloudbase-ai-toolkit
+
+  - id: qoderwork-marketplace
+    product: QoderWork
+    region: cn
+    channel_type: community_plugin_directory
+    listing_statuses:
+      official_curated: unknown
+      community_directory: submittable
+      self_marketplace: not_applicable
+      native_connector_or_builtin: not_applicable
+      open_plugin_spec: not_applicable
+      mcp_or_skill_registry: submittable
+      docs_only: listed
+    submit_url_or_process: |
+      QoderWork public marketplace is self-serve inside the client: submit → review → live.
+      Four extension types: Skill / Plugin (专家套件) / Connector / 工作台.
+      Recommended first path for CloudBase: **Plugin** (skills + optional `.mcp.json` for cloudbase-mcp) or a thin **Skill**.
+      Guidelines: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+      Plugin layout requires `.qoder-plugin/plugin.json` under the package root.
+    eligibility: self_serve_submit
+    blockers: []
+    evidence_links:
+      - https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+      - https://docs.qoder.com/zh/qoderwork/connectors
+    local_evidence:
+      - plugin/cloudbase
+      - config/source/skills
+    submit_checklist:
+      - Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)
+      - Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)
+      - Submit from QoderWork client marketplace / 我的发布
+      - Pass structure precheck + automated review
+      - After live: mark community_directory listed
+    recommended_install_path: null
+    priority_hint: ready_to_submit
+    last_reviewed_at: "2026-07-30"
     owner: cloudbase-ai-toolkit
 
   - id: qoderwork-connector
@@ -470,20 +524,60 @@ markets:
       mcp_or_skill_registry: not_applicable
       docs_only: unknown
     submit_url_or_process: |
-      QoderWork has connector / integration marketplace plus custom MCP. CloudBase listing requires partner outreach.
+      Connector is a separate QoderWork extension type: public HTTPS MCP + OAuth, company identity verification, privacy/ToS, self-test report, then human review.
+      Prefer shipping CloudBase first as Plugin/Skill (`qoderwork-marketplace`); treat official Connector as a later partner track.
+      Docs: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines (Connector section)
     eligibility: partner_outreach_required
     blockers:
-      - No confirmed CloudBase listing
-      - Third-party connector submit path unclear
+      - Requires public HTTPS MCP with OAuth (current CloudBase MCP is primarily npx stdio)
+      - Company identity phone verification + legal docs
     evidence_links:
+      - https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
       - https://docs.qoder.com/zh/qoderwork/connectors
     local_evidence: []
     submit_checklist:
-      - Confirm connector onboarding with QoderWork
-      - MCP or connector packaging requirements
+      - Decide whether hosted CloudBase MCP HTTPS endpoint is in scope
+      - Prepare OAuth, privacy policy, ToS, connectivity self-test
+      - Submit Connector via QoderWork + complete company verification
     recommended_install_path: null
     priority_hint: needs_partner_outreach
-    last_reviewed_at: "2026-07-27"
+    last_reviewed_at: "2026-07-30"
+    owner: cloudbase-ai-toolkit
+
+  - id: minimax-agent-mcp
+    product: MiniMax Agent
+    region: cn
+    channel_type: mcp_registry_or_aggregator
+    listing_statuses:
+      official_curated: unknown
+      community_directory: unknown
+      self_marketplace: unknown
+      native_connector_or_builtin: not_applicable
+      open_plugin_spec: not_applicable
+      mcp_or_skill_registry: unknown
+      docs_only: listed
+    submit_url_or_process: |
+      MiniMax Agent supports custom MCP and an in-product MCP Builder; changelog mentions adding completed MCPs to a marketplace for reuse.
+      No stable public third-party developer submission URL found (2026-07-30).
+      Near-term path: document manual MCP config (`npx @cloudbase/cloudbase-mcp@latest`) for MiniMax Agent users; watch Agent docs/changelog for publisher onboarding.
+      Refs: https://agent.minimaxi.com/docs/user-guide ; https://agent.minimax.io/docs/changelog
+    eligibility: unknown_or_partner
+    blockers:
+      - No public third-party plugin/MCP submit form found
+      - Marketplace reuse appears product-internal after MCP Builder
+    evidence_links:
+      - https://agent.minimaxi.com/docs/user-guide
+      - https://agent.minimax.io/docs/user-guide
+      - https://agent.minimax.io/docs/changelog
+    local_evidence: []
+    submit_checklist:
+      - Smoke-test CloudBase MCP inside MiniMax Agent (manual add)
+      - Add ide-setup / docs note if product fit is confirmed
+      - Monitor MiniMax for public marketplace publisher docs
+      - Partner outreach if curated catalog is required
+    recommended_install_path: null
+    priority_hint: needs_partner_outreach
+    last_reviewed_at: "2026-07-30"
     owner: cloudbase-ai-toolkit
 
   - id: trae-mcp-marketplace

--- a/specs/plugin-marketplace-listing/reports/latest.json
+++ b/specs/plugin-marketplace-listing/reports/latest.json
@@ -1,10 +1,10 @@
 {
-  "generated_at": "2026-07-28T03:32:40.305Z",
+  "generated_at": "2026-07-30T10:38:16.628Z",
   "matrix_version": 1,
   "reviewed_stale_days": 90,
-  "total_markets": 42,
+  "total_markets": 44,
   "summary": {
-    "ready_to_submit": 6,
+    "ready_to_submit": 8,
     "needs_packaging_or_manifest": 0,
     "needs_partner_outreach": 13,
     "listed": 7,
@@ -189,11 +189,12 @@
         "eligibility": "public_github_repo_required",
         "blockers": [],
         "evidence_links": [
+          "https://cursor.directory/plugins/cloudbase",
           "https://cursor.directory",
           "https://cursor.directory/plugins/new",
           "https://cursor.com/docs/plugins"
         ],
-        "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new\n(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)\n",
+        "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).\nSource repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).\n",
         "recommended_install_path": "doc/ide-setup/cursor.mdx",
         "last_reviewed_at": "2026-07-28",
         "owner": "cloudbase-ai-toolkit",
@@ -436,6 +437,144 @@
         "priority": "ready_to_submit",
         "stale": false,
         "manual_submit_only": true
+      },
+      {
+        "id": "qoder-plugin",
+        "product": "Qoder",
+        "region": "cn",
+        "channel_type": "community_plugin_directory",
+        "listing_statuses": {
+          "official_curated": "unknown",
+          "community_directory": "submittable",
+          "self_marketplace": "not_applicable",
+          "native_connector_or_builtin": "not_applicable",
+          "open_plugin_spec": "not_applicable",
+          "mcp_or_skill_registry": "not_applicable",
+          "docs_only": "listed"
+        },
+        "eligibility": "marketplace_add_or_catalog_pr",
+        "blockers": [
+          "Need to map CloudBase package to `.qoder-plugin` layout and try community submit",
+          "Featured / official curated placement process unclear"
+        ],
+        "evidence_links": [
+          "https://docs.qoder.com/zh/extensions/plugins",
+          "https://qoder.com.cn/marketplace",
+          "https://qoder.com.cn/account/apphub-publications",
+          "doc/ide-setup/qoder.mdx"
+        ],
+        "submit_url_or_process": "Qoder IDE has an in-product plugin marketplace (Featured/Coding/DataBase/…).\nCN community skill hub: https://qoder.com.cn/marketplace (submit via https://qoder.com.cn/account/apphub-publications).\nPlugin packaging uses `.qoder-plugin/plugin.json` (+ skills/MCP/hooks). See https://docs.qoder.com/zh/extensions/plugins\nCloudBase already has ide-setup docs; Featured/curated placement may still need partner outreach.\n",
+        "recommended_install_path": "doc/ide-setup/qoder.mdx",
+        "last_reviewed_at": "2026-07-30",
+        "owner": "cloudbase-ai-toolkit",
+        "local_evidence": [
+          {
+            "id": "doc/ide-setup/qoder.mdx",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"doc/ide-setup/qoder.mdx\"",
+            "paths": []
+          }
+        ],
+        "submit_checklist": [
+          "Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout",
+          "Submit Skill or Plugin via Qoder CN community / AppHub publications",
+          "Verify install from Qoder plugin marketplace UI",
+          "Ask Qoder for Featured category if needed"
+        ],
+        "materials": [
+          {
+            "item": "Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Submit Skill or Plugin via Qoder CN community / AppHub publications",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Verify install from Qoder plugin marketplace UI",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Ask Qoder for Featured category if needed",
+            "status": "manual_or_external"
+          }
+        ],
+        "priority": "ready_to_submit",
+        "stale": false,
+        "manual_submit_only": true
+      },
+      {
+        "id": "qoderwork-marketplace",
+        "product": "QoderWork",
+        "region": "cn",
+        "channel_type": "community_plugin_directory",
+        "listing_statuses": {
+          "official_curated": "unknown",
+          "community_directory": "submittable",
+          "self_marketplace": "not_applicable",
+          "native_connector_or_builtin": "not_applicable",
+          "open_plugin_spec": "not_applicable",
+          "mcp_or_skill_registry": "submittable",
+          "docs_only": "listed"
+        },
+        "eligibility": "self_serve_submit",
+        "blockers": [],
+        "evidence_links": [
+          "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
+          "https://docs.qoder.com/zh/qoderwork/connectors"
+        ],
+        "submit_url_or_process": "QoderWork public marketplace is self-serve inside the client: submit → review → live.\nFour extension types: Skill / Plugin (专家套件) / Connector / 工作台.\nRecommended first path for CloudBase: **Plugin** (skills + optional `.mcp.json` for cloudbase-mcp) or a thin **Skill**.\nGuidelines: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines\nPlugin layout requires `.qoder-plugin/plugin.json` under the package root.\n",
+        "recommended_install_path": null,
+        "last_reviewed_at": "2026-07-30",
+        "owner": "cloudbase-ai-toolkit",
+        "local_evidence": [
+          {
+            "id": "plugin/cloudbase",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"plugin/cloudbase\"",
+            "paths": []
+          },
+          {
+            "id": "config/source/skills",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"config/source/skills\"",
+            "paths": []
+          }
+        ],
+        "submit_checklist": [
+          "Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)",
+          "Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)",
+          "Submit from QoderWork client marketplace / 我的发布",
+          "Pass structure precheck + automated review",
+          {
+            "After live": "mark community_directory listed"
+          }
+        ],
+        "materials": [
+          {
+            "item": "Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Submit from QoderWork client marketplace / 我的发布",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Pass structure precheck + automated review",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "[object Object]",
+            "status": "manual_or_external"
+          }
+        ],
+        "priority": "ready_to_submit",
+        "stale": false,
+        "manual_submit_only": true
       }
     ],
     "needs_packaging_or_manifest": [],
@@ -498,22 +637,23 @@
         "listing_statuses": {
           "official_curated": "unknown",
           "community_directory": "unknown",
-          "self_marketplace": "not_applicable",
+          "self_marketplace": "listed",
           "native_connector_or_builtin": "not_applicable",
           "open_plugin_spec": "listed",
           "mcp_or_skill_registry": "not_applicable",
-          "docs_only": "unknown"
+          "docs_only": "listed"
         },
-        "eligibility": "unknown_or_partner",
+        "eligibility": "marketplace_add_or_catalog_pr",
         "blockers": [
-          "Official third-party listing process not fully documented"
+          "Official / Third-party curated listing process not publicly documented"
         ],
         "evidence_links": [
-          "https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html"
+          "https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html",
+          "https://www.kimi.com/code/docs/en/kimi-code/whats-new.html"
         ],
-        "submit_url_or_process": "Official / third-party marketplace tabs plus custom marketplace JSON URL (KIMI_CODE_PLUGIN_MARKETPLACE_URL). Public third-party listing path needs verification.\n",
+        "submit_url_or_process": "Kimi Code CLI `/plugins` has Official / Third-party / Custom tabs.\nUsers can already install via GitHub URL or `npx plugins add TencentCloudBase/cloudbase-plugin` (kimi target).\nCustom catalog: set KIMI_CODE_PLUGIN_MARKETPLACE_URL or `/plugins marketplace <json-url>`.\nHow to land in Official/Third-party curated tabs is not publicly documented (2026-07-30) — needs Moonshot outreach.\nDocs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html\n",
         "recommended_install_path": null,
-        "last_reviewed_at": "2026-07-27",
+        "last_reviewed_at": "2026-07-30",
         "owner": "cloudbase-ai-toolkit",
         "local_evidence": [
           {
@@ -523,20 +663,36 @@
             "paths": [
               "plugin/cloudbase/.plugin/plugin.json"
             ]
+          },
+          {
+            "id": "plugin/cloudbase",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"plugin/cloudbase\"",
+            "paths": []
           }
         ],
         "submit_checklist": [
-          "Confirm Kimi official vs third-party submission path",
-          "Plugin zip or GitHub URL installable via /plugins"
+          "Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)",
+          "Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin",
+          "Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab",
+          "Keep docs install path updated"
         ],
         "materials": [
           {
-            "item": "Confirm Kimi official vs third-party submission path",
-            "status": "repo_ready_or_external"
+            "item": "Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)",
+            "status": "manual_or_external"
           },
           {
-            "item": "Plugin zip or GitHub URL installable via /plugins",
-            "status": "repo_ready_or_external"
+            "item": "Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Keep docs install path updated",
+            "status": "manual_or_external"
           }
         ],
         "priority": "needs_partner_outreach",
@@ -549,38 +705,59 @@
         "region": "cn",
         "channel_type": "native_connector_or_builtin",
         "listing_statuses": {
-          "official_curated": "unknown",
+          "official_curated": "listed",
           "community_directory": "unknown",
           "self_marketplace": "not_applicable",
-          "native_connector_or_builtin": "unknown",
+          "native_connector_or_builtin": "listed",
           "open_plugin_spec": "not_applicable",
           "mcp_or_skill_registry": "not_applicable",
           "docs_only": "listed"
         },
         "eligibility": "partner_outreach_required",
         "blockers": [
-          "Official listing status for CloudBase needs confirmation"
+          "Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)"
         ],
         "evidence_links": [
+          "https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase",
+          "https://cnb.cool/tencent/cloud/cloudbase/marketplace",
+          "https://cnb.cool/codebuddy/marketplace/-/pulls/19",
           "https://www.codebuddy.cn/docs/cli/plugins",
           "doc/ide-setup/codebuddy.mdx"
         ],
-        "submit_url_or_process": "CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.\n",
+        "submit_url_or_process": "Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).\nFork: https://cnb.cool/tencent/cloud/cloudbase/marketplace\nPR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).\n",
         "recommended_install_path": "doc/ide-setup/codebuddy.mdx",
-        "last_reviewed_at": "2026-07-27",
+        "last_reviewed_at": "2026-07-29",
         "owner": "cloudbase-ai-toolkit",
-        "local_evidence": [],
+        "local_evidence": [
+          {
+            "id": "config/codebuddy-plugin",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"config/codebuddy-plugin\"",
+            "paths": []
+          },
+          {
+            "id": "specs/plugin-marketplace-listing/submission-log.md",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"specs/plugin-marketplace-listing/submission-log.md\"",
+            "paths": []
+          }
+        ],
         "submit_checklist": [
-          "Confirm CodeBuddy marketplace submission process",
-          "Align with config/codebuddy-plugin if applicable"
+          "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
+          "Confirm keep rules/cloudbase_rules.md in marketplace package",
+          "Ask CodeBuddy product team about built-in IDE sync if needed"
         ],
         "materials": [
           {
-            "item": "Confirm CodeBuddy marketplace submission process",
+            "item": "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
             "status": "manual_or_external"
           },
           {
-            "item": "Align with config/codebuddy-plugin if applicable",
+            "item": "Confirm keep rules/cloudbase_rules.md in marketplace package",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Ask CodeBuddy product team about built-in IDE sync if needed",
             "status": "manual_or_external"
           }
         ],
@@ -634,51 +811,6 @@
         "manual_submit_only": true
       },
       {
-        "id": "qoder-plugin",
-        "product": "Qoder",
-        "region": "cn",
-        "channel_type": "community_plugin_directory",
-        "listing_statuses": {
-          "official_curated": "unknown",
-          "community_directory": "unknown",
-          "self_marketplace": "not_applicable",
-          "native_connector_or_builtin": "not_applicable",
-          "open_plugin_spec": "not_applicable",
-          "mcp_or_skill_registry": "not_applicable",
-          "docs_only": "listed"
-        },
-        "eligibility": "partner_outreach_required",
-        "blockers": [
-          "Self-serve listing docs incomplete for third parties"
-        ],
-        "evidence_links": [
-          "https://help.aliyun.com/zh/lingma/plugin-hidden-release",
-          "doc/ide-setup/qoder.mdx"
-        ],
-        "submit_url_or_process": "Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).\n",
-        "recommended_install_path": "doc/ide-setup/qoder.mdx",
-        "last_reviewed_at": "2026-07-27",
-        "owner": "cloudbase-ai-toolkit",
-        "local_evidence": [],
-        "submit_checklist": [
-          "Confirm Qoder CN plugin publish channel",
-          "Package plugin.json compatible layout"
-        ],
-        "materials": [
-          {
-            "item": "Confirm Qoder CN plugin publish channel",
-            "status": "manual_or_external"
-          },
-          {
-            "item": "Package plugin.json compatible layout",
-            "status": "manual_or_external"
-          }
-        ],
-        "priority": "needs_partner_outreach",
-        "stale": false,
-        "manual_submit_only": true
-      },
-      {
         "id": "qoderwork-connector",
         "product": "QoderWork",
         "region": "cn",
@@ -694,28 +826,91 @@
         },
         "eligibility": "partner_outreach_required",
         "blockers": [
-          "No confirmed CloudBase listing",
-          "Third-party connector submit path unclear"
+          "Requires public HTTPS MCP with OAuth (current CloudBase MCP is primarily npx stdio)",
+          "Company identity phone verification + legal docs"
         ],
         "evidence_links": [
+          "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
           "https://docs.qoder.com/zh/qoderwork/connectors"
         ],
-        "submit_url_or_process": "QoderWork has connector / integration marketplace plus custom MCP. CloudBase listing requires partner outreach.\n",
+        "submit_url_or_process": "Connector is a separate QoderWork extension type: public HTTPS MCP + OAuth, company identity verification, privacy/ToS, self-test report, then human review.\nPrefer shipping CloudBase first as Plugin/Skill (`qoderwork-marketplace`); treat official Connector as a later partner track.\nDocs: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines (Connector section)\n",
         "recommended_install_path": null,
-        "last_reviewed_at": "2026-07-27",
+        "last_reviewed_at": "2026-07-30",
         "owner": "cloudbase-ai-toolkit",
         "local_evidence": [],
         "submit_checklist": [
-          "Confirm connector onboarding with QoderWork",
-          "MCP or connector packaging requirements"
+          "Decide whether hosted CloudBase MCP HTTPS endpoint is in scope",
+          "Prepare OAuth, privacy policy, ToS, connectivity self-test",
+          "Submit Connector via QoderWork + complete company verification"
         ],
         "materials": [
           {
-            "item": "Confirm connector onboarding with QoderWork",
+            "item": "Decide whether hosted CloudBase MCP HTTPS endpoint is in scope",
             "status": "manual_or_external"
           },
           {
-            "item": "MCP or connector packaging requirements",
+            "item": "Prepare OAuth, privacy policy, ToS, connectivity self-test",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Submit Connector via QoderWork + complete company verification",
+            "status": "manual_or_external"
+          }
+        ],
+        "priority": "needs_partner_outreach",
+        "stale": false,
+        "manual_submit_only": true
+      },
+      {
+        "id": "minimax-agent-mcp",
+        "product": "MiniMax Agent",
+        "region": "cn",
+        "channel_type": "mcp_registry_or_aggregator",
+        "listing_statuses": {
+          "official_curated": "unknown",
+          "community_directory": "unknown",
+          "self_marketplace": "unknown",
+          "native_connector_or_builtin": "not_applicable",
+          "open_plugin_spec": "not_applicable",
+          "mcp_or_skill_registry": "unknown",
+          "docs_only": "listed"
+        },
+        "eligibility": "unknown_or_partner",
+        "blockers": [
+          "No public third-party plugin/MCP submit form found",
+          "Marketplace reuse appears product-internal after MCP Builder"
+        ],
+        "evidence_links": [
+          "https://agent.minimaxi.com/docs/user-guide",
+          "https://agent.minimax.io/docs/user-guide",
+          "https://agent.minimax.io/docs/changelog"
+        ],
+        "submit_url_or_process": "MiniMax Agent supports custom MCP and an in-product MCP Builder; changelog mentions adding completed MCPs to a marketplace for reuse.\nNo stable public third-party developer submission URL found (2026-07-30).\nNear-term path: document manual MCP config (`npx @cloudbase/cloudbase-mcp@latest`) for MiniMax Agent users; watch Agent docs/changelog for publisher onboarding.\nRefs: https://agent.minimaxi.com/docs/user-guide ; https://agent.minimax.io/docs/changelog\n",
+        "recommended_install_path": null,
+        "last_reviewed_at": "2026-07-30",
+        "owner": "cloudbase-ai-toolkit",
+        "local_evidence": [],
+        "submit_checklist": [
+          "Smoke-test CloudBase MCP inside MiniMax Agent (manual add)",
+          "Add ide-setup / docs note if product fit is confirmed",
+          "Monitor MiniMax for public marketplace publisher docs",
+          "Partner outreach if curated catalog is required"
+        ],
+        "materials": [
+          {
+            "item": "Smoke-test CloudBase MCP inside MiniMax Agent (manual add)",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Add ide-setup / docs note if product fit is confirmed",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Monitor MiniMax for public marketplace publisher docs",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Partner outreach if curated catalog is required",
             "status": "manual_or_external"
           }
         ],
@@ -2045,11 +2240,12 @@
       "eligibility": "public_github_repo_required",
       "blockers": [],
       "evidence_links": [
+        "https://cursor.directory/plugins/cloudbase",
         "https://cursor.directory",
         "https://cursor.directory/plugins/new",
         "https://cursor.com/docs/plugins"
       ],
-      "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new\n(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)\n",
+      "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).\nSource repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).\n",
       "recommended_install_path": "doc/ide-setup/cursor.mdx",
       "last_reviewed_at": "2026-07-28",
       "owner": "cloudbase-ai-toolkit",
@@ -2239,22 +2435,23 @@
       "listing_statuses": {
         "official_curated": "unknown",
         "community_directory": "unknown",
-        "self_marketplace": "not_applicable",
+        "self_marketplace": "listed",
         "native_connector_or_builtin": "not_applicable",
         "open_plugin_spec": "listed",
         "mcp_or_skill_registry": "not_applicable",
-        "docs_only": "unknown"
+        "docs_only": "listed"
       },
-      "eligibility": "unknown_or_partner",
+      "eligibility": "marketplace_add_or_catalog_pr",
       "blockers": [
-        "Official third-party listing process not fully documented"
+        "Official / Third-party curated listing process not publicly documented"
       ],
       "evidence_links": [
-        "https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html"
+        "https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html",
+        "https://www.kimi.com/code/docs/en/kimi-code/whats-new.html"
       ],
-      "submit_url_or_process": "Official / third-party marketplace tabs plus custom marketplace JSON URL (KIMI_CODE_PLUGIN_MARKETPLACE_URL). Public third-party listing path needs verification.\n",
+      "submit_url_or_process": "Kimi Code CLI `/plugins` has Official / Third-party / Custom tabs.\nUsers can already install via GitHub URL or `npx plugins add TencentCloudBase/cloudbase-plugin` (kimi target).\nCustom catalog: set KIMI_CODE_PLUGIN_MARKETPLACE_URL or `/plugins marketplace <json-url>`.\nHow to land in Official/Third-party curated tabs is not publicly documented (2026-07-30) — needs Moonshot outreach.\nDocs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html\n",
       "recommended_install_path": null,
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-30",
       "owner": "cloudbase-ai-toolkit",
       "local_evidence": [
         {
@@ -2264,20 +2461,36 @@
           "paths": [
             "plugin/cloudbase/.plugin/plugin.json"
           ]
+        },
+        {
+          "id": "plugin/cloudbase",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"plugin/cloudbase\"",
+          "paths": []
         }
       ],
       "submit_checklist": [
-        "Confirm Kimi official vs third-party submission path",
-        "Plugin zip or GitHub URL installable via /plugins"
+        "Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)",
+        "Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin",
+        "Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab",
+        "Keep docs install path updated"
       ],
       "materials": [
         {
-          "item": "Confirm Kimi official vs third-party submission path",
-          "status": "repo_ready_or_external"
+          "item": "Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)",
+          "status": "manual_or_external"
         },
         {
-          "item": "Plugin zip or GitHub URL installable via /plugins",
-          "status": "repo_ready_or_external"
+          "item": "Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Keep docs install path updated",
+          "status": "manual_or_external"
         }
       ],
       "priority": "needs_partner_outreach",
@@ -2469,38 +2682,59 @@
       "region": "cn",
       "channel_type": "native_connector_or_builtin",
       "listing_statuses": {
-        "official_curated": "unknown",
+        "official_curated": "listed",
         "community_directory": "unknown",
         "self_marketplace": "not_applicable",
-        "native_connector_or_builtin": "unknown",
+        "native_connector_or_builtin": "listed",
         "open_plugin_spec": "not_applicable",
         "mcp_or_skill_registry": "not_applicable",
         "docs_only": "listed"
       },
       "eligibility": "partner_outreach_required",
       "blockers": [
-        "Official listing status for CloudBase needs confirmation"
+        "Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)"
       ],
       "evidence_links": [
+        "https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase",
+        "https://cnb.cool/tencent/cloud/cloudbase/marketplace",
+        "https://cnb.cool/codebuddy/marketplace/-/pulls/19",
         "https://www.codebuddy.cn/docs/cli/plugins",
         "doc/ide-setup/codebuddy.mdx"
       ],
-      "submit_url_or_process": "CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.\n",
+      "submit_url_or_process": "Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).\nFork: https://cnb.cool/tencent/cloud/cloudbase/marketplace\nPR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).\n",
       "recommended_install_path": "doc/ide-setup/codebuddy.mdx",
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-29",
       "owner": "cloudbase-ai-toolkit",
-      "local_evidence": [],
+      "local_evidence": [
+        {
+          "id": "config/codebuddy-plugin",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"config/codebuddy-plugin\"",
+          "paths": []
+        },
+        {
+          "id": "specs/plugin-marketplace-listing/submission-log.md",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"specs/plugin-marketplace-listing/submission-log.md\"",
+          "paths": []
+        }
+      ],
       "submit_checklist": [
-        "Confirm CodeBuddy marketplace submission process",
-        "Align with config/codebuddy-plugin if applicable"
+        "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
+        "Confirm keep rules/cloudbase_rules.md in marketplace package",
+        "Ask CodeBuddy product team about built-in IDE sync if needed"
       ],
       "materials": [
         {
-          "item": "Confirm CodeBuddy marketplace submission process",
+          "item": "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
           "status": "manual_or_external"
         },
         {
-          "item": "Align with config/codebuddy-plugin if applicable",
+          "item": "Confirm keep rules/cloudbase_rules.md in marketplace package",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Ask CodeBuddy product team about built-in IDE sync if needed",
           "status": "manual_or_external"
         }
       ],
@@ -2560,41 +2794,134 @@
       "channel_type": "community_plugin_directory",
       "listing_statuses": {
         "official_curated": "unknown",
-        "community_directory": "unknown",
+        "community_directory": "submittable",
         "self_marketplace": "not_applicable",
         "native_connector_or_builtin": "not_applicable",
         "open_plugin_spec": "not_applicable",
         "mcp_or_skill_registry": "not_applicable",
         "docs_only": "listed"
       },
-      "eligibility": "partner_outreach_required",
+      "eligibility": "marketplace_add_or_catalog_pr",
       "blockers": [
-        "Self-serve listing docs incomplete for third parties"
+        "Need to map CloudBase package to `.qoder-plugin` layout and try community submit",
+        "Featured / official curated placement process unclear"
       ],
       "evidence_links": [
-        "https://help.aliyun.com/zh/lingma/plugin-hidden-release",
+        "https://docs.qoder.com/zh/extensions/plugins",
+        "https://qoder.com.cn/marketplace",
+        "https://qoder.com.cn/account/apphub-publications",
         "doc/ide-setup/qoder.mdx"
       ],
-      "submit_url_or_process": "Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).\n",
+      "submit_url_or_process": "Qoder IDE has an in-product plugin marketplace (Featured/Coding/DataBase/…).\nCN community skill hub: https://qoder.com.cn/marketplace (submit via https://qoder.com.cn/account/apphub-publications).\nPlugin packaging uses `.qoder-plugin/plugin.json` (+ skills/MCP/hooks). See https://docs.qoder.com/zh/extensions/plugins\nCloudBase already has ide-setup docs; Featured/curated placement may still need partner outreach.\n",
       "recommended_install_path": "doc/ide-setup/qoder.mdx",
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-30",
       "owner": "cloudbase-ai-toolkit",
-      "local_evidence": [],
+      "local_evidence": [
+        {
+          "id": "doc/ide-setup/qoder.mdx",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"doc/ide-setup/qoder.mdx\"",
+          "paths": []
+        }
+      ],
       "submit_checklist": [
-        "Confirm Qoder CN plugin publish channel",
-        "Package plugin.json compatible layout"
+        "Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout",
+        "Submit Skill or Plugin via Qoder CN community / AppHub publications",
+        "Verify install from Qoder plugin marketplace UI",
+        "Ask Qoder for Featured category if needed"
       ],
       "materials": [
         {
-          "item": "Confirm Qoder CN plugin publish channel",
+          "item": "Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout",
           "status": "manual_or_external"
         },
         {
-          "item": "Package plugin.json compatible layout",
+          "item": "Submit Skill or Plugin via Qoder CN community / AppHub publications",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Verify install from Qoder plugin marketplace UI",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Ask Qoder for Featured category if needed",
           "status": "manual_or_external"
         }
       ],
-      "priority": "needs_partner_outreach",
+      "priority": "ready_to_submit",
+      "stale": false,
+      "manual_submit_only": true
+    },
+    {
+      "id": "qoderwork-marketplace",
+      "product": "QoderWork",
+      "region": "cn",
+      "channel_type": "community_plugin_directory",
+      "listing_statuses": {
+        "official_curated": "unknown",
+        "community_directory": "submittable",
+        "self_marketplace": "not_applicable",
+        "native_connector_or_builtin": "not_applicable",
+        "open_plugin_spec": "not_applicable",
+        "mcp_or_skill_registry": "submittable",
+        "docs_only": "listed"
+      },
+      "eligibility": "self_serve_submit",
+      "blockers": [],
+      "evidence_links": [
+        "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
+        "https://docs.qoder.com/zh/qoderwork/connectors"
+      ],
+      "submit_url_or_process": "QoderWork public marketplace is self-serve inside the client: submit → review → live.\nFour extension types: Skill / Plugin (专家套件) / Connector / 工作台.\nRecommended first path for CloudBase: **Plugin** (skills + optional `.mcp.json` for cloudbase-mcp) or a thin **Skill**.\nGuidelines: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines\nPlugin layout requires `.qoder-plugin/plugin.json` under the package root.\n",
+      "recommended_install_path": null,
+      "last_reviewed_at": "2026-07-30",
+      "owner": "cloudbase-ai-toolkit",
+      "local_evidence": [
+        {
+          "id": "plugin/cloudbase",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"plugin/cloudbase\"",
+          "paths": []
+        },
+        {
+          "id": "config/source/skills",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"config/source/skills\"",
+          "paths": []
+        }
+      ],
+      "submit_checklist": [
+        "Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)",
+        "Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)",
+        "Submit from QoderWork client marketplace / 我的发布",
+        "Pass structure precheck + automated review",
+        {
+          "After live": "mark community_directory listed"
+        }
+      ],
+      "materials": [
+        {
+          "item": "Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Submit from QoderWork client marketplace / 我的发布",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Pass structure precheck + automated review",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "[object Object]",
+          "status": "manual_or_external"
+        }
+      ],
+      "priority": "ready_to_submit",
       "stale": false,
       "manual_submit_only": true
     },
@@ -2614,28 +2941,91 @@
       },
       "eligibility": "partner_outreach_required",
       "blockers": [
-        "No confirmed CloudBase listing",
-        "Third-party connector submit path unclear"
+        "Requires public HTTPS MCP with OAuth (current CloudBase MCP is primarily npx stdio)",
+        "Company identity phone verification + legal docs"
       ],
       "evidence_links": [
+        "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
         "https://docs.qoder.com/zh/qoderwork/connectors"
       ],
-      "submit_url_or_process": "QoderWork has connector / integration marketplace plus custom MCP. CloudBase listing requires partner outreach.\n",
+      "submit_url_or_process": "Connector is a separate QoderWork extension type: public HTTPS MCP + OAuth, company identity verification, privacy/ToS, self-test report, then human review.\nPrefer shipping CloudBase first as Plugin/Skill (`qoderwork-marketplace`); treat official Connector as a later partner track.\nDocs: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines (Connector section)\n",
       "recommended_install_path": null,
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-30",
       "owner": "cloudbase-ai-toolkit",
       "local_evidence": [],
       "submit_checklist": [
-        "Confirm connector onboarding with QoderWork",
-        "MCP or connector packaging requirements"
+        "Decide whether hosted CloudBase MCP HTTPS endpoint is in scope",
+        "Prepare OAuth, privacy policy, ToS, connectivity self-test",
+        "Submit Connector via QoderWork + complete company verification"
       ],
       "materials": [
         {
-          "item": "Confirm connector onboarding with QoderWork",
+          "item": "Decide whether hosted CloudBase MCP HTTPS endpoint is in scope",
           "status": "manual_or_external"
         },
         {
-          "item": "MCP or connector packaging requirements",
+          "item": "Prepare OAuth, privacy policy, ToS, connectivity self-test",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Submit Connector via QoderWork + complete company verification",
+          "status": "manual_or_external"
+        }
+      ],
+      "priority": "needs_partner_outreach",
+      "stale": false,
+      "manual_submit_only": true
+    },
+    {
+      "id": "minimax-agent-mcp",
+      "product": "MiniMax Agent",
+      "region": "cn",
+      "channel_type": "mcp_registry_or_aggregator",
+      "listing_statuses": {
+        "official_curated": "unknown",
+        "community_directory": "unknown",
+        "self_marketplace": "unknown",
+        "native_connector_or_builtin": "not_applicable",
+        "open_plugin_spec": "not_applicable",
+        "mcp_or_skill_registry": "unknown",
+        "docs_only": "listed"
+      },
+      "eligibility": "unknown_or_partner",
+      "blockers": [
+        "No public third-party plugin/MCP submit form found",
+        "Marketplace reuse appears product-internal after MCP Builder"
+      ],
+      "evidence_links": [
+        "https://agent.minimaxi.com/docs/user-guide",
+        "https://agent.minimax.io/docs/user-guide",
+        "https://agent.minimax.io/docs/changelog"
+      ],
+      "submit_url_or_process": "MiniMax Agent supports custom MCP and an in-product MCP Builder; changelog mentions adding completed MCPs to a marketplace for reuse.\nNo stable public third-party developer submission URL found (2026-07-30).\nNear-term path: document manual MCP config (`npx @cloudbase/cloudbase-mcp@latest`) for MiniMax Agent users; watch Agent docs/changelog for publisher onboarding.\nRefs: https://agent.minimaxi.com/docs/user-guide ; https://agent.minimax.io/docs/changelog\n",
+      "recommended_install_path": null,
+      "last_reviewed_at": "2026-07-30",
+      "owner": "cloudbase-ai-toolkit",
+      "local_evidence": [],
+      "submit_checklist": [
+        "Smoke-test CloudBase MCP inside MiniMax Agent (manual add)",
+        "Add ide-setup / docs note if product fit is confirmed",
+        "Monitor MiniMax for public marketplace publisher docs",
+        "Partner outreach if curated catalog is required"
+      ],
+      "materials": [
+        {
+          "item": "Smoke-test CloudBase MCP inside MiniMax Agent (manual add)",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Add ide-setup / docs note if product fit is confirmed",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Monitor MiniMax for public marketplace publisher docs",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Partner outreach if curated catalog is required",
           "status": "manual_or_external"
         }
       ],

--- a/specs/plugin-marketplace-listing/reports/latest.md
+++ b/specs/plugin-marketplace-listing/reports/latest.md
@@ -1,16 +1,16 @@
 # CloudBase Plugin Marketplace Analysis
 
-Generated: 2026-07-28T03:32:40.305Z
+Generated: 2026-07-30T10:38:16.628Z
 
 > This report does not auto-submit to any marketplace. All submissions are manual.
 
 ## Summary
 
-Total markets: **42**
+Total markets: **44**
 
 | Priority | Count |
 |----------|------:|
-| ready_to_submit | 6 |
+| ready_to_submit | 8 |
 | needs_packaging_or_manifest | 0 |
 | needs_partner_outreach | 13 |
 | listed | 7 |
@@ -149,12 +149,13 @@ Process:
 
 ```
 Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.
-Status 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new
-(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)
+Status 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).
+Source repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).
 ```
 
 Evidence:
 
+- https://cursor.directory/plugins/cloudbase
 - https://cursor.directory
 - https://cursor.directory/plugins/new
 - https://cursor.com/docs/plugins
@@ -290,6 +291,104 @@ Evidence:
 
 Recommended install docs: `doc/ide-setup/vscode.mdx`
 
+### qoder-plugin — Qoder
+
+- Region: cn
+- Channel: `community_plugin_directory`
+- Eligibility: `marketplace_add_or_catalog_pr`
+- Last reviewed: 2026-07-30
+- Manual submit only: yes
+
+Statuses:
+
+- `official_curated`: unknown
+- `community_directory`: submittable
+- `self_marketplace`: not_applicable
+- `native_connector_or_builtin`: not_applicable
+- `open_plugin_spec`: not_applicable
+- `mcp_or_skill_registry`: not_applicable
+- `docs_only`: listed
+
+Blockers:
+
+- Need to map CloudBase package to `.qoder-plugin` layout and try community submit
+- Featured / official curated placement process unclear
+
+Local evidence:
+
+- `doc/ide-setup/qoder.mdx`: **invalid** — Unknown local_evidence id "doc/ide-setup/qoder.mdx"
+
+Submit checklist:
+
+- [ ] Adapt plugin/cloudbase (or thin wrapper) to `.qoder-plugin/plugin.json` layout
+- [ ] Submit Skill or Plugin via Qoder CN community / AppHub publications
+- [ ] Verify install from Qoder plugin marketplace UI
+- [ ] Ask Qoder for Featured category if needed
+
+Process:
+
+```
+Qoder IDE has an in-product plugin marketplace (Featured/Coding/DataBase/…).
+CN community skill hub: https://qoder.com.cn/marketplace (submit via https://qoder.com.cn/account/apphub-publications).
+Plugin packaging uses `.qoder-plugin/plugin.json` (+ skills/MCP/hooks). See https://docs.qoder.com/zh/extensions/plugins
+CloudBase already has ide-setup docs; Featured/curated placement may still need partner outreach.
+```
+
+Evidence:
+
+- https://docs.qoder.com/zh/extensions/plugins
+- https://qoder.com.cn/marketplace
+- https://qoder.com.cn/account/apphub-publications
+- doc/ide-setup/qoder.mdx
+
+Recommended install docs: `doc/ide-setup/qoder.mdx`
+
+### qoderwork-marketplace — QoderWork
+
+- Region: cn
+- Channel: `community_plugin_directory`
+- Eligibility: `self_serve_submit`
+- Last reviewed: 2026-07-30
+- Manual submit only: yes
+
+Statuses:
+
+- `official_curated`: unknown
+- `community_directory`: submittable
+- `self_marketplace`: not_applicable
+- `native_connector_or_builtin`: not_applicable
+- `open_plugin_spec`: not_applicable
+- `mcp_or_skill_registry`: submittable
+- `docs_only`: listed
+
+Local evidence:
+
+- `plugin/cloudbase`: **invalid** — Unknown local_evidence id "plugin/cloudbase"
+- `config/source/skills`: **invalid** — Unknown local_evidence id "config/source/skills"
+
+Submit checklist:
+
+- [ ] Choose Plugin vs Skill packaging (prefer Plugin wrapping CloudBase skills + MCP)
+- [ ] Produce `.qoder-plugin/plugin.json` + skills/ + optional `.mcp.json` (stdio npx @cloudbase/cloudbase-mcp)
+- [ ] Submit from QoderWork client marketplace / 我的发布
+- [ ] Pass structure precheck + automated review
+- [ ] [object Object]
+
+Process:
+
+```
+QoderWork public marketplace is self-serve inside the client: submit → review → live.
+Four extension types: Skill / Plugin (专家套件) / Connector / 工作台.
+Recommended first path for CloudBase: **Plugin** (skills + optional `.mcp.json` for cloudbase-mcp) or a thin **Skill**.
+Guidelines: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+Plugin layout requires `.qoder-plugin/plugin.json` under the package root.
+```
+
+Evidence:
+
+- https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+- https://docs.qoder.com/zh/qoderwork/connectors
+
 ## needs_packaging_or_manifest
 
 _None_
@@ -340,78 +439,97 @@ Recommended install docs: `doc/ide-setup/claude-code.mdx`
 
 - Region: cn
 - Channel: `community_plugin_directory`
-- Eligibility: `unknown_or_partner`
-- Last reviewed: 2026-07-27
+- Eligibility: `marketplace_add_or_catalog_pr`
+- Last reviewed: 2026-07-30
 - Manual submit only: yes
 
 Statuses:
 
 - `official_curated`: unknown
 - `community_directory`: unknown
-- `self_marketplace`: not_applicable
+- `self_marketplace`: listed
 - `native_connector_or_builtin`: not_applicable
 - `open_plugin_spec`: listed
 - `mcp_or_skill_registry`: not_applicable
-- `docs_only`: unknown
+- `docs_only`: listed
 
 Blockers:
 
-- Official third-party listing process not fully documented
+- Official / Third-party curated listing process not publicly documented
 
 Local evidence:
 
 - `open_plugin_spec_cloudbase`: **present** — plugin/cloudbase/.plugin/plugin.json has $schema
+- `plugin/cloudbase`: **invalid** — Unknown local_evidence id "plugin/cloudbase"
 
 Submit checklist:
 
-- [ ] Confirm Kimi official vs third-party submission path
-- [ ] Plugin zip or GitHub URL installable via /plugins
+- [ ] Confirm install works via /plugins install GitHub URL (TencentCloudBase/cloudbase-plugin)
+- [ ] Optionally publish a Kimi-compatible marketplace.json pointing at cloudbase-plugin
+- [ ] Ask Moonshot / Kimi Code team how to appear under Official or Third-party tab
+- [ ] Keep docs install path updated
 
 Process:
 
 ```
-Official / third-party marketplace tabs plus custom marketplace JSON URL (KIMI_CODE_PLUGIN_MARKETPLACE_URL). Public third-party listing path needs verification.
+Kimi Code CLI `/plugins` has Official / Third-party / Custom tabs.
+Users can already install via GitHub URL or `npx plugins add TencentCloudBase/cloudbase-plugin` (kimi target).
+Custom catalog: set KIMI_CODE_PLUGIN_MARKETPLACE_URL or `/plugins marketplace <json-url>`.
+How to land in Official/Third-party curated tabs is not publicly documented (2026-07-30) — needs Moonshot outreach.
+Docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
 ```
 
 Evidence:
 
 - https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+- https://www.kimi.com/code/docs/en/kimi-code/whats-new.html
 
 ### codebuddy-plugin — CodeBuddy
 
 - Region: cn
 - Channel: `native_connector_or_builtin`
 - Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
+- Last reviewed: 2026-07-29
 - Manual submit only: yes
 
 Statuses:
 
-- `official_curated`: unknown
+- `official_curated`: listed
 - `community_directory`: unknown
 - `self_marketplace`: not_applicable
-- `native_connector_or_builtin`: unknown
+- `native_connector_or_builtin`: listed
 - `open_plugin_spec`: not_applicable
 - `mcp_or_skill_registry`: not_applicable
 - `docs_only`: listed
 
 Blockers:
 
-- Official listing status for CloudBase needs confirmation
+- Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)
+
+Local evidence:
+
+- `config/codebuddy-plugin`: **invalid** — Unknown local_evidence id "config/codebuddy-plugin"
+- `specs/plugin-marketplace-listing/submission-log.md`: **invalid** — Unknown local_evidence id "specs/plugin-marketplace-listing/submission-log.md"
 
 Submit checklist:
 
-- [ ] Confirm CodeBuddy marketplace submission process
-- [ ] Align with config/codebuddy-plugin if applicable
+- [ ] Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19
+- [ ] Confirm keep rules/cloudbase_rules.md in marketplace package
+- [ ] Ask CodeBuddy product team about built-in IDE sync if needed
 
 Process:
 
 ```
-CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.
+Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).
+Fork: https://cnb.cool/tencent/cloud/cloudbase/marketplace
+PR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).
 ```
 
 Evidence:
 
+- https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase
+- https://cnb.cool/tencent/cloud/cloudbase/marketplace
+- https://cnb.cool/codebuddy/marketplace/-/pulls/19
 - https://www.codebuddy.cn/docs/cli/plugins
 - doc/ide-setup/codebuddy.mdx
 
@@ -457,52 +575,12 @@ Evidence:
 
 Recommended install docs: `doc/ide-setup/codebuddy-code.mdx`
 
-### qoder-plugin — Qoder
-
-- Region: cn
-- Channel: `community_plugin_directory`
-- Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
-- Manual submit only: yes
-
-Statuses:
-
-- `official_curated`: unknown
-- `community_directory`: unknown
-- `self_marketplace`: not_applicable
-- `native_connector_or_builtin`: not_applicable
-- `open_plugin_spec`: not_applicable
-- `mcp_or_skill_registry`: not_applicable
-- `docs_only`: listed
-
-Blockers:
-
-- Self-serve listing docs incomplete for third parties
-
-Submit checklist:
-
-- [ ] Confirm Qoder CN plugin publish channel
-- [ ] Package plugin.json compatible layout
-
-Process:
-
-```
-Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).
-```
-
-Evidence:
-
-- https://help.aliyun.com/zh/lingma/plugin-hidden-release
-- doc/ide-setup/qoder.mdx
-
-Recommended install docs: `doc/ide-setup/qoder.mdx`
-
 ### qoderwork-connector — QoderWork
 
 - Region: cn
 - Channel: `native_connector_or_builtin`
 - Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
+- Last reviewed: 2026-07-30
 - Manual submit only: yes
 
 Statuses:
@@ -517,23 +595,72 @@ Statuses:
 
 Blockers:
 
-- No confirmed CloudBase listing
-- Third-party connector submit path unclear
+- Requires public HTTPS MCP with OAuth (current CloudBase MCP is primarily npx stdio)
+- Company identity phone verification + legal docs
 
 Submit checklist:
 
-- [ ] Confirm connector onboarding with QoderWork
-- [ ] MCP or connector packaging requirements
+- [ ] Decide whether hosted CloudBase MCP HTTPS endpoint is in scope
+- [ ] Prepare OAuth, privacy policy, ToS, connectivity self-test
+- [ ] Submit Connector via QoderWork + complete company verification
 
 Process:
 
 ```
-QoderWork has connector / integration marketplace plus custom MCP. CloudBase listing requires partner outreach.
+Connector is a separate QoderWork extension type: public HTTPS MCP + OAuth, company identity verification, privacy/ToS, self-test report, then human review.
+Prefer shipping CloudBase first as Plugin/Skill (`qoderwork-marketplace`); treat official Connector as a later partner track.
+Docs: https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines (Connector section)
 ```
 
 Evidence:
 
+- https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
 - https://docs.qoder.com/zh/qoderwork/connectors
+
+### minimax-agent-mcp — MiniMax Agent
+
+- Region: cn
+- Channel: `mcp_registry_or_aggregator`
+- Eligibility: `unknown_or_partner`
+- Last reviewed: 2026-07-30
+- Manual submit only: yes
+
+Statuses:
+
+- `official_curated`: unknown
+- `community_directory`: unknown
+- `self_marketplace`: unknown
+- `native_connector_or_builtin`: not_applicable
+- `open_plugin_spec`: not_applicable
+- `mcp_or_skill_registry`: unknown
+- `docs_only`: listed
+
+Blockers:
+
+- No public third-party plugin/MCP submit form found
+- Marketplace reuse appears product-internal after MCP Builder
+
+Submit checklist:
+
+- [ ] Smoke-test CloudBase MCP inside MiniMax Agent (manual add)
+- [ ] Add ide-setup / docs note if product fit is confirmed
+- [ ] Monitor MiniMax for public marketplace publisher docs
+- [ ] Partner outreach if curated catalog is required
+
+Process:
+
+```
+MiniMax Agent supports custom MCP and an in-product MCP Builder; changelog mentions adding completed MCPs to a marketplace for reuse.
+No stable public third-party developer submission URL found (2026-07-30).
+Near-term path: document manual MCP config (`npx @cloudbase/cloudbase-mcp@latest`) for MiniMax Agent users; watch Agent docs/changelog for publisher onboarding.
+Refs: https://agent.minimaxi.com/docs/user-guide ; https://agent.minimax.io/docs/changelog
+```
+
+Evidence:
+
+- https://agent.minimaxi.com/docs/user-guide
+- https://agent.minimax.io/docs/user-guide
+- https://agent.minimax.io/docs/changelog
 
 ### trae-mcp-marketplace — Trae IDE / Trae Work
 

--- a/specs/plugin-marketplace-listing/requirements.md
+++ b/specs/plugin-marketplace-listing/requirements.md
@@ -51,8 +51,10 @@ CloudBase AI Toolkit 的插件 / Skills / MCP 已在部分产品（如 WorkBuddy
 | `zcode-plugin` | ZCode | IDE 插件市场（已上架） |
 | `codebuddy-plugin` | CodeBuddy | 插件市场 / CLI plugins |
 | `codebuddy-code-plugin` | CodeBuddy Code | CLI plugin marketplace |
-| `qoder-plugin` | Qoder | 插件分发（plugin.json 等） |
-| `qoderwork-connector` | QoderWork | 连接器 / 集成市场 |
+| `qoder-plugin` | Qoder | 插件市场 / CN 社区 AppHub |
+| `qoderwork-marketplace` | QoderWork | Skill / Plugin 自助公开市场 |
+| `qoderwork-connector` | QoderWork | Connector（HTTPS MCP + OAuth，商务/合规） |
+| `minimax-agent-mcp` | MiniMax Agent | 自定义 MCP / 产品内 marketplace（公开投稿待核实） |
 | `trae-mcp-marketplace` | Trae IDE / Trae Work | **内置 MCP 市场**（设置 → MCP → 从市场添加）；与 Claude/Cursor 的 Agent Plugin 市场不是同一形态 |
 | `trae-work-skills-marketplace` | Trae Work | **技能市场**（安装 `SKILL.md` / `.skill` / zip）；可本地上传，公开上架通道需核实 |
 | `trae-ide-extension` | Trae IDE | VS Code 兼容 **编辑器扩展**市场（`.vsix`）；面向语言/调试类扩展，**不是** CloudBase Agent Plugin 的正确上架通道 |

--- a/specs/plugin-marketplace-listing/submission-checklist.md
+++ b/specs/plugin-marketplace-listing/submission-checklist.md
@@ -110,11 +110,41 @@ Examples of good targets:
 - [x] Fork + sync PR — https://cnb.cool/codebuddy/marketplace/-/pulls/19 (2026-07-29)
 - [ ] Enrich PR description with Summary + Checklist if CNB UI allows edit (API token cannot PATCH target PR)
 - [ ] Await merge; then mark `codebuddy-plugin` curated listed
-- **Future sync to fork:** `npm run sync:codebuddy-marketplace`
-  - Regenerates skills, overlays `config/codebuddy-plugin` onto fork `plugins/cloudbase` (keeps `rules/`), bumps catalog entry, pushes fork `main`
-  - Fork: https://cnb.cool/tencent/cloud/cloudbase/marketplace
-  - Upstream PR still needs CNB UI / `repo-pr:rw` (script does not open upstream PR)
+- **Future sync to fork:** `npm run sync:codebuddy-marketplace` (if available on main)
   - Dry-run: `npm run sync:codebuddy-marketplace -- --dry-run`
+
+### 7. QoderWork marketplace (CN — ready to package)
+
+Self-serve inside QoderWork client. Prefer **Plugin** first (not Connector).
+
+- [ ] Package CloudBase as QoderWork Plugin:
+  - Root `.qoder-plugin/plugin.json`
+  - `skills/` (reuse / adapt CloudBase skills)
+  - optional `.mcp.json` → `npx -y @cloudbase/cloudbase-mcp@latest`
+- [ ] Follow https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+- [ ] Submit from QoderWork → marketplace → 我的发布
+- [ ] After live: flip `qoderwork-marketplace.community_directory` → `listed`
+
+### 8. Qoder IDE / CN community
+
+- [ ] Map package to `.qoder-plugin` layout (same family as QoderWork)
+- [ ] Try community submit: https://qoder.com.cn/account/apphub-publications
+- [ ] Verify browse/install on https://qoder.com.cn/marketplace and in-IDE plugin market
+- [ ] Featured placement: partner outreach if needed
+
+### 9. Kimi Code
+
+- [ ] Verify `/plugins install` from `TencentCloudBase/cloudbase-plugin` GitHub URL
+- [ ] Optional: host a Kimi marketplace.json (Custom tab / `KIMI_CODE_PLUGIN_MARKETPLACE_URL`)
+- [ ] Ask Moonshot how to appear under Official or Third-party curated tabs
+- Docs: https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html
+
+### 10. MiniMax Agent
+
+- [ ] Smoke-test manual MCP add in MiniMax Agent (`npx @cloudbase/cloudbase-mcp@latest`)
+- [ ] Watch https://agent.minimax.io/docs/changelog for public publisher / marketplace docs
+- [ ] Partner outreach if curated MCP marketplace opens
+- [ ] Optional later: add `doc/ide-setup/minimax-agent.mdx` once install path is stable
 
 ## Needs partner outreach (do not fake as ready)
 
@@ -123,9 +153,11 @@ Examples of good targets:
 | Claude Official curated | Wait for / request Anthropic partnership |
 | Trae official MCP marketplace | Contact Trae for curated catalog inclusion (community list PR is separate) |
 | Trae Work skills marketplace | Confirm publisher onboarding |
-| Qoder / QoderWork | Confirm plugin/connector submit path |
-| CodeBuddy / CodeBuddy Code | Confirm whether already listed or need submit |
-| Kimi Code official | Confirm third-party listing path |
+| Qoder Featured / curated | After community submit, ask for Featured if needed |
+| QoderWork Connector | Only if HTTPS+OAuth CloudBase MCP is in scope |
+| CodeBuddy / CodeBuddy Code | Await CNB #19 merge; built-in may still need PM sync |
+| Kimi Code Official / Third-party tabs | Confirm curated listing with Moonshot |
+| MiniMax Agent marketplace | No public submit form yet — monitor + outreach |
 
 ## After each submission
 

--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -169,3 +169,13 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 - **Awesome Copilot #2459:** already has Submission checklist (issue form) — OK.
 - **CodeBuddy CNB #19:** body still short (“AI-generated…”); token cannot PATCH upstream PR — edit in CNB UI if needed.
 
+### 2026-07-30 — CN markets refresh (Qoder / Kimi / MiniMax)
+
+- Updated `markets.yaml`:
+  - `qoder-plugin` → community submit + `.qoder-plugin` packaging (ready_to_submit)
+  - new `qoderwork-marketplace` → QoderWork Skill/Plugin self-serve (ready_to_submit)
+  - `qoderwork-connector` → HTTPS+OAuth Connector track (partner, deferred)
+  - `kimi-code-marketplace` → GitHub/custom install listed; curated tabs need outreach
+  - new `minimax-agent-mcp` → manual MCP + monitor publisher docs
+- Checklist / followup-research updated with how-to order: **QoderWork Plugin → Qoder community → Kimi verify → MiniMax watch**
+


### PR DESCRIPTION
## Summary
- Refresh CN marketplace matrix for **Qoder / QoderWork / Kimi / MiniMax**
- Add `qoderwork-marketplace` (self-serve Skill/Plugin) and `minimax-agent-mcp`
- Clarify Connector vs Plugin path on QoderWork (Connector deferred: HTTPS+OAuth)
- Update checklist / followup-research with execution order
- Regenerate `reports/latest.*`

## Recommended next (human)
1. Package CloudBase as **QoderWork Plugin** (`.qoder-plugin` + skills + optional MCP) and submit in-client
2. Qoder CN community AppHub submit
3. Verify Kimi `/plugins install` GitHub URL; outreach for Official/Third-party tabs
4. MiniMax: manual MCP smoke-test + watch publisher docs

## Test plan
- [x] `loadMatrix(markets.yaml)` OK (44 markets)
- [x] `npm run analyze:plugin-marketplaces`


Made with [Cursor](https://cursor.com)