### PR TITLE
feat(pg-mcp): prefer native manager-node migration APIs over commonService

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cloudbase/cals": "^1.2.23",
         "@cloudbase/functions-framework": "^1.14.0",
-        "@cloudbase/manager-node": "5.6.4",
+        "@cloudbase/manager-node": "5.6.6",
         "@cloudbase/mcp": "1.0.0-beta.25",
         "@cloudbase/toolbox": "^0.8.1",
         "@modelcontextprotocol/sdk": "1.13.1",
@@ -243,9 +243,9 @@
       }
     },
     "node_modules/@cloudbase/manager-node": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.4.tgz",
-      "integrity": "sha512-fjSR0PmlpeeZNifpJ+gKBOKQ9emRZvFgxO2DqnG9cs1UYzIafLR58RdOWF0idyXLEHRSQ+WdJadpXF8Eq3ps8Q==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.6.tgz",
+      "integrity": "sha512-kwK+Ox2wbnJ0cgRja2ClgmIErbwRqje2kDIjS+1/Uxg9YmwZvR+RiWDdarqElxqwVj90V4sYx3Aa2wx6ldjWXQ==",
       "license": "ISC",
       "dependencies": {
         "@cloudbase/database": "^0.6.2",
@@ -11267,9 +11267,9 @@
       "integrity": "sha512-IteJl7RjPYjsqQbmSr6Vr0el6I19SzI1ya6Nw1ov4KEHxXdwrjJ2uubBeUK4mc54kmzFmvTwqBuyJdhUQ/YDXA=="
     },
     "@cloudbase/manager-node": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.4.tgz",
