### PR TITLE
test(ci): add npm tarball live-smoke path-shadow / primary WARN regression

### DIFF
--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -44,7 +44,8 @@ import { execFileSync } from "node:child_process";
 import { pipeline } from "node:stream/promises";
 import { Readable } from "node:stream";
 
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 const packageDir = path.resolve(__dirname, "..");
 
 const PACKAGE_NAME = process.env.PACKAGE_NAME || "@cloudbase/cloudbase-mcp";
@@ -221,6 +222,43 @@ function parseToolPayload(result) {
   return JSON.parse(text);
 }
 
+/**
+ * Evaluate a live queryPermissions tool envelope for post-publish smoke.
+ *
+ * Pure / sync so PR CI and local vitest can cover primary-path WARN and OPA
+ * fallback PASS without cloud credentials.
+ *
+ * IMPORTANT: Do not bind the route label to a local named `path` inside
+ * runLiveWithFreshServer — that shadows the node:path import and triggers TDZ
+ * on earlier path.join() calls (ReferenceError in live smoke only).
+ *
+ * @param {object} payload Parsed tool JSON payload
+ * @returns {{ routePath: "primary" | "opa-fallback", fallback: string | null, usedOpaFallback: boolean, warnPrimaryWithoutOpa: boolean, message: string }}
+ */
+export function evaluateLiveQueryPermissionsPayload(payload) {
+  assert(
+    payload?.success === true,
+    `Live queryPermissions failed: ${payload?.message || JSON.stringify(payload)}`,
+  );
+
+  // OPA fallback is optional: some PG envs still route through describeEnvAuthzConfig,
+  // but a healthy primary-path success must not fail the release smoke.
+  // Tool envelopes nest fallback under data (see permissions.ts buildEnvelope).
+  const fallbackValue = payload.data?.fallback ?? payload.fallback;
+  const usedOpaFallback =
+    fallbackValue === "describeEnvAuthzConfig" ||
+    String(payload.message || "").includes("describeEnvAuthzConfig");
+  const routePath = usedOpaFallback ? "opa-fallback" : "primary";
+
+  return {
+    routePath,
+    fallback: fallbackValue || null,
+    usedOpaFallback,
+    warnPrimaryWithoutOpa: !usedOpaFallback,
+    message: String(payload.message || ""),
+  };
+}
+
 async function runLiveWithFreshServer(pkgRoot) {
   if (SKIP_LIVE_SMOKE) {
     log("live-smoke", "skipped (SKIP_LIVE_SMOKE=1)");
@@ -255,36 +293,27 @@ async function runLiveWithFreshServer(pkgRoot) {
     resourceId: SMOKE_PG_FUNCTION_ID,
   });
   const payload = parseToolPayload(result);
-
-  assert(payload.success === true, `Live queryPermissions failed: ${payload.message || JSON.stringify(payload)}`);
-
-  // OPA fallback is optional: some PG envs still route through describeEnvAuthzConfig,
-  // but a healthy primary-path success must not fail the release smoke.
-  // Tool envelopes nest fallback under data (see permissions.ts buildEnvelope).
-  const fallbackValue = payload.data?.fallback ?? payload.fallback;
-  const usedOpaFallback =
-    fallbackValue === "describeEnvAuthzConfig" ||
-    String(payload.message || "").includes("describeEnvAuthzConfig");
+  const evaluated = evaluateLiveQueryPermissionsPayload(payload);
   // Do not name this `path` — it shadows the node:path import and triggers TDZ
   // on earlier path.join() calls in this function (live smoke ReferenceError).
-  const routePath = usedOpaFallback ? "opa-fallback" : "primary";
+  const routePath = evaluated.routePath;
 
-  if (!usedOpaFallback) {
+  if (evaluated.warnPrimaryWithoutOpa) {
     log(
       "live-smoke",
-      `WARN primary path succeeded without OPA fallback (acceptable); message=${payload.message}`,
+      `WARN primary path succeeded without OPA fallback (acceptable); message=${evaluated.message}`,
     );
   }
 
   log(
     "live-smoke",
-    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${routePath} fallback=${fallbackValue || "none"}`,
+    `PASS env=${envId} function=${SMOKE_PG_FUNCTION_ID} path=${routePath} fallback=${evaluated.fallback || "none"}`,
   );
   return {
     skipped: false,
     envId,
     functionId: SMOKE_PG_FUNCTION_ID,
-    fallback: fallbackValue || null,
+    fallback: evaluated.fallback,
     path: routePath,
   };
 }
@@ -359,7 +388,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error("[npm-tarball-smoke] FAILED:", error);
-  process.exit(1);
-});
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch((error) => {
+    console.error("[npm-tarball-smoke] FAILED:", error);
+    process.exit(1);
+  });
+}

--- a/tests/verify-npm-tarball-smoke.test.js
+++ b/tests/verify-npm-tarball-smoke.test.js
@@ -1,0 +1,109 @@
+/**
+ * Unit regression for mcp/scripts/verify-npm-tarball-smoke.mjs live assertion.
+ *
+ * Covers:
+ * 1) primary-path success → PASS + WARN (no OPA fallback required)
+ * 2) OPA fallback envelopes (nested data.fallback / message / top-level fallback)
+ * 3) static guard: runLiveWithFreshServer must not bind a local `path` that
+ *    shadows node:path (TDZ ReferenceError only visible in live smoke)
+ *
+ * Run:
+ *   npx vitest run tests/verify-npm-tarball-smoke.test.js
+ */
+
+import { describe, expect, test } from "vitest";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { evaluateLiveQueryPermissionsPayload } from "../mcp/scripts/verify-npm-tarball-smoke.mjs";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const SMOKE_SCRIPT = path.join(ROOT, "mcp/scripts/verify-npm-tarball-smoke.mjs");
+
+describe("evaluateLiveQueryPermissionsPayload", () => {
+  test("primary path success PASSes with WARN flag (no OPA fallback)", () => {
+    const evaluated = evaluateLiveQueryPermissionsPayload({
+      success: true,
+      message: "资源权限查询成功",
+      data: {
+        resourceType: "function",
+        resourceId: "atoPgPermProbe",
+      },
+    });
+
+    expect(evaluated.routePath).toBe("primary");
+    expect(evaluated.usedOpaFallback).toBe(false);
+    expect(evaluated.warnPrimaryWithoutOpa).toBe(true);
+    expect(evaluated.fallback).toBeNull();
+    expect(evaluated.message).toBe("资源权限查询成功");
+  });
+
+  test("nested data.fallback describeEnvAuthzConfig is opa-fallback without WARN", () => {
+    const evaluated = evaluateLiveQueryPermissionsPayload({
+      success: true,
+      message: "资源权限查询成功（OPA fallback）",
+      data: {
+        fallback: "describeEnvAuthzConfig",
+      },
+    });
+
+    expect(evaluated.routePath).toBe("opa-fallback");
+    expect(evaluated.usedOpaFallback).toBe(true);
+    expect(evaluated.warnPrimaryWithoutOpa).toBe(false);
+    expect(evaluated.fallback).toBe("describeEnvAuthzConfig");
+  });
+
+  test("top-level fallback field is also accepted", () => {
+    const evaluated = evaluateLiveQueryPermissionsPayload({
+      success: true,
+      message: "ok",
+      fallback: "describeEnvAuthzConfig",
+    });
+
+    expect(evaluated.routePath).toBe("opa-fallback");
+    expect(evaluated.fallback).toBe("describeEnvAuthzConfig");
+    expect(evaluated.warnPrimaryWithoutOpa).toBe(false);
+  });
+
+  test("message mentioning describeEnvAuthzConfig counts as OPA fallback", () => {
+    const evaluated = evaluateLiveQueryPermissionsPayload({
+      success: true,
+      message: "fell back to describeEnvAuthzConfig",
+      data: {},
+    });
+
+    expect(evaluated.routePath).toBe("opa-fallback");
+    expect(evaluated.warnPrimaryWithoutOpa).toBe(false);
+  });
+
+  test("failed payload throws (hard fail)", () => {
+    expect(() =>
+      evaluateLiveQueryPermissionsPayload({
+        success: false,
+        message: "权限查询失败",
+      }),
+    ).toThrow(/Live queryPermissions failed/);
+  });
+});
+
+describe("runLiveWithFreshServer path-shadowing guard", () => {
+  test("does not declare local const/let path that would TDZ-shadow node:path", () => {
+    const source = readFileSync(SMOKE_SCRIPT, "utf8");
+    const fnMatch = source.match(
+      /async function runLiveWithFreshServer\([\s\S]*?\n\}\n\nasync function main/,
+    );
+    expect(fnMatch, "runLiveWithFreshServer function body not found").toBeTruthy();
+
+    const body = fnMatch[0];
+    expect(body).toMatch(/\bconst routePath\b/);
+    expect(body).not.toMatch(/\b(?:const|let)\s+path\s*=/);
+    // Keep using the module-level node:path import inside the live helper.
+    expect(body).toMatch(/\bpath\.join\(/);
+  });
+
+  test("documents why the binding must not be named path", () => {
+    const source = readFileSync(SMOKE_SCRIPT, "utf8");
+    expect(source).toMatch(/Do not name this `path`/);
+    expect(source).toMatch(/shadows the node:path import/);
+  });
+});


### PR DESCRIPTION
## Summary
- Extract `evaluateLiveQueryPermissionsPayload` from `verify-npm-tarball-smoke.mjs` so primary-path WARN and OPA fallback PASS can be unit-tested with mock payloads (no live credentials).
- Add static guard that `runLiveWithFreshServer` must not bind a local `path` that TDZ-shadows `node:path` (the live-only failure class after #881).
- Includes the prior `routePath` rename fix on this branch.

## Test plan
- [x] `npx vitest run tests/verify-npm-tarball-smoke.test.js` (7 tests)
- [ ] PR CI green
- [ ] Optional: dispatch `npm-tarball-smoke.yaml` against `2.25.8` / `latest` with live credentials


Made with [Cursor](https://cursor.com)