### PR TITLE
fix(cli): break cloud-mode↔logger cycle crashing --cloud-mode

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -41,6 +41,11 @@ jobs:
         run: |
           cd mcp
           npm run build
+
+      - name: Smoke CLI cloud-mode
+        working-directory: ./mcp
+        run: npm run test:cli:cloud-mode
+
       - name: Test package
         # WARNING: Secrets are only available for non-fork PRs due to GitHub's built-in protection.
         # We still add explicit condition for defense in depth.

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -17,6 +17,9 @@ permissions:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.pkg_version.outputs.version }}
+      dist_tag: ${{ steps.npm_tag.outputs.tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
@@ -33,6 +36,14 @@ jobs:
           node -v
           npm -v
           node -e 'console.log(require("./package.json").version)'
+
+      - name: Resolve package version
+        id: pkg_version
+        working-directory: ./mcp
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Package version: $VERSION"
 
       - name: Install root dependencies
         run: npm ci
@@ -78,3 +89,26 @@ jobs:
       - name: Publish to npm
         working-directory: ./mcp
         run: NODE_AUTH_TOKEN="" npm publish --provenance --access public --tag "${{ steps.npm_tag.outputs.tag }}" --verbose
+
+  # Automates the v2.25.7 production regression checklist against the just-published tarball.
+  post-publish-smoke:
+    needs: publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '24'
+
+      - name: Smoke published npm tarball
+        working-directory: ./mcp
+        env:
+          PACKAGE_VERSION: ${{ needs.publish.outputs.version }}
+          TENCENTCLOUD_SECRETID: ${{ secrets.TENCENTCLOUD_SECRETID }}
+          TENCENTCLOUD_SECRETKEY: ${{ secrets.TENCENTCLOUD_SECRETKEY }}
+          CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
+          SMOKE_PG_FUNCTION_ID: atoPgPermProbe
+        run: node ./scripts/verify-npm-tarball-smoke.mjs

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -60,6 +60,10 @@ jobs:
         working-directory: ./mcp
         run: npx vitest run
 
+      - name: Smoke CLI cloud-mode
+        working-directory: ./mcp
+        run: npm run test:cli:cloud-mode
+
       - name: Resolve npm dist-tag
         id: npm_tag
         working-directory: ./mcp

--- a/.github/workflows/npm-tarball-smoke.yaml
+++ b/.github/workflows/npm-tarball-smoke.yaml
@@ -1,0 +1,61 @@
+name: npm tarball smoke
+
+# Scheduled / manual check of the published package on npm (latest or a chosen tag/version).
+# Post-publish coverage also runs from npm-publish.yaml after a successful publish.
+
+on:
+  schedule:
+    # Daily check that latest still boots and retains OPA permission fallback strings.
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "npm version or dist-tag to smoke (default latest)"
+        required: false
+        default: "latest"
+      expected_shasum:
+        description: "Optional expected tarball sha1"
+        required: false
+        default: ""
+      skip_live_smoke:
+        description: "Skip optional live PG queryPermissions probe (true/false)"
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+
+jobs:
+  tarball-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "24"
+
+      - name: Resolve smoke version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          else
+            VERSION="latest"
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Smoking npm package version/tag: $VERSION"
+
+      - name: Run published tarball smoke
+        working-directory: ./mcp
+        env:
+          PACKAGE_VERSION: ${{ steps.version.outputs.version }}
+          EXPECTED_SHASUM: ${{ github.event_name == 'workflow_dispatch' && inputs.expected_shasum || '' }}
+          SKIP_LIVE_SMOKE: ${{ github.event_name == 'workflow_dispatch' && inputs.skip_live_smoke == 'true' && '1' || '0' }}
+          TENCENTCLOUD_SECRETID: ${{ secrets.TENCENTCLOUD_SECRETID }}
+          TENCENTCLOUD_SECRETKEY: ${{ secrets.TENCENTCLOUD_SECRETKEY }}
+          CLOUDBASE_ENV_ID: ${{ secrets.CLOUDBASE_ENV_ID }}
+          SMOKE_PG_FUNCTION_ID: atoPgPermProbe
+        run: node ./scripts/verify-npm-tarball-smoke.mjs

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -48,6 +48,7 @@
     "test:watch": "npm run build && vitest",
     "test:coverage": "npm run build && vitest run --coverage",
     "test:pg:cloud": "npm run build && node ./scripts/verify-pg-cloud-smoke.mjs",
+    "test:npm:tarball-smoke": "node ./scripts/verify-npm-tarball-smoke.mjs",
     "test:inspector": "npm run build && npx @modelcontextprotocol/inspector node ./dist/cli.js",
     "prepublishOnly": "npm run build && node scripts/prepare-publish.cjs",
     "postpublish": "node scripts/restore-deps.cjs"

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -48,6 +48,7 @@
     "test:watch": "npm run build && vitest",
     "test:coverage": "npm run build && vitest run --coverage",
     "test:pg:cloud": "npm run build && node ./scripts/verify-pg-cloud-smoke.mjs",
+    "test:cli:cloud-mode": "node ./scripts/verify-cli-cloud-mode-smoke.mjs",
     "test:npm:tarball-smoke": "node ./scripts/verify-npm-tarball-smoke.mjs",
     "test:inspector": "npm run build && npx @modelcontextprotocol/inspector node ./dist/cli.js",
     "prepublishOnly": "npm run build && node scripts/prepare-publish.cjs",

--- a/mcp/scripts/verify-cli-cloud-mode-smoke.mjs
+++ b/mcp/scripts/verify-cli-cloud-mode-smoke.mjs
@@ -1,0 +1,195 @@
+#!/usr/bin/env node
+/**
+ * Smoke: `node dist/cli.cjs --cloud-mode` must stay alive on stdio.
+ *
+ * Catches the historical cloud-mode ↔ logger circular-dependency crash
+ * (misreported as an ajv SyntaxError because Node dumps the minified line).
+ *
+ * Usage:
+ *   node ./scripts/verify-cli-cloud-mode-smoke.mjs
+ *   CLI_PATH=/path/to/cli.cjs node ./scripts/verify-cli-cloud-mode-smoke.mjs
+ *
+ * Env:
+ *   CLI_PATH           absolute/relative path to cli.cjs (default: ../dist/cli.cjs)
+ *   SMOKE_ALIVE_MS     how long the process must stay alive (default: 2500)
+ */
+
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(__dirname, "..");
+const CLI_PATH = path.resolve(
+  process.env.CLI_PATH || path.join(packageDir, "dist", "cli.cjs"),
+);
+const SMOKE_ALIVE_MS = Number(process.env.SMOKE_ALIVE_MS || 2500);
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function log(step, detail) {
+  console.log(`[cli-cloud-mode-smoke] ${step}${detail ? `: ${detail}` : ""}`);
+}
+
+function runOnce(args, envExtra = {}) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, args, {
+      stdio: ["pipe", "pipe", "pipe"],
+      env: {
+        ...process.env,
+        ...envExtra,
+        // Keep telemetry/network noise out of smoke.
+        NODE_ENV: "test",
+        VITEST: "true",
+      },
+    });
+
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk.toString();
+    });
+
+    let settled = false;
+    let killRequested = false;
+    const startedAt = Date.now();
+
+    const finish = (result) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+
+    const timer = setTimeout(() => {
+      killRequested = true;
+      child.kill("SIGTERM");
+      // Fallback if the process ignores SIGTERM.
+      setTimeout(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // ignore
+        }
+        finish({
+          status: "alive",
+          code: null,
+          signal: "SIGTERM",
+          stdout,
+          stderr,
+        });
+      }, 1000);
+    }, SMOKE_ALIVE_MS);
+
+    child.on("error", (error) => {
+      finish({
+        status: "spawn-error",
+        error,
+        stdout,
+        stderr,
+      });
+    });
+
+    child.on("exit", (code, signal) => {
+      const livedMs = Date.now() - startedAt;
+      // Success: we asked it to stop after the alive window, or it outlived the window.
+      if (killRequested || livedMs >= SMOKE_ALIVE_MS - 50) {
+        finish({
+          status: "alive",
+          code,
+          signal,
+          stdout,
+          stderr,
+          livedMs,
+        });
+        return;
+      }
+      finish({
+        status: "exited",
+        code,
+        signal,
+        stdout,
+        stderr,
+        livedMs,
+      });
+    });
+  });
+}
+
+function summarizeStderr(stderr) {
+  const text = stderr || "";
+  const markers = [
+    "TypeError: (0 , r.debug) is not a function",
+    "debug is not a function",
+    "SyntaxError",
+    "Fatal error",
+    "Uncaught",
+  ];
+  const hits = markers.filter((marker) => text.includes(marker));
+  // Prefer the useful tail; the minified dump can be multi-MB.
+  const tail = text.slice(-1200);
+  return { hits, tail, bytes: Buffer.byteLength(text, "utf8") };
+}
+
+async function assertCloudModeBoot(label, args, envExtra = {}) {
+  log("run", `${label} -> ${args.join(" ")}`);
+  const result = await runOnce(args, envExtra);
+  const errSummary = summarizeStderr(result.stderr);
+
+  if (result.status === "spawn-error") {
+    throw new Error(`${label}: failed to spawn: ${result.error?.message}`);
+  }
+
+  if (result.status === "exited") {
+    throw new Error(
+      `${label}: process exited early code=${result.code} signal=${result.signal}; stderrTail=${JSON.stringify(errSummary.tail)}; markers=${errSummary.hits.join("|") || "none"}`,
+    );
+  }
+
+  assert(result.status === "alive", `${label}: unexpected status ${result.status}`);
+  assert(
+    errSummary.hits.length === 0,
+    `${label}: stderr contained crash markers: ${errSummary.hits.join(", ")}`,
+  );
+  log("pass", `${label} stayed alive for ${SMOKE_ALIVE_MS}ms (stderrBytes=${errSummary.bytes})`);
+}
+
+async function main() {
+  assert(existsSync(CLI_PATH), `CLI bundle missing: ${CLI_PATH}. Run npm run build first.`);
+  log("cli", CLI_PATH);
+
+  await assertCloudModeBoot("flag", [CLI_PATH, "--cloud-mode"]);
+  await assertCloudModeBoot("env", [CLI_PATH], {
+    CLOUDBASE_MCP_CLOUD_MODE: "true",
+  });
+
+  // Control: default stdio mode must also stay alive.
+  await assertCloudModeBoot("default", [CLI_PATH]);
+
+  console.log(
+    JSON.stringify(
+      {
+        success: true,
+        cli: CLI_PATH,
+        aliveMs: SMOKE_ALIVE_MS,
+        cases: ["--cloud-mode", "CLOUDBASE_MCP_CLOUD_MODE=true", "default"],
+      },
+      null,
+      2,
+    ),
+  );
+  log("done", "all cases passed");
+}
+
+main().catch((error) => {
+  console.error("[cli-cloud-mode-smoke] FAILED:", error);
+  process.exit(1);
+});

