### PR TITLE
feat(mcp): prefer SDK over TCP DB and gate connection info

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -32,12 +32,14 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - You still need to decide between Event Function and HTTP Function.
 - The task mentions `manageFunctions`, `queryFunctions`, `manageGateway`, or legacy function-tool names.
 - The task might require `callCloudApi` as a fallback for logs or gateway setup.
-- The function uses classic TCP DB clients (`DATABASE_URL` / `mysql2` / `pg` / Redis) instead of CloudBase native SDK → also read `references/vpc-and-tcp-database.md`.
+
+### Exception only (do not read by default)
+
+- Migrating an **existing** app that already uses classic TCP DB clients (`DATABASE_URL` / Prisma / `mysql2` / `pg` / Redis) → read `./references/vpc-and-tcp-database.md` via `./references.md`. New business CRUD must prefer CloudBase native SDK (`app.database()` / `app.rdb()`) or MCP SQL tools instead of TCP.
 
 ### Then also read
 
 - Detailed reference routing -> `./references.md`
-- Non-native TCP DB / VPC egress -> `./references/vpc-and-tcp-database.md`
 - Auth setup or provider-related backend work -> `../auth-tool-cloudbase/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/auth-tool-cloudbase/SKILL.md`)
 - CloudBase Integration Center generated WeChat Pay or Official Account functions -> `../cloudbase-wechat-integration/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/cloudbase-wechat-integration/SKILL.md`; official docs: `https://docs.cloudbase.net/integration/introduce/index.md`)
 - AI in functions -> `../ai-model-nodejs/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/ai-model-nodejs/SKILL.md`)
@@ -69,8 +71,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Assuming MCP covers the whole image pipeline. `manageFunctions` covers SCF image deploy (Stage B) via `runtime: "CustomImage"` + `imageConfig`, but the CloudApp custom build → TCR push (Stage A) is a raw Tencent Cloud API path — confirm action names and parameters from official docs before any `callCloudApi` fallback.
 - Making code or configuration changes without first following the Change Safety Protocol (`cloudbase-platform/references/protocols/change-safety-protocol.md`).
 - Exposing functions publicly or deploying without first completing the checks in `cloudbase-platform/references/protocols/deployment-gate.md`.
-- **Using non-native TCP DB clients (`DATABASE_URL` / `mysql2` / `pg` / Redis) without `vpc.vpcId` + `vpc.subnetId`** — create/update succeeds, then runtime cannot reach the private DB. Native `app.rdb()` / `app.database()` does not need this.
-- **Guessing VPC IDs** (`vpc-xxxxx` placeholders or copied samples). Resolve real IDs from the DB console, an existing resource detail, `callCloudApi`, or the user; stop if still unknown. See `references/vpc-and-tcp-database.md`.
+- **Defaulting new CRUD to TCP DB clients** (`DATABASE_URL` / `mysql2` / `pg` / Redis) instead of native `app.rdb()` / `app.database()` or MCP SQL. TCP is exception-only for existing ORM migrations — see `references/vpc-and-tcp-database.md` only then.
 
 ### Minimal checklist
 

--- a/config/source/skills/cloud-functions/references.md
+++ b/config/source/skills/cloud-functions/references.md
@@ -43,19 +43,24 @@ Read this when the task is about:
 - function logs
 - timeout / environment-variable updates
 - timer cron format
-- VPC field shape only (examples) — for TCP DB policy see `vpc-and-tcp-database.md`
+- VPC field shape only (examples) — for TCP DB policy see `vpc-and-tcp-database.md` (exception-only)
 - gateway exposure for Event Functions
 - legacy tool-name translation
 - `callCloudApi` fallback for Cloud Functions
 
-### `./references/vpc-and-tcp-database.md`
+### `./references/vpc-and-tcp-database.md` (exception-only — do not read by default)
 
-Read this when the task is about:
+Read this **only** when the task is migrating an **existing** app that already uses classic TCP clients:
 
