### PR TITLE
fix(ci): 🩹 pin clawhub CLI and harden plugin skills sync push

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -75,8 +75,10 @@ jobs:
 
       - name: Install ClawHub CLI
         if: ${{ !inputs.dry_run }}
-        # TODO: Pin to specific version once stable versioning is available
-        run: npm install -g clawhub@latest
+        # Pin to 0.23.1: clawhub@0.23.3 (2026-08-04) stages uploads via Convex
+        # and fails every publish with "Uploaded file does not match its skill upload ticket".
+        # Last known-good publish on this repo used 0.23.1 (v2.25.5, 2026-08-03).
+        run: npm install -g clawhub@0.23.1
 
       - name: Login to ClawHub
         if: ${{ !inputs.dry_run }}

--- a/.github/workflows/sync-cloudbase-plugin-skills.yml
+++ b/.github/workflows/sync-cloudbase-plugin-skills.yml
@@ -48,7 +48,22 @@ jobs:
             echo "pushed=false" >> "$GITHUB_OUTPUT"
           else
             git commit -m "chore: sync cloudbase plugin skills from upstream"
-            git push
+            # Release and other sync workflows often push main in parallel
+            # (e.g. Sync Claude Skills Mirror); rebase and retry like that workflow.
+            pushed=false
+            for i in 1 2 3; do
+              if git push; then
+                pushed=true
+                break
+              fi
+              echo "Push rejected (attempt $i); rebasing onto origin/main..."
+              git pull --rebase origin main
+              sleep $((i * 2))
+            done
+            if [ "$pushed" != "true" ]; then
+              echo "Failed to push after retries"
+              exit 1
+            fi
             echo "pushed=true" >> "$GITHUB_OUTPUT"
           fi
 


### PR DESCRIPTION
## Summary
- Pin ClawHub CLI to `0.23.1` — `clawhub@0.23.3` stages Convex uploads and fails every publish with `Uploaded file does not match its skill upload ticket` (broke after v2.25.5).
- Add rebase+retry to Sync CloudBase Plugin Skills push (same pattern as Sync Claude Skills Mirror) so release-time parallel bot pushes no longer leave `plugin/cloudbase` and dedicated plugin repos stuck behind source versions (v2.25.6 race).

## Context
- Failed ClawHub run: https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/actions/runs/30894334622
- Failed plugin skills sync: https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/actions/runs/30894334257 (`main` non-fast-forward vs concurrent Claude mirror sync)

## Test plan
- [ ] Merge to main
- [ ] `workflow_dispatch` **Sync CloudBase Plugin Skills** — expect commit syncing 2.25.6 into `plugin/cloudbase` and dispatch of **Push Plugin Repos**
- [ ] Confirm `TencentCloudBase/cloudbase-plugin` receives sync commit (sites repo may be no-op if unchanged)
- [ ] `workflow_dispatch` **Publish ClawHub & SkillHub Registry** with `dry_run=false` — expect ClawHub publish success on pinned 0.23.1


Made with [Cursor](https://cursor.com)