--- a/mcp/scripts/verify-cli-cloud-mode-smoke.mjs
+++ b/mcp/scripts/verify-cli-cloud-mode-smoke.mjs
@@ -3,7 +3,8 @@
  * Smoke: `node dist/cli.cjs --cloud-mode` must stay alive on stdio.
  *
  * Catches the historical cloud-mode ↔ logger circular-dependency crash
- * (misreported as an ajv SyntaxError because Node dumps the minified line).
+ * (misreported as an ajv SyntaxError because Node dumps the minified line
+ * before printing `TypeError: (0 , *.debug) is not a function`).
  *
  * Usage:
  *   node ./scripts/verify-cli-cloud-mode-smoke.mjs
@@ -15,7 +16,15 @@
  */
 
 import { spawn } from "node:child_process";
-import { existsSync } from "node:fs";
+import {
+  closeSync,
+  existsSync,
+  mkdtempSync,
+  openSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -38,8 +47,15 @@ function log(step, detail) {
 
 function runOnce(args, envExtra = {}) {
   return new Promise((resolve) => {
+    // Attach stderr to a real file fd (not a pipe). Node's crash printer can
+    // emit a multi-MB minified line; a pipe silently truncates around 64KB
+    // and hides `TypeError: (0 , *.debug) is not a function` at the end.
+    const workDir = mkdtempSync(path.join(tmpdir(), "cli-cloud-mode-smoke-"));
+    const stderrPath = path.join(workDir, "stderr.txt");
+    const stderrFd = openSync(stderrPath, "w");
+
     const child = spawn(process.execPath, args, {
-      stdio: ["pipe", "pipe", "pipe"],
+      stdio: ["pipe", "ignore", stderrFd],
       env: {
         ...process.env,
         ...envExtra,
@@ -49,24 +65,39 @@ function runOnce(args, envExtra = {}) {
       },
     });
 
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", (chunk) => {
-      stdout += chunk.toString();
-    });
-    child.stderr.on("data", (chunk) => {
-      stderr += chunk.toString();
-    });
+    // Parent no longer needs the fd after spawn inherits it.
+    closeSync(stderrFd);
 
     let settled = false;
     let killRequested = false;
     const startedAt = Date.now();
 
+    const cleanup = () => {
+      try {
+        rmSync(workDir, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+    };
+
+    const readStderr = () => {
+      try {
+        return readFileSync(stderrPath, "utf8");
+      } catch {
+        return "";
+      }
+    };
+
     const finish = (result) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolve(result);
+      // Give the OS a tick to flush the inherited fd writes.
+      setTimeout(() => {
+        const stderr = readStderr();
+        cleanup();
+        resolve({ ...result, stderr });
+      }, 50);
     };
 
     const timer = setTimeout(() => {
@@ -83,8 +114,6 @@ function runOnce(args, envExtra = {}) {
           status: "alive",
           code: null,
           signal: "SIGTERM",
-          stdout,
-          stderr,
         });
       }, 1000);
     }, SMOKE_ALIVE_MS);
@@ -93,8 +122,6 @@ function runOnce(args, envExtra = {}) {
       finish({
         status: "spawn-error",
         error,
-        stdout,
-        stderr,
       });
     });
 
@@ -106,8 +133,6 @@ function runOnce(args, envExtra = {}) {
           status: "alive",
           code,
           signal,
-          stdout,
-          stderr,
           livedMs,
         });
         return;
