### PR TITLE
docs(marketplace): record awesome-copilot intake pass

### DIFF
--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -84,7 +84,7 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 
 | Field | Value |
 |-------|-------|
-| Status | **Resubmitted after security fix** — remote skill-fetch URLs removed; `/rerun-intake` requested 2026-08-05 |
+| Status | **Intake passed after security fix** — label `ready-for-review`; awaiting maintainer review |
 | Issue | https://github.com/github/awesome-copilot/issues/2459 |
 | Packet | `specs/plugin-marketplace-listing/awesome-copilot-submission-packet.md` |
 | Response | `specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md` |


### PR DESCRIPTION
## Summary
- Update submission-log after #2459 intake re-run passed (`ready-for-review`) on SHA `4082ba957d41f8fc6545411d8a929884ab88980c`.

## Test plan
- [x] Confirm issue labels / intake status on https://github.com/github/awesome-copilot/issues/2459


Made with [Cursor](https://cursor.com)