### PR TITLE
feat(ci): add post-publish npm tarball smoke

### DIFF
--- a/.github/actions/notify-npm-smoke-failure/action.yml
+++ b/.github/actions/notify-npm-smoke-failure/action.yml
@@ -1,0 +1,192 @@
+name: Notify npm smoke failure
+description: >
+  Open or update a GitHub issue (and optionally Slack) when post-publish or
+  scheduled npm tarball smoke fails, so published regressions are not silent.
+
+inputs:
+  github-token:
+    description: Token with issues:write
+    required: true
+  smoke-name:
+    description: Human-readable smoke job name (e.g. post-publish-smoke)
+    required: true
+  package-version:
+    description: npm version or dist-tag that was smoked
+    required: false
+    default: ""
+  slack-webhook-url:
+    description: Optional Slack incoming webhook URL
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Open or update GitHub issue
+      id: issue
+      uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+      env:
+        SMOKE_NAME: ${{ inputs.smoke-name }}
+        PACKAGE_VERSION: ${{ inputs.package-version }}
+      with:
+        github-token: ${{ inputs.github-token }}
+        script: |
+          const smokeName = process.env.SMOKE_NAME || 'npm-tarball-smoke';
+          const packageVersion = (process.env.PACKAGE_VERSION || '').trim() || 'unknown';
+          const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+          const marker = `<!-- npm-smoke-failure:${smokeName} -->`;
+          const title = `[ci] npm smoke failed: ${smokeName} (@cloudbase/cloudbase-mcp@${packageVersion})`;
+
+          const labelsToEnsure = [
+            {
+              name: 'ci-npm-smoke-failure',
+              color: 'B60205',
+              description: 'Automated alert: published npm tarball smoke failed'
+            },
+            {
+              name: 'no-ai',
+              color: '666666',
+              description: 'Skip AI automation for this issue'
+            }
+          ];
+
+          for (const label of labelsToEnsure) {
+            try {
+              await github.rest.issues.getLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name
+              });
+            } catch (err) {
+              if (err.status !== 404) throw err;
+              await github.rest.issues.createLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                name: label.name,
+                color: label.color,
+                description: label.description
+              });
+            }
+          }
+
+          // Prefer label listing over search API (search index can lag on new issues).
+          const openIssues = await github.paginate(github.rest.issues.listForRepo, {
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            state: 'open',
+            labels: 'ci-npm-smoke-failure',
+            per_page: 50,
+            sort: 'updated',
+            direction: 'desc'
+          });
+          const existing = openIssues.find(
+            (issue) => !issue.pull_request && typeof issue.body === 'string' && issue.body.includes(marker)
+          );
+
+          const bodyLines = [
+            marker,
+            '',
+            '## npm tarball smoke failure',
+            '',
+            'Published package smoke failed. Investigate before the next release.',
+            '',
+            `| Field | Value |`,
+            `| --- | --- |`,
+            `| Smoke | \`${smokeName}\` |`,
+            `| Package | \`@cloudbase/cloudbase-mcp@${packageVersion}\` |`,
+            `| Workflow | \`${context.workflow}\` |`,
+            `| Run | ${runUrl} |`,
+            `| Ref | \`${context.ref}\` |`,
+            `| Actor | @${context.actor} |`,
+            `| Event | \`${context.eventName}\` |`,
+            '',
+            '### Checklist',
+            '',
+            '- [ ] Open the Actions run log and capture the failing assertion',
+            '- [ ] Confirm whether npm metadata / tarball shasum drifted',
+            '- [ ] Confirm `managePermissions` / `queryPermissions` still register',
+            '- [ ] Confirm OPA fallback strings still exist in dist',
+            '- [ ] Close this issue after the smoke is green again',
+            ''
+          ];
+
+          const commentBody = [
+            marker,
+            '',
+            `## Recurrence: ${smokeName}`,
+            '',
+            `- Package: \`@cloudbase/cloudbase-mcp@${packageVersion}\``,
+            `- Run: ${runUrl}`,
+            `- Ref: \`${context.ref}\``,
+            `- Event: \`${context.eventName}\``,
+            ''
+          ].join('\n');
+
+          let issueNumber;
+          let issueUrl;
+          let action;
+
+          if (existing) {
+            issueNumber = existing.number;
+            issueUrl = existing.html_url;
+            action = 'commented';
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: commentBody
+            });
+            // Keep title fresh with latest version
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              title,
+              labels: ['ci-npm-smoke-failure', 'no-ai']
+            });
+          } else {
+            const created = await github.rest.issues.create({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              title,
+              body: bodyLines.join('\n'),
+              labels: ['ci-npm-smoke-failure', 'no-ai']
+            });
+            issueNumber = created.data.number;
+            issueUrl = created.data.html_url;
+            action = 'created';
+          }
+
+          core.setOutput('issue_number', String(issueNumber));
+          core.setOutput('issue_url', issueUrl);
+          core.setOutput('action', action);
+          core.info(`Smoke failure alert ${action} issue #${issueNumber}: ${issueUrl}`);
+
+    - name: Notify Slack (optional)
+      if: inputs.slack-webhook-url != ''
+      shell: bash
+      env:
+        SLACK_WEBHOOK_URL: ${{ inputs.slack-webhook-url }}
+        SMOKE_NAME: ${{ inputs.smoke-name }}
+        PACKAGE_VERSION: ${{ inputs.package-version }}
+        ISSUE_URL: ${{ steps.issue.outputs.issue_url }}
+        RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      run: |
+        set -euo pipefail
+        VERSION="${PACKAGE_VERSION:-unknown}"
+        TEXT=$(printf '%s\n%s\n%s' \
+          "[CloudBase-MCP] npm smoke failed: ${SMOKE_NAME} (@cloudbase/cloudbase-mcp@${VERSION})" \
+          "Run: ${RUN_URL}" \
+          "Issue: ${ISSUE_URL}")
+        PAYLOAD=$(TEXT="$TEXT" node -e 'process.stdout.write(JSON.stringify({ text: process.env.TEXT }))')
+        HTTP_CODE=$(curl -sS -o /tmp/slack-notify-body.txt -w '%{http_code}' \
+          -X POST \
+          -H 'Content-Type: application/json' \
+          --data "$PAYLOAD" \
+          "$SLACK_WEBHOOK_URL" || true)
+        if [ "$HTTP_CODE" != "200" ]; then
+          echo "::warning::Slack notify returned HTTP ${HTTP_CODE}; issue alert still filed."
+          cat /tmp/slack-notify-body.txt || true
+        else
+          echo "Slack notification sent."
+        fi

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pkg_version.outputs.version }}
+      dist_tag: ${{ steps.npm_tag.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
@@ -33,6 +36,14 @@ jobs:
           node -v
           npm -v
           node -e 'console.log(require("./package.json").version)'
+
+      - name: Resolve package version
+        id: pkg_version
+        working-directory: ./mcp
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Package version: $VERSION"
 
       - name: Install root dependencies
         run: npm ci
@@ -78,3 +89,26 @@ jobs:
       - name: Publish to npm
         working-directory: ./mcp
         run: NODE_AUTH_TOKEN="" npm publish --provenance --access public --tag "${{ steps.npm_tag.outputs.tag }}" --verbose
+
+  # Automates the v2.25.7 production regression checklist against the just-published tarball.
+  post-publish-smoke:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+
+      - name: Smoke published npm tarball
+        working-directory: ./mcp
+        env:
+          PACKAGE_VERSION: ${{ needs.publish.outputs.version }}
+          TENCENTCLOUD_SECRETID: ${{ secrets.TENCENTCLOUD_SECRETID }}
+          TENCENTCLOUD_SECRETKEY: ${{ secrets.TENCENTCLOUD_SECRETKEY }}
+          CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
+          SMOKE_PG_FUNCTION_ID: atoPgPermProbe
+        run: node ./scripts/verify-npm-tarball-smoke.mjs

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -112,3 +112,23 @@ jobs:
           CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
           SMOKE_PG_FUNCTION_ID: atoPgPermProbe
         run: node ./scripts/verify-npm-tarball-smoke.mjs
+
+  # Alert maintainers when the published tarball smoke fails (GitHub Issue + optional Slack).
+  notify-post-publish-smoke-failure:
+    needs: [publish, post-publish-smoke]
+    if: always() && needs.publish.result == 'success' && needs.post-publish-smoke.result == 'failure'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Notify maintainers
+        uses: ./.github/actions/notify-npm-smoke-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          smoke-name: post-publish-smoke
+          package-version: ${{ needs.publish.outputs.version }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/npm-tarball-smoke.yaml
+++ b/.github/workflows/npm-tarball-smoke.yaml
@@ -1,0 +1,61 @@
+name: npm tarball smoke
+
+# Scheduled / manual check of the published package on npm (latest or a chosen tag/version).
+# Post-publish coverage also runs from npm-publish.yaml after a successful publish.
+
+on:
+  schedule:
+    # Daily check that latest still boots and retains OPA permission fallback strings.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm version or dist-tag to smoke (default latest)"
+        required: false
+        default: "latest"
+      expected_shasum:
+        description: "Optional expected tarball sha1"
+        required: false
+        default: ""
+      skip_live_smoke:
+        description: "Skip optional live PG queryPermissions probe (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  tarball-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
+      - name: Resolve smoke version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="latest"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Smoking npm package version/tag: $VERSION"
+
+      - name: Run published tarball smoke
+        working-directory: ./mcp
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          EXPECTED_SHASUM: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_shasum || '' }}
+          SKIP_LIVE_SMOKE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_live_smoke == 'true' && '1' || '0' }}
+          TENCENTCLOUD_SECRETID: ${{ secrets.TENCENTCLOUD_SECRETID }}
+          TENCENTCLOUD_SECRETKEY: ${{ secrets.TENCENTCLOUD_SECRETKEY }}
+          CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
+          SMOKE_PG_FUNCTION_ID: atoPgPermProbe
+        run: node ./scripts/verify-npm-tarball-smoke.mjs

