### PR TITLE
chore(ci): ⬆️ bump clawhub CLI pin to 0.23.3 after upload-ticket fix

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -80,10 +80,10 @@ jobs:
 
       - name: Install ClawHub CLI
         if: ${{ !inputs.dry_run }}
-        # Pin to 0.23.1: clawhub@0.23.3 (2026-08-04) stages uploads via Convex
-        # and fails every publish with "Uploaded file does not match its skill upload ticket".
-        # Last known-good publish on this repo used 0.23.1 (v2.25.5, 2026-08-03).
-        run: npm install -g clawhub@0.23.1
+        # Exact version pin for supply-chain reproducibility (do not use bare @latest).
+        # 0.23.3 upload-ticket regression was fixed server-side in openclaw/clawhub#3395
+        # and verified with a real publish after production backend deploy (2026-08-05).
+        run: npm install -g clawhub@0.23.3
 
       - name: Login to ClawHub
         if: ${{ !inputs.dry_run }}


### PR DESCRIPTION
## Summary
- Upstream `openclaw/clawhub#3394` is closed; `#3395` fixed the Convex upload-ticket digest mismatch **server-side** (no CLI contract change).
- Production backend deploy succeeded after the fix; local real publish with `clawhub@0.23.3` to `ui-design-guide@1.18.26` succeeded.
- Bump CI pin `0.23.1` → `0.23.3` and remove the regression downgrade comments; keep exact version pin (not bare `@latest`) for supply-chain reproducibility.

## Test plan
- [x] Confirmed `#3394` CLOSED via `#3395`
- [x] Confirmed production `deploy.yml` backend success after merge
- [x] Real publish with `clawhub@0.23.3` succeeded (`ui-design-guide@1.18.26`)
- [ ] CI on this PR green
- [ ] Optional: workflow_dispatch publish after merge to confirm CI path


Made with [Cursor](https://cursor.com)