@@ -116,8 +141,6 @@ function runOnce(args, envExtra = {}) {
         status: "exited",
         code,
         signal,
-        stdout,
-        stderr,
         livedMs,
       });
     });
@@ -126,16 +149,21 @@ function runOnce(args, envExtra = {}) {
 
 function summarizeStderr(stderr) {
   const text = stderr || "";
+  // Specific to the cloud-mode↔logger circular-dep crash shape after webpack.
+  // Avoid bare "SyntaxError"/"TypeError" — those substrings appear inside the
+  // minified dump itself and cause false positives.
   const markers = [
-    "TypeError: (0 , r.debug) is not a function",
+    "TypeError: (0 , ",
+    ".debug) is not a function",
     "debug is not a function",
-    "SyntaxError",
-    "Fatal error",
-    "Uncaught",
   ];
   const hits = markers.filter((marker) => text.includes(marker));
-  // Prefer the useful tail; the minified dump can be multi-MB.
-  const tail = text.slice(-1200);
+  // Prefer the real error line when present; otherwise the useful tail.
+  // Node dumps a multi-MB minified source line before the TypeError.
+  const typeErrorMatch = text.match(/TypeError: \(0 , [^\n]+/);
+  const tail = typeErrorMatch
+    ? typeErrorMatch[0]
+    : text.slice(-1200);
   return { hits, tail, bytes: Buffer.byteLength(text, "utf8") };
 }
 
@@ -150,7 +178,7 @@ async function assertCloudModeBoot(label, args, envExtra = {}) {
 
   if (result.status === "exited") {
     throw new Error(
-      `${label}: process exited early code=${result.code} signal=${result.signal}; stderrTail=${JSON.stringify(errSummary.tail)}; markers=${errSummary.hits.join("|") || "none"}`,
+      `${label}: process exited early code=${result.code} signal=${result.signal}; stderrBytes=${errSummary.bytes}; error=${JSON.stringify(errSummary.tail)}; markers=${errSummary.hits.join("|") || "none"}`,
     );
   }
 

--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -1,0 +1,326 @@
+#!/usr/bin/env node
+/**
+ * Post-publish smoke for @cloudbase/cloudbase-mcp.
+ *
+ * Automates the production regression checklist used for v2.25.7:
+ * 1) download published tarball
+ * 2) verify shasum against npm metadata (and optional EXPECTED_SHASUM)
+ * 3) createCloudBaseMcpServer registers managePermissions / queryPermissions
+ * 4) OPA fallback strings exist in dist
+ * 5) optional live PG queryPermissions smoke when cloud credentials are present
+ *
+ * Usage:
+ *   node ./scripts/verify-npm-tarball-smoke.mjs [version|latest|dist-tag]
+ *
+ * Env:
+ *   PACKAGE_NAME          default @cloudbase/cloudbase-mcp
+ *   PACKAGE_VERSION       version or dist-tag (overrides argv)
+ *   EXPECTED_SHASUM       optional exact sha1 of the tarball
+ *   NPM_REGISTRY          default https://registry.npmjs.org
+ *   SMOKE_WORKDIR         optional work directory (default mkdtemp)
+ *   KEEP_SMOKE_WORKDIR    set to 1 to retain temp workdir
+ *   SKIP_LIVE_SMOKE       set to 1 to skip live cloud probe
+ *   CLOUDBASE_ENV_ID      env for optional live probe
+ *   TENCENTCLOUD_SECRETID / TENCENTCLOUD_SECRETKEY
+ *   SMOKE_PG_FUNCTION_ID  default atoPgPermProbe
+ */
+
+import { createHash } from "node:crypto";
+import {
+  createWriteStream,
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { createRequire } from "node:module";
+import { execFileSync } from "node:child_process";
+import { pipeline } from "node:stream/promises";
+import { Readable } from "node:stream";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageDir = path.resolve(__dirname, "..");
+
+const PACKAGE_NAME = process.env.PACKAGE_NAME || "@cloudbase/cloudbase-mcp";
+const NPM_REGISTRY = (process.env.NPM_REGISTRY || "https://registry.npmjs.org").replace(/\/$/, "");
+const EXPECTED_SHASUM = process.env.EXPECTED_SHASUM || "";
+const SKIP_LIVE_SMOKE = process.env.SKIP_LIVE_SMOKE === "1";
+const SMOKE_PG_FUNCTION_ID = process.env.SMOKE_PG_FUNCTION_ID || "atoPgPermProbe";
+
+const OPA_STRINGS = [
+  "modifyEnvAuthzConfig",
+  "describeEnvAuthzConfig",
+  "authz.user.rego",
+];
+
+const REQUIRED_TOOLS = ["managePermissions", "queryPermissions"];
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+function log(step, detail) {
+  console.log(`[npm-tarball-smoke] ${step}${detail ? `: ${detail}` : ""}`);
+}
+
+function resolveRequestedVersion() {
+  if (process.env.PACKAGE_VERSION) {
+    return process.env.PACKAGE_VERSION;
+  }
+  if (process.argv[2]) {
+    return process.argv[2];
+  }
+  try {
+    const local = JSON.parse(readFileSync(path.join(packageDir, "package.json"), "utf8"));
+    return local.version || "latest";
+  } catch {
+    return "latest";
+  }
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url, {
+    headers: { accept: "application/json" },
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} for ${url}`);
+  }
+  return response.json();
+}
+
+async function resolvePackageMeta(requested) {
+  const encodedName = PACKAGE_NAME.replace("/", "%2F");
+  const metaUrl = `${NPM_REGISTRY}/${encodedName}/${encodeURIComponent(requested)}`;
+  log("resolve", metaUrl);
+
+  let lastError;
+  for (let attempt = 1; attempt <= 8; attempt++) {
+    try {
+      const meta = await fetchJson(metaUrl);
+      assert(meta?.version, `Registry response missing version for ${requested}`);
+      assert(meta?.dist?.tarball, `Registry response missing dist.tarball for ${requested}`);
+      assert(meta?.dist?.shasum, `Registry response missing dist.shasum for ${requested}`);
+      return {
+        version: meta.version,
+        tarball: meta.dist.tarball,
+        shasum: meta.dist.shasum,
+        requested,
+      };
+    } catch (error) {
+      lastError = error;
+      const delayMs = Math.min(15000, 1000 * attempt);
+      log("resolve-retry", `attempt ${attempt}/8 failed (${error.message}); wait ${delayMs}ms`);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+  }
+  throw lastError;
+}
+
+async function downloadToFile(url, destPath) {
+  const response = await fetch(url);
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to download tarball: HTTP ${response.status}`);
+  }
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(destPath));
+}
+
+function sha1File(filePath) {
+  const hash = createHash("sha1");
+  hash.update(readFileSync(filePath));
+  return hash.digest("hex");
+}
+
+function extractTarball(tarballPath, extractRoot) {
+  mkdirSync(extractRoot, { recursive: true });
+  // Use system tar (available on macOS + Ubuntu runners); avoids adding an npm dependency.
+  execFileSync("tar", ["-xzf", tarballPath, "-C", extractRoot], { stdio: "pipe" });
+  const pkgRoot = path.join(extractRoot, "package");
+  assert(existsSync(pkgRoot), `Extracted tarball missing package/ directory at ${extractRoot}`);
+  return pkgRoot;
+}
+
+function assertOpaStrings(pkgRoot) {
+  const distFiles = ["dist/index.cjs", "dist/index.js", "dist/cli.cjs"];
+  const haystacks = [];
+  for (const rel of distFiles) {
+    const abs = path.join(pkgRoot, rel);
+    if (existsSync(abs)) {
+      haystacks.push({ rel, text: readFileSync(abs, "utf8") });
+    }
+  }
+  assert(haystacks.length > 0, `No dist bundles found under ${pkgRoot}`);
+
+  for (const needle of OPA_STRINGS) {
+    const hit = haystacks.some((file) => file.text.includes(needle));
+    assert(hit, `OPA fallback string missing from published dist: ${needle}`);
+    log("opa-string", `found ${needle}`);
+  }
+}
+
+async function assertToolRegistration(pkgRoot) {
+  const entryCjs = path.join(pkgRoot, "dist", "index.cjs");
+  assert(existsSync(entryCjs), `Missing published entry ${entryCjs}`);
+
+  const require = createRequire(path.join(pkgRoot, "package.json"));
+  const mod = require("./dist/index.cjs");
+  assert(
+    typeof mod.createCloudBaseMcpServer === "function",
+    "createCloudBaseMcpServer export missing from published package",
+  );
+
+  const server = await mod.createCloudBaseMcpServer({
+    enableTelemetry: false,
+    cloudBaseOptions: {
+      envId: "smoke-env",
+      secretId: "smoke-secret-id",
+      secretKey: "smoke-secret-key",
+    },
+  });
+
+  assert(Array.isArray(server.toolDefs), "server.toolDefs missing after createCloudBaseMcpServer");
+  const toolNames = server.toolDefs.map((tool) => tool.name);
+  for (const toolName of REQUIRED_TOOLS) {
+    assert(toolNames.includes(toolName), `Missing expected tool registration: ${toolName}`);
+    log("tool", `registered ${toolName}`);
+  }
+
+  log("tools", `total=${toolNames.length}`);
+  return { toolNames };
+}
+
+function parseToolPayload(result) {
+  const text = result?.content?.[0]?.text;
+  assert(typeof text === "string" && text.length > 0, "Tool result did not contain JSON text payload");
+  return JSON.parse(text);
+}
+
+async function runLiveWithFreshServer(pkgRoot) {
+  if (SKIP_LIVE_SMOKE) {
+    log("live-smoke", "skipped (SKIP_LIVE_SMOKE=1)");
+    return { skipped: true, reason: "SKIP_LIVE_SMOKE" };
+  }
+
+  const secretId = process.env.TENCENTCLOUD_SECRETID || process.env.TCB_SECRETID;
+  const secretKey = process.env.TENCENTCLOUD_SECRETKEY || process.env.TCB_SECRETKEY;
+  const envId = process.env.CLOUDBASE_ENV_ID || process.env.TCB_ENV;
+  if (!secretId || !secretKey || !envId) {
+    log("live-smoke", "skipped (missing TENCENTCLOUD_SECRETID/SECRETKEY or CLOUDBASE_ENV_ID)");
+    return { skipped: true, reason: "missing-credentials" };
+  }
+
+  const require = createRequire(path.join(pkgRoot, "package.json"));
+  const { createCloudBaseMcpServer } = require("./dist/index.cjs");
+  const server = await createCloudBaseMcpServer({
+    enableTelemetry: false,
+    cloudBaseOptions: {
+      envId,
+      secretId,
+      secretKey,
+    },
+  });
+
+  const queryTool = server.toolDefs.find((tool) => tool.name === "queryPermissions");
+  assert(queryTool, "queryPermissions tool missing for live smoke");
+
+  const result = await queryTool.handler({
+    action: "getResourcePermission",
+    resourceType: "function",
+    resourceId: SMOKE_PG_FUNCTION_ID,
+  });
+  const payload = parseToolPayload(result);
+
+  assert(payload.success === true, `Live queryPermissions failed: ${payload.message || JSON.stringify(payload)}`);
+  assert(
+    payload.fallback === "describeEnvAuthzConfig" ||
+      String(payload.message || "").includes("describeEnvAuthzConfig"),
+    `Live PG smoke did not exercise OPA fallback; got fallback=${payload.fallback} message=${payload.message}`,
+  );
+
+  log("live-smoke", `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} fallback=${payload.fallback}`);
+  return {
+    skipped: false,
+    envId,
+    functionId: SMOKE_PG_FUNCTION_ID,
+    fallback: payload.fallback,
+  };
+}
+
+async function main() {
+  const requested = resolveRequestedVersion();
+  const workRoot =
+    process.env.SMOKE_WORKDIR ||
+    mkdtempSync(path.join(tmpdir(), "cloudbase-mcp-tarball-smoke-"));
+  mkdirSync(workRoot, { recursive: true });
+
+  const createdTemp = !process.env.SMOKE_WORKDIR;
+  log("workdir", workRoot);
+
+  try {
+    const meta = await resolvePackageMeta(requested);
+    log("version", `${meta.requested} -> ${meta.version}`);
+    log("tarball", meta.tarball);
+    log("registry-shasum", meta.shasum);
+
+    const tarballPath = path.join(workRoot, `${PACKAGE_NAME.replace("/", "-")}-${meta.version}.tgz`);
+    await downloadToFile(meta.tarball, tarballPath);
+    const actualShasum = sha1File(tarballPath);
+    log("actual-shasum", actualShasum);
+
+    assert(
+      actualShasum === meta.shasum,
+      `Tarball shasum mismatch vs registry: expected ${meta.shasum}, got ${actualShasum}`,
+    );
+    if (EXPECTED_SHASUM) {
+      assert(
+        actualShasum === EXPECTED_SHASUM,
+        `Tarball shasum mismatch vs EXPECTED_SHASUM: expected ${EXPECTED_SHASUM}, got ${actualShasum}`,
+      );
+      log("expected-shasum", "matched");
+    }
+
+    const extractRoot = path.join(workRoot, "extract");
+    const pkgRoot = extractTarball(tarballPath, extractRoot);
+
+    const pkgJson = JSON.parse(readFileSync(path.join(pkgRoot, "package.json"), "utf8"));
+    assert(pkgJson.version === meta.version, `package.json version ${pkgJson.version} != ${meta.version}`);
+    log("package.json", `version=${pkgJson.version}`);
+
+    assertOpaStrings(pkgRoot);
+    const { toolNames } = await assertToolRegistration(pkgRoot);
+    const live = await runLiveWithFreshServer(pkgRoot);
+
+    const summary = {
+      success: true,
+      package: PACKAGE_NAME,
+      requested,
+      version: meta.version,
+      shasum: actualShasum,
+      tools: {
+        total: toolNames.length,
+        required: REQUIRED_TOOLS,
+      },
+      opaStrings: OPA_STRINGS,
+      live,
+    };
+    const summaryPath = path.join(workRoot, "smoke-summary.json");
+    writeFileSync(summaryPath, `${JSON.stringify(summary, null, 2)}\n`);
+    console.log(JSON.stringify(summary, null, 2));
+    log("done", summaryPath);
+  } finally {
+    if (createdTemp && process.env.KEEP_SMOKE_WORKDIR !== "1") {
+      rmSync(workRoot, { recursive: true, force: true });
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error("[npm-tarball-smoke] FAILED:", error);
+  process.exit(1);
+});

--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -7,7 +7,8 @@
  * 2) verify shasum against npm metadata (and optional EXPECTED_SHASUM)
  * 3) createCloudBaseMcpServer registers managePermissions / queryPermissions
  * 4) OPA fallback strings exist in dist
