### PR TITLE
docs(marketplace): mark Trae community MCP and skills listed

### DIFF
--- a/specs/plugin-marketplace-listing/followup-research.md
+++ b/specs/plugin-marketplace-listing/followup-research.md
@@ -53,8 +53,8 @@ They accept `.claude-plugin/plugin.json` for Claude-ecosystem plugins; our repo 
 
 | Market | Finding | Next action |
 |--------|---------|-------------|
-| Trae MCP | Community list: [trae-community/trae-mcp](https://github.com/trae-community/trae-mcp) — PRs add rows to README MCP table. Official IDE also has in-app MCP marketplace (publisher onboarding unclear). | Open PR to `trae-mcp` listing `@cloudbase/cloudbase-mcp` / docs; separately ask Trae for curated marketplace inclusion. |
-| Trae Skills | Separate from MCP (`README-skills.md` / Trae skills docs). | Confirm whether CloudBase skills map to Trae Agent Skills format; may need a thin adapter + second PR. |
+| Trae MCP | Community list merged: [trae-community/trae-mcp#4](https://github.com/trae-community/trae-mcp/pull/4). Official IDE in-app MCP marketplace still partner-only. | Watch [trae-mcp#5](https://github.com/trae-community/trae-mcp/issues/5); human posts forum draft from `trae-official-outreach-packet.md`. |
+| Trae Skills | Community skills merged: [trae-community/trae-skills#20](https://github.com/trae-community/trae-skills/pull/20). Forum confirms personal upload ≠ global market publish. | Watch [trae-skills#21](https://github.com/trae-community/trae-skills/issues/21); package zip/`.skill` if Trae requests. |
 | Qoder / QoderWork | No public third-party plugin submit docs found in this pass. | Keep `needs_partner_outreach`; monitor Qoder docs / BD. |
 | CodeBuddy | CloudBase already deep-integrated; may already be listed/native. | Confirm with CodeBuddy PM whether catalog entry is needed vs built-in. |
 | Kimi Code | No clear public third-party listing path. | Outreach / watch docs. |

--- a/specs/plugin-marketplace-listing/markets.yaml
+++ b/specs/plugin-marketplace-listing/markets.yaml
@@ -511,7 +511,7 @@ markets:
     channel_type: mcp_registry_or_aggregator
     listing_statuses:
       official_curated: unknown
-      community_directory: unknown
+      community_directory: listed
       self_marketplace: not_applicable
       native_connector_or_builtin: not_applicable
       open_plugin_spec: not_applicable
@@ -519,7 +519,7 @@ markets:
       docs_only: listed
     submit_url_or_process: |
       Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.
-      Status 2026-07-28: Community list PR opened https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).
+      Status 2026-08-05: Community list PR merged https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).
     eligibility: partner_outreach_required
     blockers:
       - No public developer submit form for Trae official MCP marketplace
@@ -527,19 +527,20 @@ markets:
       - https://docs.trae.cn/work_remote-mcp-server
       - https://docs.trae.cn/ide_model-context-protocol
       - https://github.com/trae-community/trae-mcp/pull/4
+      - https://github.com/trae-community/trae-mcp/blob/main/README.md
       - doc/ide-setup/trae.mdx
     local_evidence:
       - trae_mcp_deeplink_docs
     submit_checklist:
       - Partner outreach for official MCP marketplace inclusion
-      - Provide stdio npx config for CloudBase MCP
-      - Community README PR to trae-community/trae-mcp
     recommended_install_path: doc/ide-setup/trae.mdx
     priority_hint: needs_partner_outreach
-    last_reviewed_at: "2026-07-28"
+    last_reviewed_at: "2026-08-05"
     owner: cloudbase-ai-toolkit
     notes: |
-      2026-07-28: Community MCP list PR #4 opened. Official in-app marketplace still partner-only.
+      2026-07-28: Community MCP list PR #4 opened.
+      2026-08-05: PR #4 merged (YeatsLiao approved). Catalog row live in trae-community/trae-mcp README.
+      Official in-app MCP marketplace still partner-only.
 
   - id: trae-work-skills-marketplace
     product: Trae Work
@@ -547,27 +548,37 @@ markets:
     channel_type: skill_registry
     listing_statuses:
       official_curated: unknown
-      community_directory: unknown
+      community_directory: listed
       self_marketplace: not_applicable
       native_connector_or_builtin: not_applicable
       open_plugin_spec: not_applicable
-      mcp_or_skill_registry: unknown
-      docs_only: unknown
+      mcp_or_skill_registry: listed
+      docs_only: listed
     submit_url_or_process: |
-      Users can upload local SKILL.md zip/.skill or install from Trae Work skills marketplace. Public publisher onboarding unclear.
+      Community catalog: trae-community/trae-skills (merged PR #20).
+      Users can also upload local SKILL.md zip/.skill or install from Trae Work skills marketplace.
+      Official Trae Work publisher onboarding still unclear / partner outreach.
+      Status 2026-08-05: Community skills PR merged https://github.com/trae-community/trae-skills/pull/20
     eligibility: partner_outreach_required
     blockers:
-      - Public skill publishing path not documented
+      - Official Trae Work in-app skill market publisher path not documented
     evidence_links:
       - https://docs.trae.cn/solo_skills
+      - https://github.com/trae-community/trae-skills/pull/20
+      - https://github.com/trae-community/trae-skills/blob/main/README.md
+      - https://github.com/trae-community/trae-skills/blob/main/skills/cloudbase/SKILL.md
     local_evidence: []
     submit_checklist:
-      - Confirm Trae Work skill market publisher process
-      - Package SKILL.md zip if allowed
-    recommended_install_path: null
+      - Confirm Trae Work official skill market publisher process
+      - Package SKILL.md zip if official market requires it
+    recommended_install_path: doc/ide-setup/trae.mdx
     priority_hint: needs_partner_outreach
-    last_reviewed_at: "2026-07-27"
+    last_reviewed_at: "2026-08-05"
     owner: cloudbase-ai-toolkit
+    notes: |
+      2026-07-28: Community skills PR #20 opened.
+      2026-08-05: PR #20 merged (YeatsLiao approved). Catalog row `cloudbase` live in trae-community/trae-skills README.
+      Official Trae Work in-app skills marketplace still partner-only.
 
   - id: trae-ide-extension
     product: Trae IDE

--- a/specs/plugin-marketplace-listing/markets.yaml
+++ b/specs/plugin-marketplace-listing/markets.yaml
@@ -520,19 +520,26 @@ markets:
     submit_url_or_process: |
       Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.
       Status 2026-08-05: Community list PR merged https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).
+      Outreach 2026-08-05: Asked community maintainers for official in-app curation path — https://github.com/trae-community/trae-mcp/issues/5
+      Packet: specs/plugin-marketplace-listing/trae-official-outreach-packet.md
     eligibility: partner_outreach_required
     blockers:
       - No public developer submit form for Trae official MCP marketplace
+      - Awaiting Trae product / community reply on curation sync + partner contact
     evidence_links:
       - https://docs.trae.cn/work_remote-mcp-server
       - https://docs.trae.cn/ide_model-context-protocol
       - https://github.com/trae-community/trae-mcp/pull/4
+      - https://github.com/trae-community/trae-mcp/issues/5
       - https://github.com/trae-community/trae-mcp/blob/main/README.md
       - doc/ide-setup/trae.mdx
+      - specs/plugin-marketplace-listing/trae-official-outreach-packet.md
     local_evidence:
       - trae_mcp_deeplink_docs
     submit_checklist:
       - Partner outreach for official MCP marketplace inclusion
+      - Await reply on trae-community/trae-mcp#5
+      - Human: post forum draft from outreach packet (社区伙伴 / 产品建议)
     recommended_install_path: doc/ide-setup/trae.mdx
     priority_hint: needs_partner_outreach
     last_reviewed_at: "2026-08-05"
@@ -540,7 +547,7 @@ markets:
     notes: |
       2026-07-28: Community MCP list PR #4 opened.
       2026-08-05: PR #4 merged (YeatsLiao approved). Catalog row live in trae-community/trae-mcp README.
-      Official in-app MCP marketplace still partner-only.
+      2026-08-05: Official in-app outreach started (GitHub issue #5 + packet). Still partner-only; do not mark official_curated listed.
 
   - id: trae-work-skills-marketplace
     product: Trae Work
@@ -559,18 +566,27 @@ markets:
       Users can also upload local SKILL.md zip/.skill or install from Trae Work skills marketplace.
       Official Trae Work publisher onboarding still unclear / partner outreach.
       Status 2026-08-05: Community skills PR merged https://github.com/trae-community/trae-skills/pull/20
+      Outreach 2026-08-05: Asked community maintainers for official skills market path — https://github.com/trae-community/trae-skills/issues/21
+      Forum signal (custom skills not globally shareable via upload): https://forum.trae.cn/t/topic/171994
+      Packet: specs/plugin-marketplace-listing/trae-official-outreach-packet.md
     eligibility: partner_outreach_required
     blockers:
       - Official Trae Work in-app skill market publisher path not documented
+      - Awaiting Trae product / community reply on curation sync + partner contact
     evidence_links:
       - https://docs.trae.cn/solo_skills
       - https://github.com/trae-community/trae-skills/pull/20
+      - https://github.com/trae-community/trae-skills/issues/21
       - https://github.com/trae-community/trae-skills/blob/main/README.md
       - https://github.com/trae-community/trae-skills/blob/main/skills/cloudbase/SKILL.md
+      - https://forum.trae.cn/t/topic/171994
+      - specs/plugin-marketplace-listing/trae-official-outreach-packet.md
     local_evidence: []
     submit_checklist:
       - Confirm Trae Work official skill market publisher process
+      - Await reply on trae-community/trae-skills#21
       - Package SKILL.md zip if official market requires it
+      - Human: post forum draft from outreach packet (TraeWork 专区 / 社区伙伴)
     recommended_install_path: doc/ide-setup/trae.mdx
     priority_hint: needs_partner_outreach
     last_reviewed_at: "2026-08-05"
@@ -578,7 +594,7 @@ markets:
     notes: |
       2026-07-28: Community skills PR #20 opened.
       2026-08-05: PR #20 merged (YeatsLiao approved). Catalog row `cloudbase` live in trae-community/trae-skills README.
-      Official Trae Work in-app skills marketplace still partner-only.
+      2026-08-05: Official in-app skills market outreach started (issue #21 + packet). Still partner-only; do not mark official_curated listed.
 
   - id: trae-ide-extension
     product: Trae IDE

--- a/specs/plugin-marketplace-listing/reports/latest.json
+++ b/specs/plugin-marketplace-listing/reports/latest.json
@@ -1,12 +1,12 @@
 {
-  "generated_at": "2026-07-28T03:32:40.305Z",
+  "generated_at": "2026-08-05T07:36:57.965Z",
   "matrix_version": 1,
   "reviewed_stale_days": 90,
   "total_markets": 42,
   "summary": {
     "ready_to_submit": 6,
-    "needs_packaging_or_manifest": 0,
-    "needs_partner_outreach": 13,
+    "needs_packaging_or_manifest": 1,
+    "needs_partner_outreach": 12,
     "listed": 7,
     "not_applicable": 15,
     "unknown": 1
@@ -189,11 +189,12 @@
         "eligibility": "public_github_repo_required",
         "blockers": [],
         "evidence_links": [
+          "https://cursor.directory/plugins/cloudbase",
           "https://cursor.directory",
           "https://cursor.directory/plugins/new",
           "https://cursor.com/docs/plugins"
         ],
-        "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new\n(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)\n",
+        "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).\nSource repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).\n",
         "recommended_install_path": "doc/ide-setup/cursor.mdx",
         "last_reviewed_at": "2026-07-28",
         "owner": "cloudbase-ai-toolkit",
@@ -393,11 +394,12 @@
         "blockers": [],
         "evidence_links": [
           "https://code.visualstudio.com/docs/agent-customization/agent-plugins",
-          "https://github.com/github/awesome-copilot/issues/2459"
+          "https://github.com/github/awesome-copilot/issues/2459",
+          "specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md"
         ],
-        "submit_url_or_process": "Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.\nStatus 2026-07-28: Awesome Copilot external plugin issue opened https://github.com/github/awesome-copilot/issues/2459\n",
+        "submit_url_or_process": "Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.\nStatus 2026-08-05: Awesome Copilot #2459 intake re-passed after stripping remote skill-fetch URLs (SHA 4082ba95...). Awaiting maintainer re-review.\nSee specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md\n",
         "recommended_install_path": "doc/ide-setup/vscode.mdx",
-        "last_reviewed_at": "2026-07-28",
+        "last_reviewed_at": "2026-08-05",
         "owner": "cloudbase-ai-toolkit",
         "local_evidence": [
           {
@@ -419,6 +421,7 @@
         ],
         "submit_checklist": [
           "Users can add TencentCloudBase/CloudBase-MCP as marketplace",
+          "Strip remote skill-fetch URLs; sync cloudbase-plugin; /rerun-intake on",
           {
             "Optional": "PR/request inclusion in default curated catalogs"
           }
@@ -426,6 +429,10 @@
         "materials": [
           {
             "item": "Users can add TencentCloudBase/CloudBase-MCP as marketplace",
+            "status": "repo_ready_or_external"
+          },
+          {
+            "item": "Strip remote skill-fetch URLs; sync cloudbase-plugin; /rerun-intake on",
             "status": "repo_ready_or_external"
           },
           {
@@ -438,7 +445,82 @@
         "manual_submit_only": true
       }
     ],
-    "needs_packaging_or_manifest": [],
+    "needs_packaging_or_manifest": [
+      {
+        "id": "qoder-plugin",
+        "product": "Qoder / QoderWork",
+        "region": "cn",
+        "channel_type": "community_plugin_directory",
+        "listing_statuses": {
+          "official_curated": "unknown",
+          "community_directory": "unknown",
+          "self_marketplace": "submittable",
+          "native_connector_or_builtin": "not_applicable",
+          "open_plugin_spec": "listed",
+          "mcp_or_skill_registry": "submittable",
+          "docs_only": "listed"
+        },
+        "eligibility": "public_github_repo_required",
+        "blockers": [
+          "Awaiting QoderWork review / listing confirmation"
+        ],
+        "evidence_links": [
+          "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
+          "https://qoder.com.cn/account/apphub-publications",
+          "doc/ide-setup/qoder.mdx",
+          "plugin/cloudbase/docs/qoder-submit.md"
+        ],
+        "submit_url_or_process": "QoderWork self-serve: Plugin (专家套件) + Skill marketplace.\nPack: npm run pack:qoder-plugin / pack:qoder-skill\nGuide: plugin/cloudbase/docs/qoder-submit.md\nStatus 2026-07-30: Plugin zip + Skill zip both submitted (awaiting review).\nQoder CN AppHub: https://qoder.com.cn/account/apphub-publications (optional follow-up).\n",
+        "recommended_install_path": "doc/ide-setup/qoder.mdx",
+        "last_reviewed_at": "2026-07-30",
+        "owner": "cloudbase-ai-toolkit",
+        "local_evidence": [
+          {
+            "id": "open_plugin_spec_cloudbase",
+            "status": "present",
+            "detail": "plugin/cloudbase/.plugin/plugin.json has $schema",
+            "paths": [
+              "plugin/cloudbase/.plugin/plugin.json"
+            ]
+          },
+          {
+            "id": "qoder_plugin_manifest",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"qoder_plugin_manifest\"",
+            "paths": []
+          }
+        ],
+        "submit_checklist": [
+          "Pack Plugin zip (dist/cloudbase-qoder-v*.zip)",
+          "Pack Skill zip (dist/cloudbase-skill-v*.zip)",
+          "Submit Plugin + Skill in QoderWork",
+          {
+            "After live": "flip self_marketplace / mcp_or_skill_registry → listed"
+          }
+        ],
+        "materials": [
+          {
+            "item": "Pack Plugin zip (dist/cloudbase-qoder-v*.zip)",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Pack Skill zip (dist/cloudbase-skill-v*.zip)",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Submit Plugin + Skill in QoderWork",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "[object Object]",
+            "status": "manual_or_external"
+          }
+        ],
+        "priority": "needs_packaging_or_manifest",
+        "stale": false,
+        "manual_submit_only": true
+      }
+    ],
     "needs_partner_outreach": [
       {
         "id": "claude-code-official",
@@ -549,38 +631,59 @@
         "region": "cn",
         "channel_type": "native_connector_or_builtin",
         "listing_statuses": {
-          "official_curated": "unknown",
+          "official_curated": "listed",
           "community_directory": "unknown",
           "self_marketplace": "not_applicable",
-          "native_connector_or_builtin": "unknown",
+          "native_connector_or_builtin": "listed",
           "open_plugin_spec": "not_applicable",
           "mcp_or_skill_registry": "not_applicable",
           "docs_only": "listed"
         },
         "eligibility": "partner_outreach_required",
         "blockers": [
-          "Official listing status for CloudBase needs confirmation"
+          "Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)"
         ],
         "evidence_links": [
+          "https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase",
+          "https://cnb.cool/tencent/cloud/cloudbase/marketplace",
+          "https://cnb.cool/codebuddy/marketplace/-/pulls/19",
           "https://www.codebuddy.cn/docs/cli/plugins",
           "doc/ide-setup/codebuddy.mdx"
         ],
-        "submit_url_or_process": "CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.\n",
+        "submit_url_or_process": "Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).\nFork: https://cnb.cool/tencent/cloud/cloudbase/marketplace\nPR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).\n",
         "recommended_install_path": "doc/ide-setup/codebuddy.mdx",
-        "last_reviewed_at": "2026-07-27",
+        "last_reviewed_at": "2026-07-29",
         "owner": "cloudbase-ai-toolkit",
-        "local_evidence": [],
+        "local_evidence": [
+          {
+            "id": "config/codebuddy-plugin",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"config/codebuddy-plugin\"",
+            "paths": []
+          },
+          {
+            "id": "specs/plugin-marketplace-listing/submission-log.md",
+            "status": "invalid",
+            "detail": "Unknown local_evidence id \"specs/plugin-marketplace-listing/submission-log.md\"",
+            "paths": []
+          }
+        ],
         "submit_checklist": [
-          "Confirm CodeBuddy marketplace submission process",
-          "Align with config/codebuddy-plugin if applicable"
+          "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
+          "Confirm keep rules/cloudbase_rules.md in marketplace package",
+          "Ask CodeBuddy product team about built-in IDE sync if needed"
         ],
         "materials": [
           {
-            "item": "Confirm CodeBuddy marketplace submission process",
+            "item": "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
             "status": "manual_or_external"
           },
           {
-            "item": "Align with config/codebuddy-plugin if applicable",
+            "item": "Confirm keep rules/cloudbase_rules.md in marketplace package",
+            "status": "manual_or_external"
+          },
+          {
+            "item": "Ask CodeBuddy product team about built-in IDE sync if needed",
             "status": "manual_or_external"
           }
         ],
@@ -626,51 +729,6 @@
           },
           {
             "item": "Marketplace listing steps from CodeBuddy docs",
-            "status": "manual_or_external"
-          }
-        ],
-        "priority": "needs_partner_outreach",
-        "stale": false,
-        "manual_submit_only": true
-      },
-      {
-        "id": "qoder-plugin",
-        "product": "Qoder",
-        "region": "cn",
-        "channel_type": "community_plugin_directory",
-        "listing_statuses": {
-          "official_curated": "unknown",
-          "community_directory": "unknown",
-          "self_marketplace": "not_applicable",
-          "native_connector_or_builtin": "not_applicable",
-          "open_plugin_spec": "not_applicable",
-          "mcp_or_skill_registry": "not_applicable",
-          "docs_only": "listed"
-        },
-        "eligibility": "partner_outreach_required",
-        "blockers": [
-          "Self-serve listing docs incomplete for third parties"
-        ],
-        "evidence_links": [
-          "https://help.aliyun.com/zh/lingma/plugin-hidden-release",
-          "doc/ide-setup/qoder.mdx"
-        ],
-        "submit_url_or_process": "Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).\n",
-        "recommended_install_path": "doc/ide-setup/qoder.mdx",
-        "last_reviewed_at": "2026-07-27",
-        "owner": "cloudbase-ai-toolkit",
-        "local_evidence": [],
-        "submit_checklist": [
-          "Confirm Qoder CN plugin publish channel",
-          "Package plugin.json compatible layout"
-        ],
-        "materials": [
-          {
-            "item": "Confirm Qoder CN plugin publish channel",
-            "status": "manual_or_external"
-          },
-          {
-            "item": "Package plugin.json compatible layout",
             "status": "manual_or_external"
           }
         ],
@@ -730,7 +788,7 @@
         "channel_type": "mcp_registry_or_aggregator",
         "listing_statuses": {
           "official_curated": "unknown",
-          "community_directory": "unknown",
+          "community_directory": "listed",
           "self_marketplace": "not_applicable",
           "native_connector_or_builtin": "not_applicable",
           "open_plugin_spec": "not_applicable",
@@ -745,11 +803,12 @@
           "https://docs.trae.cn/work_remote-mcp-server",
           "https://docs.trae.cn/ide_model-context-protocol",
           "https://github.com/trae-community/trae-mcp/pull/4",
+          "https://github.com/trae-community/trae-mcp/blob/main/README.md",
           "doc/ide-setup/trae.mdx"
         ],
-        "submit_url_or_process": "Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.\nStatus 2026-07-28: Community list PR opened https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).\n",
+        "submit_url_or_process": "Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.\nStatus 2026-08-05: Community list PR merged https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).\n",
         "recommended_install_path": "doc/ide-setup/trae.mdx",
-        "last_reviewed_at": "2026-07-28",
+        "last_reviewed_at": "2026-08-05",
         "owner": "cloudbase-ai-toolkit",
         "local_evidence": [
           {
@@ -762,21 +821,11 @@
           }
         ],
         "submit_checklist": [
-          "Partner outreach for official MCP marketplace inclusion",
-          "Provide stdio npx config for CloudBase MCP",
-          "Community README PR to trae-community/trae-mcp"
+          "Partner outreach for official MCP marketplace inclusion"
         ],
         "materials": [
           {
             "item": "Partner outreach for official MCP marketplace inclusion",
-            "status": "repo_ready_or_external"
-          },
-          {
-            "item": "Provide stdio npx config for CloudBase MCP",
-            "status": "repo_ready_or_external"
-          },
-          {
-            "item": "Community README PR to trae-community/trae-mcp",
             "status": "repo_ready_or_external"
           }
         ],
@@ -791,36 +840,39 @@
         "channel_type": "skill_registry",
         "listing_statuses": {
           "official_curated": "unknown",
-          "community_directory": "unknown",
+          "community_directory": "listed",
           "self_marketplace": "not_applicable",
           "native_connector_or_builtin": "not_applicable",
           "open_plugin_spec": "not_applicable",
-          "mcp_or_skill_registry": "unknown",
-          "docs_only": "unknown"
+          "mcp_or_skill_registry": "listed",
+          "docs_only": "listed"
         },
         "eligibility": "partner_outreach_required",
         "blockers": [
-          "Public skill publishing path not documented"
+          "Official Trae Work in-app skill market publisher path not documented"
         ],
         "evidence_links": [
-          "https://docs.trae.cn/solo_skills"
+          "https://docs.trae.cn/solo_skills",
+          "https://github.com/trae-community/trae-skills/pull/20",
+          "https://github.com/trae-community/trae-skills/blob/main/README.md",
+          "https://github.com/trae-community/trae-skills/blob/main/skills/cloudbase/SKILL.md"
         ],
-        "submit_url_or_process": "Users can upload local SKILL.md zip/.skill or install from Trae Work skills marketplace. Public publisher onboarding unclear.\n",
-        "recommended_install_path": null,
-        "last_reviewed_at": "2026-07-27",
+        "submit_url_or_process": "Community catalog: trae-community/trae-skills (merged PR #20).\nUsers can also upload local SKILL.md zip/.skill or install from Trae Work skills marketplace.\nOfficial Trae Work publisher onboarding still unclear / partner outreach.\nStatus 2026-08-05: Community skills PR merged https://github.com/trae-community/trae-skills/pull/20\n",
+        "recommended_install_path": "doc/ide-setup/trae.mdx",
+        "last_reviewed_at": "2026-08-05",
         "owner": "cloudbase-ai-toolkit",
         "local_evidence": [],
         "submit_checklist": [
-          "Confirm Trae Work skill market publisher process",
-          "Package SKILL.md zip if allowed"
+          "Confirm Trae Work official skill market publisher process",
+          "Package SKILL.md zip if official market requires it"
         ],
         "materials": [
           {
-            "item": "Confirm Trae Work skill market publisher process",
+            "item": "Confirm Trae Work official skill market publisher process",
             "status": "manual_or_external"
           },
           {
-            "item": "Package SKILL.md zip if allowed",
+            "item": "Package SKILL.md zip if official market requires it",
             "status": "manual_or_external"
           }
         ],
@@ -2045,11 +2097,12 @@
       "eligibility": "public_github_repo_required",
       "blockers": [],
       "evidence_links": [
+        "https://cursor.directory/plugins/cloudbase",
         "https://cursor.directory",
         "https://cursor.directory/plugins/new",
         "https://cursor.com/docs/plugins"
       ],
-      "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new\n(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)\n",
+      "submit_url_or_process": "Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.\nStatus 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).\nSource repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).\n",
       "recommended_install_path": "doc/ide-setup/cursor.mdx",
       "last_reviewed_at": "2026-07-28",
       "owner": "cloudbase-ai-toolkit",
@@ -2302,11 +2355,12 @@
       "blockers": [],
       "evidence_links": [
         "https://code.visualstudio.com/docs/agent-customization/agent-plugins",
-        "https://github.com/github/awesome-copilot/issues/2459"
+        "https://github.com/github/awesome-copilot/issues/2459",
+        "specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md"
       ],
-      "submit_url_or_process": "Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.\nStatus 2026-07-28: Awesome Copilot external plugin issue opened https://github.com/github/awesome-copilot/issues/2459\n",
+      "submit_url_or_process": "Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.\nStatus 2026-08-05: Awesome Copilot #2459 intake re-passed after stripping remote skill-fetch URLs (SHA 4082ba95...). Awaiting maintainer re-review.\nSee specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md\n",
       "recommended_install_path": "doc/ide-setup/vscode.mdx",
-      "last_reviewed_at": "2026-07-28",
+      "last_reviewed_at": "2026-08-05",
       "owner": "cloudbase-ai-toolkit",
       "local_evidence": [
         {
@@ -2328,6 +2382,7 @@
       ],
       "submit_checklist": [
         "Users can add TencentCloudBase/CloudBase-MCP as marketplace",
+        "Strip remote skill-fetch URLs; sync cloudbase-plugin; /rerun-intake on",
         {
           "Optional": "PR/request inclusion in default curated catalogs"
         }
@@ -2335,6 +2390,10 @@
       "materials": [
         {
           "item": "Users can add TencentCloudBase/CloudBase-MCP as marketplace",
+          "status": "repo_ready_or_external"
+        },
+        {
+          "item": "Strip remote skill-fetch URLs; sync cloudbase-plugin; /rerun-intake on",
           "status": "repo_ready_or_external"
         },
         {
@@ -2469,38 +2528,59 @@
       "region": "cn",
       "channel_type": "native_connector_or_builtin",
       "listing_statuses": {
-        "official_curated": "unknown",
+        "official_curated": "listed",
         "community_directory": "unknown",
         "self_marketplace": "not_applicable",
-        "native_connector_or_builtin": "unknown",
+        "native_connector_or_builtin": "listed",
         "open_plugin_spec": "not_applicable",
         "mcp_or_skill_registry": "not_applicable",
         "docs_only": "listed"
       },
       "eligibility": "partner_outreach_required",
       "blockers": [
-        "Official listing status for CloudBase needs confirmation"
+        "Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)"
       ],
       "evidence_links": [
+        "https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase",
+        "https://cnb.cool/tencent/cloud/cloudbase/marketplace",
+        "https://cnb.cool/codebuddy/marketplace/-/pulls/19",
         "https://www.codebuddy.cn/docs/cli/plugins",
         "doc/ide-setup/codebuddy.mdx"
       ],
-      "submit_url_or_process": "CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.\n",
+      "submit_url_or_process": "Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).\nFork: https://cnb.cool/tencent/cloud/cloudbase/marketplace\nPR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).\n",
       "recommended_install_path": "doc/ide-setup/codebuddy.mdx",
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-29",
       "owner": "cloudbase-ai-toolkit",
-      "local_evidence": [],
+      "local_evidence": [
+        {
+          "id": "config/codebuddy-plugin",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"config/codebuddy-plugin\"",
+          "paths": []
+        },
+        {
+          "id": "specs/plugin-marketplace-listing/submission-log.md",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"specs/plugin-marketplace-listing/submission-log.md\"",
+          "paths": []
+        }
+      ],
       "submit_checklist": [
-        "Confirm CodeBuddy marketplace submission process",
-        "Align with config/codebuddy-plugin if applicable"
+        "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
+        "Confirm keep rules/cloudbase_rules.md in marketplace package",
+        "Ask CodeBuddy product team about built-in IDE sync if needed"
       ],
       "materials": [
         {
-          "item": "Confirm CodeBuddy marketplace submission process",
+          "item": "Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19",
           "status": "manual_or_external"
         },
         {
-          "item": "Align with config/codebuddy-plugin if applicable",
+          "item": "Confirm keep rules/cloudbase_rules.md in marketplace package",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Ask CodeBuddy product team about built-in IDE sync if needed",
           "status": "manual_or_external"
         }
       ],
@@ -2555,46 +2635,75 @@
     },
     {
       "id": "qoder-plugin",
-      "product": "Qoder",
+      "product": "Qoder / QoderWork",
       "region": "cn",
       "channel_type": "community_plugin_directory",
       "listing_statuses": {
         "official_curated": "unknown",
         "community_directory": "unknown",
-        "self_marketplace": "not_applicable",
+        "self_marketplace": "submittable",
         "native_connector_or_builtin": "not_applicable",
-        "open_plugin_spec": "not_applicable",
-        "mcp_or_skill_registry": "not_applicable",
+        "open_plugin_spec": "listed",
+        "mcp_or_skill_registry": "submittable",
         "docs_only": "listed"
       },
-      "eligibility": "partner_outreach_required",
+      "eligibility": "public_github_repo_required",
       "blockers": [
-        "Self-serve listing docs incomplete for third parties"
+        "Awaiting QoderWork review / listing confirmation"
       ],
       "evidence_links": [
-        "https://help.aliyun.com/zh/lingma/plugin-hidden-release",
-        "doc/ide-setup/qoder.mdx"
+        "https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines",
+        "https://qoder.com.cn/account/apphub-publications",
+        "doc/ide-setup/qoder.mdx",
+        "plugin/cloudbase/docs/qoder-submit.md"
       ],
-      "submit_url_or_process": "Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).\n",
+      "submit_url_or_process": "QoderWork self-serve: Plugin (专家套件) + Skill marketplace.\nPack: npm run pack:qoder-plugin / pack:qoder-skill\nGuide: plugin/cloudbase/docs/qoder-submit.md\nStatus 2026-07-30: Plugin zip + Skill zip both submitted (awaiting review).\nQoder CN AppHub: https://qoder.com.cn/account/apphub-publications (optional follow-up).\n",
       "recommended_install_path": "doc/ide-setup/qoder.mdx",
-      "last_reviewed_at": "2026-07-27",
+      "last_reviewed_at": "2026-07-30",
       "owner": "cloudbase-ai-toolkit",
-      "local_evidence": [],
+      "local_evidence": [
+        {
+          "id": "open_plugin_spec_cloudbase",
+          "status": "present",
+          "detail": "plugin/cloudbase/.plugin/plugin.json has $schema",
+          "paths": [
+            "plugin/cloudbase/.plugin/plugin.json"
+          ]
+        },
+        {
+          "id": "qoder_plugin_manifest",
+          "status": "invalid",
+          "detail": "Unknown local_evidence id \"qoder_plugin_manifest\"",
+          "paths": []
+        }
+      ],
       "submit_checklist": [
-        "Confirm Qoder CN plugin publish channel",
-        "Package plugin.json compatible layout"
+        "Pack Plugin zip (dist/cloudbase-qoder-v*.zip)",
+        "Pack Skill zip (dist/cloudbase-skill-v*.zip)",
+        "Submit Plugin + Skill in QoderWork",
+        {
+          "After live": "flip self_marketplace / mcp_or_skill_registry → listed"
+        }
       ],
       "materials": [
         {
-          "item": "Confirm Qoder CN plugin publish channel",
+          "item": "Pack Plugin zip (dist/cloudbase-qoder-v*.zip)",
           "status": "manual_or_external"
         },
         {
-          "item": "Package plugin.json compatible layout",
+          "item": "Pack Skill zip (dist/cloudbase-skill-v*.zip)",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "Submit Plugin + Skill in QoderWork",
+          "status": "manual_or_external"
+        },
+        {
+          "item": "[object Object]",
           "status": "manual_or_external"
         }
       ],
-      "priority": "needs_partner_outreach",
+      "priority": "needs_packaging_or_manifest",
       "stale": false,
       "manual_submit_only": true
     },
@@ -2650,7 +2759,7 @@
       "channel_type": "mcp_registry_or_aggregator",
       "listing_statuses": {
         "official_curated": "unknown",
-        "community_directory": "unknown",
+        "community_directory": "listed",
         "self_marketplace": "not_applicable",
         "native_connector_or_builtin": "not_applicable",
         "open_plugin_spec": "not_applicable",
@@ -2665,11 +2774,12 @@
         "https://docs.trae.cn/work_remote-mcp-server",
         "https://docs.trae.cn/ide_model-context-protocol",
         "https://github.com/trae-community/trae-mcp/pull/4",
+        "https://github.com/trae-community/trae-mcp/blob/main/README.md",
         "doc/ide-setup/trae.mdx"
       ],
-      "submit_url_or_process": "Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.\nStatus 2026-07-28: Community list PR opened https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).\n",
+      "submit_url_or_process": "Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.\nStatus 2026-08-05: Community list PR merged https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).\n",
       "recommended_install_path": "doc/ide-setup/trae.mdx",
-      "last_reviewed_at": "2026-07-28",
+      "last_reviewed_at": "2026-08-05",
       "owner": "cloudbase-ai-toolkit",
       "local_evidence": [
         {
@@ -2682,21 +2792,11 @@
         }
       ],
       "submit_checklist": [
-        "Partner outreach for official MCP marketplace inclusion",
-        "Provide stdio npx config for CloudBase MCP",
-        "Community README PR to trae-community/trae-mcp"
+        "Partner outreach for official MCP marketplace inclusion"
       ],
       "materials": [
         {
           "item": "Partner outreach for official MCP marketplace inclusion",
-          "status": "repo_ready_or_external"
-        },
-        {
-          "item": "Provide stdio npx config for CloudBase MCP",
-          "status": "repo_ready_or_external"
-        },
-        {
-          "item": "Community README PR to trae-community/trae-mcp",
           "status": "repo_ready_or_external"
         }
       ],
@@ -2711,36 +2811,39 @@
       "channel_type": "skill_registry",
       "listing_statuses": {
         "official_curated": "unknown",
-        "community_directory": "unknown",
+        "community_directory": "listed",
         "self_marketplace": "not_applicable",
         "native_connector_or_builtin": "not_applicable",
         "open_plugin_spec": "not_applicable",
-        "mcp_or_skill_registry": "unknown",
-        "docs_only": "unknown"
+        "mcp_or_skill_registry": "listed",
+        "docs_only": "listed"
       },
       "eligibility": "partner_outreach_required",
       "blockers": [
-        "Public skill publishing path not documented"
+        "Official Trae Work in-app skill market publisher path not documented"
       ],
       "evidence_links": [
-        "https://docs.trae.cn/solo_skills"
+        "https://docs.trae.cn/solo_skills",
+        "https://github.com/trae-community/trae-skills/pull/20",
+        "https://github.com/trae-community/trae-skills/blob/main/README.md",
+        "https://github.com/trae-community/trae-skills/blob/main/skills/cloudbase/SKILL.md"
       ],
-      "submit_url_or_process": "Users can upload local SKILL.md zip/.skill or install from Trae Work skills marketplace. Public publisher onboarding unclear.\n",
-      "recommended_install_path": null,
-      "last_reviewed_at": "2026-07-27",
+      "submit_url_or_process": "Community catalog: trae-community/trae-skills (merged PR #20).\nUsers can also upload local SKILL.md zip/.skill or install from Trae Work skills marketplace.\nOfficial Trae Work publisher onboarding still unclear / partner outreach.\nStatus 2026-08-05: Community skills PR merged https://github.com/trae-community/trae-skills/pull/20\n",
+      "recommended_install_path": "doc/ide-setup/trae.mdx",
+      "last_reviewed_at": "2026-08-05",
       "owner": "cloudbase-ai-toolkit",
       "local_evidence": [],
       "submit_checklist": [
-        "Confirm Trae Work skill market publisher process",
-        "Package SKILL.md zip if allowed"
+        "Confirm Trae Work official skill market publisher process",
+        "Package SKILL.md zip if official market requires it"
       ],
       "materials": [
         {
-          "item": "Confirm Trae Work skill market publisher process",
+          "item": "Confirm Trae Work official skill market publisher process",
           "status": "manual_or_external"
         },
         {
-          "item": "Package SKILL.md zip if allowed",
+          "item": "Package SKILL.md zip if official market requires it",
           "status": "manual_or_external"
         }
       ],

--- a/specs/plugin-marketplace-listing/reports/latest.md
+++ b/specs/plugin-marketplace-listing/reports/latest.md
@@ -1,6 +1,6 @@
 # CloudBase Plugin Marketplace Analysis
 
-Generated: 2026-07-28T03:32:40.305Z
+Generated: 2026-08-05T07:36:57.965Z
 
 > This report does not auto-submit to any marketplace. All submissions are manual.
 
@@ -11,8 +11,8 @@ Total markets: **42**
 | Priority | Count |
 |----------|------:|
 | ready_to_submit | 6 |
-| needs_packaging_or_manifest | 0 |
-| needs_partner_outreach | 13 |
+| needs_packaging_or_manifest | 1 |
+| needs_partner_outreach | 12 |
 | listed | 7 |
 | not_applicable | 15 |
 | unknown | 1 |
@@ -149,12 +149,13 @@ Process:
 
 ```
 Community listing via cursor.directory (plugin discovery). Prefer official Cursor Marketplace for primary listing.
-Status 2026-07-28: packet ready — submit https://github.com/TencentCloudBase/cloudbase-plugin at https://cursor.directory/plugins/new
-(Use dedicated OPS repo: has root .mcp.json for auto-detect; monorepo does not.)
+Status 2026-07-28: submitted — https://cursor.directory/plugins/cloudbase (being verified).
+Source repo: https://github.com/TencentCloudBase/cloudbase-plugin (root .mcp.json).
 ```
 
 Evidence:
 
+- https://cursor.directory/plugins/cloudbase
 - https://cursor.directory
 - https://cursor.directory/plugins/new
 - https://cursor.com/docs/plugins
@@ -253,7 +254,7 @@ Evidence:
 - Region: global
 - Channel: `self_hosted_marketplace`
 - Eligibility: `marketplace_add_or_catalog_pr`
-- Last reviewed: 2026-07-28
+- Last reviewed: 2026-08-05
 - Manual submit only: yes
 
 Statuses:
@@ -274,25 +275,79 @@ Local evidence:
 Submit checklist:
 
 - [ ] Users can add TencentCloudBase/CloudBase-MCP as marketplace
+- [ ] Strip remote skill-fetch URLs; sync cloudbase-plugin; /rerun-intake on
 - [ ] [object Object]
 
 Process:
 
 ```
 Users add marketplaces via chat.plugins.marketplaces (default: github/copilot-plugins, awesome-copilot). Can point at this repo; curated default catalog inclusion needs outreach.
-Status 2026-07-28: Awesome Copilot external plugin issue opened https://github.com/github/awesome-copilot/issues/2459
+Status 2026-08-05: Awesome Copilot #2459 intake re-passed after stripping remote skill-fetch URLs (SHA 4082ba95...). Awaiting maintainer re-review.
+See specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md
 ```
 
 Evidence:
 
 - https://code.visualstudio.com/docs/agent-customization/agent-plugins
 - https://github.com/github/awesome-copilot/issues/2459
+- specs/plugin-marketplace-listing/awesome-copilot-rejection-response.md
 
 Recommended install docs: `doc/ide-setup/vscode.mdx`
 
 ## needs_packaging_or_manifest
 
-_None_
+### qoder-plugin — Qoder / QoderWork
+
+- Region: cn
+- Channel: `community_plugin_directory`
+- Eligibility: `public_github_repo_required`
+- Last reviewed: 2026-07-30
+- Manual submit only: yes
+
+Statuses:
+
+- `official_curated`: unknown
+- `community_directory`: unknown
+- `self_marketplace`: submittable
+- `native_connector_or_builtin`: not_applicable
+- `open_plugin_spec`: listed
+- `mcp_or_skill_registry`: submittable
+- `docs_only`: listed
+
+Blockers:
+
+- Awaiting QoderWork review / listing confirmation
+
+Local evidence:
+
+- `open_plugin_spec_cloudbase`: **present** — plugin/cloudbase/.plugin/plugin.json has $schema
+- `qoder_plugin_manifest`: **invalid** — Unknown local_evidence id "qoder_plugin_manifest"
+
+Submit checklist:
+
+- [ ] Pack Plugin zip (dist/cloudbase-qoder-v*.zip)
+- [ ] Pack Skill zip (dist/cloudbase-skill-v*.zip)
+- [ ] Submit Plugin + Skill in QoderWork
+- [ ] [object Object]
+
+Process:
+
+```
+QoderWork self-serve: Plugin (专家套件) + Skill marketplace.
+Pack: npm run pack:qoder-plugin / pack:qoder-skill
+Guide: plugin/cloudbase/docs/qoder-submit.md
+Status 2026-07-30: Plugin zip + Skill zip both submitted (awaiting review).
+Qoder CN AppHub: https://qoder.com.cn/account/apphub-publications (optional follow-up).
+```
+
+Evidence:
+
+- https://docs.qoder.com/zh/qoderwork/skill-marketplace-guidelines
+- https://qoder.com.cn/account/apphub-publications
+- doc/ide-setup/qoder.mdx
+- plugin/cloudbase/docs/qoder-submit.md
+
+Recommended install docs: `doc/ide-setup/qoder.mdx`
 
 ## needs_partner_outreach
 
@@ -382,36 +437,47 @@ Evidence:
 - Region: cn
 - Channel: `native_connector_or_builtin`
 - Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
+- Last reviewed: 2026-07-29
 - Manual submit only: yes
 
 Statuses:
 
-- `official_curated`: unknown
+- `official_curated`: listed
 - `community_directory`: unknown
 - `self_marketplace`: not_applicable
-- `native_connector_or_builtin`: unknown
+- `native_connector_or_builtin`: listed
 - `open_plugin_spec`: not_applicable
 - `mcp_or_skill_registry`: not_applicable
 - `docs_only`: listed
 
 Blockers:
 
-- Official listing status for CloudBase needs confirmation
+- Awaiting merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19 (refresh to v2.25.0)
+
+Local evidence:
+
+- `config/codebuddy-plugin`: **invalid** — Unknown local_evidence id "config/codebuddy-plugin"
+- `specs/plugin-marketplace-listing/submission-log.md`: **invalid** — Unknown local_evidence id "specs/plugin-marketplace-listing/submission-log.md"
 
 Submit checklist:
 
-- [ ] Confirm CodeBuddy marketplace submission process
-- [ ] Align with config/codebuddy-plugin if applicable
+- [ ] Await merge of https://cnb.cool/codebuddy/marketplace/-/pulls/19
+- [ ] Confirm keep rules/cloudbase_rules.md in marketplace package
+- [ ] Ask CodeBuddy product team about built-in IDE sync if needed
 
 Process:
 
 ```
-CodeBuddy has plugin marketplace / CLI plugins. Confirm whether CloudBase is already listed or needs partner submission.
+Official catalog already has plugins/cloudbase on cnb.cool/codebuddy/marketplace (content stale vs v2.25.0).
+Fork: https://cnb.cool/tencent/cloud/cloudbase/marketplace
+PR open: https://cnb.cool/codebuddy/marketplace/-/pulls/19 (from fork main).
 ```
 
 Evidence:
 
+- https://cnb.cool/codebuddy/marketplace/-/tree/main/plugins/cloudbase
+- https://cnb.cool/tencent/cloud/cloudbase/marketplace
+- https://cnb.cool/codebuddy/marketplace/-/pulls/19
 - https://www.codebuddy.cn/docs/cli/plugins
 - doc/ide-setup/codebuddy.mdx
 
@@ -457,46 +523,6 @@ Evidence:
 
 Recommended install docs: `doc/ide-setup/codebuddy-code.mdx`
 
-### qoder-plugin — Qoder
-
-- Region: cn
-- Channel: `community_plugin_directory`
-- Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
-- Manual submit only: yes
-
-Statuses:
-
-- `official_curated`: unknown
-- `community_directory`: unknown
-- `self_marketplace`: not_applicable
-- `native_connector_or_builtin`: not_applicable
-- `open_plugin_spec`: not_applicable
-- `mcp_or_skill_registry`: not_applicable
-- `docs_only`: listed
-
-Blockers:
-
-- Self-serve listing docs incomplete for third parties
-
-Submit checklist:
-
-- [ ] Confirm Qoder CN plugin publish channel
-- [ ] Package plugin.json compatible layout
-
-Process:
-
-```
-Qoder CN plugins use plugin.json packaging (skills/MCP/hooks). Public marketplace listing process needs verification (Aliyun Lingma docs overlap).
-```
-
-Evidence:
-
-- https://help.aliyun.com/zh/lingma/plugin-hidden-release
-- doc/ide-setup/qoder.mdx
-
-Recommended install docs: `doc/ide-setup/qoder.mdx`
-
 ### qoderwork-connector — QoderWork
 
 - Region: cn
@@ -540,13 +566,13 @@ Evidence:
 - Region: cn
 - Channel: `mcp_registry_or_aggregator`
 - Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-28
+- Last reviewed: 2026-08-05
 - Manual submit only: yes
 
 Statuses:
 
 - `official_curated`: unknown
-- `community_directory`: unknown
+- `community_directory`: listed
 - `self_marketplace`: not_applicable
 - `native_connector_or_builtin`: not_applicable
 - `open_plugin_spec`: not_applicable
@@ -564,14 +590,12 @@ Local evidence:
 Submit checklist:
 
 - [ ] Partner outreach for official MCP marketplace inclusion
-- [ ] Provide stdio npx config for CloudBase MCP
-- [ ] Community README PR to trae-community/trae-mcp
 
 Process:
 
 ```
 Users can add MCP from Trae built-in MCP marketplace or manual config. Third-party submission into Trae MCP marketplace is not publicly documented.
-Status 2026-07-28: Community list PR opened https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).
+Status 2026-08-05: Community list PR merged https://github.com/trae-community/trae-mcp/pull/4 (README catalog; not official Trae store).
 ```
 
 Evidence:
@@ -579,6 +603,7 @@ Evidence:
 - https://docs.trae.cn/work_remote-mcp-server
 - https://docs.trae.cn/ide_model-context-protocol
 - https://github.com/trae-community/trae-mcp/pull/4
+- https://github.com/trae-community/trae-mcp/blob/main/README.md
 - doc/ide-setup/trae.mdx
 
 Recommended install docs: `doc/ide-setup/trae.mdx`
@@ -588,37 +613,45 @@ Recommended install docs: `doc/ide-setup/trae.mdx`
 - Region: cn
 - Channel: `skill_registry`
 - Eligibility: `partner_outreach_required`
-- Last reviewed: 2026-07-27
+- Last reviewed: 2026-08-05
 - Manual submit only: yes
 
 Statuses:
 
 - `official_curated`: unknown
-- `community_directory`: unknown
+- `community_directory`: listed
 - `self_marketplace`: not_applicable
 - `native_connector_or_builtin`: not_applicable
 - `open_plugin_spec`: not_applicable
-- `mcp_or_skill_registry`: unknown
-- `docs_only`: unknown
+- `mcp_or_skill_registry`: listed
+- `docs_only`: listed
 
 Blockers:
 
-- Public skill publishing path not documented
+- Official Trae Work in-app skill market publisher path not documented
 
 Submit checklist:
 
-- [ ] Confirm Trae Work skill market publisher process
-- [ ] Package SKILL.md zip if allowed
+- [ ] Confirm Trae Work official skill market publisher process
+- [ ] Package SKILL.md zip if official market requires it
 
 Process:
 
 ```
-Users can upload local SKILL.md zip/.skill or install from Trae Work skills marketplace. Public publisher onboarding unclear.
+Community catalog: trae-community/trae-skills (merged PR #20).
+Users can also upload local SKILL.md zip/.skill or install from Trae Work skills marketplace.
+Official Trae Work publisher onboarding still unclear / partner outreach.
+Status 2026-08-05: Community skills PR merged https://github.com/trae-community/trae-skills/pull/20
 ```
 
 Evidence:
 
 - https://docs.trae.cn/solo_skills
+- https://github.com/trae-community/trae-skills/pull/20
+- https://github.com/trae-community/trae-skills/blob/main/README.md
+- https://github.com/trae-community/trae-skills/blob/main/skills/cloudbase/SKILL.md
+
+Recommended install docs: `doc/ide-setup/trae.mdx`
 
 ### mcp-official-registry — Official MCP Registry
 

--- a/specs/plugin-marketplace-listing/submission-checklist.md
+++ b/specs/plugin-marketplace-listing/submission-checklist.md
@@ -99,13 +99,18 @@ Examples of good targets:
 - [x] Open PR to https://github.com/trae-community/trae-mcp — https://github.com/trae-community/trae-mcp/pull/4 (2026-07-28)
 - [x] PR body aligned to CONTRIBUTING PR Checklist (2026-07-29)
 - [x] Merged 2026-08-05 — mark `trae-mcp-marketplace.community_directory` listed
-- [ ] Official Trae in-app MCP marketplace still needs partner outreach
+- [x] Official Trae in-app MCP marketplace outreach started — https://github.com/trae-community/trae-mcp/issues/5 + `trae-official-outreach-packet.md` (2026-08-05)
+- [ ] Await Trae reply; then mark `official_curated` listed if accepted
+- [ ] Human: post forum draft (社区伙伴 / 产品建议) from outreach packet
 
 ### 6b. Trae community Skills
 
 - [x] Open PR to https://github.com/trae-community/trae-skills — https://github.com/trae-community/trae-skills/pull/20 (2026-07-28)
 - [x] PR body aligned to CONTRIBUTING Pull request checklist (2026-07-29)
 - [x] Merged 2026-08-05 — mark `trae-work-skills-marketplace.community_directory` / `mcp_or_skill_registry` listed
+- [x] Official Trae Work skills marketplace outreach started — https://github.com/trae-community/trae-skills/issues/21 + packet (2026-08-05)
+- [ ] Await Trae reply; then mark `official_curated` listed if accepted
+- [ ] Human: post forum draft (TraeWork 专区 / 社区伙伴) from outreach packet
 
 ### 6c. CodeBuddy official marketplace (CNB)
 
@@ -134,8 +139,8 @@ Examples of good targets:
 | Market | Action |
 |--------|--------|
 | Claude Official curated | Wait for / request Anthropic partnership |
-| Trae official MCP marketplace | Contact Trae for curated catalog inclusion (community list PR is separate) |
-| Trae Work skills marketplace | Confirm publisher onboarding |
+| Trae official MCP marketplace | Outreach opened: trae-mcp#5 + packet; still need product reply / forum BD post |
+| Trae Work skills marketplace | Outreach opened: trae-skills#21 + packet; forum confirms upload ≠ global publish |
 | Qoder Featured / curated | After community submit, ask for Featured if needed |
 | QoderWork Connector | Only if HTTPS+OAuth CloudBase MCP is in scope |
 | CodeBuddy / CodeBuddy Code | Await CNB #19 merge; built-in may still need PM sync |

--- a/specs/plugin-marketplace-listing/submission-checklist.md
+++ b/specs/plugin-marketplace-listing/submission-checklist.md
@@ -98,14 +98,14 @@ Examples of good targets:
 
 - [x] Open PR to https://github.com/trae-community/trae-mcp — https://github.com/trae-community/trae-mcp/pull/4 (2026-07-28)
 - [x] PR body aligned to CONTRIBUTING PR Checklist (2026-07-29)
-- [ ] Await merge; then mark community channel listed
+- [x] Merged 2026-08-05 — mark `trae-mcp-marketplace.community_directory` listed
 - [ ] Official Trae in-app MCP marketplace still needs partner outreach
 
 ### 6b. Trae community Skills
 
 - [x] Open PR to https://github.com/trae-community/trae-skills — https://github.com/trae-community/trae-skills/pull/20 (2026-07-28)
 - [x] PR body aligned to CONTRIBUTING Pull request checklist (2026-07-29)
-- [ ] Await merge; then mark community channel listed
+- [x] Merged 2026-08-05 — mark `trae-work-skills-marketplace.community_directory` / `mcp_or_skill_registry` listed
 
 ### 6c. CodeBuddy official marketplace (CNB)
 

--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -103,30 +103,42 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 
 | Field | Value |
 |-------|-------|
-| Status | **PR opened** — awaiting community review |
+| Status | **Merged / listed** — community README catalog |
 | PR | https://github.com/trae-community/trae-mcp/pull/4 |
+| Merged at | 2026-08-05 |
 | Submitted at | 2026-07-28 |
+| Catalog | https://github.com/trae-community/trae-mcp/blob/main/README.md |
 | Note | Community README list (not Trae official in-app marketplace) |
 
 ### How to check progress (Trae community MCP)
 
-1. Watch PR #4 merge
+1. Confirm CloudBase row in https://github.com/trae-community/trae-mcp/blob/main/README.md
 2. Official Trae MCP marketplace still needs partner outreach separately
 
 ## Trae community Skills
 
 | Field | Value |
 |-------|-------|
-| Status | **PR opened** — awaiting community review |
+| Status | **Merged / listed** — community skills catalog |
 | PR | https://github.com/trae-community/trae-skills/pull/20 |
+| Merged at | 2026-08-05 |
 | Skill | `skills/cloudbase/SKILL.md` (Trae MCP-first entry skill) |
 | Submitted at | 2026-07-28 |
+| Catalog | https://github.com/trae-community/trae-skills/blob/main/README.md |
 | Note | Community skills catalog (not Trae official in-app marketplace) |
 
 ### How to check progress (Trae community Skills)
 
-1. Watch PR #20 merge
-2. After merge, confirm catalog row in https://github.com/trae-community/trae-skills/blob/main/README.md
+1. Confirm catalog row in https://github.com/trae-community/trae-skills/blob/main/README.md
+2. Official Trae Work in-app skills marketplace still needs partner outreach separately
+
+### 2026-08-05 — Trae community MCP + Skills approved
+
+- Trae community maintainer YeatsLiao approved and merged both PRs the same day.
+- MCP: https://github.com/trae-community/trae-mcp/pull/4 (`good MCP :)`)
+- Skills: https://github.com/trae-community/trae-skills/pull/20 (`good SKILL :)`)
+- Flip `markets.yaml` `community_directory` → `listed` for `trae-mcp-marketplace` and `trae-work-skills-marketplace`.
+- Closed conflicting docs PR #876 as superseded by already-merged #877 (Awesome Copilot intake status).
 
 ### 2026-07-29 — CodeBuddy official marketplace sync (CNB staging)
 

--- a/specs/plugin-marketplace-listing/submission-log.md
+++ b/specs/plugin-marketplace-listing/submission-log.md
@@ -113,7 +113,7 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 ### How to check progress (Trae community MCP)
 
 1. Confirm CloudBase row in https://github.com/trae-community/trae-mcp/blob/main/README.md
-2. Official Trae MCP marketplace still needs partner outreach separately
+2. Watch official marketplace outreach: https://github.com/trae-community/trae-mcp/issues/5
 
 ## Trae community Skills
 
@@ -130,7 +130,7 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 ### How to check progress (Trae community Skills)
 
 1. Confirm catalog row in https://github.com/trae-community/trae-skills/blob/main/README.md
-2. Official Trae Work in-app skills marketplace still needs partner outreach separately
+2. Watch official skills marketplace outreach: https://github.com/trae-community/trae-skills/issues/21
 
 ### 2026-08-05 — Trae community MCP + Skills approved
 
@@ -139,6 +139,24 @@ When live: set `markets.yaml` `listing_statuses.official_curated: listed`, check
 - Skills: https://github.com/trae-community/trae-skills/pull/20 (`good SKILL :)`)
 - Flip `markets.yaml` `community_directory` → `listed` for `trae-mcp-marketplace` and `trae-work-skills-marketplace`.
 - Closed conflicting docs PR #876 as superseded by already-merged #877 (Awesome Copilot intake status).
+
+### 2026-08-05 — Trae official in-app MCP / Skills marketplace outreach
+
+| Field | Value |
+|-------|-------|
+| Status | **Outreach initiated** — awaiting Trae product / community reply |
+| Packet | `specs/plugin-marketplace-listing/trae-official-outreach-packet.md` |
+| MCP GitHub ask | https://github.com/trae-community/trae-mcp/issues/5 |
+| Skills GitHub ask | https://github.com/trae-community/trae-skills/issues/21 |
+| PR follow-ups | [mcp#4 comment](https://github.com/trae-community/trae-mcp/pull/4#issuecomment-5189097225) · [skills#20 comment](https://github.com/trae-community/trae-skills/pull/20#issuecomment-5189097487) |
+| Forum (human) | Draft in packet → 社区伙伴 / 产品建议 / TraeWork 专区 |
+| Note | Community listed ≠ official curated. Forum https://forum.trae.cn/t/topic/171994 indicates personal Skill upload is not global marketplace publish. |
+
+### How to check progress (Trae official in-app markets)
+
+1. Watch replies on trae-mcp#5 and trae-skills#21
+2. After human posts forum draft, record thread URL here
+3. When Trae accepts curation, flip `official_curated` → `listed` in `markets.yaml` and re-run `npm run analyze:plugin-marketplaces`
 
 ### 2026-07-29 — CodeBuddy official marketplace sync (CNB staging)
 

--- a/specs/plugin-marketplace-listing/trae-official-outreach-packet.md
+++ b/specs/plugin-marketplace-listing/trae-official-outreach-packet.md
@@ -1,0 +1,149 @@
+# Trae 官方 in-app MCP / Skills 市场 — Partner Outreach Packet
+
+Prepared: 2026-08-05  
+Owner: CloudBase AI Toolkit  
+Status: **outreach initiated** (community listed; official in-app still partner-only)
+
+## 背景（一句话）
+
+CloudBase MCP / Skills 已进入 Trae **社区目录**；Trae IDE 内置 MCP 市场与 Trae Work 技能市场仍无公开第三方提交通道，需产品侧合作上架。
+
+## 已完成（社区通道，≠ 官方商店）
+
+| 通道 | 状态 | 证据 |
+|------|------|------|
+| `trae-community/trae-mcp` README 目录 | **Merged** 2026-08-05 | https://github.com/trae-community/trae-mcp/pull/4 |
+| `trae-community/trae-skills` Skills 目录 | **Merged** 2026-08-05 | https://github.com/trae-community/trae-skills/pull/20 |
+| 本仓安装文档 | listed (docs) | `doc/ide-setup/trae.mdx`、MCP deeplink 文档 |
+| Trae 官方 in-app MCP 市场 | **未上架** | 无公开 submit form（见 docs.trae.cn） |
+| Trae Work 官方技能市场 | **未上架** | 论坛确认个人上传仅本地生效；市场项为官方策展 |
+
+## 公开文档结论（2026-08-05 复核）
+
+1. **MCP**：用户可「从市场添加」或「手动配置」；文档未给出第三方如何进入内置 MCP 市场。  
+   - https://docs.trae.cn/ide_add-mcp-servers  
+   - https://docs.trae.cn/work_remote-mcp-server
+2. **Skills**：可上传本地 `zip` / `.skill`，或从技能市场安装；论坛帖说明市场侧以官方策展为主，本地上传不对其他用户同步。  
+   - https://docs.trae.cn/solo_skills  
+   - https://forum.trae.cn/t/topic/171994
+3. **社区目录**是公开 PR 通道；**官方 in-app 市场**仍为 partner / 官方策展。
+
+## 推荐对接入口（按优先级）
+
+| # | 渠道 | 用途 | Agent 能否直接发送 |
+|---|------|------|-------------------|
+| 1 | GitHub issue → `trae-community/trae-mcp` + `trae-skills` | 请社区维护者转发官方策展 / 说明 in-app 收录路径 | ✅ 可发 |
+| 2 | 合并 PR 跟帖 @YeatsLiao | 社区已审通过，请求官方市场路径指引 | ✅ 可发 |
+| 3 | 论坛「社区伙伴」/「产品建议」/「TraeWork 专区」 | 正式产品侧可见的合作申请 | ❌ 需人类登录发帖 |
+| 4 | 字节跳动 / Trae 产品商务或生态对接（内部） | 腾讯云开发 × Trae 官方策展 | ❌ 需人类 BD |
+
+## 产品一页纸（给 Trae 产品 / 生态）
+
+### 我们是谁
+
+腾讯云开发（CloudBase）官方 AI Toolkit：`@cloudbase/cloudbase-mcp` + Agent Skills，覆盖 Web / 小程序 / 云函数 / 数据库 / 存储 / CloudRun / 认证等。
+
+### 希望上架的两个官方入口
+
+1. **Trae IDE / Trae Work 内置 MCP 市场**：一键添加 CloudBase MCP（stdio / `npx`）
+2. **Trae Work 技能市场**：策展 CloudBase 入口 Skill（MCP-first + 场景路由）
+
+### 推荐安装配置（MCP，stdio）
+
+```json
+{
+  "mcpServers": {
+    "cloudbase": {
+      "command": "npx",
+      "args": ["-y", "@cloudbase/cloudbase-mcp@latest"]
+    }
+  }
+}
+```
+
+### 关键链接
+
+| 项 | URL |
+|----|-----|
+| 产品文档 | https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ |
+| Trae 配置指南 | https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ide-setup/trae |
+| MCP npm | https://www.npmjs.com/package/@cloudbase/cloudbase-mcp |
+| Open Plugin 专用仓 | https://github.com/TencentCloudBase/cloudbase-plugin |
+| 社区 MCP 目录行 | https://github.com/trae-community/trae-mcp |
+| 社区 Skills | https://github.com/trae-community/trae-skills/tree/main/skills/cloudbase |
+| License | MIT |
+
+### 价值主张（中文，可直接粘贴）
+
+```text
+CloudBase 是腾讯云开发官方 BaaS / 全栈后端。将 CloudBase MCP 与 Skills 放入 Trae 官方市场后，Trae 用户可在 IDE / Trae Work 内用自然语言完成环境开通、数据库建模、云函数部署、静态托管、小程序联调等，而无需离开编辑器。我们已通过 Trae 社区目录审核（MCP + Skills），希望进一步进入官方 in-app 策展，降低安装摩擦。
+```
+
+### 英文短描述（marketplace card）
+
+```text
+Tencent CloudBase MCP + skills: auth, databases, cloud functions, storage, CloudRun, and WeChat Mini Program workflows — install via npx and build full-stack apps inside Trae.
+```
+
+## 论坛发帖草稿（人类登录后发送）
+
+**建议版块：** 社区伙伴（优先）或 产品建议；Skills 相关可同步 TraeWork 专区。
+
+**标题：**
+
+```text
+【合作申请】腾讯云开发 CloudBase MCP / Skills 申请进入 Trae 官方 in-app 市场策展
+```
+
+**正文：**
+
+```markdown
+您好，我们是腾讯云开发（CloudBase）团队。
+
+## 背景
+- 已在 Trae 社区目录上架并合并：
+  - MCP：https://github.com/trae-community/trae-mcp/pull/4
+  - Skills：https://github.com/trae-community/trae-skills/pull/20
+- 文档侧：用户可手动配置 / deeplink 安装；希望进一步进入 **Trae 内置 MCP 市场** 与 **Trae Work 技能市场** 官方策展。
+
+## 申请事项
+1. 请告知官方 in-app MCP 市场的第三方 / 合作伙伴收录流程与对接人。
+2. 请告知 Trae Work 技能市场的官方策展 / 投稿流程（本地上传是否仅个人生效？是否有 partner 通道？）。
+3. 如需材料包（logo、描述、安装 JSON、Skill zip、安全说明），我们可按模板补齐。
+
+## 安装示意（MCP）
+`npx -y @cloudbase/cloudbase-mcp@latest`
+
+## 联系
+- GitHub：https://github.com/TencentCloudBase/CloudBase-AI-Toolkit
+- 文档：https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/
+- Issues：https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/issues
+
+感谢支持！
+```
+
+## GitHub Issue 草稿（Agent 可直接开）
+
+已开：
+
+- MCP：https://github.com/trae-community/trae-mcp/issues/5
+- Skills：https://github.com/trae-community/trae-skills/issues/21
+- PR 跟帖：https://github.com/trae-community/trae-mcp/pull/4#issuecomment-5189097225 · https://github.com/trae-community/trae-skills/pull/20#issuecomment-5189097487
+
+核心问题：
+
+1. 社区 README 目录与 Trae 客户端内置市场是否同源 / 如何同步？
+2. 官方策展的申请材料与联系人是谁？
+3. Skills 市场是否接受社区仓 Skill 自动同步，或仅官方策展？
+
+## 验收标准（本 outreach 任务）
+
+1. When 社区目录已 listed 且官方无公开 submit form, the outreach packet shall 明确区分 community vs official_curated，且不得把官方市场标成 listed。
+2. When outreach 发起后, the submission log shall 记录渠道、时间、链接与下一步（论坛人类发帖 / BD）。
+3. When Trae 回复收录路径, the follow-up task shall 按官方模板补材料并更新 `markets.yaml` `official_curated`。
+
+## 明确不做
+
+- 不在 `doc/ide-setup/trae.mdx` 声称「已上架官方市场」
+- 不伪造官方 submit URL
+- 不等同社区 PR merge = in-app marketplace listed


### PR DESCRIPTION
## Summary
- Record Trae community approval/merge for CloudBase MCP (`trae-community/trae-mcp#4`) and Skills (`trae-community/trae-skills#20`) on 2026-08-05.
- Flip `markets.yaml` community listing statuses to `listed` (official Trae in-app markets remain partner-outreach).
- Start official in-app marketplace outreach: packet + GitHub asks ([trae-mcp#5](https://github.com/trae-community/trae-mcp/issues/5), [trae-skills#21](https://github.com/trae-community/trae-skills/issues/21)).
- Close superseded conflicting PR #876 (Awesome Copilot intake already landed via #877).

## Test plan
- [x] Confirm catalog rows live in trae-community READMEs
- [x] Confirm GitHub outreach issues opened
- [x] YAML loads (`markets.yaml`)
- [ ] CI green on this PR
- [ ] Human follow-up: post forum draft from `trae-official-outreach-packet.md`