--- a/.github/workflows/npm-tarball-smoke.yaml
+++ b/.github/workflows/npm-tarball-smoke.yaml
@@ -28,6 +28,8 @@ permissions:
 jobs:
   tarball-smoke:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
@@ -59,3 +61,23 @@ jobs:
           CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
           SMOKE_PG_FUNCTION_ID: atoPgPermProbe
         run: node ./scripts/verify-npm-tarball-smoke.mjs
+
+  # Alert maintainers when scheduled/manual tarball smoke fails (GitHub Issue + optional Slack).
+  notify-tarball-smoke-failure:
+    needs: tarball-smoke
+    if: failure()
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Notify maintainers
+        uses: ./.github/actions/notify-npm-smoke-failure
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          smoke-name: npm-tarball-smoke
+          package-version: ${{ needs.tarball-smoke.outputs.version }}
+          slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -48,6 +48,7 @@
     "test:watch": "npm run build && vitest",
     "test:coverage": "npm run build && vitest run --coverage",
     "test:pg:cloud": "npm run build && node ./scripts/verify-pg-cloud-smoke.mjs",
+    "test:npm:tarball-smoke": "node ./scripts/verify-npm-tarball-smoke.mjs",
     "test:inspector": "npm run build && npx @modelcontextprotocol/inspector node ./dist/cli.js",
     "prepublishOnly": "npm run build && node scripts/prepare-publish.cjs",
     "postpublish": "node scripts/restore-deps.cjs"

