### PR TITLE
fix(gateway): ❓ report unknown status when privilege fields are missing

### DIFF
--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -775,6 +775,21 @@ describe("gateway tools", () => {
     ]);
   });
 
+  it("queryGateway(action=getPrivilege) should report unknown status when API returns missing fields", async () => {
+    mockCommonServiceCall.mockResolvedValue({});
+
+    const result = await tools.queryGateway.handler({
+      action: "getPrivilege",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.enableService).toBe(false);
+    expect(payload.data.enableAuth).toBe(false);
+    expect(payload.message).toContain("未知");
+  });
+
   it("queryGateway(action=getPrivilege) should not suggest enable when service is on", async () => {
     mockCommonServiceCall.mockResolvedValue({
       EnableService: true,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -250,7 +250,11 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
 
   const buildPrivilegeDescription = (privilege: GatewayPrivilege) => {
     const serviceStatus =
-      privilege.EnableService === true ? "已开启" : "未开启";
+      privilege.EnableService === undefined
+        ? "未知"
+        : privilege.EnableService === true
+          ? "已开启"
+          : "未开启";
     const authStatus =
       privilege.EnableAuth === undefined
         ? "未知"


### PR DESCRIPTION
## 变更内容

修复 review 发现的防御性缺陷：`buildPrivilegeDescription`（gateway.ts）中 `EnableService === undefined` 时被当作「未开启」，而 `EnableAuth` 已正确处理为「未知」。若 `DescribeCloudBaseGWPrivilege` 返回结构异常（字段缺失），会误报「未开启」并引导 AI 执行 `enableService` 开关操作。

## 改动

- `buildPrivilegeDescription`：`EnableService` 与 `EnableAuth` 对齐，`undefined` 均显示「未知」
- 新增测试：API 返回缺失字段时报未知状态

## 验证

- gateway 29 个测试全绿（新增 1 个）
- 全量 732 passed / 60 skipped