### PR TITLE
feat(gateway): 🔗 add bindCustomDomain accessType/customCname

### DIFF
--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -2397,7 +2397,7 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
       name: "action",
       type: "string",
       required: true,
-      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "enableService", "authSwitch"`,
+      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname；普通场景用默认 DIRECT）。接入说明：https://docs.cloudbase.net/service/custom-domain 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "enableService", "authSwitch"`,
     },
     {
       name: "targetName",
@@ -2467,12 +2467,12 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
     {
       name: "accessType",
       type: "string",
-      description: `绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。 可填写的值: "DIRECT", "CDN", "CUSTOM"`,
+      description: `绑定类型（仅 bindCustomDomain，默认 DIRECT）。DIRECT=直连（普通绑域名用这个）；CDN=云开发 CDN；CUSTOM=自有 CDN/WAF（需 customCname）。详见 https://docs.cloudbase.net/service/custom-domain 可填写的值: "DIRECT", "CDN", "CUSTOM"`,
     },
     {
       name: "customCname",
       type: "string",
-      description: `自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。accessType 非 CUSTOM 时传此参数会报错。`,
+      description: `自有 CDN/WAF 的回源/回填地址（仅 bindCustomDomain 且 accessType=CUSTOM）。不是 DNS 里用户域名要解析到的那个 CNAME；DIRECT/CDN 不要传。详见 https://docs.cloudbase.net/service/custom-domain`,
     },
     {
       name: "enable",

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1799,7 +1799,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.3），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.4），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -2397,7 +2397,7 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
       name: "action",
       type: "string",
       required: true,
-      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "enableService", "authSwitch"`,
+      description: `写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。 可填写的值: "createRoute", "updateRoute", "deleteRoute", "bindCustomDomain", "deleteCustomDomain", "enableService", "authSwitch"`,
     },
     {
       name: "targetName",
@@ -2465,9 +2465,19 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
       description: `证书 ID。仅首次 bindCustomDomain 必填。在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。`,
     },
     {
+      name: "accessType",
+      type: "string",
+      description: `绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。 可填写的值: "DIRECT", "CDN", "CUSTOM"`,
+    },
+    {
+      name: "customCname",
+      type: "string",
+      description: `自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。accessType 非 CUSTOM 时传此参数会报错。`,
+    },
+    {
       name: "enable",
       type: "boolean",
-      description: `开关目标状态（仅 enableService / authSwitch 使用，必填）：enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。`,
+      description: `开关目标状态（enableService / authSwitch 必填）：enable=true 开启，enable=false 关闭。bindCustomDomain 可选：enable=false 表示绑定后禁用域名（默认启用）。省略或非布尔值会返回参数错误。`,
     }
   ]}
 />

--- a/mcp/src/tools/gateway.test.ts
+++ b/mcp/src/tools/gateway.test.ts
@@ -731,12 +731,151 @@ describe("gateway tools", () => {
       Domain: {
         Domain: "api.example.com",
         CertId: "cert-1",
+        AccessType: "DIRECT",
       },
     });
     expect(payload).toMatchObject({
       success: true,
       data: {
         action: "bindCustomDomain",
+        domain: "api.example.com",
+        accessType: "DIRECT",
+      },
+    });
+  });
+
+  it("manageGateway(action=bindCustomDomain) should pass accessType and enable", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "bindCustomDomain",
+      domain: "api.example.com",
+      certificateId: "cert-1",
+      accessType: "CDN",
+      enable: false,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockBindCustomDomain).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: {
+        Domain: "api.example.com",
+        CertId: "cert-1",
+        AccessType: "CDN",
+        Enable: false,
+      },
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "bindCustomDomain",
+        accessType: "CDN",
+        enable: false,
+      },
+    });
+  });
+
+  it("manageGateway(action=bindCustomDomain) should pass customCname for CUSTOM access", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "bindCustomDomain",
+      domain: "api.example.com",
+      certificateId: "cert-1",
+      accessType: "CUSTOM",
+      customCname: "origin.example.com",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockBindCustomDomain).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: {
+        Domain: "api.example.com",
+        CertId: "cert-1",
+        AccessType: "CUSTOM",
+        CustomCname: "origin.example.com",
+      },
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "bindCustomDomain",
+        accessType: "CUSTOM",
+        customCname: "origin.example.com",
+      },
+    });
+  });
+
+  it("manageGateway(action=bindCustomDomain) should require customCname for CUSTOM access", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "bindCustomDomain",
+      domain: "api.example.com",
+      certificateId: "cert-1",
+      accessType: "CUSTOM",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("customCname");
+    expect(mockBindCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it("manageGateway(action=bindCustomDomain) should reject customCname without CUSTOM access", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "bindCustomDomain",
+      domain: "api.example.com",
+      certificateId: "cert-1",
+      customCname: "origin.example.com",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("customCname");
+    expect(mockBindCustomDomain).not.toHaveBeenCalled();
+  });
+
+  it("manageGateway(action=deleteCustomDomain) should guide deleting routes first", async () => {
+    mockDeleteCustomDomain.mockRejectedValue(
+      new Error(
+        "Domain api.example.com has 2 route binding(s) (/a, /b). Please delete the routes before deleting the domain.",
+      ),
+    );
+
+    const result = await tools.manageGateway.handler({
+      action: "deleteCustomDomain",
+      domain: "api.example.com",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("先删除路由");
+    expect(payload.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tool: "manageGateway",
+          action: "deleteRoute",
+        }),
+      ]),
+    );
+  });
+
+  it("manageGateway(action=deleteCustomDomain) should delete custom domain", async () => {
+    const result = await tools.manageGateway.handler({
+      action: "deleteCustomDomain",
+      domain: "api.example.com",
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDeleteCustomDomain).toHaveBeenCalledWith({
+      EnvId: "env-test",
+      Domain: "api.example.com",
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "deleteCustomDomain",
         domain: "api.example.com",
       },
     });

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -79,6 +79,8 @@ type ManageGatewayInput = {
   };
   domain?: string;
   certificateId?: string;
+  accessType?: "DIRECT" | "CDN" | "CUSTOM";
+  customCname?: string;
   enable?: boolean;
 };
 
@@ -723,12 +725,30 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             "action=bindCustomDomain 时必须提供 domain 和 certificateId",
           );
         }
+        const accessType = input.accessType ?? "DIRECT";
+        if (accessType === "CUSTOM" && !input.customCname) {
+          throw new Error(
+            "action=bindCustomDomain 且 accessType=CUSTOM 时必须提供 customCname（自定义 CNAME）",
+          );
+        }
+        if (accessType !== "CUSTOM" && input.customCname) {
+          throw new Error(
+            "customCname 参数仅在 accessType=CUSTOM 时可用",
+          );
+        }
         const cloudbase = await getManager();
         const result = await cloudbase.env.bindCustomDomain({
           EnvId: await resolveEnvId(),
           Domain: {
             Domain: input.domain,
             CertId: input.certificateId,
+            AccessType: accessType,
+            ...(input.enable !== undefined
+              ? { Enable: input.enable }
+              : {}),
+            ...(input.customCname
+              ? { CustomCname: input.customCname }
+              : {}),
           },
         } as any);
         logCloudBaseResult(server.logger, result);
@@ -738,9 +758,24 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             action: input.action,
             domain: input.domain,
             certificateId: input.certificateId,
+            accessType,
+            ...(input.customCname
+              ? { customCname: input.customCname }
+              : {}),
+            ...(input.enable !== undefined
+              ? { enable: input.enable }
+              : {}),
             raw: result,
           },
-          "自定义域名绑定成功",
+          `自定义域名绑定成功（${accessType}）`,
+          [
+            {
+              tool: "manageGateway",
+              action: "createRoute",
+              reason:
+                "绑定后需 createRoute 添加访问路径，并完成 DNS CNAME 解析后才可访问",
+            },
+          ],
         );
       }
       case "deleteCustomDomain": {
@@ -748,20 +783,49 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           throw new Error("action=deleteCustomDomain 时必须提供 domain");
         }
         const cloudbase = await getManager();
-        const result = await cloudbase.env.deleteCustomDomain({
-          EnvId: await resolveEnvId(),
-          Domain: input.domain,
-        });
-        logCloudBaseResult(server.logger, result);
+        try {
+          const result = await cloudbase.env.deleteCustomDomain({
+            EnvId: await resolveEnvId(),
+            Domain: input.domain,
+          });
+          logCloudBaseResult(server.logger, result);
 
-        return buildEnvelope(
-          {
-            action: input.action,
-            domain: input.domain,
-            raw: result,
-          },
-          "自定义域名删除成功",
-        );
+          return buildEnvelope(
+            {
+              action: input.action,
+              domain: input.domain,
+              raw: result,
+            },
+            "自定义域名删除成功",
+          );
+        } catch (error) {
+          const message =
+            error instanceof Error ? error.message : String(error);
+          // SDK 在域名下仍有路由绑定时抛错，需先删路由再删域名
+          if (/route binding/i.test(message)) {
+            return {
+              success: false,
+              data: { action: input.action, domain: input.domain },
+              message:
+                `域名 ${input.domain} 下仍有路由绑定，需先删除路由再删除域名。` +
+                `原始错误：${message}`,
+              nextActions: [
+                {
+                  tool: "queryGateway",
+                  action: "listRoutes",
+                  reason: "查看该域名下的路由，确认需要删除的路径",
+                },
+                {
+                  tool: "manageGateway",
+                  action: "deleteRoute",
+                  reason:
+                    "先删除该域名下的全部路由（逐个 deleteRoute），再重试 deleteCustomDomain",
+                },
+              ],
+            };
+          }
+          throw error;
+        }
       }
       case "enableService": {
         if (typeof input.enable !== "boolean") {
@@ -904,7 +968,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
               "enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。" +
               "createRoute/updateRoute 必须提供 upstreamResourceType。" +
               "已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；" +
-              "bindCustomDomain 仅用于首次绑定新域名。",
+              "bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。",
           ),
         targetName: z
           .string()
@@ -990,12 +1054,27 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
             "证书 ID。仅首次 bindCustomDomain 必填。" +
               "在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。",
           ),
+        accessType: z
+          .enum(["DIRECT", "CDN", "CUSTOM"])
+          .optional()
+          .describe(
+            "绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：" +
+              "DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。",
+          ),
+        customCname: z
+          .string()
+          .optional()
+          .describe(
+            "自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。" +
+              "accessType 非 CUSTOM 时传此参数会报错。",
+          ),
         enable: z
           .boolean()
           .optional()
           .describe(
-            "开关目标状态（仅 enableService / authSwitch 使用，必填）：" +
-              "enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。",
+            "开关目标状态（enableService / authSwitch 必填）：enable=true 开启，enable=false 关闭。" +
+              "bindCustomDomain 可选：enable=false 表示绑定后禁用域名（默认启用）。" +
+              "省略或非布尔值会返回参数错误。",
           ),
       },
       annotations: {

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -728,12 +728,14 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         const accessType = input.accessType ?? "DIRECT";
         if (accessType === "CUSTOM" && !input.customCname) {
           throw new Error(
-            "action=bindCustomDomain 且 accessType=CUSTOM 时必须提供 customCname（自定义 CNAME）",
+            "action=bindCustomDomain 且 accessType=CUSTOM 时必须提供 customCname（自有 CDN/WAF 的回源/回填地址，不是 DNS 解析目标）。" +
+              "说明：https://docs.cloudbase.net/service/custom-domain",
           );
         }
         if (accessType !== "CUSTOM" && input.customCname) {
           throw new Error(
-            "customCname 参数仅在 accessType=CUSTOM 时可用",
+            "customCname 仅在 accessType=CUSTOM 时可用；普通绑定用默认 DIRECT，不要传 customCname。" +
+              "说明：https://docs.cloudbase.net/service/custom-domain",
           );
         }
         const cloudbase = await getManager();
@@ -968,7 +970,8 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
               "enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。" +
               "createRoute/updateRoute 必须提供 upstreamResourceType。" +
               "已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；" +
-              "bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。",
+              "bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname；普通场景用默认 DIRECT）。" +
+              "接入说明：https://docs.cloudbase.net/service/custom-domain",
           ),
         targetName: z
           .string()
@@ -1058,15 +1061,17 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
           .enum(["DIRECT", "CDN", "CUSTOM"])
           .optional()
           .describe(
-            "绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：" +
-              "DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。",
+            "绑定类型（仅 bindCustomDomain，默认 DIRECT）。" +
+              "DIRECT=直连（普通绑域名用这个）；CDN=云开发 CDN；CUSTOM=自有 CDN/WAF（需 customCname）。" +
+              "详见 https://docs.cloudbase.net/service/custom-domain",
           ),
         customCname: z
           .string()
           .optional()
           .describe(
-            "自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。" +
-              "accessType 非 CUSTOM 时传此参数会报错。",
+            "自有 CDN/WAF 的回源/回填地址（仅 bindCustomDomain 且 accessType=CUSTOM）。" +
+              "不是 DNS 里用户域名要解析到的那个 CNAME；DIRECT/CDN 不要传。" +
+              "详见 https://docs.cloudbase.net/service/custom-domain",
           ),
         enable: z
           .boolean()

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2536,7 +2536,7 @@
               "enableService",
               "authSwitch"
             ],
-            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。"
+            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname；普通场景用默认 DIRECT）。接入说明：https://docs.cloudbase.net/service/custom-domain"
           },
           "targetName": {
             "type": "string",
@@ -2612,11 +2612,11 @@
               "CDN",
               "CUSTOM"
             ],
-            "description": "绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。"
+            "description": "绑定类型（仅 bindCustomDomain，默认 DIRECT）。DIRECT=直连（普通绑域名用这个）；CDN=云开发 CDN；CUSTOM=自有 CDN/WAF（需 customCname）。详见 https://docs.cloudbase.net/service/custom-domain"
           },
           "customCname": {
             "type": "string",
-            "description": "自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。accessType 非 CUSTOM 时传此参数会报错。"
+            "description": "自有 CDN/WAF 的回源/回填地址（仅 bindCustomDomain 且 accessType=CUSTOM）。不是 DNS 里用户域名要解析到的那个 CNAME；DIRECT/CDN 不要传。详见 https://docs.cloudbase.net/service/custom-domain"
           },
           "enable": {
             "type": "boolean",

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1852,7 +1852,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.3），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.4），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2536,7 +2536,7 @@
               "enableService",
               "authSwitch"
             ],
-            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名。"
+            "description": "写操作：createRoute/updateRoute/deleteRoute 管理路由；bindCustomDomain/deleteCustomDomain 管理自定义域名；enableService/authSwitch 开关 HTTP 网关总开关与访问鉴权（需配合 enable 参数）。createRoute/updateRoute 必须提供 upstreamResourceType。已有自定义域名时优先 createRoute(domain=已有域名) 实现访问，不必再次 bindCustomDomain / 传入 certificateId；bindCustomDomain 仅用于首次绑定新域名（需 certificateId；可选 accessType=DIRECT|CDN|CUSTOM，CUSTOM 需 customCname）。"
           },
           "targetName": {
             "type": "string",
@@ -2605,9 +2605,22 @@
             "type": "string",
             "description": "证书 ID。仅首次 bindCustomDomain 必填。在已有自定义域名上 createRoute / updateRoute / deleteRoute 不需要 certificateId。"
           },
+          "accessType": {
+            "type": "string",
+            "enum": [
+              "DIRECT",
+              "CDN",
+              "CUSTOM"
+            ],
+            "description": "绑定类型（仅 bindCustomDomain 使用，默认 DIRECT）：DIRECT=直连（默认），CDN=接入云开发 CDN，CUSTOM=自定义接入（需 customCname）。"
+          },
+          "customCname": {
+            "type": "string",
+            "description": "自定义 CNAME（仅 bindCustomDomain 且 accessType=CUSTOM 时可用）。accessType 非 CUSTOM 时传此参数会报错。"
+          },
           "enable": {
             "type": "boolean",
-            "description": "开关目标状态（仅 enableService / authSwitch 使用，必填）：enable=true 开启，enable=false 关闭。省略或非布尔值会返回参数错误。"
+            "description": "开关目标状态（enableService / authSwitch 必填）：enable=true 开启，enable=false 关闭。bindCustomDomain 可选：enable=false 表示绑定后禁用域名（默认启用）。省略或非布尔值会返回参数错误。"
           }
         },
         "required": [


### PR DESCRIPTION
## Summary
- Add `accessType` (`DIRECT`/`CDN`/`CUSTOM`) and `customCname` to `manageGateway(action=bindCustomDomain)`, with validation and SDK passthrough.
- Improve `deleteCustomDomain` errors when routes still bind the domain, guiding `listRoutes` → `deleteRoute` first.
- Sync `doc/mcp-tools.md` and `scripts/tools.json` schema/docs.

Note: HTTPSERVICE `IsDefault` preference vs static hosting CDN (`STATIC_STORE` / `*.tcloudbaseapp.com`) plus skill clarifications already landed via merged `#854` on `feature/sdk-first-db-guidance`. This PR covers the remaining uncommitted gateway bind-domain follow-up (task `7242c91d`).

## Test plan
- [x] `pnpm exec vitest run src/tools/gateway.test.ts` (35 passed)
- [ ] CI green on PR
- [ ] Spot-check manageGateway schema for accessType enum in generated tools.json


Made with [Cursor](https://cursor.com)