-- non-native TCP clients (`DATABASE_URL`, `mysql2`, `pg`, Prisma, Redis)
-- private MySQL / PostgreSQL / Redis connectivity from Event or HTTP Functions
-- when `vpc.vpcId` / `vpc.subnetId` is mandatory vs when native `app.rdb()` / `app.database()` is enough
-- **never guessing** VPC IDs
+- existing `DATABASE_URL` / Prisma / TypeORM / Sequelize / `mysql2` / `pg` / Redis TCP clients
+- private MySQL / PostgreSQL / Redis connectivity from Event or HTTP Functions that cannot use native SDK
+
+**Do NOT read this for new business CRUD.** Prefer CloudBase native SDK (`app.rdb()` / `app.database()`) or MCP SQL tools. New apps must not introduce TCP DB clients, ask users for DB passwords, or treat VPC binding as the default path.
+
+When this exception applies:
+
+- `vpc.vpcId` / `vpc.subnetId` is mandatory for private TCP access
+- **never guess** VPC IDs
 
 ## Keep these distinctions straight
 

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -118,9 +118,9 @@ Examples:
 - `0 0 2 1 * * *` -> 2:00 AM on the first day of every month
 - `0 30 9 * * * *` -> 9:30 AM every day
 
-### VPC access
+### VPC field shape (example only)
 
-For **non-native TCP** MySQL / PostgreSQL / Redis clients, `vpc` is mandatory and IDs must be real (never placeholders). Full policy: `./vpc-and-tcp-database.md`.
+When a function already needs VPC egress (exception path: existing TCP DB clients), `vpc` IDs must be real (never placeholders). This is a field-shape example — not a recommendation to introduce TCP DB access. Prefer native SDK / MCP SQL for new CRUD. Full exception policy: `./vpc-and-tcp-database.md`.
 
 ```javascript
 {

--- a/config/source/skills/cloud-functions/references/vpc-and-tcp-database.md
+++ b/config/source/skills/cloud-functions/references/vpc-and-tcp-database.md
@@ -1,5 +1,7 @@
 # VPC and non-native TCP database access (cloud functions)
 
+> **STOP — exception-only path.** Prefer CloudBase native SDK (`app.database()` / `app.rdb()`) or MCP SQL tools (`queryMysqlDatabase` / `manageMysqlDatabase` / `queryPgDatabase` / `managePgDatabase`) for business data. Do **not** read this file for new CRUD, notepads, CMS, or greenfield APIs. Continue only when migrating an **existing** app that already ships classic TCP clients (`DATABASE_URL`, Prisma, `mysql2`, `pg`, Redis). Credentials must come from the user or console env config — do **not** infer passwords from standard MCP instance-status queries (`getInstanceInfo`).
+
 ## When this applies
 
 Use this only when the Event Function or HTTP Function uses a **classic TCP client** to reach MySQL / PostgreSQL / Redis / MongoDB (for example `DATABASE_URL`, `mysql2`, `pg`, Prisma, TypeORM, Sequelize).
@@ -15,7 +17,7 @@ Native SDK access is platform-managed and does **not** require function VPC bind
 
 | Field | Meaning |
 | --- | --- |
-| `envVariables.DATABASE_URL` (or `MYSQL_*` / `PG*` / `REDIS_*`) | Connection string / host for the **private** DB endpoint |
+| `envVariables.DATABASE_URL` (or `MYSQL_*` / `PG*` / `REDIS_*`) | Connection string / host for the **private** DB endpoint. Set from console or user-provided secrets — never invent credentials. |
 | `vpc.vpcId` | Real VPC ID of that database (same region) |
 | `vpc.subnetId` | Real subnet ID in that VPC with free IPs |
 
@@ -49,7 +51,8 @@ await manageFunctions({
     name: "api",
     type: "HTTP", // or Event — same VPC rule
     envVariables: {
-      DATABASE_URL: "postgres://user:pass@10.x.x.x:5432/app"
+      // Replace with user/console-provided secret — do not paste passwords into chat logs
+      DATABASE_URL: "<private-db-url-from-console-or-user>"
     },
     vpc: {
       vpcId: "<real-vpc-id>",
@@ -61,6 +64,8 @@ await manageFunctions({
 ```
 
 After create/update, call `queryFunctions(action="getFunctionDetail")` and verify `VpcConfig.VpcId` / `SubnetId`. Do not treat create/update success alone as proof that private TCP DB access works.
+
+For TCP migration only, connection payloads may be fetched via `queryMysqlDatabase(action="getConnectionInfo")`. Standard `getInstanceInfo` does **not** return credentials.
 
 ## Side effects of enabling VPC
 

--- a/config/source/skills/relational-database-mcp-cloudbase/SKILL.md
+++ b/config/source/skills/relational-database-mcp-cloudbase/SKILL.md
@@ -43,6 +43,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating document database tasks as MySQL management tasks.
 - Skipping `_openid` and permissions review after creating new SQL tables.
 - Destroying MySQL without explicit confirmation or without checking whether the environment still needs the instance.
