### PR TITLE
feat(pg): align cloudbase/migrations path, auto-write local SQL, CLI-parity task poll

### DIFF
--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -82,11 +82,13 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 
    **Default schema-change workflow (local file first, then remote history):**
    1. Choose `migrationVersion` = 14-digit UTC timestamp `YYYYMMDDHHMMSS` and `migrationName` = snake_case (e.g. `add_users`).
-   2. Write local file `migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file).
+   2. Write local file `cloudbase/migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file). This path **must** match CloudBase CLI `MIGRATIONS_DIR` (`tcb db pg migration *`). If an older workspace still has root `migrations/`, move those files into `cloudbase/migrations/` before mixed MCP+CLI use.
    3. Optional preview: `managePgDatabase(action=planMigration, migrationName=..., migrationVersion=..., sql=...)`.
-   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file.
+   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file. MCP waits for the async task by default (up to **10 minutes**, same as CLI); override with `taskPollTimeoutMs` or set `waitForTask=false` if the host tool-call timeout is short.
    5. Verify: `managePgDatabase(action=listMigrations)` and confirm the remote history records the same `migrationVersion`.
    6. Then write frontend CRUD / RLS checks.
+
+   **If applyMigration returns `MIGRATION_TASK_TIMEOUT` or `MIGRATION_TASK_PENDING`:** the task may still be running (large DDL / lock waits). Call `listMigrations` **first**. Do **not** re-push the same `migrationVersion`, and do **not** fall back to `execute` until list confirms the version never landed.
 
    Other migration actions:
    - `managePgDatabase(action=migrationDetail, migrationVersion=...)` — inspect a single migration

--- a/config/.claude/skills/postgresql-development-cloudbase/references/app-workflow.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/references/app-workflow.md
@@ -17,7 +17,7 @@ Use this reference when building or repairing a real user-facing Web app backed 
    - PostgreSQL resource
    - Cloud Storage if the app uploads files. In CloudBase PG, "having storage" means having an explicitly-created `pgstore` bucket — same model as Supabase Storage. Check existing buckets with `queryPgStorage(action="buckets")`. If the upload target (e.g. `covers`) is missing, create/select the bucket through the documented CloudBase management surface or console before writing browser upload code. Browser SDKs cannot create a pgstore bucket; the legacy NoSQL bucket reported in `EnvInfo.Storages[]` is NOT a valid pgstore target.
 4. Create or repair the minimal PG schema via the migration workflow (not bare `execute` for DDL):
-   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `migrations/<version>_<name>.sql`, then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
+   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `cloudbase/migrations/<version>_<name>.sql` (same dir as CLI `tcb db pg migration`), then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
    - Apply required `GRANT` statements, sequence grants for `serial`/`bigserial`, `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, and RLS policies (same migration SQL or follow-up `execute` for ops-only GRANT/POLICY).
 5. Immediately call `queryPgDatabase(action="objects")`, then `queryPgDatabase(action="schema", objectName="public.<table>")` for every table touched by the app.
 6. Implement browser CRUD with one shared CloudBase Web SDK app instance and `app.rdb()`.

--- a/config/.claude/skills/postgresql-development-cloudbase/references/troubleshooting.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/references/troubleshooting.md
@@ -24,6 +24,18 @@ DO $$ BEGIN EXECUTE 'CREATE TABLE public.products (id serial PRIMARY KEY, name t
 
 Do not use this as a way to hide real syntax errors. If the wrapped SQL also fails, inspect the exact error and simplify.
 
+## `MIGRATION_TASK_TIMEOUT` / `MIGRATION_TASK_PENDING` after applyMigration
+
+Cause: `PushPGUserMigrations` is async. MCP polls `DescribeTaskResult` by default for up to **10 minutes** (CLI parity). Large DDL or lock waits can outlive the poll window, or the caller set `waitForTask=false`.
+
+Fix:
+
+1. Call `managePgDatabase(action=listMigrations)` **first** and look for your `migrationVersion`.
+2. If the version is present → treat as applied; do not re-push.
+3. If missing, wait and list again. Do **not** immediately re-push the same version (duplicate / conflict risk while the task may still run).
+4. Only after list confirms the version never landed, fix SQL/Conflicts and retry with a **new** version, or use `taskPollTimeoutMs` / CLI `tcb db pg migration up` for longer waits.
+5. Optional: `waitForTask=false` returns `MIGRATION_TASK_PENDING` immediately with TaskId — still must listMigrations before any retry.
+
 ## Permissions pass in MCP but fail in browser
 
 Likely cause: admin/default execution bypassed user-facing role checks.

--- a/config/source/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/source/skills/postgresql-development-cloudbase/SKILL.md
@@ -82,11 +82,13 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 
    **Default schema-change workflow (local file first, then remote history):**
    1. Choose `migrationVersion` = 14-digit UTC timestamp `YYYYMMDDHHMMSS` and `migrationName` = snake_case (e.g. `add_users`).
-   2. Write local file `migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file).
+   2. Write local file `cloudbase/migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file). This path **must** match CloudBase CLI `MIGRATIONS_DIR` (`tcb db pg migration *`). If an older workspace still has root `migrations/`, move those files into `cloudbase/migrations/` before mixed MCP+CLI use.
    3. Optional preview: `managePgDatabase(action=planMigration, migrationName=..., migrationVersion=..., sql=...)`.
-   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file.
+   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file. If the local file is missing, MCP auto-writes `cloudbase/migrations/<version>_<name>.sql`; if an existing file's content differs from `sql`, apply fails closed (`LOCAL_MIGRATION_FILE_MISMATCH`) and does not Push. MCP waits for the async task by default (up to **10 minutes**, same as CLI); override with `taskPollTimeoutMs` or set `waitForTask=false` if the host tool-call timeout is short.
    5. Verify: `managePgDatabase(action=listMigrations)` and confirm the remote history records the same `migrationVersion`.
    6. Then write frontend CRUD / RLS checks.
+
+   **If applyMigration returns `MIGRATION_TASK_TIMEOUT` or `MIGRATION_TASK_PENDING`:** the task may still be running (large DDL / lock waits). Call `listMigrations` **first**. Do **not** re-push the same `migrationVersion`, and do **not** fall back to `execute` until list confirms the version never landed.
 
    Other migration actions:
    - `managePgDatabase(action=migrationDetail, migrationVersion=...)` — inspect a single migration

--- a/config/source/skills/postgresql-development-cloudbase/references/app-workflow.md
+++ b/config/source/skills/postgresql-development-cloudbase/references/app-workflow.md
@@ -17,7 +17,7 @@ Use this reference when building or repairing a real user-facing Web app backed 
    - PostgreSQL resource
    - Cloud Storage if the app uploads files. In CloudBase PG, "having storage" means having an explicitly-created `pgstore` bucket — same model as Supabase Storage. Check existing buckets with `queryPgStorage(action="buckets")`. If the upload target (e.g. `covers`) is missing, create/select the bucket through the documented CloudBase management surface or console before writing browser upload code. Browser SDKs cannot create a pgstore bucket; the legacy NoSQL bucket reported in `EnvInfo.Storages[]` is NOT a valid pgstore target.
 4. Create or repair the minimal PG schema via the migration workflow (not bare `execute` for DDL):
-   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `migrations/<version>_<name>.sql`, then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
+   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `cloudbase/migrations/<version>_<name>.sql` (same dir as CLI `tcb db pg migration`), then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
    - Apply required `GRANT` statements, sequence grants for `serial`/`bigserial`, `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, and RLS policies (same migration SQL or follow-up `execute` for ops-only GRANT/POLICY).
 5. Immediately call `queryPgDatabase(action="objects")`, then `queryPgDatabase(action="schema", objectName="public.<table>")` for every table touched by the app.
 6. Implement browser CRUD with one shared CloudBase Web SDK app instance and `app.rdb()`.

