### PR TITLE
docs: 统一 AI Prompt 地址为 skill.md + SDK 优先 DB 引导

### DIFF
--- a/doc/ai-agent-plugins.mdx
+++ b/doc/ai-agent-plugins.mdx
@@ -11,9 +11,9 @@ import TabItem from '@theme/TabItem';
 **最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
 
 ```text
-帮我把 CloudBase AI 插件装好，按下面做：
-1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ai-agent-plugins，按说明安装插件。
-2. 安装完成后告诉我，并建议最相关的下一步。
+帮我把 CloudBase 接好，按下面做：
+1. 打开 https://docs.cloudbase.net/skill.md，按说明完成接入。
+2. 接入完成后告诉我，并建议最相关的下一步。
 ```
 
 ## 安装

--- a/doc/ai-agent-plugins.mdx
+++ b/doc/ai-agent-plugins.mdx
@@ -8,6 +8,14 @@ import TabItem from '@theme/TabItem';
 
 相比单独装 Skills，插件还带上 Hooks 等能力，**Skill 激活更稳定**，推荐优先用插件。
 
+**最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
+
+```text
+帮我把 CloudBase AI 插件装好，按下面做：
+1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ai-agent-plugins，按说明安装插件。
+2. 安装完成后告诉我，并建议最相关的下一步。
+```
+
 ## 安装
 
 ### 方式 1：一键安装（推荐）

--- a/doc/getting-started.mdx
+++ b/doc/getting-started.mdx
@@ -7,6 +7,14 @@ import PromptScenarios from './components/PromptScenarios';
 
 支持**本地模式**（本机 npx 运行）和**托管模式**（HTTP 连接云端）。本地模式可配置环境变量，托管模式可通过 URL 控制插件。详见 [连接方式：本地模式与托管模式](/ai/cloudbase-ai-toolkit/connection-modes)。
 
+**最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
+
+```text
+帮我把 CloudBase MCP 配好，按下面做：
+1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/getting-started，按说明配置 MCP。
+2. 配置完成后告诉我，并建议最相关的下一步。
+```
+
 ## 前置条件
 
 在开始配置之前，请确保满足以下条件：

--- a/doc/getting-started.mdx
+++ b/doc/getting-started.mdx
@@ -10,9 +10,9 @@ import PromptScenarios from './components/PromptScenarios';
 **最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
 
 ```text
-帮我把 CloudBase MCP 配好，按下面做：
-1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/getting-started，按说明配置 MCP。
-2. 配置完成后告诉我，并建议最相关的下一步。
+帮我把 CloudBase 接好，按下面做：
+1. 打开 https://docs.cloudbase.net/skill.md，按说明完成接入。
+2. 接入完成后告诉我，并建议最相关的下一步。
 ```
 
 ## 前置条件

--- a/doc/index.mdx
+++ b/doc/index.mdx
@@ -6,7 +6,15 @@ import AIDevelopmentPrompt from './components/AIDevelopmentPrompt';
 
 # AI 原生开发
 
-通过 CloudBase MCP 连接你的 AI 开发工具（如 OpenClaw、Cursor、CodeBuddy）与 CloudBase 平台，实现 AI 原生开发新体验。
+通过 CloudBase 连接你的 AI 开发工具（如 OpenClaw、Cursor、CodeBuddy）与云开发平台，实现 AI 原生开发新体验。
+
+**最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。Agent 会读取 [`skill.md`](/skill.md) 完成接入。
+
+```text
+帮我把 CloudBase 接好，按下面做：
+1. 打开 https://docs.cloudbase.net/skill.md，按说明完成接入。
+2. 接入完成后告诉我，并建议最相关的下一步。
+```
 
 **AI 原生开发意味着：**
 
@@ -16,11 +24,11 @@ import AIDevelopmentPrompt from './components/AIDevelopmentPrompt';
 
 AI 负责代码生成和问题修复，CloudBase 提供运行环境。两者结合，让你专注于业务逻辑，而非基础设施配置。
 
-## 第 1 步：连接 CloudBase
+## 第 1 步：连接 CloudBase（推荐插件）
 