-      "integrity": "sha512-fjSR0PmlpeeZNifpJ+gKBOKQ9emRZvFgxO2DqnG9cs1UYzIafLR58RdOWF0idyXLEHRSQ+WdJadpXF8Eq3ps8Q==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.6.tgz",
+      "integrity": "sha512-kwK+Ox2wbnJ0cgRja2ClgmIErbwRqje2kDIjS+1/Uxg9YmwZvR+RiWDdarqElxqwVj90V4sYx3Aa2wx6ldjWXQ==",
       "requires": {
         "@cloudbase/database": "^0.6.2",
         "@cloudbase/signature-nodejs": "^1.0.0",

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -68,7 +68,7 @@
   "dependencies": {
     "@cloudbase/cals": "^1.2.23",
     "@cloudbase/functions-framework": "^1.14.0",
-    "@cloudbase/manager-node": "5.6.4",
+    "@cloudbase/manager-node": "5.6.6",
     "@cloudbase/mcp": "1.0.0-beta.25",
     "@cloudbase/toolbox": "^0.8.1",
     "@modelcontextprotocol/sdk": "1.13.1",

--- a/mcp/src/tools/databasePG.test.ts
+++ b/mcp/src/tools/databasePG.test.ts
@@ -767,6 +767,97 @@ describe("PG database tools", () => {
       });
     }
 
+    /**
+     * Default applyMigration cloud-API sequence after hydrate + task poll:
+     * List (hydrate) → optional Describe → Preview → Push → DescribeTaskResult → List (verify).
+     */
+    function mockApplyMigrationCloudApis(options?: {
+      remoteMigrations?: Array<{ Version: string; Name: string; Query?: string }>;
+      pendingVersion?: string;
+      pendingName?: string;
+      previewExecutable?: boolean;
+      previewConflicts?: unknown[];
+      taskStatus?: string;
+      taskReason?: string;
+      omitPendingFromVerifyList?: boolean;
+      listThrowsAfterPush?: boolean;
+    }) {
+      const remote = options?.remoteMigrations ?? [];
+      const pendingVersion = options?.pendingVersion ?? "20260720160000";
+      const pendingName = options?.pendingName ?? "create_test_table";
+      const previewExecutable = options?.previewExecutable ?? true;
+      const taskStatus = options?.taskStatus ?? "Succeed";
+      let pushed = false;
+
+      mockCommonServiceCall.mockImplementation(async ({ Action, Param }: { Action: string; Param?: Record<string, unknown> }) => {
+        if (Action === "ListPGUserMigrations") {
+          if (options?.listThrowsAfterPush && pushed) {
+            throw new Error("ListPGUserMigrations unavailable");
+          }
+          if (pushed && !options?.omitPendingFromVerifyList) {
+            return {
+              RequestId: "req-list-verify",
+              Migrations: [
+                ...remote.map(({ Version, Name }) => ({ Version, Name })),
+                { Version: pendingVersion, Name: pendingName },
+              ],
+              Total: remote.length + 1,
+              LatestVersion: pendingVersion,
+            };
+          }
+          return {
+            RequestId: "req-list-hydrate",
+            Migrations: remote.map(({ Version, Name }) => ({ Version, Name })),
+            Total: remote.length,
+            LatestVersion: remote[remote.length - 1]?.Version ?? "",
+          };
+        }
+        if (Action === "DescribePGUserMigration") {
+          const version = String(Param?.MigrationVersion ?? "");
+          const hit = remote.find((item) => item.Version === version);
+          return {
+            RequestId: "req-describe",
+            Version: version,
+            Name: hit?.Name ?? "unknown",
+            Query: hit?.Query ?? `SELECT '${version}'`,
+          };
+        }
+        if (Action === "PreviewPGUserMigrations") {
+          return {
+            RequestId: "req-preview",
+            Executable: previewExecutable,
+            Pending: previewExecutable
+              ? [{ Version: pendingVersion, Name: pendingName, Status: "pending" }]
+              : null,
+            Applied: null,
+            Conflicts: options?.previewConflicts ?? (previewExecutable ? [] : [
+              {
+                Version: pendingVersion,
+                Name: pendingName,
+                Reason: "remote_history_not_found_locally",
+                Message: "not executable",
+              },
+            ]),
+          };
+        }
+        if (Action === "PushPGUserMigrations") {
+          pushed = true;
+          return { RequestId: "req-apply", TaskId: "task-1" };
+        }
+        if (Action === "DescribeTaskResult") {
+          return {
+            RequestId: "req-task",
+            TaskId: String(Param?.TaskId ?? "task-1"),
+            TaskType: "PGUserMigration",
+            Status: taskStatus,
+            Phase: "RunMigrations",
+            Reason: options?.taskReason ?? "",
+          };
+        }
+        throw new Error(`Unexpected Action ${Action}`);
+      });
+    }
+
     it("listMigrations returns migration list", async () => {
       const { server, tools } = createMockServer();
       registerPGDatabaseTools(server, { createClient: vi.fn() });
@@ -855,12 +946,25 @@ describe("PG database tools", () => {
       const { server, tools } = createMockServer();
       registerPGDatabaseTools(server, { createClient: vi.fn() });
       setupMigrationMock();
-      mockCommonServiceCall.mockResolvedValue({
-        RequestId: "req-plan",
-        Pending: [],
-        Applied: [],
-        Conflicts: [],
-        Executable: true,
+      mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
+        if (Action === "ListPGUserMigrations") {
+          return {
+            RequestId: "req-list",
+            Migrations: [],
+            Total: 0,
+            LatestVersion: "",
+          };
+        }
+        if (Action === "PreviewPGUserMigrations") {
+          return {
+            RequestId: "req-plan",
+            Pending: [],
+            Applied: [],
+            Conflicts: [],
+            Executable: true,
+          };
+        }
+        throw new Error(`Unexpected Action ${Action}`);
       });
 
       const payload = buildToolPayload(
@@ -879,6 +983,8 @@ describe("PG database tools", () => {
           migrationVersion: "20260720160000",
           migrationName: "create_test_table",
           localFileHint: "migrations/20260720160000_create_test_table.sql",
+          hydratedRemoteCount: 0,
+          executable: true,
         },
         nextActions: [
           {
@@ -954,14 +1060,7 @@ describe("PG database tools", () => {
       const { server, tools } = createMockServer();
       registerPGDatabaseTools(server, { createClient: vi.fn() });
       setupMigrationMock();
-      mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) =>
-        Action === "PushPGUserMigrations"
-          ? { RequestId: "req-apply", TaskId: "task-1" }
-          : {
-              RequestId: "req-list",
-              Migrations: [{ Version: "20260720160000", Name: "create_test_table" }],
-            },
-      );
+      mockApplyMigrationCloudApis();
 
       const payload = buildToolPayload(
         await tools.managePgDatabase.handler({
@@ -979,7 +1078,9 @@ describe("PG database tools", () => {
           migrationVersion: "20260720160000",
           migrationName: "create_test_table",
           localFileHint: "migrations/20260720160000_create_test_table.sql",
+          hydratedRemoteCount: 0,
           apiResult: { TaskId: "task-1" },
+          taskResult: expect.objectContaining({ Status: "Succeed" }),
           verified: true,
         },
       });
@@ -997,92 +1098,196 @@ describe("PG database tools", () => {
           }),
         }),
       );
+      expect(mockCommonServiceCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Action: "DescribeTaskResult",
+          Param: expect.objectContaining({ TaskId: "task-1" }),
+        }),
+      );
     });
 
-    it("applyMigration fails when the version is missing from remote migration history", async () => {
-      vi.useFakeTimers();
-      try {
-        const { server, tools } = createMockServer();
-        registerPGDatabaseTools(server, { createClient: vi.fn() });
-        setupMigrationMock();
-        // Push reports success with a TaskId, but the history never records the version.
-        mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) =>
-          Action === "PushPGUserMigrations"
-            ? { RequestId: "req-apply", TaskId: "task-f5966fd0" }
-            : {
-                RequestId: "req-list",
-                Migrations: [{ Version: "20260801200000", Name: "older_migration" }],
-              },
-        );
+    it("applyMigration hydrates remote history into Push payload", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis({
+        remoteMigrations: [
+          {
+            Version: "20260701000000",
+            Name: "init_schema",
+            Query: "CREATE TABLE public.init(id int)",
+          },
+        ],
+        pendingVersion: "20260720160000",
+        pendingName: "create_test_table",
+      });
 
-        const pending = tools.managePgDatabase.handler({
-          action: "applyMigration",
-          migrationName: "mcptest0802_tmp",
-          migrationVersion: "20260802200900",
-          sql: "CREATE TABLE mcptest0802 (id serial primary key, name text)",
-          confirm: true,
-        });
-        await vi.runAllTimersAsync();
-        const payload = buildToolPayload(await pending);
-
-        expect(payload).toMatchObject({
-          success: false,
-          errorCode: "MIGRATION_NOT_APPLIED",
-          data: { migrationVersion: "20260802200900", verified: false },
-        });
-        expect(mockCommonServiceCall).toHaveBeenCalledWith(
-          expect.objectContaining({ Action: "ListPGUserMigrations" }),
-        );
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("applyMigration reports verification failure when history cannot be read", async () => {
-      vi.useFakeTimers();
-      try {
-        const { server, tools } = createMockServer();
-        registerPGDatabaseTools(server, { createClient: vi.fn() });
-        setupMigrationMock();
-        mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) => {
-          if (Action === "PushPGUserMigrations") {
-            return { RequestId: "req-apply", TaskId: "task-3" };
-          }
-          throw new Error("ListPGUserMigrations unavailable");
-        });
-
-        const pending = tools.managePgDatabase.handler({
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
           action: "applyMigration",
           migrationName: "create_test_table",
           migrationVersion: "20260720160000",
           sql: "CREATE TABLE public.test(id int)",
           confirm: true,
-        });
-        await vi.runAllTimersAsync();
-        const payload = buildToolPayload(await pending);
+        }),
+      );
 
-        expect(payload).toMatchObject({
-          success: false,
-          errorCode: "MIGRATION_VERIFICATION_FAILED",
-          data: { verified: null },
-        });
-      } finally {
-        vi.useRealTimers();
-      }
+      expect(payload).toMatchObject({
+        success: true,
+        data: { hydratedRemoteCount: 1, verified: true },
+      });
+      expect(mockCommonServiceCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Action: "DescribePGUserMigration",
+          Param: expect.objectContaining({ MigrationVersion: "20260701000000" }),
+        }),
+      );
+      expect(mockCommonServiceCall).toHaveBeenCalledWith(
+        expect.objectContaining({
+          Action: "PushPGUserMigrations",
+          Param: expect.objectContaining({
+            Migrations: [
+              expect.objectContaining({
+                Version: "20260701000000",
+                Name: "init_schema",
+                Query: "CREATE TABLE public.init(id int)",
+              }),
+              expect.objectContaining({
+                Version: "20260720160000",
+                Name: "create_test_table",
+                Query: "CREATE TABLE public.test(id int)",
+              }),
+            ],
+          }),
+        }),
+      );
+    });
+
+    it("applyMigration fails closed when Preview reports not executable", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis({
+        previewExecutable: false,
+        pendingVersion: "20260802200900",
+        pendingName: "mcptest0802_tmp",
+      });
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "mcptest0802_tmp",
+          migrationVersion: "20260802200900",
+          sql: "CREATE TABLE mcptest0802 (id serial primary key, name text)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "MIGRATION_NOT_EXECUTABLE",
+        data: { verified: false },
+      });
+      expect(mockCommonServiceCall).not.toHaveBeenCalledWith(
+        expect.objectContaining({ Action: "PushPGUserMigrations" }),
+      );
+    });
+
+    it("applyMigration surfaces DescribeTaskResult failure reason", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis({
+        taskStatus: "Failed",
+        taskReason: "migration plan is not executable",
+        pendingVersion: "20260802200900",
+        pendingName: "mcptest0802_tmp",
+      });
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "mcptest0802_tmp",
+          migrationVersion: "20260802200900",
+          sql: "CREATE TABLE mcptest0802 (id serial primary key, name text)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "MIGRATION_TASK_FAILED",
+        data: {
+          taskResult: expect.objectContaining({
+            Status: "Failed",
+            Reason: "migration plan is not executable",
+          }),
+        },
+      });
+      expect(payload.message).toContain("migration plan is not executable");
+    });
+
+    it("applyMigration fails when the version is missing from remote migration history", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis({
+        pendingVersion: "20260802200900",
+        pendingName: "mcptest0802_tmp",
+        omitPendingFromVerifyList: true,
+        remoteMigrations: [{ Version: "20260801200000", Name: "older_migration", Query: "SELECT 1" }],
+      });
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "mcptest0802_tmp",
+          migrationVersion: "20260802200900",
+          sql: "CREATE TABLE mcptest0802 (id serial primary key, name text)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "MIGRATION_NOT_APPLIED",
+        data: { migrationVersion: "20260802200900", verified: false },
+      });
+      expect(mockCommonServiceCall).toHaveBeenCalledWith(
+        expect.objectContaining({ Action: "ListPGUserMigrations" }),
+      );
+    });
+
+    it("applyMigration reports verification failure when history cannot be read", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis({
+        listThrowsAfterPush: true,
+      });
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "MIGRATION_VERIFICATION_FAILED",
+        data: { verified: null },
+      });
     });
 
     it("applyMigration passes lockTimeoutMs and statementTimeoutMs", async () => {
       const { server, tools } = createMockServer();
       registerPGDatabaseTools(server, { createClient: vi.fn() });
       setupMigrationMock();
-      mockCommonServiceCall.mockImplementation(async ({ Action }: { Action: string }) =>
-        Action === "PushPGUserMigrations"
-          ? { RequestId: "req-apply-2", TaskId: "task-2" }
-          : {
-              RequestId: "req-list",
-              Migrations: [{ Version: "20260720160000", Name: "create_test_table" }],
-            },
-      );
+      mockApplyMigrationCloudApis();
 
       await tools.managePgDatabase.handler({
         action: "applyMigration",

--- a/mcp/src/tools/databasePG.test.ts
+++ b/mcp/src/tools/databasePG.test.ts
@@ -1526,5 +1526,281 @@ describe("PG database tools", () => {
         Reason: "remove bad record",
       });
     });
+
+    describe("native manager-node PG migration API (>= 5.6.5)", () => {
+      /**
+       * Mock a manager whose `database` exposes the native migration methods.
+       * The commonService stub throws, proving the native path is preferred and
+       * the fallback is never reached for actions with a native wrapper.
+       */
+      function setupNativeMigrationMock() {
+        const nativeDb = {
+          previewPGUserMigrations: vi.fn(),
+          pushPGUserMigrations: vi.fn(),
+          repairPGUserMigrationHistory: vi.fn(),
+          listPGUserMigrations: vi.fn(),
+          listAllPGUserMigrations: vi.fn(),
+          describePGUserMigration: vi.fn(),
+          describeTaskResult: vi.fn(),
+        };
+        const commonServiceCall = vi.fn(async ({ Action }: { Action: string }) => {
+          throw new Error(`commonService fallback should not be used for ${Action}`);
+        });
+        mockGetCloudBaseManager.mockResolvedValue({
+          commonService: vi.fn(() => ({ call: commonServiceCall })),
+          database: nativeDb,
+        });
+        return { nativeDb, commonServiceCall };
+      }
+
+      it("listMigrations prefers native listPGUserMigrations over commonService", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        const { nativeDb, commonServiceCall } = setupNativeMigrationMock();
+        nativeDb.listPGUserMigrations.mockResolvedValue({
+          RequestId: "req-list-native",
+          Migrations: [{ Version: "20260701000000", Name: "init" }],
+          Total: 1,
+          LatestVersion: "20260701000000",
+        });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "listMigrations",
+            limit: 10,
+            offset: 0,
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true, data: { Total: 1 } });
+        expect(nativeDb.listPGUserMigrations).toHaveBeenCalledWith(
+          expect.objectContaining({ EnvId: "env-test", Limit: 10, Offset: 0 }),
+        );
+        expect(commonServiceCall).not.toHaveBeenCalled();
+      });
+
+      it("migrationDetail prefers native describePGUserMigration", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        const { nativeDb, commonServiceCall } = setupNativeMigrationMock();
+        nativeDb.describePGUserMigration.mockResolvedValue({
+          RequestId: "req-detail-native",
+          Version: "20260701000000",
+          Name: "init",
+          Query: "SELECT 1",
+        });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "migrationDetail",
+            migrationVersion: "20260701000000",
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true, data: { Name: "init" } });
+        expect(nativeDb.describePGUserMigration).toHaveBeenCalledWith(
+          expect.objectContaining({
+            EnvId: "env-test",
+            MigrationVersion: "20260701000000",
+          }),
+        );
+        expect(commonServiceCall).not.toHaveBeenCalled();
+      });
+
+      it("planMigration prefers native list + preview over commonService", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        const { nativeDb, commonServiceCall } = setupNativeMigrationMock();
+        nativeDb.listPGUserMigrations.mockResolvedValue({
+          RequestId: "req-list-native",
+          Migrations: [],
+          Total: 0,
+          LatestVersion: "",
+        });
+        nativeDb.previewPGUserMigrations.mockResolvedValue({
+          RequestId: "req-preview-native",
+          Pending: [{ Version: "20260720160000", Name: "create_test_table", Status: "pending" }],
+          Applied: null,
+          Conflicts: [],
+          Executable: true,
+        });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "planMigration",
+            migrationName: "create_test_table",
+            migrationVersion: "20260720160000",
+            sql: "CREATE TABLE public.test(id int)",
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true, data: { executable: true } });
+        expect(nativeDb.previewPGUserMigrations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            EnvId: "env-test",
+            Migrations: expect.arrayContaining([
+              expect.objectContaining({ Version: "20260720160000" }),
+            ]),
+          }),
+        );
+        expect(commonServiceCall).not.toHaveBeenCalled();
+      });
+
+      it("applyMigration runs the full native chain (list→describe→preview→push→task→verify)", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        const { nativeDb, commonServiceCall } = setupNativeMigrationMock();
+
+        nativeDb.listPGUserMigrations.mockImplementation(async (options: { Offset?: number }) => {
+          // Hydrate page: one remote migration; verify call after Push returns it plus pending.
+          const remote = [{ Version: "20260701000000", Name: "init" }];
+          const pushed = nativeDb.pushPGUserMigrations.mock.calls.length > 0;
+          return pushed
+            ? {
+                RequestId: "req-list-verify-native",
+                Migrations: [
+                  ...remote,
+                  { Version: "20260720160000", Name: "create_test_table" },
+                ],
+                Total: 2,
+                LatestVersion: "20260720160000",
+              }
+            : {
+                RequestId: "req-list-hydrate-native",
+                Migrations: remote,
+                Total: 1,
+                LatestVersion: "20260701000000",
+              };
+        });
+        nativeDb.describePGUserMigration.mockResolvedValue({
+          RequestId: "req-describe-native",
+          Version: "20260701000000",
+          Name: "init",
+          Query: "SELECT 1",
+        });
+        nativeDb.previewPGUserMigrations.mockResolvedValue({
+          RequestId: "req-preview-native",
+          Pending: [],
+          Applied: [],
+          Conflicts: [],
+          Executable: true,
+        });
+        nativeDb.pushPGUserMigrations.mockResolvedValue({
+          RequestId: "req-apply-native",
+          TaskId: "task-native-1",
+        });
+        nativeDb.describeTaskResult.mockResolvedValue({
+          RequestId: "req-task-native",
+          TaskId: "task-native-1",
+          TaskType: "PGUserMigration",
+          Status: "Succeed",
+          Phase: "RunMigrations",
+          Reason: "",
+        });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "applyMigration",
+            migrationName: "create_test_table",
+            migrationVersion: "20260720160000",
+            sql: "CREATE TABLE public.test(id int)",
+            confirm: true,
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true, data: { verified: true } });
+        expect(nativeDb.pushPGUserMigrations).toHaveBeenCalledWith(
+          expect.objectContaining({
+            EnvId: "env-test",
+            Migrations: expect.arrayContaining([
+              expect.objectContaining({ Version: "20260701000000", Query: "SELECT 1" }),
+              expect.objectContaining({ Version: "20260720160000" }),
+            ]),
+          }),
+        );
+        expect(nativeDb.describeTaskResult).toHaveBeenCalledWith(
+          expect.objectContaining({ EnvId: "env-test", TaskId: "task-native-1" }),
+        );
+        expect(commonServiceCall).not.toHaveBeenCalled();
+      });
+
+      it("repairMigration prefers native repairPGUserMigrationHistory", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        const { nativeDb, commonServiceCall } = setupNativeMigrationMock();
+        nativeDb.repairPGUserMigrationHistory.mockResolvedValue({
+          RequestId: "req-repair-native",
+        });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "repairMigration",
+            migrationVersion: "20260526000000",
+            migrationName: "test_init",
+            repairStatus: "applied",
+            repairReason: "recover history",
+            sql: "SELECT 1",
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true });
+        expect(nativeDb.repairPGUserMigrationHistory).toHaveBeenCalledWith(
+          expect.objectContaining({
+            EnvId: "env-test",
+            MigrationVersion: "20260526000000",
+            Name: "test_init",
+            Status: "applied",
+            Reason: "recover history",
+            Query: "SELECT 1",
+          }),
+        );
+        expect(commonServiceCall).not.toHaveBeenCalled();
+      });
+
+      it("rollbackMigration has no native wrapper and keeps using commonService", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        setupMigrationMock();
+        mockCommonServiceCall.mockResolvedValue({ RequestId: "req-rollback-native" });
+
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({
+            action: "rollbackMigration",
+            lastN: 2,
+            confirm: true,
+          }),
+        );
+
+        expect(payload).toMatchObject({ success: true });
+        expect(mockCommonServiceCall).toHaveBeenCalledWith(
+          expect.objectContaining({
+            Action: "RollbackPGUserMigrations",
+            Param: expect.objectContaining({ LastN: 2 }),
+          }),
+        );
+      });
+
+      it("falls back to commonService when database lacks native methods", async () => {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        setupMigrationMock();
+        mockCommonServiceCall.mockResolvedValue({
+          RequestId: "req-list-fallback",
+          Migrations: [],
+          Total: 0,
+          LatestVersion: "",
+        });
+
+        // manager has no `database` (older runtime shape) — commonService path is used.
+        const payload = buildToolPayload(
+          await tools.managePgDatabase.handler({ action: "listMigrations" }),
+        );
+
+        expect(payload).toMatchObject({ success: true, data: { Total: 0 } });
+        expect(mockCommonServiceCall).toHaveBeenCalledWith(
+          expect.objectContaining({ Action: "ListPGUserMigrations" }),
+        );
+      });
+    });
   });
 });