--- a/config/source/skills/postgresql-development-cloudbase/references/troubleshooting.md
+++ b/config/source/skills/postgresql-development-cloudbase/references/troubleshooting.md
@@ -24,6 +24,18 @@ DO $$ BEGIN EXECUTE 'CREATE TABLE public.products (id serial PRIMARY KEY, name t
 
 Do not use this as a way to hide real syntax errors. If the wrapped SQL also fails, inspect the exact error and simplify.
 
+## `MIGRATION_TASK_TIMEOUT` / `MIGRATION_TASK_PENDING` after applyMigration
+
+Cause: `PushPGUserMigrations` is async. MCP polls `DescribeTaskResult` by default for up to **10 minutes** (CLI parity). Large DDL or lock waits can outlive the poll window, or the caller set `waitForTask=false`.
+
+Fix:
+
+1. Call `managePgDatabase(action=listMigrations)` **first** and look for your `migrationVersion`.
+2. If the version is present → treat as applied; do not re-push.
+3. If missing, wait and list again. Do **not** immediately re-push the same version (duplicate / conflict risk while the task may still run).
+4. Only after list confirms the version never landed, fix SQL/Conflicts and retry with a **new** version, or use `taskPollTimeoutMs` / CLI `tcb db pg migration up` for longer waits.
+5. Optional: `waitForTask=false` returns `MIGRATION_TASK_PENDING` immediately with TaskId — still must listMigrations before any retry.
+
 ## Permissions pass in MCP but fail in browser
 
 Likely cause: admin/default execution bypassed user-facing role checks.

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -704,7 +704,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
 ---
 
 ### `managePgDatabase`
-管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion + 本地 migrations/ 留档），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。
+管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion；成功前自动写入或校验本地 cloudbase/migrations/&lt;version&gt;_&lt;name&gt;.sql，与 CLI tcb db pg migration 一致），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。
 
 #### 参数
 
@@ -714,7 +714,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "action",
       type: "string",
       required: true,
