### PR TITLE
fix(ci): 🩹 restore ClawHub workflow_dispatch inputs

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -14,12 +14,6 @@ on:
       - 'scripts/publish-to-skillhub.mjs'
       - '.github/workflows/publish-clawhub-registry.yml'
   workflow_dispatch:
-
-# Avoid concurrent publish races that collide on the same next patch version.
-concurrency:
-  group: publish-clawhub-registry
-  cancel-in-progress: false
-
     inputs:
       targets:
         description: 'Comma-separated publish targets: miniprogram-development, cloudbase-wechat-integration, all-in-one, ui-design, web-development, spec-workflow'
@@ -49,6 +43,11 @@ concurrency:
         required: false
         default: true
         type: boolean
+
+# Avoid concurrent publish races that collide on the same next patch version.
+concurrency:
+  group: publish-clawhub-registry
+  cancel-in-progress: false
 
 jobs:
   publish:


### PR DESCRIPTION
## Summary
- Restore `workflow_dispatch.inputs` placement broken when inserting the concurrency block in #869.
- Without this, GitHub treats the workflow as having no `workflow_dispatch` trigger and rejects manual publishes / may fail path-filtered runs.

## Test plan
- [ ] Workflow appears as dispatchable again
- [ ] Manual publish with `dry_run=false` reaches SkillHub step


Made with [Cursor](https://cursor.com)