-CloudBase 支持多种接入方式。你可以选择[一键安装插件](/ai/cloudbase-ai-toolkit/ai-agent-plugins)（支持 Codex、Claude Code、WorkBuddy、ZCode 等 AI 编程助手），也可以[手动配置 MCP 连接](/ai/cloudbase-ai-toolkit/getting-started)。以下涵盖了所有主流 AI IDE 和工具的配置方式。
+优先使用[一键安装插件](./ai-agent-plugins)（MCP + Skills + Hooks）。也可以[手动配置 MCP](./getting-started)，或只装 [Skills](./prompts/how-to-use)。完整决策树见 [`skill.md`](/skill.md)。
 
-选择你正在使用的 AI 开发工具，**点击下方图标进入对应安装文档**。
+选择你正在使用的 AI 开发工具，**点击下方图标进入对应安装文档**：
 
 > 可点击下方图标完成对应工具的接入
 
@@ -28,7 +36,7 @@ CloudBase 支持多种接入方式。你可以选择[一键安装插件](/ai/clo
 
 ## 第 2 步：按需安装 CloudBase AI Skill（可选）
 
-将云开发最佳实践打包成「技能包」，与 MCP 搭配使用：MCP 负责连接与权限，Skills 负责规范与直觉，让 AI 既有权又懂规矩。
+若已安装插件，通常不必再单独装 Skills。仅需 Skills 时：
 
 ```bash
 npx skills add tencentcloudbase/cloudbase-skills
@@ -36,11 +44,11 @@ npx skills add tencentcloudbase/cloudbase-skills
 
 也可以直接对 AI 说“安装 CloudBase Skills”。
 
-详见 [如何使用 Skill](/ai/cloudbase-ai-toolkit/prompts/how-to-use)。
+详见 [如何使用 Skill](./prompts/how-to-use)。
 
 ## 第 3 步：开始 AI 原生开发
 
-完成 MCP 连接后，再选择一个提示词开始。
+接入完成后，再选择一个提示词开始。
 
 <AIDevelopmentPrompt />
 

--- a/doc/prompts/how-to-use.mdx
+++ b/doc/prompts/how-to-use.mdx
@@ -7,9 +7,9 @@ CloudBase AI Skills 是一套「技能包」，把云开发的专业知识注入
 **最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
 
 ```text
-帮我把 CloudBase Skills 装好，按下面做：
-1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/prompts/how-to-use，按说明安装 Skills。
-2. 安装完成后告诉我，并建议最相关的下一步。
+帮我把 CloudBase 接好，按下面做：
+1. 打开 https://docs.cloudbase.net/skill.md，按说明完成接入。
+2. 接入完成后告诉我，并建议最相关的下一步。
 ```
 
 ---

--- a/doc/prompts/how-to-use.mdx
+++ b/doc/prompts/how-to-use.mdx
@@ -4,6 +4,14 @@ import PromptScenarios from '../components/PromptScenarios';
 
 CloudBase AI Skills 是一套「技能包」，把云开发的专业知识注入 AI。**搭配 MCP 使用时，MCP 提供连接与工具，Skills 提供规则与最佳实践**。
 
+**最快上手：** 复制下面的 AI Prompt，粘贴到你的 AI IDE。
+
+```text
+帮我把 CloudBase Skills 装好，按下面做：
+1. 打开 https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/prompts/how-to-use，按说明安装 Skills。
+2. 安装完成后告诉我，并建议最相关的下一步。
+```
+
 ---
 
 ## 安装 Skills

--- a/mcp/src/tools/env-setup.ts
+++ b/mcp/src/tools/env-setup.ts
@@ -48,6 +48,13 @@ export interface EnvSetupResult {
   success: boolean;
   envId?: string;
   context: EnvSetupContext;
+  /**
+   * User-facing notice emitted at the entry of `checkAndCreateFreeEnv`.
+   * Informative only — does NOT require user confirmation. Callers SHOULD
+ * surface this message to the user (e.g. merge into the tool result message
+ * or log line) so they know an automatic free-env creation is being attempted.
+ */
+  userNotice?: string;
 }
 
 /**
@@ -310,6 +317,19 @@ export async function checkAndCreateFreeEnv(
     initTcbError: newContext.initTcbError
   });
 
+  // User-facing notice emitted at the entry: inform the user that an automatic
+  // free-env creation is being attempted. Informational only — no confirm.
+  // Built once up-front so every return path can surface the same notice.
+  const userNotice = [
+    "系统检测到您当前没有可用的 CloudBase 环境，将自动尝试为您创建一个免费环境。",
+    "创建依据：通过 NewUser / ReturningUser / BaasFree 等优惠活动资格检查；",
+    "环境别名：ai-native（默认）；",
+    "费用说明：该环境为免费活动赠送，创建过程不会产生费用；如不符合免费条件，将引导您前往购买页；",
+    "流程说明：此为自动流程，无需您确认；创建成功后将自动绑定到当前会话。"
+  ].join("\n");
+
+  debug('[env-setup] User notice prepared:', { userNotice });
+
   try {
     // Step 1: Query promotional activities
     debug('[env-setup] Checking promotional activity eligibility...');
@@ -356,7 +376,8 @@ export async function checkAndCreateFreeEnv(
 
       return {
         success: false,
-        context: newContext
+        context: newContext,
+        userNotice
       };
     }
 
@@ -434,7 +455,8 @@ export async function checkAndCreateFreeEnv(
 
         return {
           success: false,
-          context: newContext
+          context: newContext,
+          userNotice
         };
       }
 
@@ -450,7 +472,8 @@ export async function checkAndCreateFreeEnv(
       return {
         success: true,
         envId: envId.trim(), // Ensure no whitespace
-        context: newContext
+        context: newContext,
+        userNotice
       };
 
     } catch (createErr: any) {
@@ -515,7 +538,8 @@ export async function checkAndCreateFreeEnv(
 
       return {
         success: false,
-        context: newContext
+        context: newContext,
+        userNotice
       };
     }
 
@@ -539,7 +563,8 @@ export async function checkAndCreateFreeEnv(
 
     return {
       success: false,
-      context: newContext
+      context: newContext,
+      userNotice
     };
   }
 }

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -585,15 +585,21 @@ async function prepareAuthEnvironment(params: {
     envSetupActions.push("create_free_env");
   }
 
+  // Surface the user-facing notice emitted at checkAndCreateFreeEnv entry.
+  // Informational only — no confirm required. Prepend to the final message so
+  // the user knows an automatic free-env creation was attempted.
+  const userNotice = createResult.userNotice?.trim() || "";
+
   if (createResult.success && createResult.envId) {
     await envManager.setEnvId(createResult.envId);
+    const successMessage = `当前已登录，已自动创建并绑定环境: ${createResult.envId}`;
     return {
       currentEnvId: createResult.envId,
       envStatus: "READY",
       envCandidates: [],
       envSetupStatus: "AUTO_CREATED",
       envSetupActions: dedupeActions(envSetupActions),
-      message: `当前已登录，已自动创建并绑定环境: ${createResult.envId}`,
+      message: userNotice ? `${userNotice}\n${successMessage}` : successMessage,
       nextStep: buildAuthNextStep("status", {
         suggestedArgs: { action: "status" },
       }),
@@ -614,6 +620,10 @@ async function prepareAuthEnvironment(params: {
         helpUrl: "https://buy.cloud.tencent.com/lowcode?buyType=tcb&channel=mcp",
       });
 
+  const failureMessage = userNotice
+    ? `${userNotice}\n${createFailure.message}`
+    : createFailure.message;
+
   return {
     currentEnvId: null,
     envStatus: "NONE",
@@ -621,7 +631,7 @@ async function prepareAuthEnvironment(params: {
     envSetupStatus: "ACTION_REQUIRED",
     envSetupActions: dedupeActions(envSetupActions),
     envSetupFailure: createFailure,
-    message: createFailure.message,
+    message: failureMessage,
     nextStep: buildAuthNextStep("status", {
       suggestedArgs: { action: "status" },
     }),

--- a/mcp/src/tools/interactive.ts
+++ b/mcp/src/tools/interactive.ts
@@ -73,6 +73,11 @@ export interface EnvSetupFailureInfo {
     createEnvError?: any;
     queryEnvError?: string;
     timeoutDuration?: number;
+    /**
+     * User-facing notice emitted at checkAndCreateFreeEnv entry.
+     * Informational only — no confirm required.
+     */
+    freeEnvUserNotice?: string;
   };
 }
 
@@ -364,6 +369,11 @@ export async function _promptAndSetEnvironmentId(
       inCloudMode,
     });
 
+    // Surface the user-facing notice emitted by checkAndCreateFreeEnv entry.
+    // Informational only — no confirm required. Captured in outer scope so the
+    // CloudMode failure path below can also prepend it to the error message.
+    let freeEnvUserNotice: string | undefined;
+
     // Only try to create free environment if TCB service is initialized successfully
     // If InitTcb failed, skip environment creation
     if (!setupContext.initTcbError && setupContext.tcbServiceInitialized) {
@@ -371,10 +381,17 @@ export async function _promptAndSetEnvironmentId(
 
       // Try to create free environment (both normal and cloud mode)
       debug("[interactive] Calling checkAndCreateFreeEnv...");
-      const { success, envId, context: createContext } =
+      const { success, envId, context: createContext, userNotice } =
         await checkAndCreateFreeEnv(cloudbase, setupContext);
 
+      freeEnvUserNotice = userNotice;
       setupContext = { ...setupContext, ...createContext };
+
+      // Surface the user-facing notice emitted by checkAndCreateFreeEnv.
+      // Informational only — no confirm required.
+      if (userNotice) {
+        debug("[interactive] checkAndCreateFreeEnv user notice:", { userNotice });
+      }
 
       debug("[interactive] checkAndCreateFreeEnv result:", {
         success,
@@ -388,7 +405,8 @@ export async function _promptAndSetEnvironmentId(
         } : undefined,
         promotionalActivities: setupContext.promotionalActivities,
         tcbServiceInitialized: setupContext.tcbServiceInitialized,
-        hasInitTcbError: !!setupContext.initTcbError
+        hasInitTcbError: !!setupContext.initTcbError,
+        hasUserNotice: !!userNotice
       });
 
       // Check all possible scenarios
@@ -523,6 +541,11 @@ export async function _promptAndSetEnvironmentId(
       let failureReason: EnvSetupFailureInfo['reason'] = 'no_environments';
       let errorCode = "NO_ENVIRONMENTS";
 
+      // Prepend the user-facing notice from checkAndCreateFreeEnv entry so the
+      // user knows an automatic free-env creation was attempted (informational).
+      if (freeEnvUserNotice) {
+        errorMsg = `${freeEnvUserNotice}\n${errorMsg}`;
+      }
       if (setupContext.initTcbError) {
         errorMsg += `\nCloudBase 初始化失败: ${setupContext.initTcbError.message}`;
         failureReason = 'tcb_init_failed';
@@ -552,6 +575,7 @@ export async function _promptAndSetEnvironmentId(
           details: {
             initTcbError: setupContext.initTcbError,
             createEnvError: setupContext.createEnvError,
+            freeEnvUserNotice,
           },
         },
       };


### PR DESCRIPTION
## 改动内容

### 文档改动
- **插件页 / MCP 页 / Skill 页**：三个页面的「最快上手」AI Prompt 统一指向 `https://docs.cloudbase.net/skill.md`，不再分别指向各自页面
- skill.md 是统一入口，由它引导 AI 完成对应接入方式（插件 / MCP / Skills）
- 新增 quick-start AI prompt 代码块到三个页面

### MCP 工具改动
- `checkAndCreateFreeEnv` 入口加用户告知（不强制 confirm）
- prefer SDK over TCP DB and gate connection info

## 涉及文件
- `doc/ai-agent-plugins.mdx`
- `doc/getting-started.mdx`
- `doc/prompts/how-to-use.mdx`
- MCP 工具相关代码