+- Using `getConnectionInfo` (or inferred host/password) to build a default TCP client for new apps. Prefer SDK / `runQuery` / `runStatement`; TCP credentials are an explicit migration exception only.
 
 ## When to use this skill
 
@@ -89,8 +90,9 @@ These tools are the supported way to interact with CloudBase Relational Database
 - **Purpose:** Query SQL data and provisioning state.
 - **Use for:**
   - Running `SELECT` and other read-only SQL queries with `action="runQuery"`
-  - Checking whether MySQL already exists with `action="getInstanceInfo"`
+  - Checking whether MySQL already exists with `action="getInstanceInfo"` (lifecycle only — no connection credentials)
   - Inspecting asynchronous provisioning progress with `action="describeCreateResult"` or `action="describeTaskStatus"`
+  - **Exception only:** `action="getConnectionInfo"` returns the raw connection/cluster payload (may include credentials) for migrating existing TCP/ORM clients. Do **not** use this for new business CRUD — prefer Web/Node SDK or `runQuery` / `runStatement`.
 
 **Example flow:**
 
@@ -100,6 +102,8 @@ These tools are the supported way to interact with CloudBase Relational Database
   "sql": "SELECT id, email FROM users ORDER BY created_at DESC LIMIT 50"
 }
 ```
+
+**Do NOT** call `getConnectionInfo` and then wire `pymysql` / `mysql2` / `DATABASE_URL` into a cloud function for greenfield apps. Platform-delegated SQL and SDK access are the default.
 
 ### 2. `manageMysqlDatabase`
 

--- a/doc/prompts/cloud-functions.mdx
+++ b/doc/prompts/cloud-functions.mdx
@@ -70,12 +70,14 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - You still need to decide between Event Function and HTTP Function.
 - The task mentions `manageFunctions`, `queryFunctions`, `manageGateway`, or legacy function-tool names.
 - The task might require `callCloudApi` as a fallback for logs or gateway setup.
-- The function uses classic TCP DB clients (`DATABASE_URL` / `mysql2` / `pg` / Redis) instead of CloudBase native SDK → also read `references/vpc-and-tcp-database.md`.
+
+### Exception only (do not read by default)
+
+- Migrating an **existing** app that already uses classic TCP DB clients (`DATABASE_URL` / Prisma / `mysql2` / `pg` / Redis) → read `./references/vpc-and-tcp-database.md` via `./references.md`. New business CRUD must prefer CloudBase native SDK (`app.database()` / `app.rdb()`) or MCP SQL tools instead of TCP.
 
 ### Then also read
 
 - Detailed reference routing -> `./references.md`
-- Non-native TCP DB / VPC egress -> `./references/vpc-and-tcp-database.md`
 - Auth setup or provider-related backend work -> `../auth-tool-cloudbase/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/auth-tool-cloudbase/SKILL.md`)
 - CloudBase Integration Center generated WeChat Pay or Official Account functions -> `../cloudbase-wechat-integration/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/cloudbase-wechat-integration/SKILL.md`; official docs: `https://docs.cloudbase.net/integration/introduce/index.md`)
 - AI in functions -> `../ai-model-nodejs/SKILL.md` (standalone fallback: `https://cnb.cool/tencent/cloud/cloudbase/cloudbase-skills/-/git/raw/main/skills/cloudbase/references/ai-model-nodejs/SKILL.md`)
@@ -107,8 +109,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Assuming MCP covers the whole image pipeline. `manageFunctions` covers SCF image deploy (Stage B) via `runtime: "CustomImage"` + `imageConfig`, but the CloudApp custom build → TCR push (Stage A) is a raw Tencent Cloud API path — confirm action names and parameters from official docs before any `callCloudApi` fallback.
 - Making code or configuration changes without first following the Change Safety Protocol (`cloudbase-platform/references/protocols/change-safety-protocol.md`).
 - Exposing functions publicly or deploying without first completing the checks in `cloudbase-platform/references/protocols/deployment-gate.md`.
-- **Using non-native TCP DB clients (`DATABASE_URL` / `mysql2` / `pg` / Redis) without `vpc.vpcId` + `vpc.subnetId`** — create/update succeeds, then runtime cannot reach the private DB. Native `app.rdb()` / `app.database()` does not need this.
-- **Guessing VPC IDs** (`vpc-xxxxx` placeholders or copied samples). Resolve real IDs from the DB console, an existing resource detail, `callCloudApi`, or the user; stop if still unknown. See `references/vpc-and-tcp-database.md`.
+- **Defaulting new CRUD to TCP DB clients** (`DATABASE_URL` / `mysql2` / `pg` / Redis) instead of native `app.rdb()` / `app.database()` or MCP SQL. TCP is exception-only for existing ORM migrations — see `references/vpc-and-tcp-database.md` only then.
 
 ### Minimal checklist
 

