### PR TITLE
feat(gateway): 🔌 add HTTP gateway privilege query and switch actions

### DIFF
--- a/config/source/skills/auth-tool-cloudbase/references/extended-guide.md
+++ b/config/source/skills/auth-tool-cloudbase/references/extended-guide.md
@@ -122,7 +122,9 @@ Preferred MCP tool path: `manageAppAuth(action="patchLoginStrategy")`
 
 Use `patch.phone = true/false` for the login method itself.
 
-If SMS provider behavior also needs to change, keep using provider-side or raw API configuration for the extra fields such as `SmsVerificationConfig`.
+**Default SMS channel is ready out of the box.** After `patch.phone = true`, the CloudBase default SMS channel sends and receives verification codes without any extra setup — no SMS signature, template, or custom provider configuration is required. Frontend flow: `auth.getVerification({ phone_number })` to send the code, then `auth.signInWithSms({ verificationInfo, verificationCode, phoneNum })` to sign in. Note: SMS login is only supported in the `ap-shanghai` region, and phone numbers must include a country code (e.g. `+86 13800000000`).
+
+Only when you need custom SMS templates, custom signatures, or a different SMS vendor should you configure a custom SMS channel (or raw API fields such as `SmsVerificationConfig`). Do not block SMS login on provider/signature setup — the default channel already works.
 
 Short MCP example:
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1110,7 +1110,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
         {
           name: "protocolType",
           type: "string",
-          description: `HTTP 云函数协议类型 可填写的值: "HTTP", "WS"`,
+          description: `HTTP 函数访问协议，当前仅支持 WebSockets，取值为 WS（配合 protocolParams.wsParams 使用）。普通 HTTP 函数不要传此字段；传其他值（如 HTTP）会报 InvalidParameterValue.ProtocolType。 可填写的值: "WS"`,
         },
         {
           name: "protocolParams",
@@ -1799,7 +1799,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.2），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.3），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -2349,7 +2349,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 ---
 
 ### `queryGateway`
-CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路径路由及其上游：WEB_SCF/SCF=云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器。主键为 Domain + Path；listRoutes / getRoute / listCustomDomains。实现自定义域名访问前，先 listCustomDomains：若已有自定义域名，优先 createRoute 挂路由（无需证书 ID）；仅在没有可用自定义域名时才 bindCustomDomain。
+CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路径路由及其上游：WEB_SCF/SCF=云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器。主键为 Domain + Path；listRoutes / getRoute / listCustomDomains / getPrivilege。getPrivilege 查询 HTTP 网关总开关（enableService）与访问鉴权（enableAuth）状态。实现自定义域名访问前，先 listCustomDomains：若已有自定义域名，优先 createRoute 挂路由（无需证书 ID）；仅在没有可用自定义域名时才 bindCustomDomain。
 
 #### 参数
 
@@ -2359,7 +2359,7 @@ CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路�
       name: "action",
       type: "string",
       required: true,
-      description: `只读操作类型：listRoutes、getRoute、listCustomDomains。自定义域名访问场景先 listCustomDomains 确认是否已有域名可复用。 可填写的值: "listRoutes", "getRoute", "listCustomDomains"`,
+      description: `只读操作类型：listRoutes、getRoute、listCustomDomains、getPrivilege。getPrivilege 无需其他参数，直接返回 HTTP 网关总开关与访问鉴权状态。自定义域名访问场景先 listCustomDomains 确认是否已有域名可复用。 可填写的值: "listRoutes", "getRoute", "listCustomDomains", "getPrivilege"`,
     },
     {
       name: "targetName",
@@ -2387,7 +2387,7 @@ CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路�
 ---
 
 ### `manageGateway`
-CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute/deleteRoute 把域名下的 path 转到上游；未传 domain 时用 DomainType=HTTPSERVICE 的 IsDefault 默认 HTTP 域名（形如 *.\{region\}.app.tcloudbase.com），不会使用静态托管 CDN 域名（*.tcloudbaseapp.com，DomainType=STATIC_STORE）。这是网关默认域上的路径路由，不是 STATIC_STORE 上游绑定；STATIC_STORE 上游必须显式传 upstreamResourceType=STATIC_STORE。创建后可用 queryGateway(action="listRoutes") 核对 Domain / DomainType / Path / UpstreamResourceType。上游类型只用一个参数 upstreamResourceType（也可写在 route.upstreamResourceType，route 优先）：WEB_SCF=HTTP云函数，SCF=Event云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器；配合 targetName 或 route.serviceName（云函数名/云托管服务名/静态托管实例名，常见 staticstore）。createRoute 只建网关入口，不改上游权限。enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。
+CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute/deleteRoute 把域名下的 path 转到上游；未传 domain 时用 DomainType=HTTPSERVICE 的 IsDefault 默认 HTTP 域名（形如 *.\{region\}.app.tcloudbase.com），不会使用静态托管 CDN 域名（*.tcloudbaseapp.com，DomainType=STATIC_STORE）。这是网关默认域上的路径路由，不是 STATIC_STORE 上游绑定；STATIC_STORE 上游必须显式传 upstreamResourceType=STATIC_STORE。创建后可用 queryGateway(action="listRoutes") 核对 Domain / DomainType / Path / UpstreamResourceType。上游类型只用一个参数 upstreamResourceType（也可写在 route.upstreamResourceType，route 优先）：WEB_SCF=HTTP云函数，SCF=Event云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器；配合 targetName 或 route.serviceName（云函数名/云托管服务名/静态托管实例名，常见 staticstore）。createRoute 只建网关入口，不改上游权限。enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。enableService/authSwitch：HTTP 网关总开关与访问鉴权开关；createRoute 后若访问报 HTTPSERVICE_NONACTIVATED，通常是总开关未开启（用 queryGateway getPrivilege 查询、enableService 开启）。
 
 #### 参数
 
@@ -2397,7 +2397,7 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
       name: "action",
       type: "string",
       required: true,
-      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain"`,
+      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "enableService", "authSwitch"`,
     },
     {
       name: "targetName",
@@ -2463,6 +2463,11 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
       name: "certificateId",
       type: "string",
       description: `证书 ID。仅首次 bindCustomDomain 必填。在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。`,
+    },
+    {
+      name: "enable",
+      type: "boolean",
+      description: `开关目标状态（仅 enableService / authSwitch 使用，必填）：enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。`,
     }
   ]}
 />

--- a/mcp/src/tools/app-auth.test.ts
+++ b/mcp/src/tools/app-auth.test.ts
@@ -336,6 +336,45 @@ describe("app auth tools", () => {
     });
   });
 
+  it("queryAppAuth(action=getLoginConfig) should return smsHint when phone login is on", async () => {
+    mockGetLoginConfig.mockResolvedValueOnce({
+      AnonymousLogin: false,
+      UserNameLogin: true,
+      PhoneNumberLogin: true,
+      EmailLogin: false,
+    });
+
+    const result = await tools.queryAppAuth.handler({ action: "getLoginConfig" });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      success: true,
+      loginMethods: {
+        phone: true,
+      },
+      smsHint: {
+        defaultChannelReady: true,
+      },
+    });
+    expect(payload.smsHint.message).toContain("无需配置短信签名");
+    expect(payload.smsHint.message).toContain("auth.getVerification");
+  });
+
+  it("queryAppAuth(action=getLoginConfig) should omit smsHint when phone login is off", async () => {
+    mockGetLoginConfig.mockResolvedValueOnce({
+      AnonymousLogin: false,
+      UserNameLogin: true,
+      PhoneNumberLogin: false,
+      EmailLogin: false,
+    });
+
+    const result = await tools.queryAppAuth.handler({ action: "getLoginConfig" });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.smsHint).toBeUndefined();
+  });
+
   it("queryAppAuth should return a short error when no active environment is selected", async () => {
     mockGetEnvId.mockRejectedValueOnce({
       name: "ToolPayloadError",

--- a/mcp/src/tools/app-auth.ts
+++ b/mcp/src/tools/app-auth.ts
@@ -210,6 +210,25 @@ function buildLoginConfigNextStep(loginMethods: ReturnType<typeof buildLoginMeth
   };
 }
 
+/**
+ * 短信验证码默认通道提示：开启 phone 登录后即可用云开发默认短信通道收发验证码，
+ * 不需要配置短信签名/模板/自定义 Provider。仅当需要自定义模板、签名或更换短信服务商时，
+ * 才需要配置 SmsVerificationConfig / 自定义短信通道。
+ */
+function buildSmsHint(loginMethods: ReturnType<typeof buildLoginMethods>) {
+  if (!loginMethods.phone) {
+    return undefined;
+  }
+
+  return {
+    defaultChannelReady: true,
+    message:
+      "短信验证码登录已开启，可直接使用云开发默认短信通道收发验证码，无需配置短信签名/模板/自定义 Provider。" +
+      "前端调用 auth.getVerification({ phone_number }) 发送验证码、auth.signInWithSms({ verificationInfo, verificationCode, phoneNum }) 登录。" +
+      "仅当需要自定义短信模板/签名或更换短信服务商时，才需要配置 SmsVerificationConfig 或接入自定义短信通道。",
+  };
+}
+
 function extractProviders(value: unknown): Array<Record<string, unknown>> {
   const payload = normalizePlainObject(value, "providersResult");
   const providers = payload?.Providers ?? payload?.ProviderList ?? payload?.Data ?? [];
@@ -450,12 +469,14 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
             const loginMethods = buildLoginMethods(result);
             const nextStep = buildLoginConfigNextStep(loginMethods);
             const webSdkHint = buildWebSdkHint(loginMethods);
+            const smsHint = buildSmsHint(loginMethods);
             return buildSupabaseLikeAuthResponse({
               success: true,
               envId,
               loginMethods,
               ...(nextStep ? { next_step: nextStep } : {}),
               ...(webSdkHint ? { webSdkHint } : {}),
+              ...(smsHint ? { smsHint } : {}),
             });
           }
           case "listProviders": {
@@ -543,7 +564,7 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
     {
       title: "管理 CloudBase 应用认证配置",
       description:
-        "CloudBase 应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。⚠️ 本工具为管理端配置工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具完成配置（如启用 usernamePassword、获取 publishable key），再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。⚠️ action=createApiKey 返回体中的 created 字段表示是否真正新建：created=false 说明复用了环境中已存在的 key，此时 keyName/expireIn 入参不会生效，返回的 keyName/expireAt 均为服务端真实值，并会附带 warnings，切勿把它当作临时凭证分发。",
+        "CloudBase 应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。⚠️ 本工具为管理端配置工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具完成配置（如启用 usernamePassword、获取 publishable key），再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。⚠️ 短信验证码登录（patch={ phone: true }）使用云开发默认短信通道，开启后即可收发验证码，不需要配置短信签名/模板/自定义 Provider；仅当需要自定义模板/签名或更换短信服务商时才需配置 SmsVerificationConfig 或自定义短信通道。⚠️ action=createApiKey 返回体中的 created 字段表示是否真正新建：created=false 说明复用了环境中已存在的 key，此时 keyName/expireIn 入参不会生效，返回的 keyName/expireAt 均为服务端真实值，并会附带 warnings，切勿把它当作临时凭证分发。",
       inputSchema: {
         action: z.enum(MANAGE_APP_AUTH_ACTIONS),
         patch: z
@@ -642,12 +663,14 @@ export function registerAppAuthTools(server: ExtendedMcpServer) {
             const loginMethods = buildLoginMethods(confirmed);
             const nextStep = buildLoginConfigNextStep(loginMethods);
             const webSdkHint = buildWebSdkHint(loginMethods);
+            const smsHint = buildSmsHint(loginMethods);
             return buildSupabaseLikeAuthResponse({
               success: true,
               envId,
               loginMethods,
               ...(nextStep ? { next_step: nextStep } : {}),
               ...(webSdkHint ? { webSdkHint } : {}),
+              ...(smsHint ? { smsHint } : {}),
             });
           }
           case "addProvider": {

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -324,4 +324,15 @@ describe("functions tool helpers", () => {
     expect(payload.success).toBe(true);
     expect(mockCreateFunction).toHaveBeenCalled();
   });
+
+  it("protocolType schema should only accept WS (reject HTTP)", async () => {
+    const schema = tools.manageFunctions.meta.inputSchema;
+    const protocolType = schema.func.unwrap().shape.protocolType;
+
+    expect(protocolType.unwrap()._def.values).toEqual(["WS"]);
+    expect(protocolType.safeParse("WS").success).toBe(true);
+    expect(protocolType.safeParse("HTTP").success).toBe(false);
+    expect(protocolType.description).toContain("WS");
+    expect(protocolType.description).toContain("WebSocket");
+  });
 });

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -297,7 +297,9 @@ const TRIGGER_SCHEMA = z.object({
 const CREATE_FUNCTION_SCHEMA = z.object({
   name: z.string().describe("函数名称"),
   type: z.enum(["Event", "HTTP"]).optional().describe("函数类型"),
-  protocolType: z.enum(["HTTP", "WS"]).optional().describe("HTTP 云函数协议类型"),
+  protocolType: z.enum(["WS"]).optional().describe(
+    "HTTP 函数访问协议，当前仅支持 WebSockets，取值为 WS（配合 protocolParams.wsParams 使用）。普通 HTTP 函数不要传此字段；传其他值（如 HTTP）会报 InvalidParameterValue.ProtocolType。",
+  ),
   protocolParams: z
     .object({
       wsParams: z

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -12,6 +12,8 @@ const {
   mockGetCloudBaseManager,
   mockLogCloudBaseResult,
   mockGetEnvId,
+  mockCommonServiceCall,
+  mockSwitchAuth,
 } = vi.hoisted(() => ({
   mockDescribeHttpServiceRoute: vi.fn(),
   mockCreateHttpServiceRoute: vi.fn(),
@@ -22,6 +24,8 @@ const {
   mockGetCloudBaseManager: vi.fn(),
   mockLogCloudBaseResult: vi.fn(),
   mockGetEnvId: vi.fn(),
+  mockCommonServiceCall: vi.fn(),
+  mockSwitchAuth: vi.fn(),
 }));
 
 vi.mock("../cloudbase-manager.js", () => ({
@@ -111,6 +115,13 @@ describe("gateway tools", () => {
     mockDeleteCustomDomain.mockResolvedValue({
       RequestId: "req-domain-delete",
     });
+    mockCommonServiceCall.mockResolvedValue({
+      EnableService: true,
+      EnableAuth: false,
+    });
+    mockSwitchAuth.mockResolvedValue({
+      RequestId: "req-switch-auth",
+    });
     mockGetCloudBaseManager.mockResolvedValue({
       env: {
         describeHttpServiceRoute: mockDescribeHttpServiceRoute,
@@ -119,6 +130,12 @@ describe("gateway tools", () => {
         deleteHttpServiceRoute: mockDeleteHttpServiceRoute,
         bindCustomDomain: mockBindCustomDomain,
         deleteCustomDomain: mockDeleteCustomDomain,
+      },
+      commonService: vi.fn(() => ({
+        call: mockCommonServiceCall,
+      })),
+      access: {
+        switchAuth: mockSwitchAuth,
       },
     });
 
@@ -130,13 +147,20 @@ describe("gateway tools", () => {
     const manageActions = tools.manageGateway.meta.inputSchema.action._def.values;
     const schema = tools.manageGateway.meta.inputSchema;
 
-    expect(queryActions).toEqual(["listRoutes", "getRoute", "listCustomDomains"]);
+    expect(queryActions).toEqual([
+      "listRoutes",
+      "getRoute",
+      "listCustomDomains",
+      "getPrivilege",
+    ]);
     expect(manageActions).toEqual([
       "createRoute",
       "updateRoute",
       "deleteRoute",
       "bindCustomDomain",
       "deleteCustomDomain",
+      "enableService",
+      "authSwitch",
     ]);
     expect(schema.targetType).toBeUndefined();
     expect(schema.type).toBeUndefined();
@@ -716,5 +740,197 @@ describe("gateway tools", () => {
         domain: "api.example.com",
       },
     });
+  });
+
+  it("queryGateway(action=getPrivilege) should return service and auth status", async () => {
+    mockCommonServiceCall.mockResolvedValue({
+      EnableService: false,
+      EnableAuth: true,
+    });
+
+    const result = await tools.queryGateway.handler({
+      action: "getPrivilege",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCommonServiceCall).toHaveBeenCalledWith({
+      Action: "DescribeCloudBaseGWPrivilege",
+      Param: { ServiceId: "env-test" },
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "getPrivilege",
+        enableService: false,
+        enableAuth: true,
+      },
+    });
+    expect(payload.message).toContain("未开启");
+    expect(payload.nextActions).toEqual([
+      expect.objectContaining({
+        tool: "manageGateway",
+        action: "enableService",
+      }),
+    ]);
+  });
+
+  it("queryGateway(action=getPrivilege) should not suggest enable when service is on", async () => {
+    mockCommonServiceCall.mockResolvedValue({
+      EnableService: true,
+      EnableAuth: false,
+    });
+
+    const result = await tools.queryGateway.handler({
+      action: "getPrivilege",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.enableService).toBe(true);
+    expect(payload.message).toContain("已开启");
+    expect(payload.nextActions).toBeUndefined();
+  });
+
+  it("manageGateway(action=enableService) should turn on the gateway service", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "enableService",
+      enable: true,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockSwitchAuth).toHaveBeenCalledWith(true);
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "enableService",
+        enable: true,
+      },
+    });
+    expect(payload.message).toContain("开启成功");
+    expect(payload.nextActions).toEqual([
+      expect.objectContaining({
+        tool: "queryGateway",
+        action: "getPrivilege",
+      }),
+    ]);
+  });
+
+  it("manageGateway(action=enableService) should require enable parameter", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "enableService",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("enable");
+    expect(mockSwitchAuth).not.toHaveBeenCalled();
+  });
+
+  it("manageGateway(action=authSwitch) should switch auth via ModifyCloudBaseGWPrivilege", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "authSwitch",
+      enable: true,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockCommonServiceCall).toHaveBeenCalledWith({
+      Action: "ModifyCloudBaseGWPrivilege",
+      Param: {
+        ServiceId: "env-test",
+        EnableService: true,
+        Options: [{ Key: "authswitch", Value: "true" }],
+      },
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "authSwitch",
+        enable: true,
+      },
+    });
+    expect(payload.message).toContain("鉴权开启成功");
+  });
+
+  it("manageGateway(action=authSwitch) should require enable parameter", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "authSwitch",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("enable");
+    expect(mockCommonServiceCall).not.toHaveBeenCalled();
+  });
+
+  it("manageGateway(action=createRoute) should warn when gateway service is off", async () => {
+    mockCommonServiceCall.mockResolvedValue({
+      EnableService: false,
+      EnableAuth: false,
+    });
+
+    const result = await tools.manageGateway.handler({
+      action: "createRoute",
+      targetName: "helloFn",
+      path: "api/hello",
+      upstreamResourceType: "WEB_SCF",
+      auth: false,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.message).toContain("HTTP 网关总开关未开启");
+    expect(payload.message).toContain("HTTPSERVICE_NONACTIVATED");
+    expect(payload.nextActions[0]).toEqual(
+      expect.objectContaining({
+        tool: "manageGateway",
+        action: "enableService",
+      }),
+    );
+  });
+
+  it("manageGateway(action=createRoute) should not warn when gateway service is on", async () => {
+    mockCommonServiceCall.mockResolvedValue({
+      EnableService: true,
+      EnableAuth: false,
+    });
+
+    const result = await tools.manageGateway.handler({
+      action: "createRoute",
+      targetName: "helloFn",
+      path: "api/hello",
+      upstreamResourceType: "WEB_SCF",
+      auth: false,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.message).not.toContain("总开关未开启");
+    expect(payload.message).not.toContain("HTTPSERVICE_NONACTIVATED");
+  });
+
+  it("manageGateway(action=createRoute) should not fail when privilege probe errors", async () => {
+    mockCommonServiceCall.mockRejectedValue(new Error("probe failed"));
+
+    const result = await tools.manageGateway.handler({
+      action: "createRoute",
+      targetName: "helloFn",
+      path: "api/hello",
+      upstreamResourceType: "WEB_SCF",
+      auth: false,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.message).toContain("无法确认 HTTP 网关开关状态");
+    expect(mockCreateHttpServiceRoute).toHaveBeenCalled();
   });
 });

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -16,6 +16,7 @@ const QUERY_GATEWAY_ACTIONS = [
   "listRoutes",
   "getRoute",
   "listCustomDomains",
+  "getPrivilege",
 ] as const;
 
 const MANAGE_GATEWAY_ACTIONS = [
@@ -24,6 +25,8 @@ const MANAGE_GATEWAY_ACTIONS = [
   "deleteRoute",
   "bindCustomDomain",
   "deleteCustomDomain",
+  "enableService",
+  "authSwitch",
 ] as const;
 
 /** DomainType of the environment default HTTP service (gateway) domain. */
@@ -76,6 +79,14 @@ type ManageGatewayInput = {
   };
   domain?: string;
   certificateId?: string;
+  enable?: boolean;
+};
+
+/** HTTP 网关总开关与访问鉴权状态（DescribeCloudBaseGWPrivilege）。 */
+type GatewayPrivilege = {
+  EnableService?: boolean;
+  EnableAuth?: boolean;
+  [key: string]: unknown;
 };
 
 type FlatRoute = {
@@ -221,6 +232,32 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       candidates.find((item) => item.Enable !== false) ??
       candidates[0]
     );
+  };
+
+  const getGatewayPrivilege = async (): Promise<GatewayPrivilege> => {
+    const cloudbase = await getManager();
+    const result = await cloudbase
+      .commonService("tcb", "2018-06-08")
+      .call({
+        Action: "DescribeCloudBaseGWPrivilege",
+        Param: {
+          ServiceId: await resolveEnvId(),
+        },
+      });
+    logCloudBaseResult(server.logger, result);
+    return result ?? {};
+  };
+
+  const buildPrivilegeDescription = (privilege: GatewayPrivilege) => {
+    const serviceStatus =
+      privilege.EnableService === true ? "已开启" : "未开启";
+    const authStatus =
+      privilege.EnableAuth === undefined
+        ? "未知"
+        : privilege.EnableAuth === true
+          ? "已开启"
+          : "未开启";
+    return `HTTP 网关${serviceStatus}，访问鉴权${authStatus}`;
   };
 
   const resolveDefaultHttpDomain = async () => {
@@ -488,6 +525,34 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           ],
         );
       }
+      case "getPrivilege": {
+        const privilege = await getGatewayPrivilege();
+        const enableService = privilege.EnableService === true;
+        const enableAuth = privilege.EnableAuth === true;
+
+        return buildEnvelope(
+          {
+            action: input.action,
+            enableService,
+            enableAuth,
+            raw: privilege,
+          },
+          buildPrivilegeDescription(privilege) +
+            (enableService
+              ? ""
+              : "；若路由创建成功但访问报 HTTPSERVICE_NONACTIVATED（403），请先开启 HTTP 网关"),
+          enableService
+            ? undefined
+            : [
+                {
+                  tool: "manageGateway",
+                  action: "enableService",
+                  reason:
+                    "开启 HTTP 网关总开关（EnableService），开启后路由即可通过默认域访问",
+                },
+              ],
+        );
+      }
       default:
         throw new Error(`不支持的操作类型: ${input.action}`);
     }
@@ -524,6 +589,31 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         }
         logCloudBaseResult(server.logger, result);
 
+        // 探测 HTTP 网关总开关：未开启时提示 HTTPSERVICE_NONACTIVATED 风险并引导开启。
+        // 探测失败不阻断路由创建结果，仅追加弱提示。
+        let privilegeHint = "";
+        let privilegeNextActions: NonNullable<
+          GatewayToolEnvelope["nextActions"]
+        > = [];
+        try {
+          const privilege = await getGatewayPrivilege();
+          if (privilege.EnableService !== true) {
+            privilegeHint =
+              "⚠️ HTTP 网关总开关未开启，路由创建成功后访问仍将返回 HTTPSERVICE_NONACTIVATED（403）；请先调用 manageGateway(action=\"enableService\", enable=true) 开启，再等待 30 秒到 3 分钟访问。";
+            privilegeNextActions = [
+              {
+                tool: "manageGateway",
+                action: "enableService",
+                reason:
+                  "开启 HTTP 网关总开关（EnableService），否则访问路由会报 HTTPSERVICE_NONACTIVATED（403）",
+              },
+            ];
+          }
+        } catch {
+          privilegeHint =
+            "（无法确认 HTTP 网关开关状态；若访问报 HTTPSERVICE_NONACTIVATED，请用 queryGateway(action=\"getPrivilege\") 查询后用 manageGateway(action=\"enableService\") 开启）";
+        }
+
         return buildEnvelope(
           {
             action: input.action,
@@ -550,8 +640,13 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
               : payload.resolved.enablePathTransmission === false
                 ? "；路径透传关闭（网关会剥掉触发路径前缀后再转发给后端）"
                 : "；路径透传未显式设置（平台默认 false，会剥掉触发路径前缀）") +
-            `。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开上游权限；若上游是云函数且需要匿名或浏览器直接访问，请继续检查函数资源权限。`,
-          routeMutationNextActions(payload.resolved.upstreamResourceName),
+            `。注意：路由配置传播通常需要等待 30 秒到 3 分钟，请勿立即访问。该操作只创建网关入口，不会自动放开上游权限；若上游是云函数且需要匿名或浏览器直接访问，请继续检查函数资源权限。` +
+            (privilegeHint ? ` ${privilegeHint}` : ""),
+          [
+            ...privilegeNextActions,
+            ...(routeMutationNextActions(payload.resolved.upstreamResourceName) ??
+              []),
+          ],
         );
       }
       case "updateRoute": {
@@ -664,6 +759,74 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           "自定义域名删除成功",
         );
       }
+      case "enableService": {
+        if (typeof input.enable !== "boolean") {
+          throw new Error(
+            'action=enableService 时必须提供 enable 参数（boolean），如 enable=true 开启 HTTP 网关总开关、enable=false 关闭；禁止省略或传非布尔值。',
+          );
+        }
+        const cloudbase = await getManager();
+        const result = await cloudbase.access.switchAuth(input.enable);
+        logCloudBaseResult(server.logger, result);
+
+        const serviceText = input.enable ? "开启" : "关闭";
+        return buildEnvelope(
+          {
+            action: input.action,
+            enable: input.enable,
+            raw: result,
+          },
+          `HTTP 网关总开关${serviceText}成功`,
+          [
+            {
+              tool: "queryGateway",
+              action: "getPrivilege",
+              reason: "复核 HTTP 网关总开关与访问鉴权状态",
+            },
+          ],
+        );
+      }
+      case "authSwitch": {
+        if (typeof input.enable !== "boolean") {
+          throw new Error(
+            'action=authSwitch 时必须提供 enable 参数（boolean），如 enable=true 开启访问鉴权、enable=false 关闭；禁止省略或传非布尔值。',
+          );
+        }
+        const cloudbase = await getManager();
+        const result = await cloudbase
+          .commonService("tcb", "2018-06-08")
+          .call({
+            Action: "ModifyCloudBaseGWPrivilege",
+            Param: {
+              ServiceId: await resolveEnvId(),
+              EnableService: input.enable,
+              Options: [
+                {
+                  Key: "authswitch",
+                  Value: input.enable ? "true" : "false",
+                },
+              ],
+            },
+          });
+        logCloudBaseResult(server.logger, result);
+
+        const serviceText = input.enable ? "开启" : "关闭";
+        return buildEnvelope(
+          {
+            action: input.action,
+            enable: input.enable,
+            raw: result,
+          },
+          `HTTP 访问服务鉴权${serviceText}成功`,
+          [
+            {
+              tool: "queryGateway",
+              action: "getPrivilege",
+              reason: "复核 HTTP 网关总开关与访问鉴权状态",
+            },
+          ],
+        );
+      }
       default:
         throw new Error(`不支持的操作类型: ${input.action}`);
     }
@@ -676,13 +839,15 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
       description:
         "CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路径路由及其上游：" +
         "WEB_SCF/SCF=云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器。" +
-        "主键为 Domain + Path；listRoutes / getRoute / listCustomDomains。" +
+        "主键为 Domain + Path；listRoutes / getRoute / listCustomDomains / getPrivilege。" +
+        "getPrivilege 查询 HTTP 网关总开关（enableService）与访问鉴权（enableAuth）状态。" +
         "实现自定义域名访问前，先 listCustomDomains：若已有自定义域名，优先 createRoute 挂路由（无需证书 ID）；仅在没有可用自定义域名时才 bindCustomDomain。",
       inputSchema: {
         action: z
           .enum(QUERY_GATEWAY_ACTIONS)
           .describe(
-            "只读操作类型：listRoutes、getRoute、listCustomDomains。" +
+            "只读操作类型：listRoutes、getRoute、listCustomDomains、getPrivilege。" +
+              "getPrivilege 无需其他参数，直接返回 HTTP 网关总开关与访问鉴权状态。" +
               "自定义域名访问场景先 listCustomDomains 确认是否已有域名可复用。",
           ),
         targetName: z
@@ -725,12 +890,14 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         "createRoute 只建网关入口，不改上游权限。" +
         "enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。" +
         "⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；" +
-        "仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。",
+        "仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。" +
+        "enableService/authSwitch：HTTP 网关总开关与访问鉴权开关；createRoute 后若访问报 HTTPSERVICE_NONACTIVATED，通常是总开关未开启（用 queryGateway getPrivilege 查询、enableService 开启）。",
       inputSchema: {
         action: z
           .enum(MANAGE_GATEWAY_ACTIONS)
           .describe(
-            "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名。" +
+            "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；" +
+              "enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。" +
               "createRoute/updateRoute 必须提供 upstreamResourceType。" +
               "已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；" +
               "bindCustomDomain 仅用于首次绑定新域名。",
@@ -818,6 +985,13 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           .describe(
             "证书 ID。仅首次 bindCustomDomain 必填。" +
               "在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。",
+          ),
+        enable: z
+          .boolean()
+          .optional()
+          .describe(
+            "开关目标状态（仅 enableService / authSwitch 使用，必填）：" +
+              "enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。",
           ),
       },
       annotations: {

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1133,10 +1133,9 @@
               "protocolType": {
                 "type": "string",
                 "enum": [
-                  "HTTP",
                   "WS"
                 ],
-                "description": "HTTP 云函数协议类型"
+                "description": "HTTP 函数访问协议，当前仅支持 WebSockets，取值为 WS（配合 protocolParams.wsParams 使用）。普通 HTTP 函数不要传此字段；传其他值（如 HTTP）会报 InvalidParameterValue.ProtocolType。"
               },
               "protocolParams": {
                 "type": "object",
@@ -1853,7 +1852,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.2），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.3），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2482,7 +2481,7 @@
     },
     {
       "name": "queryGateway",
-      "description": "CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路径路由及其上游：WEB_SCF/SCF=云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器。主键为 Domain + Path；listRoutes / getRoute / listCustomDomains。实现自定义域名访问前，先 listCustomDomains：若已有自定义域名，优先 createRoute 挂路由（无需证书 ID）；仅在没有可用自定义域名时才 bindCustomDomain。",
+      "description": "CloudBase HTTP 网关统一只读入口（Domain/Route）。查询域名下路径路由及其上游：WEB_SCF/SCF=云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器。主键为 Domain + Path；listRoutes / getRoute / listCustomDomains / getPrivilege。getPrivilege 查询 HTTP 网关总开关（enableService）与访问鉴权（enableAuth）状态。实现自定义域名访问前，先 listCustomDomains：若已有自定义域名，优先 createRoute 挂路由（无需证书 ID）；仅在没有可用自定义域名时才 bindCustomDomain。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2491,9 +2490,10 @@
             "enum": [
               "listRoutes",
               "getRoute",
-              "listCustomDomains"
+              "listCustomDomains",
+              "getPrivilege"
             ],
-            "description": "只读操作类型：listRoutes、getRoute、listCustomDomains。自定义域名访问场景先 listCustomDomains 确认是否已有域名可复用。"
+            "description": "只读操作类型：listRoutes、getRoute、listCustomDomains、getPrivilege。getPrivilege 无需其他参数，直接返回 HTTP 网关总开关与访问鉴权状态。自定义域名访问场景先 listCustomDomains 确认是否已有域名可复用。"
           },
           "targetName": {
             "type": "string",
@@ -2521,7 +2521,7 @@
     },
     {
       "name": "manageGateway",
-      "description": "CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute/deleteRoute 把域名下的 path 转到上游；未传 domain 时用 DomainType=HTTPSERVICE 的 IsDefault 默认 HTTP 域名（形如 *.{region}.app.tcloudbase.com），不会使用静态托管 CDN 域名（*.tcloudbaseapp.com，DomainType=STATIC_STORE）。这是网关默认域上的路径路由，不是 STATIC_STORE 上游绑定；STATIC_STORE 上游必须显式传 upstreamResourceType=STATIC_STORE。创建后可用 queryGateway(action=\"listRoutes\") 核对 Domain / DomainType / Path / UpstreamResourceType。上游类型只用一个参数 upstreamResourceType（也可写在 route.upstreamResourceType，route 优先）：WEB_SCF=HTTP云函数，SCF=Event云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器；配合 targetName 或 route.serviceName（云函数名/云托管服务名/静态托管实例名，常见 staticstore）。createRoute 只建网关入口，不改上游权限。enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。",
+      "description": "CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute/deleteRoute 把域名下的 path 转到上游；未传 domain 时用 DomainType=HTTPSERVICE 的 IsDefault 默认 HTTP 域名（形如 *.{region}.app.tcloudbase.com），不会使用静态托管 CDN 域名（*.tcloudbaseapp.com，DomainType=STATIC_STORE）。这是网关默认域上的路径路由，不是 STATIC_STORE 上游绑定；STATIC_STORE 上游必须显式传 upstreamResourceType=STATIC_STORE。创建后可用 queryGateway(action=\"listRoutes\") 核对 Domain / DomainType / Path / UpstreamResourceType。上游类型只用一个参数 upstreamResourceType（也可写在 route.upstreamResourceType，route 优先）：WEB_SCF=HTTP云函数，SCF=Event云函数，CBR=云托管，STATIC_STORE=静态托管，LH=轻量应用服务器；配合 targetName 或 route.serviceName（云函数名/云托管服务名/静态托管实例名，常见 staticstore）。createRoute 只建网关入口，不改上游权限。enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；仅首次绑定全新自定义域名时用 bindCustomDomain（需 certificateId）。CORS/安全域名用 envDomainManagement。enableService/authSwitch：HTTP 网关总开关与访问鉴权开关；createRoute 后若访问报 HTTPSERVICE_NONACTIVATED，通常是总开关未开启（用 queryGateway getPrivilege 查询、enableService 开启）。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2532,9 +2532,11 @@
               "updateRoute",
               "deleteRoute",
               "bindCustomDomain",
-              "deleteCustomDomain"
+              "deleteCustomDomain",
+              "enableService",
+              "authSwitch"
             ],
-            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。"
+            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。"
           },
           "targetName": {
             "type": "string",
@@ -2602,6 +2604,10 @@
           "certificateId": {
             "type": "string",
             "description": "证书 ID。仅首次 bindCustomDomain 必填。在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。"
+          },
+          "enable": {
+            "type": "boolean",
+            "description": "开关目标状态（仅 enableService / authSwitch 使用，必填）：enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。"
           }
         },
         "required": [
@@ -2665,7 +2671,7 @@
     },
     {
       "name": "manageAppAuth",
-      "description": "CloudBase 应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。⚠️ 本工具为管理端配置工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具完成配置（如启用 usernamePassword、获取 publishable key），再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。⚠️ action=createApiKey 返回体中的 created 字段表示是否真正新建：created=false 说明复用了环境中已存在的 key，此时 keyName/expireIn 入参不会生效，返回的 keyName/expireAt 均为服务端真实值，并会附带 warnings，切勿把它当作临时凭证分发。",
+      "description": "CloudBase 应用侧认证配置写入口。用于修改登录方式、provider、client 配置，确保 publishable key，以及创建或删除 API key、自定义登录密钥。⚠️ 本工具为管理端配置工具，不执行用户登录。当任务要求编写客户端登录代码时（例如「用 JS SDK 登录」），应先通过本工具完成配置（如启用 usernamePassword、获取 publishable key），再在项目代码中编写 @cloudbase/js-sdk 客户端登录代码（如 auth.signInWithPassword()），而非使用本工具完成登录。若前端要接受普通用户名样式标识符，应先执行 action=patchLoginStrategy 并传入 patch={ usernamePassword: true }，再实现对应前端登录逻辑。⚠️ 短信验证码登录（patch={ phone: true }）使用云开发默认短信通道，开启后即可收发验证码，不需要配置短信签名/模板/自定义 Provider；仅当需要自定义模板/签名或更换短信服务商时才需配置 SmsVerificationConfig 或自定义短信通道。⚠️ action=createApiKey 返回体中的 created 字段表示是否真正新建：created=false 说明复用了环境中已存在的 key，此时 keyName/expireIn 入参不会生效，返回的 keyName/expireAt 均为服务端真实值，并会附带 warnings，切勿把它当作临时凭证分发。",
       "inputSchema": {
         "type": "object",
         "properties": {

--- a/specs/mcp-gateway-privilege/design.md
+++ b/specs/mcp-gateway-privilege/design.md
@@ -1,0 +1,112 @@
+# 技术方案：HTTP 网关总开关查询与开关能力（gateway privilege）
+
+## 背景
+
+验证 v2.25.3 时发现：`manageGateway(createRoute)` 创建路由成功、路由状态 Enable，但访问仍报 `HTTPSERVICE_NONACTIVATED`（403），根因是环境「HTTP 网关」总开关未开启。MCP 目前无法查询/控制该开关，AI 无法定位原因，只能手动通过控制台操作。
+
+同时发现 `manageFunctions` 的 `func.protocolType` schema 枚举含非法值 `"HTTP"`（SCF 官方文档仅支持 `"WS"`），需要一并修正。
+
+## 架构与选型
+
+### 1. 底层 API 能力（已查证）
+
+| 能力 | 云 API Action | 参数 | Manager SDK 覆盖 |
+|---|---|---|---|
+| 查询开关状态 | `DescribeCloudBaseGWPrivilege` | `ServiceId` | ❌ 无（`access.getDomainList()` 只返回 `EnableService`，无 `EnableAuth`） |
+| 开关总开关 | `ModifyCloudBaseGWPrivilege` | `ServiceId` + `Options:[{Key:'serviceswitch',Value:'true'/'false'}]` | ✅ `access.switchAuth(auth)`（方法名有误导性，实为总开关） |
+| 开关访问鉴权 | `ModifyCloudBaseGWPrivilege` | `ServiceId` + `Options:[{Key:'authswitch',Value:'true'/'false'}]` | ❌ 无（`switchPathAuth` 是按 APIId 的 `ModifyCloudBaseGWAPIPrivilegeBatch`，非全局） |
+
+注意：`ModifyCloudBaseGWPrivilege` 在 `Options` 存在时 `EnableService` 字段被忽略，实际生效的是 `Options`（CLI 源码注释确认）。
+
+### 2. 调用方式
+
+- **查询 `getPrivilege`**：使用 `cloudbase.commonService("tcb", "2018-06-08").call({ Action: "DescribeCloudBaseGWPrivilege", Param: { ServiceId } })`（MCP 已有此底层调用模式，见 `cloudbase-manager.ts:86`，`listAvailableEnvCandidates` 同款用法）
+- **开关 `enableService`**：优先使用 Manager SDK `cloudbase.access.switchAuth(enable)`（符合项目规则"SDK 优先"）
+- **开关 `authSwitch`**：SDK 无全局鉴权开关方法，使用 `commonService` 调 `ModifyCloudBaseGWPrivilege`（`Options:[{Key:'authswitch',...}]`）
+- **createRoute 探测**：复用 `getPrivilege` 的内部实现
+
+## 接口设计
+
+### `queryGateway` 新增 action: `getPrivilege`
+
+```
+输入: { action: "getPrivilege" }   // envId 来自当前绑定环境，无需额外参数
+输出:
+{
+  success: true,
+  data: {
+    action: "getPrivilege",
+    enableService: boolean,   // HTTP 网关总开关
+    enableAuth: boolean,      // 访问鉴权开关
+    raw: { EnableService, EnableAuth, ... }
+  },
+  message: "HTTP 网关已开启/未开启（访问鉴权已开启/未开启）",
+  nextActions?: [ { tool: "manageGateway", action: "enableService", reason: "..." } ]  // 仅 EnableService=false 时
+}
+```
+
+### `manageGateway` 新增 action: `enableService` / `authSwitch`
+
+```
+输入: { action: "enableService" | "authSwitch", enable: boolean }  // enable 必填
+输出:
+{
+  success: true,
+  data: { action, enable, enableService?, raw }
+  message: "HTTP 网关总开关已开启/关闭"（或"访问鉴权已开启/关闭"）
+  nextActions: [ { tool: "queryGateway", action: "getPrivilege", reason: "复核开关状态" } ]
+}
+```
+
+- `enable` 缺失时：`success: false` + 明确参数错误提示（不猜测默认值）
+- 成功后可调用 `getPrivilege` 复核新状态（可选，直接在 message 中附建议）
+
+### `manageGateway(createRoute)` 增加开关探测提示
+
+在现有 createRoute 成功返回前，调用 `getPrivilege` 内部实现：
+- `EnableService === false`：message 追加「⚠️ HTTP 网关总开关未开启，访问将返回 HTTPSERVICE_NONACTIVATED（403），建议调用 manageGateway(action="enableService", enable=true) 开启」；nextActions 前置插入该引导
+- `EnableService === true`：保持现有 message，不追加
+- 探测失败（网络等）：不阻断 createRoute 返回，message 追加「（无法确认 HTTP 网关开关状态）」弱提示
+
+### `manageFunctions` schema 修正（需求 5）
+
+`mcp/src/tools/functions.ts:300`：
+```ts
+// 修改前
+protocolType: z.enum(["HTTP", "WS"]).optional().describe("HTTP 云函数协议类型"),
+// 修改后
+protocolType: z.enum(["WS"]).optional().describe(
+  "HTTP 函数访问协议，当前仅支持 WebSockets，取值为 WS（配合 protocolParams.wsParams 使用）。普通 HTTP 函数不要传此字段。"
+),
+```
+
+## 测试策略
+
+`mcp/src/tools/gateway.test.ts`（现有 20 用例，mock `describeHttpServiceRoute`）新增：
+
+1. `queryGateway(action=getPrivilege)` 返回 EnableService/EnableAuth（mock `commonService.call` 或 `access` 模块）
+2. `manageGateway(action=enableService)` 传 `enable=true/false` 调用 `access.switchAuth`，断言参数与返回
+3. `manageGateway(action=enableService)` 缺 `enable` 返回参数错误
+4. `manageGateway(action=authSwitch)` 传 enable 调 `ModifyCloudBaseGWPrivilege`（authswitch），缺参报错
+5. `manageGateway(action=createRoute)` 且 EnableService=false 时 message 含「HTTP 网关总开关未开启」提示 + nextActions 引导
+6. `manageGateway(action=createRoute)` 且 EnableService=true 时无误导提示
+7. `manageGateway(action=createRoute)` 探测失败时仍成功返回路由（弱提示）
+
+`functions` 相关测试：`protocolType` schema 枚举仅接受 `WS`（拒绝 `HTTP`）。
+
+## 安全性
+
+- 只读查询与开关操作均走当前登录身份（Manager SDK / commonService），无新增密钥
+- 开关操作有明确 `enable` 参数，不猜测默认值，避免误关
+- createRoute 的探测不阻塞主流程，避免因探测失败导致路由创建结果丢失
+
+## 涉及文件
+
+| 文件 | 变更 |
+|---|---|
+| `mcp/src/tools/gateway.ts` | 新增 getPrivilege/enableService/authSwitch 分支 + createRoute 探测提示 + schema 更新 |
+| `mcp/src/tools/functions.ts` | `protocolType` 枚举修正为 `z.enum(["WS"])` + 描述 |
+| `mcp/src/tools/gateway.test.ts` | 新增上述用例 |
+| `mcp/src/tools/functions.test.ts` | protocolType 枚举校验用例 |
+| `scripts/tools.json`、`doc/mcp-tools.md` | 重新生成 |
+| `specs/mcp-gateway-privilege/requirements.md` | 已定稿 |

--- a/specs/mcp-gateway-privilege/requirements.md
+++ b/specs/mcp-gateway-privilege/requirements.md
@@ -1,0 +1,71 @@
+# 需求文档：HTTP 网关总开关查询与开关能力（gateway privilege）
+
+## 介绍
+
+MCP 的 `manageGateway`/`queryGateway` 工具目前只覆盖 Domain/Route 管理，无法感知或控制环境的「HTTP 网关」总开关（`ModifyCloudBaseGWPrivilege` / `DescribeCloudBaseGWPrivilege`）。当总开关未开启时，`createRoute` 返回成功、路由状态 Enable，但实际访问返回 `HTTPSERVICE_NONACTIVATED`（403），AI 无法从工具结果中定位原因，用户只能手动通过控制台或 curl 私有 API 开启。
+
+本次需求为 MCP 补齐 HTTP 网关总开关的查询与开关能力，并在 `createRoute` 结果中主动提示开关状态，避免「创建成功但访问 403」的误导。
+
+背景事实（2026-08-03 验证）：
+- Manager SDK `@cloudbase/manager-node` 的 `AccessService` 已内置能力：`getDomainList()`（返回 `EnableService`）、`getAccessList()`（返回 `EnableService`）、`switchAuth(auth)`（调 `ModifyCloudBaseGWPrivilege`，`Options:[{Key:'serviceswitch',...}]`，即总开关）、`switchPathAuth()`（路径级鉴权）。
+- CLI `tcb service switch` 通过 tcb 云 API `DescribeCloudBaseGWPrivilege` / `ModifyCloudBaseGWPrivilege` 实现，参数为 `ServiceId` + `EnableService` + `Options`。
+- 注意：`ModifyCloudBaseGWPrivilege` 在 `Options` 存在时 `EnableService` 会被忽略，实际生效的是 `Options`。
+
+## 需求
+
+### 需求 1 - queryGateway 支持查询 HTTP 网关总开关状态
+
+**用户故事：** 作为 AI 开发者，当访问网关路由失败时，我希望通过 `queryGateway` 直接查询当前环境的 HTTP 网关总开关状态（`EnableService`）与访问鉴权状态（`EnableAuth`），以便快速判断是否是总开关未开启导致的问题。
+
+#### 验收标准
+
+1. When 调用 `queryGateway(action="getPrivilege")`，the MCP 应当返回当前环境的 HTTP 网关总开关状态（`EnableService: boolean`）与访问鉴权状态（`EnableAuth: boolean`），无需额外参数（envId 来自当前绑定环境）。
+2. When `getPrivilege` 查询成功，the MCP 应当返回 `success: true`，并在 `data` 中给出开关状态的用户可读提示（如「HTTP 网关已开启/未开启」）。
+3. When 底层 API 调用失败（网络、鉴权等），the MCP 应当返回 `success: false` 并包含错误信息，不应抛出未捕获异常。
+4. When `EnableService=false`，the MCP 的返回中应当包含 `nextActions` 引导调用 `manageGateway(action="enableService")` 开启总开关。
+
+### 需求 2 - manageGateway 支持开关 HTTP 网关总开关与访问鉴权
+
+**用户故事：** 作为 AI 开发者，当发现 HTTP 网关总开关未开启时，我希望通过 `manageGateway` 直接开启或关闭，而不需要离开 MCP 手动操作控制台。
+
+#### 验收标准
+
+1. When 调用 `manageGateway(action="enableService", enable=true)`，the MCP 应当开启当前环境的 HTTP 网关总开关，并在成功后返回 `success: true` 与新的开关状态。
+2. When 调用 `manageGateway(action="enableService", enable=false)`，the MCP 应当关闭当前环境的 HTTP 网关总开关。
+3. When 调用 `manageGateway(action="enableService")` 未提供 `enable` 参数，the MCP 应当返回明确的参数错误提示（`success: false`），不应猜测默认值。
+4. When 调用 `manageGateway(action="authSwitch", enable=true/false)`，the MCP 应当开启/关闭 HTTP 访问服务的访问鉴权（`authswitch`）。
+5. When 开关操作成功，the MCP 的返回消息应当包含操作结果与当前状态，并给出 `nextActions` 提示可调用 `queryGateway(action="getPrivilege")` 复核状态。
+
+### 需求 3 - createRoute 创建后提示 HTTP 网关总开关状态
+
+**用户故事：** 作为 AI 开发者，当调用 `createRoute` 创建路由时，如果环境的 HTTP 网关总开关未开启，我希望工具结果中能直接看到提示，避免误以为路由创建成功即可访问。
+
+#### 验收标准
+
+1. When 调用 `manageGateway(action="createRoute")` 且当前环境 `EnableService=false`，the MCP 应当返回 `success: true`（路由本身创建成功），但在返回消息与 `nextActions` 中提示「HTTP 网关总开关未开启，访问将返回 HTTPSERVICE_NONACTIVATED，建议调用 manageGateway(action="enableService") 开启」。
+2. When `EnableService=true`，the MCP 的 `createRoute` 返回不应包含开关未开启的误导提示。
+3. When `EnableService` 查询本身失败（网络异常等），the MCP 不应让整个 `createRoute` 失败，而应在消息中附加「无法确认 HTTP 网关开关状态」的弱提示后继续返回路由创建结果。
+
+### 需求 4 - 工具 schema 与文档同步更新
+
+**用户故事：** 作为维护者，新增/修改的 MCP 工具参数需要有清晰的 schema 描述与文档说明，确保 AI 能正确调用。
+
+#### 验收标准
+
+1. When `manageGateway` 新增 `enableService`/`authSwitch` action，the MCP 的 action 枚举、参数 schema（`enable` 布尔字段）、description 应当同步更新，且描述中说明枚举含义。
+2. When 工具实现变更，the MCP 的生成产物（`scripts/tools.json`、`doc/mcp-tools.md`）应当重新生成并保持与代码一致。
+3. When 工具行为变更，the MCP 的单元测试（`mcp/src/tools/gateway.test.ts`）应当覆盖新增 action 的成功、参数错误与异常分支。
+
+### 需求 5 - 修正 manageFunctions 的 protocolType schema 枚举
+
+**用户故事：** 作为 AI 开发者，当我尝试创建 HTTP 云函数时，如果误传 `protocolType: "HTTP"` 会收到 `ProtocolType取值与规范不符` 的报错，因为该字段的唯一合法取值是 `WS`（WebSockets）。我希望 schema 描述能准确说明这一点，避免误导。
+
+背景事实（2026-08-03 查证）：SCF `CreateFunction.ProtocolType` 官方文档（`https://cloud.tencent.com/document/product/583/18586`）说明「HTTP函数支持的访问协议，当前支持WebSockets协议，值为 `WS`」。MCP schema（`mcp/src/tools/functions.ts:300`）当前为 `z.enum(["HTTP", "WS"])`，其中 `"HTTP"` 是非法值。
+
+#### 验收标准
+
+1. When 查看 `manageFunctions` 的 `func.protocolType` schema，the MCP 的枚举应当只包含合法值 `WS`（`z.enum(["WS"])`），不再包含 `"HTTP"`。
+2. When 查看 `func.protocolType` 的 description，the MCP 应当说明该字段仅用于 WebSocket 函数（配合 `protocolParams.wsParams`），普通 HTTP 函数不要传此字段。
+3. When 工具 schema 变更，the MCP 的生成产物（`scripts/tools.json`、`doc/mcp-tools.md`）应当重新生成并保持与代码一致。
+4. When schema 变更完成，the MCP 的单元测试（`mcp/src/tools/functions.test.ts` 或对应测试）应当覆盖 `protocolType` 枚举校验。
+

--- a/specs/mcp-gateway-privilege/tasks.md
+++ b/specs/mcp-gateway-privilege/tasks.md
@@ -1,0 +1,62 @@
+# 实施计划：HTTP 网关总开关查询与开关能力（gateway privilege）
+
+## 前置
+
+- [x] 需求定稿：`specs/mcp-gateway-privilege/requirements.md`（需求 1-5）
+- [x] 方案定稿：`specs/mcp-gateway-privilege/design.md`
+
+## 任务
+
+- [ ] 1. `gateway.ts` 实现 `queryGateway(action="getPrivilege")`
+  - 用 `cloudbase.commonService("tcb", "2018-06-08").call({ Action: "DescribeCloudBaseGWPrivilege", Param: { ServiceId } })` 查询
+  - 返回 `enableService`、`enableAuth`、`raw`，message 中给出用户可读状态
+  - `EnableService=false` 时 nextActions 引导 `manageGateway(action="enableService")`
+  - 抽出内部 `getGatewayPrivilege()` 供 createRoute 复用
+  - _需求: 需求 1
+
+- [ ] 2. `gateway.ts` 实现 `manageGateway(action="enableService")`
+  - 必填 `enable: boolean`，缺失时返回参数错误（不猜默认值）
+  - 调 Manager SDK `cloudbase.access.switchAuth(enable)`（serviceswitch）
+  - 返回结果 + nextActions 引导 `queryGateway(action="getPrivilege")` 复核
+  - _需求: 需求 2
+
+- [ ] 3. `gateway.ts` 实现 `manageGateway(action="authSwitch")`
+  - 必填 `enable: boolean`，缺失时返回参数错误
+  - 调 `commonService` `ModifyCloudBaseGWPrivilege`（`Options:[{Key:'authswitch',Value:'true'/'false'}]`）
+  - 返回结果 + nextActions 引导复核
+  - _需求: 需求 2
+
+- [ ] 4. `gateway.ts` 的 `createRoute` 增加开关探测提示
+  - 路由创建成功后调用 `getGatewayPrivilege()`（try/catch 包裹，失败不阻断）
+  - `EnableService=false`：message 追加「HTTP 网关总开关未开启，访问将返回 HTTPSERVICE_NONACTIVATED」+ nextActions 前置 `enableService` 引导
+  - `EnableService=true`：不追加
+  - 探测失败：message 追加弱提示「无法确认 HTTP 网关开关状态」
+  - _需求: 需求 3
+
+- [ ] 5. `functions.ts` 修正 `protocolType` schema
+  - `z.enum(["HTTP","WS"])` → `z.enum(["WS"])`，描述说明仅 WebSocket 函数使用（配合 `protocolParams.wsParams`），普通 HTTP 函数不要传
+  - _需求: 需求 5
+
+- [ ] 6. 更新 `gateway.test.ts` 测试
+  - getPrivilege 成功返回（mock commonService.call）
+  - enableService true/false 调 switchAuth；缺 enable 报参数错误
+  - authSwitch 调 ModifyCloudBaseGWPrivilege（authswitch）；缺 enable 报参数错误
+  - createRoute + EnableService=false 含提示与引导
+  - createRoute + EnableService=true 无误导提示
+  - createRoute + 探测失败仍成功返回
+  - _需求: 需求 4
+
+- [ ] 7. 更新 `functions.test.ts` 测试
+  - protocolType 枚举仅接受 `WS`，拒绝 `HTTP`
+  - _需求: 需求 5
+
+- [ ] 8. 重新生成产物并验证
+  - `npm run build:tools-json`、`npm run build:tools-doc`（或全量 `npm run build`）
+  - 确认 `scripts/tools.json`、`doc/mcp-tools.md` 与代码一致
+  - 运行 `npm test`（或对应 vitest 用例）全绿
+  - _需求: 需求 4、5
+
+- [ ] 9. 提交与 PR
+  - feature 分支（如 `feat/gateway-privilege`）提交，conventional-changelog + emoji
+  - `git push origin HEAD`，创建 PR，监控 CI
+  - _需求: 全部


### PR DESCRIPTION
## 变更内容

### 网关 HTTP 总开关（主）
- `queryGateway(action=getPrivilege)`：查询 HTTP 网关总开关（EnableService）与访问鉴权（EnableAuth）状态
- `manageGateway(action=enableService)`：开启/关闭 HTTP 网关总开关（Manager SDK `access.switchAuth`）
- `manageGateway(action=authSwitch)`：开启/关闭访问鉴权（`ModifyCloudBaseGWPrivilege` authswitch）
- `createRoute` 增加开关探测：总开关未开启时提示 `HTTPSERVICE_NONACTIVATED` 风险并引导开启，避免「创建成功但访问 403」

### 云函数 schema 修正
- `manageFunctions` 的 `protocolType` 枚举修正为仅 `WS`（原 `HTTP` 为非法值，会报 InvalidParameterValue.ProtocolType）

### 短信验证码误导修复
- `queryAppAuth` / `manageAppAuth` 在 phone 登录开启时返回 `smsHint`：默认短信通道开箱即用，无需配置签名/模板/Provider
- `auth-tool-cloudbase` extended guide 重写 SMS Login 段落

## 验证
- 295 个 tools 测试全绿（gateway 28 + functions 15 + app-auth 30 等）
- tools.json / mcp-tools.md 已重新生成

## 背景
v2.25.3 验证时踩坑：createRoute 成功但访问报 `HTTPSERVICE_NONACTIVATED`（HTTP 网关总开关未开启），MCP 无检测/无提示/无开关能力。详见 `specs/mcp-gateway-privilege/`。