--- a/mcp/src/tools/databasePG.ts
+++ b/mcp/src/tools/databasePG.ts
@@ -1039,6 +1039,77 @@ type CloudBaseWithCommonService = {
   commonService(service: string, version: string): CloudBaseCommonService;
 };
 
+/**
+ * Native PG migration methods on `manager.database`, added in
+ * @cloudbase/manager-node >= 5.6.5. Each method is a typed wrapper over the same
+ * tcb/2018-06-08 platform channel used by the commonService fallback, and returns
+ * the unwrapped API `Response` (same shape as `callPgMigrationApi`).
+ */
+type PgMigrationApiDatabase = {
+  previewPGUserMigrations(options: {
+    EnvId?: string;
+    Migrations: PgMigrationInput[];
+    IncludeAll?: boolean;
+  }): Promise<Record<string, unknown>>;
+  pushPGUserMigrations(options: {
+    EnvId?: string;
+    Migrations: PgMigrationInput[];
+    LockTimeoutMs?: number;
+    StatementTimeoutMs?: number;
+    IncludeAll?: boolean;
+  }): Promise<Record<string, unknown>>;
+  repairPGUserMigrationHistory(options: {
+    EnvId?: string;
+    MigrationVersion: string;
+    Name: string;
+    Status: "applied" | "reverted";
+    Reason: string;
+    Query?: string;
+  }): Promise<Record<string, unknown>>;
+  listPGUserMigrations(options?: {
+    EnvId?: string;
+    Limit?: number;
+    Offset?: number;
+  }): Promise<Record<string, unknown>>;
+  listAllPGUserMigrations(options?: {
+    EnvId?: string;
+    PageSize?: number;
+  }): Promise<Record<string, unknown>>;
+  describePGUserMigration(options: {
+    EnvId?: string;
+    MigrationVersion: string;
+  }): Promise<Record<string, unknown>>;
+  describeTaskResult(options: { EnvId?: string; TaskId: string }): Promise<Record<string, unknown>>;
+};
+
+function isPgMigrationApiDatabase(value: unknown): value is PgMigrationApiDatabase {
+  return Boolean(
+    value &&
+    typeof value === "object" &&
+    "previewPGUserMigrations" in value &&
+    typeof (value as { previewPGUserMigrations?: unknown }).previewPGUserMigrations === "function" &&
+    "pushPGUserMigrations" in value &&
+    typeof (value as { pushPGUserMigrations?: unknown }).pushPGUserMigrations === "function" &&
+    "listPGUserMigrations" in value &&
+    typeof (value as { listPGUserMigrations?: unknown }).listPGUserMigrations === "function" &&
+    "describeTaskResult" in value &&
+    typeof (value as { describeTaskResult?: unknown }).describeTaskResult === "function",
+  );
+}
+
+/**
+ * Actions without a native wrapper in manager-node (e.g. RollbackPGUserMigrations)
+ * are intentionally absent and keep using the commonService fallback.
+ */
+const PgMigrationNativeActionMethods: Record<string, keyof PgMigrationApiDatabase> = {
+  PreviewPGUserMigrations: "previewPGUserMigrations",
+  PushPGUserMigrations: "pushPGUserMigrations",
+  RepairPGUserMigrationHistory: "repairPGUserMigrationHistory",
+  ListPGUserMigrations: "listPGUserMigrations",
+  DescribePGUserMigration: "describePGUserMigration",
+  DescribeTaskResult: "describeTaskResult",
+};
+
 function isExecutePGSqlDatabase(value: unknown): value is ExecutePGSqlDatabase {
   return Boolean(
     value &&
@@ -1097,7 +1168,11 @@ async function executeManagerPGSql(
   );
 }
 
-/** Call a CloudBase PG migration API via commonService fallback */
+/**
+ * Call a CloudBase PG migration API, preferring native manager-node methods
+ * (>= 5.6.5) and falling back to the commonService channel for older runtimes
+ * and actions without a native wrapper (RollbackPGUserMigrations).
+ */
 async function callPgMigrationApi(
   context: PgDbContext,
   action: string,
@@ -1109,6 +1184,14 @@ async function callPgMigrationApi(
       ? { ...cloudBaseOptions, envId: context.envId }
       : { envId: context.envId },
   });
+
+  const nativeMethod = PgMigrationNativeActionMethods[action];
+  if (nativeMethod && isPgMigrationApiDatabase(manager.database)) {
+    const invoke = manager.database[nativeMethod] as (
+      options: Record<string, unknown>,
+    ) => Promise<Record<string, unknown>>;
+    return invoke.call(manager.database, { EnvId: context.envId, ...params });
+  }
 
   if (!isCloudBaseWithCommonService(manager)) {
     throw new Error(

--- a/mcp/src/tools/databasePG.ts
+++ b/mcp/src/tools/databasePG.ts
@@ -361,6 +361,34 @@ function collectMigrationVersions(value: unknown, found: Set<string> = new Set()
 const MIGRATION_VERIFY_ATTEMPTS = 4;
 const MIGRATION_VERIFY_DELAY_MS = 1500;
 
+/** Page size when hydrating remote migration history into a Push/Preview payload. */
+const MIGRATION_LIST_PAGE_SIZE = 100;
+
+/**
+ * PushPGUserMigrations is async: poll DescribeTaskResult until Succeed/Failed.
+ * Aligns with CLI `tcb db pg migration up` and Manager SDK docs.
+ */
+const MIGRATION_TASK_POLL_INTERVAL_MS = 1500;
+const MIGRATION_TASK_MAX_WAIT_MS = 90_000;
+
+type PgMigrationInput = {
+  Version: string;
+  Name: string;
+  Query: string;
+  Rollback?: string;
+};
+
+type PgMigrationTaskResult = {
+  TaskId?: string;
+  TaskType?: string;
+  Status?: string;
+  Phase?: string;
+  Reason?: string;
+  RequestId?: string;
+  CreatedAt?: string;
+  UpdatedAt?: string;
+};
+
 /**
  * Confirm a pushed migration version is present in the remote migration history.
  *
@@ -401,6 +429,143 @@ async function verifyMigrationApplied(
     return { applied: false };
   }
   return { applied: null, error: lastError };
+}
+
+function extractMigrationSummaries(history: Record<string, unknown>): Array<{ Version: string; Name: string }> {
+  const raw = history.Migrations;
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+  const summaries: Array<{ Version: string; Name: string }> = [];
+  for (const item of raw) {
+    if (!item || typeof item !== "object") {
+      continue;
+    }
+    const row = item as Record<string, unknown>;
+    const version = typeof row.Version === "string" ? row.Version.trim() : "";
+    const name = typeof row.Name === "string" ? row.Name.trim() : "";
+    if (version) {
+      summaries.push({ Version: version, Name: name || version });
+    }
+  }
+  return summaries;
+}
+
+/**
+ * List every remote migration summary (paginated). Required before Push/Preview:
+ * submitting only the pending migration while remote history exists yields
+ * Executable=false with Conflicts reason remote_history_not_found_locally, and the
+ * async task fails with "migration plan is not executable".
+ */
+async function listAllRemoteMigrationSummaries(
+  context: PgDbContext,
+  cloudBaseOptions?: ExtendedMcpServer["cloudBaseOptions"],
+): Promise<{ summaries: Array<{ Version: string; Name: string }>; latestVersion: string; total: number }> {
+  const summaries: Array<{ Version: string; Name: string }> = [];
+  let offset = 0;
+  let latestVersion = "";
+  let total = 0;
+
+  while (true) {
+    const page = await callPgMigrationApi(
+      context,
+      "ListPGUserMigrations",
+      { Limit: MIGRATION_LIST_PAGE_SIZE, Offset: offset },
+      cloudBaseOptions,
+    );
+    const pageItems = extractMigrationSummaries(page);
+    summaries.push(...pageItems);
+    if (typeof page.LatestVersion === "string" && page.LatestVersion.trim()) {
+      latestVersion = page.LatestVersion.trim();
+    }
+    if (typeof page.Total === "number" && Number.isFinite(page.Total)) {
+      total = page.Total;
+    } else {
+      total = summaries.length;
+    }
+    if (pageItems.length < MIGRATION_LIST_PAGE_SIZE) {
+      break;
+    }
+    offset += MIGRATION_LIST_PAGE_SIZE;
+  }
+
+  return { summaries, latestVersion, total };
+}
+
+/**
+ * Build Push/Preview Migrations = remote history Queries + the pending migration.
+ * Matches CLI behavior (submit full set; server skips already-applied versions).
+ */
+async function buildMigrationsPayloadWithRemoteHistory(
+  context: PgDbContext,
+  pending: PgMigrationInput,
+  cloudBaseOptions?: ExtendedMcpServer["cloudBaseOptions"],
+): Promise<{
+  migrations: PgMigrationInput[];
+  remoteCount: number;
+  latestVersion: string;
+}> {
+  const { summaries, latestVersion } = await listAllRemoteMigrationSummaries(context, cloudBaseOptions);
+  const migrations: PgMigrationInput[] = [];
+
+  for (const summary of summaries) {
+    if (summary.Version === pending.Version) {
+      // Caller supplies the authoritative SQL for this version.
+      continue;
+    }
+    const detail = await callPgMigrationApi(
+      context,
+      "DescribePGUserMigration",
+      { MigrationVersion: summary.Version },
+      cloudBaseOptions,
+    );
+    const query = typeof detail.Query === "string" ? detail.Query : "";
+    if (!query.trim()) {
+      throw new Error(
+        `DescribePGUserMigration returned empty Query for version=${summary.Version} (${summary.Name}). ` +
+          "Cannot hydrate remote history for PushPGUserMigrations.",
+      );
+    }
+    migrations.push({
+      Version: typeof detail.Version === "string" && detail.Version.trim() ? detail.Version.trim() : summary.Version,
+      Name: typeof detail.Name === "string" && detail.Name.trim() ? detail.Name.trim() : summary.Name,
+      Query: query,
+    });
+  }
+
+  migrations.push(pending);
+  return { migrations, remoteCount: summaries.length, latestVersion };
+}
+
+async function waitPgMigrationTask(
+  context: PgDbContext,
+  taskId: string,
+  cloudBaseOptions?: ExtendedMcpServer["cloudBaseOptions"],
+): Promise<PgMigrationTaskResult> {
+  const deadline = Date.now() + MIGRATION_TASK_MAX_WAIT_MS;
+  let last: PgMigrationTaskResult = { TaskId: taskId };
+
+  while (Date.now() <= deadline) {
+    last = (await callPgMigrationApi(
+      context,
+      "DescribeTaskResult",
+      { TaskId: taskId },
+      cloudBaseOptions,
+    )) as PgMigrationTaskResult;
+
+    const status = String(last.Status || "").toLowerCase();
+    if (status === "succeed" || status === "failed") {
+      return last;
+    }
+    await sleep(MIGRATION_TASK_POLL_INTERVAL_MS);
+  }
+
+  const error = new Error(
+    `DescribeTaskResult timed out after ${Math.floor(MIGRATION_TASK_MAX_WAIT_MS / 1000)}s ` +
+      `for TaskId=${taskId} (last Status=${last.Status || "-"}, Phase=${last.Phase || "-"}).`,
+  );
+  (error as Error & { lastTask?: PgMigrationTaskResult }).lastTask = last;
+  throw error;
 }
 
 const MIGRATION_VERSION_REQUIRED_MESSAGE =
@@ -1515,33 +1680,46 @@ async function handlePlanMigration(args: ManagePgDatabaseArgs, context: PgDbCont
   const version = versionOrError;
   const localFileHint = buildLocalMigrationFileHint(version, args.migrationName);
 
-  const migration: Record<string, string> = {
+  const pending: PgMigrationInput = {
     Version: version,
     Name: args.migrationName,
     Query: args.sql,
   };
   if (args.rollbackSql?.trim()) {
-    migration.Rollback = args.rollbackSql;
+    pending.Rollback = args.rollbackSql;
   }
 
   try {
+    const hydrated = await buildMigrationsPayloadWithRemoteHistory(
+      context,
+      pending,
+      cloudBaseOptions,
+    );
     const result = await callPgMigrationApi(context, "PreviewPGUserMigrations", {
-      Migrations: [migration],
+      Migrations: hydrated.migrations,
     }, cloudBaseOptions);
+    const executable = result.Executable === true;
     return buildPgToolResult({
       success: true,
       data: {
         migrationVersion: version,
         migrationName: args.migrationName,
         localFileHint,
+        hydratedRemoteCount: hydrated.remoteCount,
+        latestRemoteVersion: hydrated.latestVersion || null,
+        executable,
         apiResult: result as Record<string, unknown>,
       },
-      message: `Migration plan generated via PreviewPGUserMigrations. Reuse migrationVersion=${version} on applyMigration. Ensure local file ${localFileHint} exists and matches.`,
+      message: executable
+        ? `Migration plan generated via PreviewPGUserMigrations (hydrated ${hydrated.remoteCount} remote migration(s)). Reuse migrationVersion=${version} on applyMigration. Ensure local file ${localFileHint} exists and matches.`
+        : `Migration plan is NOT executable (PreviewPGUserMigrations.Executable=false after hydrating ${hydrated.remoteCount} remote migration(s)). Inspect apiResult.Conflicts before applyMigration. Common causes: version older than latest remote (${hydrated.latestVersion || "unknown"}), or checksum mismatch.`,
       nextActions: [
         buildNextAction(
           MANAGE_PG_DATABASE,
           "applyMigration",
-          "Review the plan above. If it looks correct, call applyMigration with the same migrationVersion.",
+          executable
+            ? "Review the plan above. If it looks correct, call applyMigration with the same migrationVersion."
+            : "Resolve Conflicts (often pick a migrationVersion newer than LatestVersion), then retry planMigration/applyMigration.",
           {
             action: "applyMigration",
             migrationName: args.migrationName,
@@ -1594,29 +1772,162 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
   const version = versionOrError;
   const localFileHint = buildLocalMigrationFileHint(version, args.migrationName);
 
-  const migration: Record<string, string> = {
+  const pending: PgMigrationInput = {
     Version: version,
     Name: args.migrationName,
     Query: args.sql,
   };
   if (args.rollbackSql?.trim()) {
-    migration.Rollback = args.rollbackSql;
-  }
-
-  const params: Record<string, unknown> = { Migrations: [migration] };
-  if (args.lockTimeoutMs !== undefined) {
-    params.LockTimeoutMs = args.lockTimeoutMs;
-  }
-  if (args.statementTimeoutMs !== undefined) {
-    params.StatementTimeoutMs = args.statementTimeoutMs;
+    pending.Rollback = args.rollbackSql;
   }
 
   try {
-    const result = await callPgMigrationApi(context, "PushPGUserMigrations", params, cloudBaseOptions);
+    // Pushing only the pending migration while remote history exists makes the plan
+    // non-executable (remote_history_not_found_locally). Hydrate remote Queries first,
+    // matching CLI `tcb db pg migration up` (full list; server skips applied).
+    const hydrated = await buildMigrationsPayloadWithRemoteHistory(
+      context,
+      pending,
+      cloudBaseOptions,
+    );
 
-    // PushPGUserMigrations may return a TaskId without the migration having taken
-    // effect. Confirm against the remote history before reporting success, so callers
-    // never get a false-positive success for a silently dropped migration.
+    const preview = await callPgMigrationApi(
+      context,
+      "PreviewPGUserMigrations",
+      { Migrations: hydrated.migrations },
+      cloudBaseOptions,
+    );
+
+    if (preview.Executable !== true) {
+      return buildPgToolResult({
+        success: false,
+        errorCode: "MIGRATION_NOT_EXECUTABLE",
+        data: {
+          migrationVersion: version,
+          migrationName: args.migrationName,
+          localFileHint,
+          hydratedRemoteCount: hydrated.remoteCount,
+          latestRemoteVersion: hydrated.latestVersion || null,
+          previewResult: preview as Record<string, unknown>,
+          verified: false,
+        },
+        message:
+          `PreviewPGUserMigrations reported Executable=false for migrationVersion=${version} ` +
+          `(latest remote=${hydrated.latestVersion || "unknown"}, hydratedRemoteCount=${hydrated.remoteCount}). ` +
+          "Push was NOT submitted. Inspect previewResult.Conflicts — common reasons: " +
+          "local_migration_before_latest_remote (pick a newer 14-digit version) or checksum_mismatch. " +
+          "If the schema change is urgent you may fall back to action=execute with allowDdlViaExecute=true, but that bypasses migration history.",
+        nextActions: [
+          buildNextAction(
+            MANAGE_PG_DATABASE,
+            "listMigrations",
+            "Check LatestVersion and pick a migrationVersion strictly newer than it.",
+            { action: "listMigrations", limit: 20 },
+          ),
+          buildNextAction(
+            MANAGE_PG_DATABASE,
+            "planMigration",
+            "Re-run planMigration after adjusting migrationVersion/SQL.",
+            {
+              action: "planMigration",
+              migrationName: args.migrationName,
+              migrationVersion: version,
+              sql: args.sql,
+              ...(args.rollbackSql ? { rollbackSql: args.rollbackSql } : {}),
+            },
+          ),
+        ],
+      });
+    }
+
+    const params: Record<string, unknown> = { Migrations: hydrated.migrations };
+    if (args.lockTimeoutMs !== undefined) {
+      params.LockTimeoutMs = args.lockTimeoutMs;
+    }
+    if (args.statementTimeoutMs !== undefined) {
+      params.StatementTimeoutMs = args.statementTimeoutMs;
+    }
+
+    const result = await callPgMigrationApi(context, "PushPGUserMigrations", params, cloudBaseOptions);
+    const taskId = typeof result.TaskId === "string" ? result.TaskId.trim() : "";
+
+    let taskResult: PgMigrationTaskResult | null = null;
+    if (taskId) {
+      try {
+        taskResult = await waitPgMigrationTask(context, taskId, cloudBaseOptions);
+      } catch (error) {
+        const lastTask = (error as Error & { lastTask?: PgMigrationTaskResult }).lastTask;
+        return buildPgToolResult({
+          success: false,
+          errorCode: "MIGRATION_TASK_TIMEOUT",
+          data: {
+            migrationVersion: version,
+            migrationName: args.migrationName,
+            localFileHint,
+            hydratedRemoteCount: hydrated.remoteCount,
+            apiResult: result as Record<string, unknown>,
+            taskResult: lastTask ?? { TaskId: taskId },
+            verified: null,
+          },
+          message:
+            `PushPGUserMigrations returned TaskId=${taskId}, but waiting for DescribeTaskResult timed out: ` +
+            `${error instanceof Error ? error.message : String(error)}. ` +
+            "The migration may still be running — check action=listMigrations before retrying or falling back to execute.",
+          nextActions: [
+            buildNextAction(
+              MANAGE_PG_DATABASE,
+              "listMigrations",
+              "Check whether the migrationVersion eventually landed.",
+              { action: "listMigrations", limit: 20 },
+            ),
+          ],
+        });
+      }
+
+      const status = String(taskResult.Status || "").toLowerCase();
+      if (status === "failed") {
+        return buildPgToolResult({
+          success: false,
+          errorCode: "MIGRATION_TASK_FAILED",
+          data: {
+            migrationVersion: version,
+            migrationName: args.migrationName,
+            localFileHint,
+            hydratedRemoteCount: hydrated.remoteCount,
+            apiResult: result as Record<string, unknown>,
+            taskResult: taskResult as Record<string, unknown>,
+            verified: false,
+          },
+          message:
+            `PushPGUserMigrations TaskId=${taskId} failed at phase=${taskResult.Phase || "-"}: ` +
+            `${taskResult.Reason || "unknown reason"}. ` +
+            "The migration did NOT take effect. Fix Conflicts/SQL (or use a newer migrationVersion), then retry applyMigration. " +
+            "Urgent bypass: action=execute with allowDdlViaExecute=true (skips migration history).",
+          nextActions: [
+            buildNextAction(
+              MANAGE_PG_DATABASE,
+              "planMigration",
+              "Preview again to inspect Conflicts before retrying apply.",
+              {
+                action: "planMigration",
+                migrationName: args.migrationName,
+                migrationVersion: version,
+                sql: args.sql,
+                ...(args.rollbackSql ? { rollbackSql: args.rollbackSql } : {}),
+              },
+            ),
+            buildNextAction(
+              MANAGE_PG_DATABASE,
+              "listMigrations",
+              "Confirm the version is still absent from remote history.",
+              { action: "listMigrations", limit: 20 },
+            ),
+          ],
+        });
+      }
+    }
+
+    // Task Succeed (or sync response without TaskId): confirm history records the version.
     const verification = await verifyMigrationApplied(context, version, cloudBaseOptions);
 
     if (verification.applied === false) {
@@ -1627,11 +1938,13 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
           migrationVersion: version,
           migrationName: args.migrationName,
           localFileHint,
+          hydratedRemoteCount: hydrated.remoteCount,
           apiResult: result as Record<string, unknown>,
+          taskResult: taskResult as Record<string, unknown> | null,
           verified: false,
         },
         message:
-          `PushPGUserMigrations returned without error, but migrationVersion=${version} is not present in the remote migration history, ` +
+          `PushPGUserMigrations completed (TaskId=${taskId || "none"}), but migrationVersion=${version} is not present in the remote migration history, ` +
           "so the migration did NOT take effect. Do not assume the schema change is applied. " +
           "Re-check the SQL and migrationVersion, inspect the migration with action=migrationDetail, and retry action=applyMigration. " +
           "If the schema change is urgent you may fall back to action=execute with allowDdlViaExecute=true, but that bypasses migration history.",
@@ -1660,7 +1973,9 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
           migrationVersion: version,
           migrationName: args.migrationName,
           localFileHint,
+          hydratedRemoteCount: hydrated.remoteCount,
           apiResult: result as Record<string, unknown>,
+          taskResult: taskResult as Record<string, unknown> | null,
           verified: null,
         },
         message:
@@ -1683,10 +1998,12 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
         migrationVersion: version,
         migrationName: args.migrationName,
         localFileHint,
+        hydratedRemoteCount: hydrated.remoteCount,
         apiResult: result as Record<string, unknown>,
+        taskResult: taskResult as Record<string, unknown> | null,
         verified: true,
       },
-      message: `Migrations applied via PushPGUserMigrations and verified present in the remote migration history. Ensure local file ${localFileHint} exists and matches.`,
+      message: `Migrations applied via PushPGUserMigrations (hydrated ${hydrated.remoteCount} remote migration(s)), task ${taskId ? `TaskId=${taskId} ` : ""}verified present in the remote migration history. Ensure local file ${localFileHint} exists and matches.`,
     });
   } catch (error) {
     return buildPgToolResult({

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "cloudbase-ai-toolkit",
       "version": "1.7.3",
       "dependencies": {
-        "@cloudbase/manager-node": "5.6.4"
+        "@cloudbase/manager-node": "5.6.6"
       },
       "devDependencies": {
         "@modelcontextprotocol/sdk": "1.16.0",
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@cloudbase/manager-node": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.4.tgz",
-      "integrity": "sha512-fjSR0PmlpeeZNifpJ+gKBOKQ9emRZvFgxO2DqnG9cs1UYzIafLR58RdOWF0idyXLEHRSQ+WdJadpXF8Eq3ps8Q==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.6.tgz",
+      "integrity": "sha512-kwK+Ox2wbnJ0cgRja2ClgmIErbwRqje2kDIjS+1/Uxg9YmwZvR+RiWDdarqElxqwVj90V4sYx3Aa2wx6ldjWXQ==",
       "license": "ISC",
       "dependencies": {
         "@cloudbase/database": "^0.6.2",
@@ -5005,9 +5005,9 @@
       }
     },
     "@cloudbase/manager-node": {
-      "version": "5.6.4",
-      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.4.tgz",
-      "integrity": "sha512-fjSR0PmlpeeZNifpJ+gKBOKQ9emRZvFgxO2DqnG9cs1UYzIafLR58RdOWF0idyXLEHRSQ+WdJadpXF8Eq3ps8Q==",
+      "version": "5.6.6",
+      "resolved": "https://registry.npmmirror.com/@cloudbase/manager-node/-/manager-node-5.6.6.tgz",
+      "integrity": "sha512-kwK+Ox2wbnJ0cgRja2ClgmIErbwRqje2kDIjS+1/Uxg9YmwZvR+RiWDdarqElxqwVj90V4sYx3Aa2wx6ldjWXQ==",
       "requires": {
         "@cloudbase/database": "^0.6.2",
         "@cloudbase/signature-nodejs": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "vitest": "^2.1.9"
   },
   "dependencies": {
-    "@cloudbase/manager-node": "5.6.4"
+    "@cloudbase/manager-node": "5.6.6"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,8 +17,8 @@ importers:
   .:
     dependencies:
       '@cloudbase/manager-node':
-        specifier: 5.6.4
-        version: 5.6.4
+        specifier: 5.6.6
+        version: 5.6.6
     devDependencies:
       '@modelcontextprotocol/sdk':
         specifier: 1.16.0
@@ -45,8 +45,8 @@ importers:
         specifier: ^1.14.0
         version: 1.18.2
       '@cloudbase/manager-node':
-        specifier: 5.6.4
-        version: 5.6.4
+        specifier: 5.6.6
+        version: 5.6.6
       '@cloudbase/mcp':
         specifier: 1.0.0-beta.25
         version: 1.0.0-beta.25
@@ -218,8 +218,8 @@ packages:
     resolution: {integrity: sha512-IteJl7RjPYjsqQbmSr6Vr0el6I19SzI1ya6Nw1ov4KEHxXdwrjJ2uubBeUK4mc54kmzFmvTwqBuyJdhUQ/YDXA==}
     engines: {node: '>=18.0.0'}
 
-  '@cloudbase/manager-node@5.6.4':
-    resolution: {integrity: sha512-fjSR0PmlpeeZNifpJ+gKBOKQ9emRZvFgxO2DqnG9cs1UYzIafLR58RdOWF0idyXLEHRSQ+WdJadpXF8Eq3ps8Q==}
+  '@cloudbase/manager-node@5.6.6':
+    resolution: {integrity: sha512-kwK+Ox2wbnJ0cgRja2ClgmIErbwRqje2kDIjS+1/Uxg9YmwZvR+RiWDdarqElxqwVj90V4sYx3Aa2wx6ldjWXQ==}
 
   '@cloudbase/mcp@1.0.0-beta.25':
     resolution: {integrity: sha512-IZw5MGTin3/SHlJVL6aoMLocAIlqsm8Oif0Xlb4OeznlAFuSIGwMV8ZJ5Dn9ftzyN/kwKjysa6x+Rmfw6MG51A==}
@@ -4148,7 +4148,7 @@ snapshots:
 
   '@cloudbase/functions-typings@1.2.1': {}
 
-  '@cloudbase/manager-node@5.6.4':
+  '@cloudbase/manager-node@5.6.6':
     dependencies:
       '@cloudbase/database': 0.6.2
       '@cloudbase/signature-nodejs': 1.1.0


### PR DESCRIPTION
## Summary

Follow-up engineering cleanup after #859. `@cloudbase/manager-node` 5.6.5+ ships **native** PG migration wrappers (`database.previewPGUserMigrations` / `pushPGUserMigrations` / `repairPGUserMigrationHistory` / `listPGUserMigrations` / `describePGUserMigration` / `describeTaskResult`), so this PR:

1. Bumps `@cloudbase/manager-node` **5.6.4 → 5.6.6** (root + `mcp/` + pnpm lockfile).
2. Routes `callPgMigrationApi` through the native `manager.database` methods **when available**, keeping the `commonService` fallback otherwise.

### Why native-first

- Native methods are typed wrappers over the **same** `tcb/2018-06-08` platform channel as the `commonService` fallback and return the same unwrapped `Response` shape — **no behavior change, all 10 call sites untouched**.
- Reduces reliance on the internal `commonService`/`Action` string convention; gives local input validation and typed options.
- `RollbackPGUserMigrations` has **no** native wrapper in 5.6.6 → intentionally keeps the `commonService` fallback.
- Older manager-node runtimes (or a manager without `database` native methods) transparently fall back to `commonService` — no breakage for downstream installs pinned to older versions.

### Behavior note (fail-fast)

Native methods validate inputs locally: 14-digit `Version`, `Name` matching `^[a-z_]+$`, non-empty `Query`. Invalid migration names now fail fast locally with a clear error instead of being rejected later by the platform.

## Tests

- `mcp/src/tools/databasePG.test.ts`: **41 → 48** (7 new cases: native preferred for list/detail/plan/apply/repair; rollback stays on fallback; fallback when native methods missing).
- Full mcp workspace: **742 passed | 60 skipped**.
- `tsc --noEmit` clean; webpack build clean (native methods present in bundled `dist/index.cjs`).

## Related

- Parent: #859 (hydrate remote history + poll DescribeTaskResult)
- Issue: #857 (applyMigration async task never executes)