--- a/doc/prompts/relational-database-mcp-cloudbase.mdx
+++ b/doc/prompts/relational-database-mcp-cloudbase.mdx
@@ -76,6 +76,7 @@ Keep local `references/...` paths for files that ship with the current skill dir
 - Treating document database tasks as MySQL management tasks.
 - Skipping `_openid` and permissions review after creating new SQL tables.
 - Destroying MySQL without explicit confirmation or without checking whether the environment still needs the instance.
+- Using `getConnectionInfo` (or inferred host/password) to build a default TCP client for new apps. Prefer SDK / `runQuery` / `runStatement`; TCP credentials are an explicit migration exception only.
 
 ## When to use this skill
 
@@ -122,8 +123,9 @@ These tools are the supported way to interact with CloudBase Relational Database
 - **Purpose:** Query SQL data and provisioning state.
 - **Use for:**
   - Running `SELECT` and other read-only SQL queries with `action="runQuery"`
-  - Checking whether MySQL already exists with `action="getInstanceInfo"`
+  - Checking whether MySQL already exists with `action="getInstanceInfo"` (lifecycle only — no connection credentials)
   - Inspecting asynchronous provisioning progress with `action="describeCreateResult"` or `action="describeTaskStatus"`
+  - **Exception only:** `action="getConnectionInfo"` returns the raw connection/cluster payload (may include credentials) for migrating existing TCP/ORM clients. Do **not** use this for new business CRUD — prefer Web/Node SDK or `runQuery` / `runStatement`.
 
 **Example flow:**
 
