### PR TITLE
fix(ci): treat live PG smoke success without OPA fallback as PASS

### DIFF
--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -258,35 +258,32 @@ async function runLiveWithFreshServer(pkgRoot) {
 
   assert(payload.success === true, `Live queryPermissions failed: ${payload.message || JSON.stringify(payload)}`);
 
-  // Prefer observing the PG OPA fallback path when the platform routes there,
-  // but accept a successful primary-path response too (env may no longer need fallback).
+  // OPA fallback is optional: some PG envs still route through describeEnvAuthzConfig,
+  // but a healthy primary-path success must not fail the release smoke.
+  // Tool envelopes nest fallback under data (see permissions.ts buildEnvelope).
+  const fallbackValue = payload.data?.fallback ?? payload.fallback;
   const usedOpaFallback =
-    payload.fallback === "describeEnvAuthzConfig" ||
+    fallbackValue === "describeEnvAuthzConfig" ||
     String(payload.message || "").includes("describeEnvAuthzConfig");
-  const primarySuccess =
-    !payload.fallback &&
-    (String(payload.message || "").includes("成功") ||
-      payload.data != null ||
-      payload.result != null ||
-      Array.isArray(payload.policies) ||
-      typeof payload.policy === "string" ||
-      typeof payload.content === "string");
+  const path = usedOpaFallback ? "opa-fallback" : "primary";
 
-  assert(
-    usedOpaFallback || primarySuccess,
-    `Live PG smoke expected OPA fallback or a successful primary permission payload; got fallback=${payload.fallback} message=${payload.message}`,
-  );
+  if (!usedOpaFallback) {
+    log(
+      "live-smoke",
+      `WARN primary path succeeded without OPA fallback (acceptable); message=${payload.message}`,
+    );
+  }
 
   log(
     "live-smoke",
-    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${usedOpaFallback ? "opa-fallback" : "primary"} fallback=${payload.fallback || "none"}`,
+    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${path} fallback=${fallbackValue || "none"}`,
   );
   return {
     skipped: false,
     envId,
     functionId: SMOKE_PG_FUNCTION_ID,
-    fallback: payload.fallback || null,
-    path: usedOpaFallback ? "opa-fallback" : "primary",
+    fallback: fallbackValue || null,
+    path,
   };
 }
 


### PR DESCRIPTION
## Summary
- Post-publish live PG smoke already accepted primary-path success via #880; this follow-up simplifies the assert so `success===true` is enough to PASS.
- When OPA fallback is not exercised, log a WARN instead of failing, and read `data.fallback` (tool envelope nesting) for accurate path reporting.
- Both `npm-publish` post-publish-smoke and scheduled `npm-tarball-smoke.yaml` share `mcp/scripts/verify-npm-tarball-smoke.mjs`.

## Test plan
- [x] Local syntax check + assertion logic for primary (`message=资源权限查询成功`) and OPA fallback envelopes
- [ ] CI green on this PR
- [ ] Optional: re-run `npm-tarball-smoke` workflow against `2.25.8` / `latest`


Made with [Cursor](https://cursor.com)