### PR TITLE
docs(marketplace): record Awesome Copilot intake re-pass

### DIFF
--- a/specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md
+++ b/specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md
@@ -9,7 +9,7 @@
 | Maintainer | aaronpowell |
 | Root cause | Agent-directed remote skill fetch via `cnb.cool/.../git/raw/...` URLs in every skill |
 | Remediation | Source-level strip of remote skill-fetch (this document) |
-| Resubmit path | Edit issue SHA → comment `/rerun-intake` |
+| Resubmit path | Done 2026-08-05 — SHA `4082ba957d41f8fc6545411d8a929884ab88980c`; intake passed; label `ready-for-review` |
 
 ## Rejection (verbatim)
 
@@ -44,6 +44,7 @@ Awesome Copilot installs the **full plugin**, so remote sibling fetch is unneces
 6. **Resubmit** — **done**
    - Edit #2459 Commit SHA → `4082ba957d41f8fc6545411d8a929884ab88980c`
    - Comment remediation summary + `/rerun-intake` (2026-08-05)
+   - Intake re-passed; `rejected` removed; label `ready-for-review`
 
 ## Explicit non-goals
 

--- a/specs/plugin-marketplace-listing/markets.yaml
+++ b/specs/plugin-marketplace-listing/markets.yaml
@@ -262,11 +262,10 @@ markets:
       docs_only: listed
     submit_url_or_process: |
       Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.
-      Status 2026-08-04: Awesome Copilot #2459 rejected (remote skill-fetch / injection). Remediation: strip cnb.cool raw skill URLs, then edit SHA + /rerun-intake.
+      Status 2026-08-05: Awesome Copilot #2459 intake re-passed after stripping remote skill-fetch URLs (SHA 4082ba95...). Awaiting maintainer re-review.
       See specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md
     eligibility: marketplace_add_or_catalog_pr
-    blockers:
-      - Awesome Copilot #2459 rejected until remote skill-fetch URLs are removed and intake re-runs
+    blockers: []
     evidence_links:
       - https://code.visualstudio.com/docs/agent-customization/agent-plugins
       - https://github.com/github/awesome-copilot/issues/2459
@@ -285,7 +284,7 @@ markets:
     notes: |
       2026-07-28: Submitted cloudbase via Awesome Copilot external-plugin issue #2459.
       2026-08-04: Rejected — skills instruct agents to fetch sibling skills from cnb.cool raw URLs.
-      2026-08-05: Source/plugin remediation to local-only sibling guidance; resubmit pending new plugin SHA.
+      2026-08-05: Source/plugin remediation merged (PR #875); plugin SHA 4082ba95; /rerun-intake passed; ready-for-review.
 
   - id: github-copilot-cli
     product: GitHub Copilot CLI

--- a/specs/plugin-marketplace-listing/submission-checklist.md
+++ b/specs/plugin-marketplace-listing/submission-checklist.md
@@ -89,7 +89,7 @@ Examples of good targets:
 - [x] Users can already add this repo / `cloudbase-plugin` as a marketplace source
 - [x] Awesome Copilot external plugin issue opened — https://github.com/github/awesome-copilot/issues/2459 (2026-07-28)
 - [x] Rejection response documented — `awesome-copilot-rejection-response.md` (remote skill-fetch)
-- [ ] Strip remote skill-fetch URLs, sync plugin SHA, `/rerun-intake` on #2459
+- [x] Strip remote skill-fetch URLs, sync plugin SHA, `/rerun-intake` on #2459 (intake passed 2026-08-05)
 - [ ] Await Awesome Copilot maintainer review → entry in `plugins/external.json`
 - [ ] Optional later: PR to official `github/copilot-plugins` (mostly Microsoft-curated; lower priority)
 - [x] Prefer documenting `npx plugins add TencentCloudBase/cloudbase-plugin --target vscode` / `github-copilot`

--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -84,14 +84,14 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 
 | Field | Value |
 |-------|-------|
-| Status | **Resubmitted after security fix** — remote skill-fetch URLs removed; `/rerun-intake` requested 2026-08-05 |
+| Status | **Intake re-passed** — awaiting maintainer re-review (`ready-for-review`) |
 | Issue | https://github.com/github/awesome-copilot/issues/2459 |
 | Packet | `specs/plugin-marketplace-listing/awesome-copilot-submission-packet.md` |
 | Response | `specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md` |
 | Source | `TencentCloudBase/cloudbase-plugin` @ `4082ba957d41f8fc6545411d8a929884ab88980c` |
 | Submitted at | 2026-07-28 |
 | Rejected at | 2026-08-04 (security: agent-directed remote skill fetch) |
-| Re-run at | 2026-08-05 (`/rerun-intake` after stripping `cnb.cool/.../git/raw` skill URLs) |
+| Re-run at | 2026-08-05 (`/rerun-intake` after stripping `cnb.cool/.../git/raw` skill URLs; intake passed) |
 
 ### How to check progress (Awesome Copilot)
 


### PR DESCRIPTION
## Summary
- Update marketplace submission log/checklist after #2459 security remediation
- Record plugin SHA `4082ba957d41f8fc6545411d8a929884ab88980c` and intake re-pass (`ready-for-review`)

## Test plan
- [x] Confirm issue https://github.com/github/awesome-copilot/issues/2459 is open with `ready-for-review`
- [x] Confirm plugin SHA has no `cnb.cool/.../git/raw` skill-fetch URLs


Made with [Cursor](https://cursor.com)