@@ -133,6 +135,8 @@ These tools are the supported way to interact with CloudBase Relational Database
   "sql": "SELECT id, email FROM users ORDER BY created_at DESC LIMIT 50"
 }
 ```
+
+**Do NOT** call `getConnectionInfo` and then wire `pymysql` / `mysql2` / `DATABASE_URL` into a cloud function for greenfield apps. Platform-delegated SQL and SDK access are the default.
 
 ### 2. `manageMysqlDatabase`
 

--- a/mcp/src/tools/databaseSQL.test.ts
+++ b/mcp/src/tools/databaseSQL.test.ts
@@ -561,7 +561,7 @@ describe("SQL database tools", () => {
     });
   });
 
-  it("queryMysqlDatabase(getInstanceInfo) uses cluster detail after create result succeeds", async () => {
+  it("queryMysqlDatabase(getInstanceInfo) returns lifecycle context without connection payloads", async () => {
     mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
       if (Action === "DescribeCreateMySQLResult") {
         return {
@@ -576,8 +576,13 @@ describe("SQL database tools", () => {
           RequestId: "req-cluster",
           Data: {
             DbClusterId: "cluster-1",
+            InstanceId: "inst-1",
             DbInfo: {
               ClusterStatus: "running",
+              Host: "10.0.0.8",
+              Port: 3306,
+              User: "root",
+              Password: "secret-password",
             },
           },
         };
@@ -598,9 +603,103 @@ describe("SQL database tools", () => {
       data: {
         exists: true,
         clusterId: "cluster-1",
-        instanceId: "default",
+        instanceId: "inst-1",
         status: "READY",
       },
     });
+    expect(payload.data.clusterDetail).toBeUndefined();
+    expect(payload.data.createResult).toBeUndefined();
+    expect(JSON.stringify(payload)).not.toContain("secret-password");
+    expect(JSON.stringify(payload)).not.toContain("10.0.0.8");
+  });
+
+  it("queryMysqlDatabase(getConnectionInfo) passthroughs raw connection payloads including credentials", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+          Data: {
+            Status: "success",
+          },
+        };
+      }
+      if (Action === "DescribeMySQLClusterDetail") {
+        return {
+          RequestId: "req-cluster",
+          Data: {
+            DbClusterId: "cluster-1",
+            InstanceId: "inst-1",
+            DbInfo: {
+              ClusterStatus: "running",
+              Host: "10.0.0.8",
+              Port: 3306,
+              User: "root",
+              Password: "secret-password",
+            },
+          },
+        };
+      }
+      return {
+        RequestId: "req-1",
+      };
+    });
+
+    const { tools } = createMockServer();
+    expect(tools.queryMysqlDatabase.meta.inputSchema.action._def.values).toContain(
+      "getConnectionInfo",
+    );
+
+    const result = await tools.queryMysqlDatabase.handler({
+      action: "getConnectionInfo",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        exists: true,
+        clusterId: "cluster-1",
+        instanceId: "inst-1",
+        status: "READY",
+        clusterDetail: {
+          DbClusterId: "cluster-1",
+          DbInfo: {
+            Host: "10.0.0.8",
+            Password: "secret-password",
+          },
+        },
+      },
+    });
+    expect(payload.message).toMatch(/TCP migration/i);
+    expect(payload.nextActions?.[0]).toMatchObject({
+      tool: "queryMysqlDatabase",
+      action: "runQuery",
+    });
+  });
+
+  it("queryMysqlDatabase(getConnectionInfo) fails when MySQL is not provisioned", async () => {
+    mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+      if (Action === "DescribeCreateMySQLResult") {
+        return {
+          RequestId: "req-create",
+          Status: "NOT_FOUND",
+        };
+      }
+      throw Object.assign(new Error("not found"), {
+        code: "FailedOperation.DataSourceNotExist",
+      });
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.queryMysqlDatabase.handler({
+      action: "getConnectionInfo",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: false,
+      errorCode: "MYSQL_NOT_CREATED",
+    });
+    expect(payload.data?.clusterDetail).toBeUndefined();
   });
 });

--- a/mcp/src/tools/databaseSQL.ts
+++ b/mcp/src/tools/databaseSQL.ts
@@ -59,6 +59,7 @@ const QUERY_ACTIONS = [
   "describeTaskStatus",
   "getInstanceInfo",
   "describeInstance",
+  "getConnectionInfo",
 ] as const;
 
 const MANAGE_ACTIONS = [
@@ -104,9 +105,31 @@ type InstanceInfoResult = {
   rawStatus: string | null;
   status: SqlLifecycleStatus;
   clusterId?: string;
+  /** Raw cluster payload — only attached for getConnectionInfo. */
   clusterDetail?: Record<string, unknown>;
+  /** Raw create-result payload — only attached for getConnectionInfo. */
   createResult?: Record<string, unknown>;
 };
+
+/** Lifecycle fields safe to return from getInstanceInfo (no connection secrets). */
+type SanitizedInstanceInfo = Omit<
+  InstanceInfoResult,
+  "clusterDetail" | "createResult"
+>;
+
+function sanitizeInstanceInfo(
+  instanceInfo: InstanceInfoResult,
+): SanitizedInstanceInfo {
+  return {
+    exists: instanceInfo.exists,
+    envId: instanceInfo.envId,
+    instanceId: instanceInfo.instanceId,
+    schema: instanceInfo.schema,
+    rawStatus: instanceInfo.rawStatus,
+    status: instanceInfo.status,
+    ...(instanceInfo.clusterId ? { clusterId: instanceInfo.clusterId } : {}),
+  };
+}
 
 type QuerySqlDatabaseArgs = {
   action: QueryAction;
@@ -784,11 +807,12 @@ async function handleGetInstanceInfo(
   context: QueryManageContext,
 ): Promise<ToolResult> {
   const instanceInfo = await getSqlInstanceInfo(context);
+  const sanitized = sanitizeInstanceInfo(instanceInfo);
   return buildSqlToolResult({
     success: true,
-    data: instanceInfo,
+    data: sanitized,
     message: instanceInfo.exists
-      ? "Resolved current SQL database instance context."
+      ? "Resolved current SQL database instance context (lifecycle only; connection credentials are omitted). Prefer SDK or runQuery/runStatement for app data access. Use getConnectionInfo only for explicit TCP migration."
       : "No SQL database instance is currently available for this environment.",
     nextActions: instanceInfo.exists
       ? undefined
@@ -800,6 +824,50 @@ async function handleGetInstanceInfo(
             { action: "provisionMySQL", confirm: true },
           ),
         ],
+  });
+}
+
+async function handleGetConnectionInfo(
+  context: QueryManageContext,
+): Promise<ToolResult> {
+  const instanceInfo = await getSqlInstanceInfo(context);
+
+  if (!instanceInfo.exists) {
+    return buildSqlToolResult({
+      success: false,
+      errorCode: "MYSQL_NOT_CREATED",
+      data: sanitizeInstanceInfo(instanceInfo),
+      message:
+        "No MySQL instance exists for the current environment, so connection details cannot be returned.",
+      nextActions: [
+        buildNextAction(
+          MANAGE_MYSQL_DATABASE,
+          "provisionMySQL",
+          "Provision MySQL before requesting connection details.",
+          { action: "provisionMySQL", confirm: true },
+        ),
+      ],
+    });
+  }
+
+  return buildSqlToolResult({
+    success: true,
+    data: {
+      ...sanitizeInstanceInfo(instanceInfo),
+      // Full backend passthrough for explicit TCP migration only (may include credentials).
+      clusterDetail: instanceInfo.clusterDetail,
+      createResult: instanceInfo.createResult,
+    },
+    message:
+      "Returned raw MySQL connection/cluster payload for explicit TCP migration only. Prefer CloudBase SDK or queryMysqlDatabase(runQuery)/manageMysqlDatabase(runStatement) for normal app CRUD — do not treat this as the default data path.",
+    nextActions: [
+      buildNextAction(
+        QUERY_MYSQL_DATABASE,
+        "runQuery",
+        "Prefer platform-delegated read-only SQL instead of embedding TCP credentials in app code.",
+        { action: "runQuery", sql: "SELECT 1" },
+      ),
+    ],
   });
 }
 
@@ -832,7 +900,7 @@ async function handleProvisionMySQL(
   ) {
     return buildSqlToolResult({
       success: true,
-      data: existing,
+      data: sanitizeInstanceInfo(existing),
       message: "A SQL database instance already exists for the current environment.",
       nextActions:
         existing.status === "READY"
@@ -1264,12 +1332,12 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
     {
       title: "查询 CloudBase MySQL 数据库状态或执行只读 SQL",
       description:
-        "查询 CloudBase MySQL 数据库信息。支持执行只读 SQL、查询 MySQL 开通结果、查询 MySQL 任务状态，以及获取当前实例上下文信息。",
+        "查询 CloudBase MySQL 数据库信息。支持执行只读 SQL、查询 MySQL 开通结果、查询 MySQL 任务状态，以及获取当前实例生命周期上下文。标准 getInstanceInfo/describeInstance 不返回连接凭据；仅 getConnectionInfo 透传原始连接/集群载荷（含可能的凭据），且仅用于显式 TCP 迁移。业务 CRUD 优先使用 SDK 或 runQuery/runStatement。",
       inputSchema: {
         action: z
           .enum(QUERY_ACTIONS)
           .describe(
-            "runQuery=execute read-only SQL; describeCreateResult=query CreateMySQL result; describeTaskStatus=query MySQL task status; getInstanceInfo=get current SQL instance context; describeInstance=alias of getInstanceInfo",
+            "runQuery=execute read-only SQL; describeCreateResult=query CreateMySQL result; describeTaskStatus=query MySQL task status; getInstanceInfo=get lifecycle context without connection credentials; describeInstance=alias of getInstanceInfo; getConnectionInfo=passthrough raw connection/cluster payload including possible credentials (TCP migration exception only)",
           ),
         sql: z
           .string()
@@ -1306,6 +1374,8 @@ export function registerSQLDatabaseTools(server: ExtendedMcpServer) {
         case "getInstanceInfo":
         case "describeInstance":
           return handleGetInstanceInfo(context);
+        case "getConnectionInfo":
+          return handleGetConnectionInfo(context);
         default:
           throw new Error(`Unsupported SQL query action: ${args.action}`);
       }


### PR DESCRIPTION
## Summary
- Weaken `cloud-functions` TCP/VPC guidance to an exception-only migration path; prefer CloudBase SDK / MCP SQL for new CRUD.
- Sanitize `queryMysqlDatabase(getInstanceInfo|describeInstance)` so lifecycle responses no longer include raw `clusterDetail` / `createResult` connection payloads.
- Add `queryMysqlDatabase(getConnectionInfo)` for explicit TCP migration, with full backend passthrough (including possible credentials) and guidance that this is not the default app path.

## Test plan
- [x] `pnpm exec vitest run src/tools/databaseSQL.test.ts` (18 passed)
- [ ] Confirm `getInstanceInfo` omits host/password fields when cluster detail contains them
- [ ] Confirm `getConnectionInfo` returns raw connection payload for TCP migration only
- [ ] Spot-check cloud-functions skill: TCP reference is exception-only, not listed as default reading


Made with [Cursor](https://cursor.com)