### PR TITLE
fix(ci): rename live-smoke path binding to avoid TDZ

### DIFF
--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -265,7 +265,9 @@ async function runLiveWithFreshServer(pkgRoot) {
   const usedOpaFallback =
     fallbackValue === "describeEnvAuthzConfig" ||
     String(payload.message || "").includes("describeEnvAuthzConfig");
-  const path = usedOpaFallback ? "opa-fallback" : "primary";
+  // Do not name this `path` — it shadows the node:path import and triggers TDZ
+  // on earlier path.join() calls in this function (live smoke ReferenceError).
+  const routePath = usedOpaFallback ? "opa-fallback" : "primary";
 
   if (!usedOpaFallback) {
     log(
@@ -276,14 +278,14 @@ async function runLiveWithFreshServer(pkgRoot) {
 
   log(
     "live-smoke",
-    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${path} fallback=${fallbackValue || "none"}`,
+    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${routePath} fallback=${fallbackValue || "none"}`,
   );
   return {
     skipped: false,
     envId,
     functionId: SMOKE_PG_FUNCTION_ID,
     fallback: fallbackValue || null,
-    path,
+    path: routePath,
   };
 }
 


### PR DESCRIPTION
## Summary
- After merging #881, live `npm-tarball-smoke` against `2.25.8` failed with `ReferenceError: Cannot access 'path' before initialization`.
- Cause: `const path = ...` in `runLiveWithFreshServer` shadowed the `node:path` import (TDZ), so `path.join` crashed before the PG probe.
- Rename the local binding to `routePath` so live primary-path PASS+WARN can run.

## Test plan
- [x] `node --check mcp/scripts/verify-npm-tarball-smoke.mjs`
- [ ] Re-dispatch `npm-tarball-smoke.yaml` with `version=2.25.8` and live credentials after merge


Made with [Cursor](https://cursor.com)