-      description: `操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；成功返回前会自动校验该 migrationVersion 已落入远端迁移历史，未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason） 可填写的值: "execute", "dryRun", "planMigration", "applyMigration", "listMigrations", "migrationDetail", "rollbackMigration", "repairMigration"`,
+      description: `操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；本地 SQL 缺失则自动写入 cloudbase/migrations/，内容不一致则 LOCAL_MIGRATION_FILE_MISMATCH fail-closed；成功返回前会轮询 DescribeTaskResult（默认最长 10 分钟，可用 taskPollTimeoutMs / waitForTask 调整）并校验 migrationVersion 已落入远端历史；超时返回 MIGRATION_TASK_TIMEOUT，必须先 listMigrations，禁止立刻重推同 version；未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason） 可填写的值: "execute", "dryRun", "planMigration", "applyMigration", "listMigrations", "migrationDetail", "rollbackMigration", "repairMigration"`,
     },
     {
       name: "sql",
@@ -759,7 +759,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "migrationVersion",
       type: "string",
-      description: `14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 migrations/<version>_<name>.sql 分叉。`,
+      description: `14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。`,
     },
     {
       name: "rollbackSql",
@@ -790,6 +790,16 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "statementTimeoutMs",
       type: "integer",
       description: `apply 可选：单条 SQL 执行最长时间（毫秒），默认 300000。`,
+    },
+    {
+      name: "taskPollTimeoutMs",
+      type: "integer",
+      description: `apply 可选：轮询 DescribeTaskResult 的最长等待（毫秒）。默认 600000（与 CLI tcb db pg migration up 的 10 分钟对齐）。范围 5000-600000。超时后务必先 listMigrations，禁止立刻重推同 version。`,
+    },
+    {
+      name: "waitForTask",
+      type: "boolean",
+      description: `apply 可选，默认 true。设为 false 时 Push 后立即返回 TaskId（errorCode=MIGRATION_TASK_PENDING），由调用方用 listMigrations 确认是否落库；适合 MCP host 工具调用超时较短的场景。默认 true 会同步等到任务终态。`,
     },
     {
       name: "repairStatus",
@@ -1799,7 +1809,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.4），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.5），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -2417,7 +2427,7 @@ CloudBase HTTP 网关统一写入口（Domain/Route）。createRoute/updateRoute
     {
       name: "auth",
       type: "boolean",
-      description: `网关路径鉴权（EnableAuth）。匿名/浏览器公网访问通常 false。只控制网关入口；云函数安全规则、云托管鉴权、静态托管权限需各自工具另行配置。`,
+      description: `网关路径鉴权（EnableAuth）。匿名/浏览器公网访问通常 false。只控制网关入口；函数是否允许匿名调用还要用 managePermissions(resourceType="function") 单独放开。云托管鉴权、静态托管权限同理。`,
     },
     {
       name: "enablePathTransmission",
@@ -2758,6 +2768,8 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 
 📌 跨后端边界提示：调用前先用 `envQuery(action="info", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType="noSqlDatabase"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action="sql", sql="SELECT * FROM pg_policies WHERE tablename=...")`。本工具不涉及 MySQL 权限。
 
+⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。
+
 #### 参数
 
 <ParameterTable
@@ -2820,6 +2832,7 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 示例：
 - 设置存储桶为私有：`action="updateResourcePermission", resourceType="storage", resourceId="bucket-name", permission="PRIVATE"`
 - 创建角色：`action="createRole", roleName="admin", roleIdentity="admin"`
+- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action="updateResourcePermission", resourceType="function", resourceId="myFn", permission="CUSTOM", securityRule='\{"invoke":true\}'`
 
 注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp(\{ username, password \})`，登录应使用 `auth.signInWithPassword(\{ username, password \})`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。
 
@@ -2827,6 +2840,8 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 - `resourceType="noSqlDatabase"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action="execute", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是"PG 环境就禁用本工具"。
 - `resourceType="storage"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。
 - 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。
+
+⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'\{"invoke":true\}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。
 
 #### 参数
 

--- a/mcp/src/tools/databasePG.test.ts
+++ b/mcp/src/tools/databasePG.test.ts
@@ -1,4 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
 import type { ExtendedMcpServer } from "../server.js";
 import { __resetPgReadyCache } from "./databasePG.js";
 import { registerPGDatabaseTools } from "./databasePG.js";
@@ -759,6 +762,24 @@ describe("PG database tools", () => {
   });
 
   describe("migration actions", () => {
+    let migrationWorkspace: string;
+    let previousWorkspaceFolderPaths: string | undefined;
+
+    beforeEach(() => {
+      migrationWorkspace = fs.mkdtempSync(path.join(os.tmpdir(), "pg-mcp-mig-"));
+      previousWorkspaceFolderPaths = process.env.WORKSPACE_FOLDER_PATHS;
+      process.env.WORKSPACE_FOLDER_PATHS = migrationWorkspace;
+    });
+
+    afterEach(() => {
+      if (previousWorkspaceFolderPaths === undefined) {
+        delete process.env.WORKSPACE_FOLDER_PATHS;
+      } else {
+        process.env.WORKSPACE_FOLDER_PATHS = previousWorkspaceFolderPaths;
+      }
+      fs.rmSync(migrationWorkspace, { recursive: true, force: true });
+    });
+
     function setupMigrationMock() {
       mockGetCloudBaseManager.mockResolvedValue({
         commonService: vi.fn(() => ({
@@ -982,7 +1003,7 @@ describe("PG database tools", () => {
         data: {
           migrationVersion: "20260720160000",
           migrationName: "create_test_table",
-          localFileHint: "migrations/20260720160000_create_test_table.sql",
+          localFileHint: "cloudbase/migrations/20260720160000_create_test_table.sql",
           hydratedRemoteCount: 0,
           executable: true,
         },
@@ -1077,13 +1098,20 @@ describe("PG database tools", () => {
         data: {
           migrationVersion: "20260720160000",
           migrationName: "create_test_table",
-          localFileHint: "migrations/20260720160000_create_test_table.sql",
+          localFileHint: "cloudbase/migrations/20260720160000_create_test_table.sql",
+          localFilePath: "cloudbase/migrations/20260720160000_create_test_table.sql",
+          localFileAction: "created",
           hydratedRemoteCount: 0,
           apiResult: { TaskId: "task-1" },
           taskResult: expect.objectContaining({ Status: "Succeed" }),
           verified: true,
         },
       });
+      const written = fs.readFileSync(
+        path.join(migrationWorkspace, "cloudbase/migrations/20260720160000_create_test_table.sql"),
+        "utf8",
+      );
+      expect(written).toBe("CREATE TABLE public.test(id int)\n");
       expect(mockCommonServiceCall).toHaveBeenCalledWith(
         expect.objectContaining({
           Action: "PushPGUserMigrations",
@@ -1104,6 +1132,106 @@ describe("PG database tools", () => {
           Param: expect.objectContaining({ TaskId: "task-1" }),
         }),
       );
+    });
+
+    it("applyMigration matches existing local file without rewriting", async () => {
+      const relative = "cloudbase/migrations/20260720160000_create_test_table.sql";
+      const absolute = path.join(migrationWorkspace, relative);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, "CREATE TABLE public.test(id int)\n", "utf8");
+      const beforeMtime = fs.statSync(absolute).mtimeMs;
+
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis();
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: true,
+        data: {
+          localFileAction: "matched",
+          localFilePath: relative,
+        },
+      });
+      expect(fs.statSync(absolute).mtimeMs).toBe(beforeMtime);
+    });
+
+    it("applyMigration fails closed when local file content mismatches", async () => {
+      const relative = "cloudbase/migrations/20260720160000_create_test_table.sql";
+      const absolute = path.join(migrationWorkspace, relative);
+      fs.mkdirSync(path.dirname(absolute), { recursive: true });
+      fs.writeFileSync(absolute, "CREATE TABLE public.other(id int);\n", "utf8");
+
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis();
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "LOCAL_MIGRATION_FILE_MISMATCH",
+        data: {
+          localFilePath: relative,
+          verified: false,
+        },
+      });
+      expect(mockCommonServiceCall).not.toHaveBeenCalled();
+      expect(fs.readFileSync(absolute, "utf8")).toBe("CREATE TABLE public.other(id int);\n");
+    });
+
+    it("applyMigration accepts matching legacy migrations/ path without duplicating", async () => {
+      const legacyRelative = "migrations/20260720160000_create_test_table.sql";
+      const legacyAbsolute = path.join(migrationWorkspace, legacyRelative);
+      fs.mkdirSync(path.dirname(legacyAbsolute), { recursive: true });
+      fs.writeFileSync(legacyAbsolute, "CREATE TABLE public.test(id int)\n", "utf8");
+
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis();
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: true,
+        data: {
+          localFileAction: "matched",
+          localFilePath: legacyRelative,
+        },
+      });
+      expect(
+        fs.existsSync(
+          path.join(migrationWorkspace, "cloudbase/migrations/20260720160000_create_test_table.sql"),
+        ),
+      ).toBe(false);
     });
 
     it("applyMigration hydrates remote history into Push payload", async () => {
@@ -1225,6 +1353,83 @@ describe("PG database tools", () => {
         },
       });
       expect(payload.message).toContain("migration plan is not executable");
+    });
+
+    it("applyMigration times out with listMigrations-first guidance when task stays running", async () => {
+      vi.useFakeTimers();
+      try {
+        const { server, tools } = createMockServer();
+        registerPGDatabaseTools(server, { createClient: vi.fn() });
+        setupMigrationMock();
+        mockApplyMigrationCloudApis({ taskStatus: "Running" });
+
+        const pending = tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+          taskPollTimeoutMs: 5000,
+        });
+
+        const payloadPromise = pending.then(buildToolPayload);
+        await vi.advanceTimersByTimeAsync(7000);
+        const payload = await payloadPromise;
+
+        expect(payload).toMatchObject({
+          success: false,
+          errorCode: "MIGRATION_TASK_TIMEOUT",
+          data: {
+            taskPollTimeoutMs: 5000,
+            verified: null,
+            taskResult: { TaskId: "task-1" },
+          },
+        });
+        expect(String(payload.message)).toContain("listMigrations FIRST");
+        expect(String(payload.message)).toContain("Do NOT re-push");
+        expect(payload.nextActions?.[0]).toMatchObject({
+          tool: "managePgDatabase",
+          action: "listMigrations",
+        });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("applyMigration waitForTask=false returns pending without polling DescribeTaskResult", async () => {
+      const { server, tools } = createMockServer();
+      registerPGDatabaseTools(server, { createClient: vi.fn() });
+      setupMigrationMock();
+      mockApplyMigrationCloudApis();
+
+      const payload = buildToolPayload(
+        await tools.managePgDatabase.handler({
+          action: "applyMigration",
+          migrationName: "create_test_table",
+          migrationVersion: "20260720160000",
+          sql: "CREATE TABLE public.test(id int)",
+          confirm: true,
+          waitForTask: false,
+        }),
+      );
+
+      expect(payload).toMatchObject({
+        success: false,
+        errorCode: "MIGRATION_TASK_PENDING",
+        data: {
+          waitForTask: false,
+          verified: null,
+          taskResult: { TaskId: "task-1" },
+        },
+      });
+      expect(String(payload.message)).toContain("listMigrations FIRST");
+      expect(mockCommonServiceCall).not.toHaveBeenCalledWith(
+        expect.objectContaining({ Action: "DescribeTaskResult" }),
+      );
+      expect(payload.nextActions?.[0]).toMatchObject({
+        tool: "managePgDatabase",
+        action: "listMigrations",
+      });
     });
 
     it("applyMigration fails when the version is missing from remote migration history", async () => {

--- a/mcp/src/tools/databasePG.ts
+++ b/mcp/src/tools/databasePG.ts
@@ -1,3 +1,5 @@
+import * as fs from "fs";
+import * as path from "path";
 import { z } from "zod";
 import { getCloudBaseManager, getEnvId } from "../cloudbase-manager.js";
 import type { ExtendedMcpServer } from "../server.js";
@@ -59,6 +61,18 @@ type ManagePgDatabaseArgs = {
   offset?: number;
   lockTimeoutMs?: number;
   statementTimeoutMs?: number;
+  /**
+   * How long applyMigration polls DescribeTaskResult before MIGRATION_TASK_TIMEOUT.
+   * Default aligns with CLI `tcb db pg migration up` (10 minutes). Clamped to
+   * [MIGRATION_TASK_MIN_WAIT_MS, MIGRATION_TASK_MAX_WAIT_MS].
+   */
+  taskPollTimeoutMs?: number;
+  /**
+   * When false, skip DescribeTaskResult polling and return TaskId immediately
+   * (MIGRATION_TASK_PENDING). Caller must listMigrations before retrying.
+   * Default true.
+   */
+  waitForTask?: boolean;
   repairStatus?: "applied" | "reverted";
   repairReason?: string;
   /** Escape hatch: allow schema DDL through execute instead of applyMigration. Default false. */
@@ -326,8 +340,145 @@ function isSchemaDdlRisk(risk: string, sql: string): boolean {
   return ["DROP", "TRUNCATE", "ALTER"].includes(verb);
 }
 
+/**
+ * Canonical local migration directory — must match CloudBase CLI
+ * `MIGRATIONS_DIR` (`cloudbase/migrations`) so MCP+CLI mixed workflows share files.
+ * Legacy bare `migrations/` is accepted only when an existing matching file is found.
+ */
+const LOCAL_MIGRATIONS_DIR = "cloudbase/migrations";
+const LOCAL_MIGRATIONS_DIR_LEGACY = "migrations";
+
+function getMigrationProjectRoot(): string {
+  const fromEnv =
+    process.env.WORKSPACE_FOLDER_PATHS ||
+    process.env.PROJECT_ROOT ||
+    process.env.GITHUB_WORKSPACE ||
+    process.env.CI_PROJECT_DIR ||
+    process.env.BUILD_SOURCESDIRECTORY;
+  if (fromEnv && fromEnv.trim()) {
+    // IDEs may inject multiple folders separated by path.delimiter.
+    const first = fromEnv.split(path.delimiter).map((p) => p.trim()).find(Boolean);
+    if (first) {
+      return first;
+    }
+  }
+  return process.cwd();
+}
+
+function buildLocalMigrationFileName(version: string, name: string): string {
+  return `${version}_${name}.sql`;
+}
+
 function buildLocalMigrationFileHint(version: string, name: string): string {
-  return `migrations/${version}_${name}.sql`;
+  return `${LOCAL_MIGRATIONS_DIR}/${buildLocalMigrationFileName(version, name)}`;
+}
+
+/** Normalize SQL for local file compare/write (LF + single trailing newline). */
+function normalizeMigrationSqlForLocalFile(sql: string): string {
+  const normalized = sql.replace(/\r\n/g, "\n").replace(/\s+$/u, "");
+  return `${normalized}\n`;
+}
+
+type LocalMigrationFileEnsureResult =
+  | {
+      ok: true;
+      relativePath: string;
+      absolutePath: string;
+      action: "created" | "matched";
+    }
+  | {
+      ok: false;
+      errorCode: "LOCAL_MIGRATION_FILE_MISMATCH" | "LOCAL_MIGRATION_FILE_WRITE_FAILED";
+      message: string;
+      relativePath?: string;
+      absolutePath?: string;
+    };
+
+/**
+ * Ensure the workspace has a Git-truth SQL file for this migration before Push.
+ * Prefer write-to-workspace when missing; fail closed on mismatch or write failure
+ * (Supabase MCP#241 class: remote apply without local truth source).
+ */
+function ensureLocalMigrationSqlFile(
+  version: string,
+  name: string,
+  sql: string,
+): LocalMigrationFileEnsureResult {
+  const fileName = buildLocalMigrationFileName(version, name);
+  const expected = normalizeMigrationSqlForLocalFile(sql);
+  const projectRoot = getMigrationProjectRoot();
+  const candidates = [
+    {
+      relativePath: `${LOCAL_MIGRATIONS_DIR}/${fileName}`,
+      absolutePath: path.join(projectRoot, LOCAL_MIGRATIONS_DIR, fileName),
+    },
+    {
+      relativePath: `${LOCAL_MIGRATIONS_DIR_LEGACY}/${fileName}`,
+      absolutePath: path.join(projectRoot, LOCAL_MIGRATIONS_DIR_LEGACY, fileName),
+    },
+  ];
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate.absolutePath)) {
+      continue;
+    }
+    let existing: string;
+    try {
+      existing = fs.readFileSync(candidate.absolutePath, "utf8");
+    } catch (error) {
+      return {
+        ok: false,
+        errorCode: "LOCAL_MIGRATION_FILE_WRITE_FAILED",
+        message:
+          `Failed to read existing local migration file ${candidate.relativePath}: ` +
+          `${error instanceof Error ? error.message : String(error)}`,
+        relativePath: candidate.relativePath,
+        absolutePath: candidate.absolutePath,
+      };
+    }
+    if (normalizeMigrationSqlForLocalFile(existing) === expected) {
+      return {
+        ok: true,
+        relativePath: candidate.relativePath,
+        absolutePath: candidate.absolutePath,
+        action: "matched",
+      };
+    }
+    return {
+      ok: false,
+      errorCode: "LOCAL_MIGRATION_FILE_MISMATCH",
+      message:
+        `Local migration file ${candidate.relativePath} already exists but its content does not match the sql argument. ` +
+        "Refuse to overwrite (fail closed). Update the local file to match, or use a new migrationVersion / migrationName. " +
+        "Push was NOT submitted.",
+      relativePath: candidate.relativePath,
+      absolutePath: candidate.absolutePath,
+    };
+  }
+
+  const target = candidates[0];
+  try {
+    fs.mkdirSync(path.dirname(target.absolutePath), { recursive: true });
+    fs.writeFileSync(target.absolutePath, expected, "utf8");
+  } catch (error) {
+    return {
+      ok: false,
+      errorCode: "LOCAL_MIGRATION_FILE_WRITE_FAILED",
+      message:
+        `Failed to write local migration file ${target.relativePath} under workspace ${projectRoot}: ` +
+        `${error instanceof Error ? error.message : String(error)}. ` +
+        "Push was NOT submitted. Fix workspace permissions or write the file manually, then retry applyMigration.",
+      relativePath: target.relativePath,
+      absolutePath: target.absolutePath,
+    };
+  }
+
+  return {
+    ok: true,
+    relativePath: target.relativePath,
+    absolutePath: target.absolutePath,
+    action: "created",
+  };
 }
 
 /** How many recent migration records to scan when verifying a freshly pushed version. */
@@ -366,10 +517,28 @@ const MIGRATION_LIST_PAGE_SIZE = 100;
 
 /**
  * PushPGUserMigrations is async: poll DescribeTaskResult until Succeed/Failed.
- * Aligns with CLI `tcb db pg migration up` and Manager SDK docs.
+ * Default wait aligns with CLI `tcb db pg migration up` (10 minutes).
+ * Override per call via applyMigration.taskPollTimeoutMs.
  */
 const MIGRATION_TASK_POLL_INTERVAL_MS = 1500;
-const MIGRATION_TASK_MAX_WAIT_MS = 90_000;
+/** CLI parity: `TASK_MAX_WAIT_MS = 10 * 60 * 1000` in cloudbase-cli migration up. */
+const MIGRATION_TASK_DEFAULT_WAIT_MS = 10 * 60 * 1000;
+const MIGRATION_TASK_MIN_WAIT_MS = 5_000;
+const MIGRATION_TASK_MAX_WAIT_MS = MIGRATION_TASK_DEFAULT_WAIT_MS;
+
+function resolveMigrationTaskPollTimeoutMs(requested?: number): number {
+  if (requested === undefined || !Number.isFinite(requested)) {
+    return MIGRATION_TASK_DEFAULT_WAIT_MS;
+  }
+  const rounded = Math.floor(requested);
+  if (rounded < MIGRATION_TASK_MIN_WAIT_MS) {
+    return MIGRATION_TASK_MIN_WAIT_MS;
+  }
+  if (rounded > MIGRATION_TASK_MAX_WAIT_MS) {
+    return MIGRATION_TASK_MAX_WAIT_MS;
+  }
+  return rounded;
+}
 
 type PgMigrationInput = {
   Version: string;
@@ -541,8 +710,9 @@ async function waitPgMigrationTask(
   context: PgDbContext,
   taskId: string,
   cloudBaseOptions?: ExtendedMcpServer["cloudBaseOptions"],
+  maxWaitMs: number = MIGRATION_TASK_DEFAULT_WAIT_MS,
 ): Promise<PgMigrationTaskResult> {
-  const deadline = Date.now() + MIGRATION_TASK_MAX_WAIT_MS;
+  const deadline = Date.now() + maxWaitMs;
   let last: PgMigrationTaskResult = { TaskId: taskId };
 
   while (Date.now() <= deadline) {
@@ -561,16 +731,33 @@ async function waitPgMigrationTask(
   }
 
   const error = new Error(
-    `DescribeTaskResult timed out after ${Math.floor(MIGRATION_TASK_MAX_WAIT_MS / 1000)}s ` +
+    `DescribeTaskResult timed out after ${Math.floor(maxWaitMs / 1000)}s ` +
       `for TaskId=${taskId} (last Status=${last.Status || "-"}, Phase=${last.Phase || "-"}).`,
   );
   (error as Error & { lastTask?: PgMigrationTaskResult }).lastTask = last;
   throw error;
 }
 
+function buildMigrationTaskPendingNextActions(version: string): ToolNextStep[] {
+  return [
+    buildNextAction(
+      MANAGE_PG_DATABASE,
+      "listMigrations",
+      "FIRST: check whether migrationVersion landed in remote history. Do NOT re-push the same version while the task may still be running.",
+      { action: "listMigrations", limit: 20 },
+    ),
+    buildNextAction(
+      MANAGE_PG_DATABASE,
+      "migrationDetail",
+      "If listMigrations already shows this version, inspect the applied record. If missing after several minutes, inspect Conflicts/SQL before considering a NEW migrationVersion.",
+      { action: "migrationDetail", migrationVersion: version },
+    ),
+  ];
+}
+
 const MIGRATION_VERSION_REQUIRED_MESSAGE =
   "migrationVersion is required (14-digit UTC timestamp YYYYMMDDHHMMSS). " +
-  "Decide the version first, write local file migrations/<version>_<migrationName>.sql, " +
+  "Decide the version first, write local file cloudbase/migrations/<version>_<migrationName>.sql, " +
   "then call planMigration/applyMigration with the same migrationVersion and migrationName.";
 
 function requireExplicitMigrationVersion(
@@ -1537,11 +1724,11 @@ async function handleExecuteSql(
       errorCode: "DDL_USE_APPLY_MIGRATION",
       message:
         "Schema DDL (CREATE/ALTER/DROP/TRUNCATE/...) must use applyMigration with an explicit migrationVersion, " +
-        "not execute. Write local migrations/<version>_<name>.sql first, then call applyMigration. " +
+        "not execute. Write local cloudbase/migrations/<version>_<name>.sql first, then call applyMigration. " +
         "Set allowDdlViaExecute=true only for exceptional one-off ops that intentionally bypass migration history.",
       data: {
         classification,
-        localFileHintPattern: "migrations/<migrationVersion>_<migrationName>.sql",
+        localFileHintPattern: "cloudbase/migrations/<migrationVersion>_<migrationName>.sql",
       },
       nextActions: [
         buildNextAction(
@@ -1698,7 +1885,7 @@ async function handleDryRun(args: ManagePgDatabaseArgs) {
         wouldExecute: false,
         sqlPreview: args.sql.trim().slice(0, 500),
         preferredAction: "applyMigration",
-        localFileHintPattern: "migrations/<migrationVersion>_<migrationName>.sql",
+        localFileHintPattern: "cloudbase/migrations/<migrationVersion>_<migrationName>.sql",
       },
       message:
         "SQL dry run completed. Schema DDL should use applyMigration with an explicit migrationVersion, not execute.",
@@ -1855,6 +2042,38 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
   const version = versionOrError;
   const localFileHint = buildLocalMigrationFileHint(version, args.migrationName);
 
+  // Prefer write-to-workspace (or fail closed) so remote history cannot advance without a Git truth source.
+  const localFile = ensureLocalMigrationSqlFile(version, args.migrationName, args.sql);
+  if (!localFile.ok) {
+    return buildPgToolResult({
+      success: false,
+      errorCode: localFile.errorCode,
+      data: {
+        migrationVersion: version,
+        migrationName: args.migrationName,
+        localFileHint,
+        localFilePath: localFile.relativePath ?? localFileHint,
+        localFileAbsolutePath: localFile.absolutePath ?? null,
+        verified: false,
+      },
+      message: localFile.message,
+      nextActions: [
+        buildNextAction(
+          MANAGE_PG_DATABASE,
+          "planMigration",
+          "After aligning the local SQL file with the sql argument (or choosing a new migrationVersion), preview again.",
+          {
+            action: "planMigration",
+            migrationName: args.migrationName,
+            migrationVersion: version,
+            sql: args.sql,
+            ...(args.rollbackSql ? { rollbackSql: args.rollbackSql } : {}),
+          },
+        ),
+      ],
+    });
+  }
+
   const pending: PgMigrationInput = {
     Version: version,
     Name: args.migrationName,
@@ -1933,11 +2152,36 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
 
     const result = await callPgMigrationApi(context, "PushPGUserMigrations", params, cloudBaseOptions);
     const taskId = typeof result.TaskId === "string" ? result.TaskId.trim() : "";
+    const pollTimeoutMs = resolveMigrationTaskPollTimeoutMs(args.taskPollTimeoutMs);
+    const shouldWaitForTask = args.waitForTask !== false;
 
     let taskResult: PgMigrationTaskResult | null = null;
+    if (taskId && !shouldWaitForTask) {
+      return buildPgToolResult({
+        success: false,
+        errorCode: "MIGRATION_TASK_PENDING",
+        data: {
+          migrationVersion: version,
+          migrationName: args.migrationName,
+          localFileHint,
+          hydratedRemoteCount: hydrated.remoteCount,
+          apiResult: result as Record<string, unknown>,
+          taskResult: { TaskId: taskId },
+          taskPollTimeoutMs: pollTimeoutMs,
+          waitForTask: false,
+          verified: null,
+        },
+        message:
+          `PushPGUserMigrations accepted TaskId=${taskId} (waitForTask=false). ` +
+          "TaskId means accepted, not applied. Call action=listMigrations FIRST to see whether " +
+          `migrationVersion=${version} landed. Do NOT re-push the same version while the task may still be running.`,
+        nextActions: buildMigrationTaskPendingNextActions(version),
+      });
+    }
+
     if (taskId) {
       try {
-        taskResult = await waitPgMigrationTask(context, taskId, cloudBaseOptions);
+        taskResult = await waitPgMigrationTask(context, taskId, cloudBaseOptions, pollTimeoutMs);
       } catch (error) {
         const lastTask = (error as Error & { lastTask?: PgMigrationTaskResult }).lastTask;
         return buildPgToolResult({
@@ -1950,20 +2194,16 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
             hydratedRemoteCount: hydrated.remoteCount,
             apiResult: result as Record<string, unknown>,
             taskResult: lastTask ?? { TaskId: taskId },
+            taskPollTimeoutMs: pollTimeoutMs,
             verified: null,
           },
           message:
-            `PushPGUserMigrations returned TaskId=${taskId}, but waiting for DescribeTaskResult timed out: ` +
-            `${error instanceof Error ? error.message : String(error)}. ` +
-            "The migration may still be running — check action=listMigrations before retrying or falling back to execute.",
-          nextActions: [
-            buildNextAction(
-              MANAGE_PG_DATABASE,
-              "listMigrations",
-              "Check whether the migrationVersion eventually landed.",
-              { action: "listMigrations", limit: 20 },
-            ),
-          ],
+            `PushPGUserMigrations returned TaskId=${taskId}, but waiting for DescribeTaskResult timed out ` +
+            `after ${Math.floor(pollTimeoutMs / 1000)}s: ${error instanceof Error ? error.message : String(error)}. ` +
+            "The migration may STILL be running in the background (large DDL / lock waits). " +
+            "Call action=listMigrations FIRST. Do NOT re-push the same migrationVersion, and do NOT fall back to " +
+            "execute until listMigrations confirms the version is missing after the task finishes.",
+          nextActions: buildMigrationTaskPendingNextActions(version),
         });
       }
 
@@ -2081,12 +2321,17 @@ async function handleApplyMigration(args: ManagePgDatabaseArgs, context: PgDbCon
         migrationVersion: version,
         migrationName: args.migrationName,
         localFileHint,
+        localFilePath: localFile.relativePath,
+        localFileAbsolutePath: localFile.absolutePath,
+        localFileAction: localFile.action,
         hydratedRemoteCount: hydrated.remoteCount,
         apiResult: result as Record<string, unknown>,
         taskResult: taskResult as Record<string, unknown> | null,
         verified: true,
       },
-      message: `Migrations applied via PushPGUserMigrations (hydrated ${hydrated.remoteCount} remote migration(s)), task ${taskId ? `TaskId=${taskId} ` : ""}verified present in the remote migration history. Ensure local file ${localFileHint} exists and matches.`,
+      message:
+        `Migrations applied via PushPGUserMigrations (hydrated ${hydrated.remoteCount} remote migration(s)), task ${taskId ? `TaskId=${taskId} ` : ""}verified present in the remote migration history. ` +
+        `Local SQL ${localFile.action === "created" ? "written" : "matched"} at ${localFile.relativePath}.`,
     });
   } catch (error) {
     return buildPgToolResult({
@@ -2432,12 +2677,12 @@ export function registerPGDatabaseTools(
     {
       title: "管理 PostgreSQL 上下文或执行写入 SQL",
       description:
-        "管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion + 本地 migrations/ 留档），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。",
+        "管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion；成功前自动写入或校验本地 cloudbase/migrations/<version>_<name>.sql，与 CLI tcb db pg migration 一致），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。",
       inputSchema: {
         action: z
           .enum(MANAGE_ACTIONS)
           .describe(
-            "操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；成功返回前会自动校验该 migrationVersion 已落入远端迁移历史，未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason）",
+            "操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；本地 SQL 缺失则自动写入 cloudbase/migrations/，内容不一致则 LOCAL_MIGRATION_FILE_MISMATCH fail-closed；成功返回前会轮询 DescribeTaskResult（默认最长 10 分钟，可用 taskPollTimeoutMs / waitForTask 调整）并校验 migrationVersion 已落入远端历史；超时返回 MIGRATION_TASK_TIMEOUT，必须先 listMigrations，禁止立刻重推同 version；未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason）",
           ),
         sql: z
           .string()
@@ -2480,7 +2725,7 @@ export function registerPGDatabaseTools(
           .string()
           .regex(/^\d{14}$/)
           .optional()
-          .describe("14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 migrations/<version>_<name>.sql 分叉。"),
+          .describe("14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。"),
         rollbackSql: z
           .string()
           .optional()
@@ -2514,6 +2759,21 @@ export function registerPGDatabaseTools(
           .int()
           .optional()
           .describe("apply 可选：单条 SQL 执行最长时间（毫秒），默认 300000。"),
+        taskPollTimeoutMs: z
+          .number()
+          .int()
+          .min(MIGRATION_TASK_MIN_WAIT_MS)
+          .max(MIGRATION_TASK_MAX_WAIT_MS)
+          .optional()
+          .describe(
+            `apply 可选：轮询 DescribeTaskResult 的最长等待（毫秒）。默认 ${MIGRATION_TASK_DEFAULT_WAIT_MS}（与 CLI tcb db pg migration up 的 10 分钟对齐）。范围 ${MIGRATION_TASK_MIN_WAIT_MS}-${MIGRATION_TASK_MAX_WAIT_MS}。超时后务必先 listMigrations，禁止立刻重推同 version。`,
+          ),
+        waitForTask: z
+          .boolean()
+          .optional()
+          .describe(
+            "apply 可选，默认 true。设为 false 时 Push 后立即返回 TaskId（errorCode=MIGRATION_TASK_PENDING），由调用方用 listMigrations 确认是否落库；适合 MCP host 工具调用超时较短的场景。默认 true 会同步等到任务终态。",
+          ),
         repairStatus: z
           .enum(["applied", "reverted"])
           .optional()

--- a/plugin/cloudbase/.sync-metadata.json
+++ b/plugin/cloudbase/.sync-metadata.json
@@ -1,7 +1,7 @@
 {
   "repo": "https://github.com/TencentCloudBase/skills.git",
   "ref": "main",
-  "commit": "30df07cc40126111a38b4fc39878de574137559a",
-  "syncedAt": "2026-08-03T15:04:21.533Z",
+  "commit": "e1971994530b8ac1a3e35940223aeaea9a2bf869",
+  "syncedAt": "2026-08-04T05:50:06.704Z",
   "skillCount": 28
 }

--- a/plugin/cloudbase/skills/postgresql-development-cloudbase/SKILL.md
+++ b/plugin/cloudbase/skills/postgresql-development-cloudbase/SKILL.md
@@ -82,11 +82,13 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 
    **Default schema-change workflow (local file first, then remote history):**
    1. Choose `migrationVersion` = 14-digit UTC timestamp `YYYYMMDDHHMMSS` and `migrationName` = snake_case (e.g. `add_users`).
-   2. Write local file `migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file).
+   2. Write local file `cloudbase/migrations/<migrationVersion>_<migrationName>.sql` with the DDL (and optional rollback SQL in comments or a paired file). This path **must** match CloudBase CLI `MIGRATIONS_DIR` (`tcb db pg migration *`). If an older workspace still has root `migrations/`, move those files into `cloudbase/migrations/` before mixed MCP+CLI use.
    3. Optional preview: `managePgDatabase(action=planMigration, migrationName=..., migrationVersion=..., sql=...)`.
-   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file.
+   4. Apply: `managePgDatabase(action=applyMigration, migrationName=..., migrationVersion=..., sql=..., confirm=true)` — reuse the **same** version/name as the local file. If the local file is missing, MCP auto-writes `cloudbase/migrations/<version>_<name>.sql`; if an existing file's content differs from `sql`, apply fails closed (`LOCAL_MIGRATION_FILE_MISMATCH`) and does not Push. MCP waits for the async task by default (up to **10 minutes**, same as CLI); override with `taskPollTimeoutMs` or set `waitForTask=false` if the host tool-call timeout is short.
    5. Verify: `managePgDatabase(action=listMigrations)` and confirm the remote history records the same `migrationVersion`.
    6. Then write frontend CRUD / RLS checks.
+
+   **If applyMigration returns `MIGRATION_TASK_TIMEOUT` or `MIGRATION_TASK_PENDING`:** the task may still be running (large DDL / lock waits). Call `listMigrations` **first**. Do **not** re-push the same `migrationVersion`, and do **not** fall back to `execute` until list confirms the version never landed.
 
    Other migration actions:
    - `managePgDatabase(action=migrationDetail, migrationVersion=...)` — inspect a single migration

--- a/plugin/cloudbase/skills/postgresql-development-cloudbase/references/app-workflow.md
+++ b/plugin/cloudbase/skills/postgresql-development-cloudbase/references/app-workflow.md
@@ -17,7 +17,7 @@ Use this reference when building or repairing a real user-facing Web app backed 
    - PostgreSQL resource
    - Cloud Storage if the app uploads files. In CloudBase PG, "having storage" means having an explicitly-created `pgstore` bucket — same model as Supabase Storage. Check existing buckets with `queryPgStorage(action="buckets")`. If the upload target (e.g. `covers`) is missing, create/select the bucket through the documented CloudBase management surface or console before writing browser upload code. Browser SDKs cannot create a pgstore bucket; the legacy NoSQL bucket reported in `EnvInfo.Storages[]` is NOT a valid pgstore target.
 4. Create or repair the minimal PG schema via the migration workflow (not bare `execute` for DDL):
-   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `migrations/<version>_<name>.sql`, then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
+   - Choose `migrationVersion` (`YYYYMMDDHHMMSS`) + `migrationName`, write `cloudbase/migrations/<version>_<name>.sql` (same dir as CLI `tcb db pg migration`), then `managePgDatabase(action="applyMigration", migrationName, migrationVersion, sql, confirm=true)`.
    - Apply required `GRANT` statements, sequence grants for `serial`/`bigserial`, `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`, and RLS policies (same migration SQL or follow-up `execute` for ops-only GRANT/POLICY).
 5. Immediately call `queryPgDatabase(action="objects")`, then `queryPgDatabase(action="schema", objectName="public.<table>")` for every table touched by the app.
 6. Implement browser CRUD with one shared CloudBase Web SDK app instance and `app.rdb()`.

--- a/plugin/cloudbase/skills/postgresql-development-cloudbase/references/troubleshooting.md
+++ b/plugin/cloudbase/skills/postgresql-development-cloudbase/references/troubleshooting.md
@@ -24,6 +24,18 @@ DO $$ BEGIN EXECUTE 'CREATE TABLE public.products (id serial PRIMARY KEY, name t
 
 Do not use this as a way to hide real syntax errors. If the wrapped SQL also fails, inspect the exact error and simplify.
 
+## `MIGRATION_TASK_TIMEOUT` / `MIGRATION_TASK_PENDING` after applyMigration
+
+Cause: `PushPGUserMigrations` is async. MCP polls `DescribeTaskResult` by default for up to **10 minutes** (CLI parity). Large DDL or lock waits can outlive the poll window, or the caller set `waitForTask=false`.
+
+Fix:
+
+1. Call `managePgDatabase(action=listMigrations)` **first** and look for your `migrationVersion`.
+2. If the version is present → treat as applied; do not re-push.
+3. If missing, wait and list again. Do **not** immediately re-push the same version (duplicate / conflict risk while the task may still run).
+4. Only after list confirms the version never landed, fix SQL/Conflicts and retry with a **new** version, or use `taskPollTimeoutMs` / CLI `tcb db pg migration up` for longer waits.
+5. Optional: `waitForTask=false` returns `MIGRATION_TASK_PENDING` immediately with TaskId — still must listMigrations before any retry.
+
 ## Permissions pass in MCP but fail in browser
 
 Likely cause: admin/default execution bypassed user-facing role checks.

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -709,7 +709,7 @@
     },
     {
       "name": "managePgDatabase",
-      "description": "管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion + 本地 migrations/ 留档），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。",
+      "description": "管理 CloudBase PostgreSQL：执行已确认的写入 SQL、SQL 风险预检、迁移管理。建表/ALTER/DROP 等 schema 变更必须使用 applyMigration（显式 migrationVersion；成功前自动写入或校验本地 cloudbase/migrations/<version>_<name>.sql，与 CLI tcb db pg migration 一致），不要默认用 execute。execute 主要用于 DML 与 GRANT/RLS 等运维 SQL。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -725,7 +725,7 @@
               "rollbackMigration",
               "repairMigration"
             ],
-            "description": "操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；成功返回前会自动校验该 migrationVersion 已落入远端迁移历史，未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason）"
+            "description": "操作类型：execute=执行已确认的写入 SQL（DML/GRANT/RLS；schema DDL 默认拒绝，需 allowDdlViaExecute=true）；dryRun=只分析 SQL 风险不执行；planMigration=预览迁移计划（需 migrationName + migrationVersion + sql）；applyMigration=应用迁移，建表/改 schema 首选（需 migrationName + migrationVersion + sql + confirm=true；本地 SQL 缺失则自动写入 cloudbase/migrations/，内容不一致则 LOCAL_MIGRATION_FILE_MISMATCH fail-closed；成功返回前会轮询 DescribeTaskResult（默认最长 10 分钟，可用 taskPollTimeoutMs / waitForTask 调整）并校验 migrationVersion 已落入远端历史；超时返回 MIGRATION_TASK_TIMEOUT，必须先 listMigrations，禁止立刻重推同 version；未落库时返回 success=false 且 errorCode=MIGRATION_NOT_APPLIED）；listMigrations=查询已应用的 Migration 列表（可传 limit/offset 分页）；migrationDetail=查看单条 Migration 详情（需 migrationVersion）；rollbackMigration=回滚最近 N 条 Migration（需 lastN + confirm=true）；repairMigration=修复 Migration 历史记录（需 migrationVersion + migrationName + repairStatus + repairReason）"
           },
           "sql": {
             "type": "string",
@@ -763,7 +763,7 @@
           "migrationVersion": {
             "type": "string",
             "pattern": "^\\d{14}$",
-            "description": "14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 migrations/<version>_<name>.sql 分叉。"
+            "description": "14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。"
           },
           "rollbackSql": {
             "type": "string",
@@ -792,6 +792,16 @@
           "statementTimeoutMs": {
             "type": "integer",
             "description": "apply 可选：单条 SQL 执行最长时间（毫秒），默认 300000。"
+          },
+          "taskPollTimeoutMs": {
+            "type": "integer",
+            "minimum": 5000,
+            "maximum": 600000,
+            "description": "apply 可选：轮询 DescribeTaskResult 的最长等待（毫秒）。默认 600000（与 CLI tcb db pg migration up 的 10 分钟对齐）。范围 5000-600000。超时后务必先 listMigrations，禁止立刻重推同 version。"
+          },
+          "waitForTask": {
+            "type": "boolean",
+            "description": "apply 可选，默认 true。设为 false 时 Push 后立即返回 TaskId（errorCode=MIGRATION_TASK_PENDING），由调用方用 listMigrations 确认是否落库；适合 MCP host 工具调用超时较短的场景。默认 true 会同步等到任务终态。"
           },
           "repairStatus": {
             "type": "string",
@@ -1852,7 +1862,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.4），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.25.5），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2559,7 +2569,7 @@
           },
           "auth": {
             "type": "boolean",
-            "description": "网关路径鉴权（EnableAuth）。匿名/浏览器公网访问通常 false。只控制网关入口；云函数安全规则、云托管鉴权、静态托管权限需各自工具另行配置。"
+            "description": "网关路径鉴权（EnableAuth）。匿名/浏览器公网访问通常 false。只控制网关入口；函数是否允许匿名调用还要用 managePermissions(resourceType=\"function\") 单独放开。云托管鉴权、静态托管权限同理。"
           },
           "enablePathTransmission": {
             "type": "boolean",
@@ -2919,7 +2929,7 @@
     },
     {
       "name": "queryPermissions",
-      "description": "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。",
+      "description": "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。\n\n⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2983,7 +2993,7 @@
     },
     {
       "name": "managePermissions",
-      "description": "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。",
+      "description": "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action=\"updateResourcePermission\", resourceType=\"function\", resourceId=\"myFn\", permission=\"CUSTOM\", securityRule='{\"invoke\":true}'`\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。\n\n⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'{\"invoke\":true}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## Summary
- Align MCP + skill local migration path with CLI `MIGRATIONS_DIR` (`cloudbase/migrations/`); legacy root `migrations/` is match-only for existing files.
- `applyMigration` auto-writes missing local SQL under `cloudbase/migrations/<version>_<name>.sql` and fail-closes with `LOCAL_MIGRATION_FILE_MISMATCH` on content drift (Supabase MCP#241 class).
- Align async task waiting with CLI `tcb db pg migration up`: default `DescribeTaskResult` poll **10 minutes** (`taskPollTimeoutMs`); `waitForTask=false` → `MIGRATION_TASK_PENDING`. Timeout/pending insist on `listMigrations` first and forbid same-version re-push.
- Sync plugin skills metadata to upstream `TencentCloudBase/skills@e197199` (already published) so marketplace `sync-cloudbase-plugin-skills` does not regress to bare `migrations/`.

## Related
- Issue: https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/issues/857
- Upstream skills publish: `TencentCloudBase/skills@e197199`
- Supersedes overlapping PR #863 (same MCP auto-write + timeout commit; this PR also carries skills upstream lock-in)

## Test plan
- [x] `npx vitest run src/tools/databasePG.test.ts` → 53 passed
- [x] Upstream skills.git SKILL.md uses `cloudbase/migrations`
- [x] `node scripts/sync-cloudbase-plugin-skills.mjs --check` clean at e197199
- [ ] CI green on this PR
- [ ] After merge, confirm `push-skills-repo` keeps `cloudbase/migrations`