--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Post-publish smoke for @cloudbase/cloudbase-mcp.
+ *
+ * Automates the production regression checklist used for v2.25.7:
+ * 1) download published tarball
+ * 2) verify shasum against npm metadata (and optional EXPECTED_SHASUM)
+ * 3) createCloudBaseMcpServer registers managePermissions / queryPermissions
+ * 4) OPA fallback strings exist in dist
+ * 5) optional live PG queryPermissions smoke when cloud credentials are present
+ *
+ * Usage:
+ *   node ./scripts/verify-npm-tarball-smoke.mjs [version|latest|dist-tag]
+ *
+ * Env:
+ *   PACKAGE_NAME          default @cloudbase/cloudbase-mcp
+ *   PACKAGE_VERSION       version or dist-tag (overrides argv)
+ *   EXPECTED_SHASUM       optional exact sha1 of the tarball
+ *   NPM_REGISTRY          default https://registry.npmjs.org
+ *   SMOKE_WORKDIR         optional work directory (default mkdtemp)
+ *   KEEP_SMOKE_WORKDIR    set to 1 to retain temp workdir
+ *   SKIP_LIVE_SMOKE       set to 1 to skip live cloud probe
+ *   CLOUDBASE_ENV_ID      env for optional live probe
+ *   TENCENTCLOUD_SECRETID / TENCENTCLOUD_SECRETKEY
+ *   SMOKE_PG_FUNCTION_ID  default atoPgPermProbe
+ */
+
+import { createHash } from "node:crypto";
+import {
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(__dirname, "..");
+
+const PACKAGE_NAME = process.env.PACKAGE_NAME || "@cloudbase/cloudbase-mcp";
+const NPM_REGISTRY = (process.env.NPM_REGISTRY || "https://registry.npmjs.org").replace(/\/$/, "");
+const EXPECTED_SHASUM = process.env.EXPECTED_SHASUM || "";
+const SKIP_LIVE_SMOKE = process.env.SKIP_LIVE_SMOKE === "1";
+const SMOKE_PG_FUNCTION_ID = process.env.SMOKE_PG_FUNCTION_ID || "atoPgPermProbe";
+
+const OPA_STRINGS = [
+  "modifyEnvAuthzConfig",
+  "describeEnvAuthzConfig",
+  "authz.user.rego",
+];
+
+const REQUIRED_TOOLS = ["managePermissions", "queryPermissions"];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function log(step, detail) {
+  console.log(`[npm-tarball-smoke] ${step}${detail ? `: ${detail}` : ""}`);
+}
+
+function resolveRequestedVersion() {
+  if (process.env.PACKAGE_VERSION) {
+    return process.env.PACKAGE_VERSION;
+  }
+  if (process.argv[2]) {
+    return process.argv[2];
+  }
+  try {
+    const local = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
+    return local.version || "latest";
+  } catch {
+    return "latest";
+  }
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`);
+  }
+  return response.json();
+}
+
+async function resolvePackageMeta(requested) {
+  const encodedName = PACKAGE_NAME.replace("/", "%2F");
+  const metaUrl = `${NPM_REGISTRY}/${encodedName}/${encodeURIComponent(requested)}`;
+  log("resolve", metaUrl);
+
+  let lastError;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const meta = await fetchJson(metaUrl);
+      assert(meta?.version, `Registry response missing version for ${requested}`);
+      assert(meta?.dist?.tarball, `Registry response missing dist.tarball for ${requested}`);
+      assert(meta?.dist?.shasum, `Registry response missing dist.shasum for ${requested}`);
+      return {
+        version: meta.version,
+        tarball: meta.dist.tarball,
+        shasum: meta.dist.shasum,
+        requested,
+      };
+    } catch (error) {
+      lastError = error;
+      const delayMs = Math.min(15000, 1000 * attempt);
+      log("resolve-retry", `attempt ${attempt}/8 failed (${error.message}); wait ${delayMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
+
+async function downloadToFile(url, destPath) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download tarball: HTTP ${response.status}`);
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destPath));
+}
+
+function sha1File(filePath) {
+  const hash = createHash("sha1");
+  hash.update(readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function extractTarball(tarballPath, extractRoot) {
+  mkdirSync(extractRoot, { recursive: true });
+  // Use system tar (available on macOS + Ubuntu runners); avoids adding an npm dependency.
+  execFileSync("tar", ["-xzf", tarballPath, "-C", extractRoot], { stdio: "pipe" });
+  const pkgRoot = path.join(extractRoot, "package");
+  assert(existsSync(pkgRoot), `Extracted tarball missing package/ directory at ${extractRoot}`);
+  return pkgRoot;
+}
+
+function assertOpaStrings(pkgRoot) {
+  const distFiles = ["dist/index.cjs", "dist/index.js", "dist/cli.cjs"];
+  const haystacks = [];
+  for (const rel of distFiles) {
+    const abs = path.join(pkgRoot, rel);
+    if (existsSync(abs)) {
+      haystacks.push({ rel, text: readFileSync(abs, "utf8") });
+    }
+  }
+  assert(haystacks.length > 0, `No dist bundles found under ${pkgRoot}`);
+
+  for (const needle of OPA_STRINGS) {
+    const hit = haystacks.some((file) => file.text.includes(needle));
+    assert(hit, `OPA fallback string missing from published dist: ${needle}`);
+    log("opa-string", `found ${needle}`);
+  }
+}
+
+async function assertToolRegistration(pkgRoot) {
+  const entryCjs = path.join(pkgRoot, "dist", "index.cjs");
+  assert(existsSync(entryCjs), `Missing published entry ${entryCjs}`);
+
+  const require = createRequire(path.join(pkgRoot, "package.json"));
+  const mod = require("./dist/index.cjs");
+  assert(
+    typeof mod.createCloudBaseMcpServer === "function",
+    "createCloudBaseMcpServer export missing from published package",
+  );
+
+  const server = await mod.createCloudBaseMcpServer({
+    enableTelemetry: false,
+    cloudBaseOptions: {
+      envId: "smoke-env",
+      secretId: "smoke-secret-id",
+      secretKey: "smoke-secret-key",
+    },
+  });
+
+  assert(Array.isArray(server.toolDefs), "server.toolDefs missing after createCloudBaseMcpServer");
+  const toolNames = server.toolDefs.map((tool) => tool.name);
+  for (const toolName of REQUIRED_TOOLS) {
+    assert(toolNames.includes(toolName), `Missing expected tool registration: ${toolName}`);
+    log("tool", `registered ${toolName}`);
+  }
+
+  log("tools", `total=${toolNames.length}`);
+  return { toolNames };
+}
+
+function parseToolPayload(result) {
+  const text = result?.content?.[0]?.text;
+  assert(typeof text === "string" && text.length > 0, "Tool result did not contain JSON text payload");
+  return JSON.parse(text);
+}
+
+async function runLiveWithFreshServer(pkgRoot) {
+  if (SKIP_LIVE_SMOKE) {
+    log("live-smoke", "skipped (SKIP_LIVE_SMOKE=1)");
+    return { skipped: true, reason: "SKIP_LIVE_SMOKE" };
+  }
+
+  const secretId = process.env.TENCENTCLOUD_SECRETID || process.env.TCB_SECRETID;
+  const secretKey = process.env.TENCENTCLOUD_SECRETKEY || process.env.TCB_SECRETKEY;
+  const envId = process.env.CLOUDBASE_ENV_ID || process.env.TCB_ENV;
+  if (!secretId || !secretKey || !envId) {
+    log("live-smoke", "skipped (missing TENCENTCLOUD_SECRETID/SECRETKEY or CLOUDBASE_ENV_ID)");
+    return { skipped: true, reason: "missing-credentials" };
+  }
+
+  const require = createRequire(path.join(pkgRoot, "package.json"));
+  const { createCloudBaseMcpServer } = require("./dist/index.cjs");
+  const server = await createCloudBaseMcpServer({
+    enableTelemetry: false,
+    cloudBaseOptions: {
+      envId,
+      secretId,
+      secretKey,
+    },
+  });
+
+  const queryTool = server.toolDefs.find((tool) => tool.name === "queryPermissions");
+  assert(queryTool, "queryPermissions tool missing for live smoke");
+
+  const result = await queryTool.handler({
+    action: "getResourcePermission",
+    resourceType: "function",
+    resourceId: SMOKE_PG_FUNCTION_ID,
+  });
+  const payload = parseToolPayload(result);
+
+  assert(payload.success === true, `Live queryPermissions failed: ${payload.message || JSON.stringify(payload)}`);
+  assert(
+    payload.fallback === "describeEnvAuthzConfig" ||
+      String(payload.message || "").includes("describeEnvAuthzConfig"),
+    `Live PG smoke did not exercise OPA fallback; got fallback=${payload.fallback} message=${payload.message}`,
+  );
+
+  log("live-smoke", `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} fallback=${payload.fallback}`);
+  return {
+    skipped: false,
+    envId,
+    functionId: SMOKE_PG_FUNCTION_ID,
+    fallback: payload.fallback,
+  };
+}
+
+async function main() {
+  const requested = resolveRequestedVersion();
+  const workRoot =
+    process.env.SMOKE_WORKDIR ||
+    mkdtempSync(path.join(tmpdir(), "cloudbase-mcp-tarball-smoke-"));
+  mkdirSync(workRoot, { recursive: true });
+
+  const createdTemp = !process.env.SMOKE_WORKDIR;
+  log("workdir", workRoot);
+
+  try {
+    const meta = await resolvePackageMeta(requested);
+    log("version", `${meta.requested} -> ${meta.version}`);
+    log("tarball", meta.tarball);
+    log("registry-shasum", meta.shasum);
+
+    const tarballPath = path.join(workRoot, `${PACKAGE_NAME.replace("/", "-")}-${meta.version}.tgz`);
+    await downloadToFile(meta.tarball, tarballPath);
+    const actualShasum = sha1File(tarballPath);
+    log("actual-shasum", actualShasum);
+
+    assert(
+      actualShasum === meta.shasum,
+      `Tarball shasum mismatch vs registry: expected ${meta.shasum}, got ${actualShasum}`,
+    );
+    if (EXPECTED_SHASUM) {
+      assert(
+        actualShasum === EXPECTED_SHASUM,
+        `Tarball shasum mismatch vs EXPECTED_SHASUM: expected ${EXPECTED_SHASUM}, got ${actualShasum}`,
+      );
+      log("expected-shasum", "matched");
+    }
+
+    const extractRoot = path.join(workRoot, "extract");
+    const pkgRoot = extractTarball(tarballPath, extractRoot);
+
+    const pkgJson = JSON.parse(readFileSync(path.join(pkgRoot, "package.json"), "utf8"));
+    assert(pkgJson.version === meta.version, `package.json version ${pkgJson.version} != ${meta.version}`);
+    log("package.json", `version=${pkgJson.version}`);
+
+    assertOpaStrings(pkgRoot);
+    const { toolNames } = await assertToolRegistration(pkgRoot);
+    const live = await runLiveWithFreshServer(pkgRoot);
+
+    const summary = {
+      success: true,
+      package: PACKAGE_NAME,
+      requested,
+      version: meta.version,
+      shasum: actualShasum,
+      tools: {
+        total: toolNames.length,
+        required: REQUIRED_TOOLS,
+      },
+      opaStrings: OPA_STRINGS,
+      live,
+    };
+    const summaryPath = path.join(workRoot, "smoke-summary.json");
+    writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    console.log(JSON.stringify(summary, null, 2));
+    log("done", summaryPath);
+  } finally {
+    if (createdTemp && process.env.KEEP_SMOKE_WORKDIR !== "1") {
+      rmSync(workRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[npm-tarball-smoke] FAILED:", error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Add `mcp/scripts/verify-npm-tarball-smoke.mjs` to download the published `@cloudbase/cloudbase-mcp` tarball, verify shasum, boot `createCloudBaseMcpServer`, assert `managePermissions`/`queryPermissions`, and check OPA fallback strings in dist.
- Run the smoke after successful npm publish (`npm-publish.yaml` → `post-publish-smoke`) and on a daily/manual workflow (`npm-tarball-smoke.yaml`).
- On smoke failure, notify maintainers via GitHub Issue (label `ci-npm-smoke-failure` + `no-ai`, deduped) and optionally Slack when `SLACK_WEBHOOK_URL` repo secret is set.
- Optional live PG `queryPermissions` probe runs when `TENCENTCLOUD_*` + `CLOUDBASE_ENV_ID` secrets are present (defaults to function `atoPgPermProbe`).

## Test plan
- [x] Locally: `SKIP_LIVE_SMOKE=1 EXPECTED_SHASUM=73486d829a43ee5478114bbcca1d9fb7c9962bfd node mcp/scripts/verify-npm-tarball-smoke.mjs 2.25.7` → PASS
- [ ] After merge: manually dispatch `npm tarball smoke` with version `latest`
- [ ] Next tag publish: confirm `post-publish-smoke` job is green
- [ ] (Optional) Set repo secret `SLACK_WEBHOOK_URL` to enable Slack alerts
- [ ] Force a dry-run failure path in a fork/branch if needed to confirm issue creation

Made with [Cursor](https://cursor.com)