- * 5) optional live PG queryPermissions smoke when cloud credentials are present
+ * 5) dist/cli.cjs --cloud-mode stays alive (circular-dep / boot smoke)
+ * 6) optional live PG queryPermissions smoke when cloud credentials are present
  *
  * Usage:
  *   node ./scripts/verify-npm-tarball-smoke.mjs [version|latest|dist-tag]
@@ -195,6 +196,25 @@ async function assertToolRegistration(pkgRoot) {
   return { toolNames };
 }
 
+async function assertCliCloudMode(pkgRoot) {
+  const cliPath = path.join(pkgRoot, "dist", "cli.cjs");
+  assert(existsSync(cliPath), `Missing published CLI ${cliPath}`);
+
+  const smokeScript = path.join(packageDir, "scripts", "verify-cli-cloud-mode-smoke.mjs");
+  assert(existsSync(smokeScript), `Missing local smoke script ${smokeScript}`);
+
+  execFileSync(process.execPath, [smokeScript], {
+    stdio: "inherit",
+    env: {
+      ...process.env,
+      CLI_PATH: cliPath,
+      NODE_ENV: "test",
+      VITEST: "true",
+    },
+  });
+  log("cli-cloud-mode", "passed");
+}
+
 function parseToolPayload(result) {
   const text = result?.content?.[0]?.text;
   assert(typeof text === "string" && text.length > 0, "Tool result did not contain JSON text payload");
@@ -294,6 +314,7 @@ async function main() {
 
     assertOpaStrings(pkgRoot);
     const { toolNames } = await assertToolRegistration(pkgRoot);
+    await assertCliCloudMode(pkgRoot);
     const live = await runLiveWithFreshServer(pkgRoot);
 
     const summary = {
@@ -307,6 +328,7 @@ async function main() {
         required: REQUIRED_TOOLS,
       },
       opaStrings: OPA_STRINGS,
+      cliCloudMode: true,
       live,
     };
     const summaryPath = path.join(workRoot, "smoke-summary.json");

--- a/mcp/src/utils/cloud-mode.test.ts
+++ b/mcp/src/utils/cloud-mode.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  enableCloudMode,
+  getCloudModeStatus,
+  isCloudMode,
+  shouldRegisterTool,
+} from "./cloud-mode.js";
+
+const ORIGINAL_ARGV = [...process.argv];
+const ENV_KEYS = ["CLOUDBASE_MCP_CLOUD_MODE", "MCP_CLOUD_MODE"] as const;
+
+function clearCloudModeSignals() {
+  process.argv = ORIGINAL_ARGV.filter((arg) => arg !== "--cloud-mode");
+  for (const key of ENV_KEYS) {
+    delete process.env[key];
+  }
+}
+
+afterEach(() => {
+  clearCloudModeSignals();
+});
+
+describe("cloud-mode", () => {
+  it("detects --cloud-mode without importing logger (no throw)", () => {
+    clearCloudModeSignals();
+    process.argv = [...process.argv, "--cloud-mode"];
+    expect(isCloudMode()).toBe(true);
+    expect(getCloudModeStatus()).toEqual({ enabled: true, source: "CLI_ARG" });
+  });
+
+  it("detects CLOUDBASE_MCP_CLOUD_MODE env", () => {
+    clearCloudModeSignals();
+    process.env.CLOUDBASE_MCP_CLOUD_MODE = "true";
+    expect(isCloudMode()).toBe(true);
+    expect(getCloudModeStatus().source).toBe("CLOUDBASE_MCP_CLOUD_MODE");
+  });
+
+  it("enableCloudMode sets env flag", () => {
+    clearCloudModeSignals();
+    expect(isCloudMode()).toBe(false);
+    enableCloudMode();
+    expect(isCloudMode()).toBe(true);
+  });
+
+  it("skips local-file tools in cloud mode", () => {
+    clearCloudModeSignals();
+    process.env.CLOUDBASE_MCP_CLOUD_MODE = "true";
+    expect(shouldRegisterTool("envQuery")).toBe(true);
+    expect(shouldRegisterTool("createFunction")).toBe(false);
+    expect(shouldRegisterTool("downloadTemplate")).toBe(false);
+  });
+});

--- a/mcp/src/utils/cloud-mode.ts
+++ b/mcp/src/utils/cloud-mode.ts
@@ -1,30 +1,23 @@
-import { debug } from './logger.js';
-
 /**
  * Check if MCP is running in cloud mode
  * Cloud mode is enabled by:
  * 1. Command line argument --cloud-mode
  * 2. Environment variable CLOUDBASE_MCP_CLOUD_MODE=true
  * 3. Environment variable MCP_CLOUD_MODE=true
+ *
+ * Intentionally does not import logger: logger.ts calls isCloudMode() during
+ * module init, so importing logger here creates a circular dependency that
+ * crashes `node dist/cli.cjs --cloud-mode` with `debug is not a function`.
  */
 export function isCloudMode(): boolean {
   // Check for CLI argument first
   const hasCloudModeArg = process.argv.includes('--cloud-mode');
-  
+
   // Check environment variables
-  const cloudModeEnabled = process.env.CLOUDBASE_MCP_CLOUD_MODE === 'true' || 
+  const cloudModeEnabled = process.env.CLOUDBASE_MCP_CLOUD_MODE === 'true' ||
                           process.env.MCP_CLOUD_MODE === 'true';
-  
-  const isEnabled = hasCloudModeArg || cloudModeEnabled;
-  
-  if (isEnabled) {
-    debug('Cloud mode is enabled', { 
-      source: hasCloudModeArg ? 'CLI_ARG' : 'ENV_VAR',
-      envVar: process.env.CLOUDBASE_MCP_CLOUD_MODE || process.env.MCP_CLOUD_MODE 
-    });
-  }
-  
-  return isEnabled;
+
+  return hasCloudModeArg || cloudModeEnabled;
 }
 
 /**
@@ -32,21 +25,20 @@ export function isCloudMode(): boolean {
  */
 export function enableCloudMode(): void {
   process.env.CLOUDBASE_MCP_CLOUD_MODE = 'true';
-  debug('Cloud mode enabled via API call');
 }
 
 /**
  * Get cloud mode status for logging/debugging
  */
-export function getCloudModeStatus(): { 
-  enabled: boolean; 
+export function getCloudModeStatus(): {
+  enabled: boolean;
   source: string | null;
 } {
   // Check CLI argument first
   if (process.argv.includes('--cloud-mode')) {
     return { enabled: true, source: 'CLI_ARG' };
   }
-  
+
   if (process.env.CLOUDBASE_MCP_CLOUD_MODE === 'true') {
     return { enabled: true, source: 'CLOUDBASE_MCP_CLOUD_MODE' };
   }
@@ -95,12 +87,5 @@ export function shouldRegisterTool(toolName: string): boolean {
     'manageStorage',
   ];
 
-  const shouldRegister = !cloudIncompatibleTools.includes(toolName);
-  
-  if (!shouldRegister) {
-    debug(`Cloud mode: skipping registration of incompatible tool: ${toolName}`);
-  }
-  
-  return shouldRegister;
+  return !cloudIncompatibleTools.includes(toolName);
 }
-


### PR DESCRIPTION
## Summary
- Fix `dist/cli.cjs --cloud-mode` crash on 2.25.6/2.25.7 caused by a circular dependency between `cloud-mode.ts` and `logger.ts` (`debug is not a function`; previously misread as an ajv SyntaxError).
- Add `npm run test:cli:cloud-mode` and wire it into nightly build, npm publish, and npm tarball smoke.
- Includes the post-publish npm tarball smoke from #878 (supersedes that PR) and extends it with a cloud-mode boot assertion.

## Test plan
- [x] `npm run build:webpack` succeeds
- [x] `npm run test:cli:cloud-mode` passes (flag / env / default)
- [x] `vitest run src/utils/cloud-mode.test.ts` 4/4
- [ ] CI green on this PR
- [ ] After merge: publish `2.25.8` and confirm npm latest `--cloud-mode` stays alive


Made with [Cursor](https://cursor.com)