### PR TITLE
fix(partner): post-#886 prewarm cleanup, skill install path, CI sync

### DIFF
--- a/.github/workflows/sync-derived-branches.yml
+++ b/.github/workflows/sync-derived-branches.yml
@@ -85,7 +85,9 @@ jobs:
 
       - name: Commit and push
         run: |
-          git add config/codebuddy-plugin/skills config/codebuddy-plugin/rules config/codebuddy-plugin/.codebuddy-plugin
+          # skills/ is gitignored on main (regenerated artifact) but must be
+          # force-added on chore/codebuddy_plugin so the marketplace branch ships it.
+          git add -f config/codebuddy-plugin/skills config/codebuddy-plugin/rules config/codebuddy-plugin/.codebuddy-plugin
           if git diff --staged --quiet; then
             echo "No changes, skipping."
           else

--- a/config/codebuddy-plugin/.codebuddy-plugin/plugin.json
+++ b/config/codebuddy-plugin/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudbase",
-  "version": "2.25.1",
+  "version": "2.25.8",
   "description": "Tencent CloudBase — AI models, authentication, NoSQL/MySQL/PostgreSQL databases, cloud functions, cloud storage, CloudRun, and WeChat Mini Program integration. Powered by cloudbase-mcp.",
   "author": {
     "name": "Tencent CloudBase",
@@ -24,6 +24,7 @@
     "cloudrun"
   ],
   "skills": [
-    "./skills/cloudbase"
+    "./skills/cloudbase",
+    "./skills/minimal-web-baas-demo"
   ]
 }

--- a/plugin/workbuddy-template-prewarm/hooks/prewarm.mjs
+++ b/plugin/workbuddy-template-prewarm/hooks/prewarm.mjs
@@ -674,13 +674,13 @@ async function main() {
   }
 
   try {
-    let state;
+    // Install/init writes state to disk; maybeStartPreview merges via writeState.
     if (decision.action === "install-only") {
-      state = await prewarmInstallOnly(args.cwd);
+      await prewarmInstallOnly(args.cwd);
     } else {
-      state = await prewarmEmpty(args.cwd, args.template, args.skipInstall);
+      await prewarmEmpty(args.cwd, args.template, args.skipInstall);
     }
-    state = maybeStartPreview(args.cwd, args.startPreview);
+    const state = maybeStartPreview(args.cwd, args.startPreview);
     process.stdout.write(JSON.stringify({ ok: true, state }, null, 2) + "\n");
     process.exit(0);
   } catch (e) {

--- a/plugin/xdf-workbuddy-expert-pack/.claude-plugin/plugin.json
+++ b/plugin/xdf-workbuddy-expert-pack/.claude-plugin/plugin.json
@@ -1,8 +1,14 @@
 {
   "name": "xdf-workbuddy-expert-pack",
-  "version": "0.1.0",
-  "description": "XDF / WorkBuddy expert distribution: BaaS-first agent prompt + pointer to minimal-web-baas-demo. SessionStart prewarm is configured via settings.snippet / sibling workbuddy-template-prewarm plugin — not via agent frontmatter hooks.",
+  "version": "0.1.1",
+  "description": "XDF / WorkBuddy expert distribution: BaaS-first agent prompt + loadable minimal-web-baas-demo skill. SessionStart prewarm is configured via settings.snippet / sibling workbuddy-template-prewarm plugin — not via agent frontmatter hooks.",
   "author": {
     "name": "CloudBase AI Toolkit"
-  }
+  },
+  "skills": [
+    "./skills/minimal-web-baas-demo"
+  ],
+  "agents": [
+    "./agents/cloudbase-baas-expert.md"
+  ]
 }

--- a/plugin/xdf-workbuddy-expert-pack/PARTNER-CHECKLIST.md
+++ b/plugin/xdf-workbuddy-expert-pack/PARTNER-CHECKLIST.md
@@ -15,12 +15,14 @@
   ```text
   plugin/
     workbuddy-template-prewarm/   # SessionStart + Sites preview CLI（含 vendor）
-    xdf-workbuddy-expert-pack/    # 本包：专家提示词 + settings 片段
+    xdf-workbuddy-expert-pack/    # 本包：专家提示词 + settings 片段 + skills/minimal-web-baas-demo
   ```
 - [ ] `workbuddy-template-prewarm/hooks/on-session-start.sh` 可执行
 - [ ] `workbuddy-template-prewarm/vendor/cloudbase-sites/bin/cloudbase-sites` 存在（或已设 `CLOUDBASE_SITES_BIN`）
 - [ ] `xdf-workbuddy-expert-pack/agents/cloudbase-baas-expert.md` 存在且 **无** frontmatter `hooks`
-- [ ] CloudBase 连接器可在 WorkBuddy 中配置 / Trust（skills 侧能解析 `minimal-web-baas-demo`）
+- [ ] 已跑 `bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh`  
+      （`~/.workbuddy/skills/minimal-web-baas-demo/SKILL.md` 存在；Trust 前 `Skill()` 可用）
+- [ ] CloudBase 连接器可在 WorkBuddy 中配置 / Trust（`searchKnowledgeBase` 为可选回退）
 
 ---
 
@@ -28,10 +30,19 @@
 
 ### 路径 A — 推荐产品化：marketplace 插件
 
-- [ ] 添加 marketplace：`TencentCloudBase/CloudBase-MCP`（或伙伴约定源）
-- [ ] 安装并启用 `workbuddy-template-prewarm`
-- [ ] **未**删除 `~/.workbuddy/settings.json` 里已有 **teamai** SessionStart
-- [ ] **未**因本包打开 `allowUntrustedFrontmatterHooks`
+> **验证记录（2026-08-05，WorkBuddy + teamai 机）：PASS**  
+> Demo：`~/WorkBuddy/partner-pathA-verify-20260805-161521`  
+> 证据：`~/.ato/workspace/fd5bacbf-3ada-4512-8660-9bff8a293004/artifacts/`  
+> - `HookManager event=SessionStart matched 2`（teamai settings + plugin `hooks/hooks.json`）  
+> - `state.json` → `ready`（~20s）；`preview.json.port=17177` ∈ 17173..17272  
+> - `sitesBin` = marketplace `vendor/cloudbase-sites`（无 monorepo 绝对路径）  
+> - settings **仅**保留 `[teamai]` SessionStart；`enabledPlugins["workbuddy-template-prewarm@tencent-cloudbase"]=true`  
+> - **注意：** 公开 GitHub `main` 目录暂未列入本插件（PR [#886](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/pull/886) 合入前），伙伴需用含 catalog 的 ref / 已同步 marketplace  checkout；安装器读 `.claude-plugin/marketplace.json`。
+
+- [x] 添加 marketplace：`TencentCloudBase/CloudBase-MCP`（或伙伴约定源）
+- [x] 安装并启用 `workbuddy-template-prewarm`
+- [x] **未**删除 `~/.workbuddy/settings.json` 里已有 **teamai** SessionStart
+- [x] **未**因本包打开 `allowUntrustedFrontmatterHooks`
 
 ### 路径 B — 离线 / 内网：settings 合并（本清单主验路径）
 
@@ -67,6 +78,7 @@ jq 'has("allowUntrustedFrontmatterHooks")' ~/.workbuddy/settings.json
   **或**粘贴进 WorkBuddy 专家 / 系统提示（伙伴既有专家位）
 - [ ] frontmatter **没有** `hooks` 字段
 - [ ] frontmatter / 正文指向 skill id：`minimal-web-baas-demo`
+- [ ] 已安装 skill：`bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh`
 - [ ] （可选）伙伴 brief：`briefs/baas-fast-path.md` 已作为一页指针归档
 
 ```bash
@@ -74,6 +86,9 @@ cp plugin/xdf-workbuddy-expert-pack/agents/cloudbase-baas-expert.md \
    ~/.workbuddy/agents/cloudbase-baas-expert.md
 # 确认无 frontmatter hooks：
 head -20 ~/.workbuddy/agents/cloudbase-baas-expert.md | grep -E '^hooks:' && echo FAIL || echo OK
+# 安装 Skill()-addressable skill（Trust 前必需）：
+bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh
+test -f ~/.workbuddy/skills/minimal-web-baas-demo/SKILL.md && echo SKILL_OK
 ```
 
 ---
@@ -153,10 +168,9 @@ node plugin/workbuddy-template-prewarm/hooks/prewarm.mjs --status --cwd "$DEMO"
 
 勾选：
 
-- [ ] **第一步**调用（或等价拉取）  
-  `searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")`  
-  （WorkBuddy 常无本机 skill 文件时 **禁止**优先瞎读本地路径）
+- [ ] **第一步**按优先级：`Skill("minimal-web-baas-demo")` → 本包 `Read skills/…/SKILL.md` →（仅 Trust 后）`searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")`
 - [ ] **未**在会话开头整包灌入全部 cloudbase-skills
+- [ ] **未**因 Skill/MCP 失败而只靠 prompt 摘要（装机应已 `install-skill.sh`）
 - [ ] 明确架构定案：**云函数数 = 0**（即使用户口头「带云函数」）
 - [ ] CRUD 路径：`@cloudbase/js-sdk` → `app.database()` 或 `app.rdb()`（视 `envQuery` 锁定的 DB）
 - [ ] Schema / 权限只走 MCP（等 Connector Trust 后）
@@ -246,4 +260,4 @@ node plugin/workbuddy-template-prewarm/hooks/prewarm.mjs --status --cwd "$TMP"
 | `HOOKS.md` | 为何不用 Agent frontmatter hooks |
 | `briefs/baas-fast-path.md` | 一页 BaaS 指针 |
 | `../workbuddy-template-prewarm/README.md` | prewarm / Sites preview 细节 |
-| skill `minimal-web-baas-demo` | 完整 Fast-path 契约 |
+| `skills/minimal-web-baas-demo/` + `scripts/install-skill.sh` | 完整 Fast-path 契约（Trust 前 Skill 面） |

--- a/plugin/xdf-workbuddy-expert-pack/README.md
+++ b/plugin/xdf-workbuddy-expert-pack/README.md
@@ -9,12 +9,14 @@
 | 路径 | 作用 |
 | --- | --- |
 | `agents/cloudbase-baas-expert.md` | 专家 Agent 正文（**无** frontmatter `hooks`） |
+| `skills/minimal-web-baas-demo/` | 可加载 BaaS Fast-path skill（Trust 前 `Skill()` 可用） |
+| `scripts/install-skill.sh` | 安装到 `~/.workbuddy/skills/`（及 `~/.codebuddy/skills/`） |
 | `briefs/baas-fast-path.md` | `minimal-web-baas-demo` 一页指针 |
 | `settings.snippet.json` | 合并进 `~/.workbuddy/settings.json` 的 SessionStart 片段 |
 | `scripts/render-settings.sh` | 把片段里的路径渲染成绝对路径 |
 | `PARTNER-CHECKLIST.md` | 伙伴侧启用验收清单（merge / preview 端口池 / 零云函数） |
 | `HOOKS.md` | frontmatter allowlist 结论（英文技术备忘） |
-| `.claude-plugin/plugin.json` | 可选插件元数据（Agent 发现用；prewarm 仍走 sibling） |
+| `.claude-plugin/plugin.json` | 插件元数据（agents + skills；prewarm 仍走 sibling） |
 
 Sibling（必须同仓 / 同目录分发）：
 
@@ -55,10 +57,13 @@ bash plugin/xdf-workbuddy-expert-pack/scripts/render-settings.sh --merge
 # 3) 把 agents/cloudbase-baas-expert.md 粘进 WorkBuddy 专家 / 系统提示
 #    或复制到 ~/.workbuddy/agents/（若伙伴用本地 agents）
 
-# 4) 确保 CloudBase 连接器已配置；skills 侧能解析 minimal-web-baas-demo
-#    （插件 skills 或 searchKnowledgeBase）
+# 4) 安装 BaaS skill 到本机 skill 面（Trust / MCP 之前也要能 Skill()）
+bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh
+# 期望：~/.workbuddy/skills/minimal-web-baas-demo/SKILL.md 存在
 
-# 5) 新开 WorkBuddy 会话，cwd 选空项目目录；引导凭据时检查：
+# 5) 配置 CloudBase 连接器（Trust 后才可用 searchKnowledgeBase；Step0 不依赖它）
+
+# 6) 新开 WorkBuddy 会话，cwd 选空项目目录；引导凭据时检查：
 #    cat <cwd>/.cloudbase-prewarm/state.json      # status=ready
 #    cat <cwd>/.cloudbase-sites/preview.json     # internalUrl @ 17173..17272
 #    保持 sibling plugin/cloudbase-sites 可用（或设 CLOUDBASE_SITES_BIN）
@@ -86,7 +91,8 @@ hooks 装不上时仍可改善体验，但弱于 SessionStart 后台任务。Pre
 - [ ] SessionStart 与 teamai hooks **并存**，未互相覆盖
 - [ ] 空目录新会话 → ~20–40s 内 `.cloudbase-prewarm/state.json` 为 `ready`
 - [ ] 同期出现 `.cloudbase-sites/preview.json`（端口池 17173..17272，非 5173）
-- [ ] 专家第一步调用 `searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")`，不为留言板创建云函数
+- [ ] `Skill("minimal-web-baas-demo")` 在 **未 Trust** 时也可解析（已跑 `install-skill.sh`）
+- [ ] 专家不为留言板创建云函数（对齐 skill 契约）
 - [ ] `allowUntrustedFrontmatterHooks` **未**因本包被强制打开
 
 ## 与上游任务的关系

--- a/plugin/xdf-workbuddy-expert-pack/agents/cloudbase-baas-expert.md
+++ b/plugin/xdf-workbuddy-expert-pack/agents/cloudbase-baas-expert.md
@@ -18,13 +18,14 @@ skills:
 **不要**把官方 cloudbase-skills / 全量 SKILL.md 在会话第一步全部读完。  
 **不要**只靠本提示词里的 ad-hoc BaaS 摘要当唯一契约 —— 完整 Fast-path 以技能文档为准。
 
-**第一步（强制）：** 调用 MCP 拉取主技能（WorkBuddy 常无本机 skill 文件，禁止优先 `Read` 本地路径）：
+**第一步（强制，按优先级尝试，Trust 前也要成功）：**
 
-```text
-searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")
-```
+1. `Skill("minimal-web-baas-demo")` — 本机 `~/.workbuddy/skills/` 或已启用插件 skills（`bash …/scripts/install-skill.sh` 安装）
+2. 若 Skill not found：`Read` 本包 `skills/minimal-web-baas-demo/SKILL.md`（相对专家包根）
+3. 若仍不可用且 CloudBase 连接器已 Trust：  
+   `searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")` 后 `Read` 返回路径
 
-拿到返回路径后 `Read` 全文，再动手。本提示词 §1–§7 只是执行清单；与技能冲突时 **以技能为准**。
+**禁止**在 connector Unauthorized / 未 Trust 时死等 MCP。本提示词 §1–§7 只是执行清单；与技能冲突时 **以技能为准**。
 
 按需再拉（仅在真正需要时）：
 
@@ -127,7 +128,7 @@ MCP → 建表/集合、权限、环境查询
 
 ### 7. 自检
 
-- [ ] 已 `searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")`（非仅靠本提示词摘要）
+- [ ] 已加载 `minimal-web-baas-demo`（`Skill` / 本包 `Read` / 或 Trust 后 `searchKnowledgeBase`；非仅靠本提示词摘要）
 - [ ] 未整包加载 cloudbase-skills
 - [ ] 凭据等待期间已有 prewarm 或 `downloadTemplate` + install
 - [ ] 预览 URL 来自 `preview.json` / Sites `preview --status`（未猜 5173）

--- a/plugin/xdf-workbuddy-expert-pack/briefs/baas-fast-path.md
+++ b/plugin/xdf-workbuddy-expert-pack/briefs/baas-fast-path.md
@@ -7,6 +7,9 @@ The full contract lives in the skill:
 | --- | --- |
 | Source skill | `config/source/skills/minimal-web-baas-demo/SKILL.md` |
 | Skill id | `minimal-web-baas-demo` |
+| Pack (loadable) | `../skills/minimal-web-baas-demo/SKILL.md` |
+| Install | `../scripts/install-skill.sh` → `~/.workbuddy/skills/` |
+| CodeBuddy plugin | `config/codebuddy-plugin` top-level `./skills/minimal-web-baas-demo` |
 | Claude mirror | `config/.claude/skills/minimal-web-baas-demo/SKILL.md` |
 | Expert agent | `../agents/cloudbase-baas-expert.md` |
 
@@ -27,11 +30,13 @@ Reusable beyond XDF: any WorkBuddy / CodeBuddy / ISV partner can point expert pr
 ## Agent routing line (paste into partner system prompt if needed)
 
 ```text
-For 最小前后端 / Lovable-like demos, FIRST call:
+For 最小前后端 / Lovable-like demos, FIRST try Skill("minimal-web-baas-demo")
+(or Read pack skills/minimal-web-baas-demo/SKILL.md). Only if connector is
+Trusted, fall back to:
   searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")
-then Read the returned path. Do not rely only on ad-hoc BaaS brief text in the
-expert prompt. Order: connector → template warmup during credential wait →
-envQuery → lock DB → MCP schema → @cloudbase/js-sdk CRUD → preview.
+Do not wait on MCP when Unauthorized. Order: connector → template warmup
+during credential wait → envQuery → lock DB → MCP schema →
+@cloudbase/js-sdk CRUD → preview.
 Do not dump all CloudBase skills. Do not create cloud functions for CRUD.
 ```
 
@@ -41,6 +46,7 @@ Do not dump all CloudBase skills. Do not create cloud functions for CRUD.
 | --- | --- |
 | WorkBuddy SessionStart | Merge `../settings.snippet.json` (rendered) into `~/.workbuddy/settings.json` |
 | Plugin marketplace | Enable sibling `workbuddy-template-prewarm` (`hooks/hooks.json`) — no frontmatter allowlist |
+| Skill surface (required) | Run `../scripts/install-skill.sh` **or** enable `cloudbase` plugin ≥2.25.8 with top-level `minimal-web-baas-demo` |
 | Expert Agent only | Ship `cloudbase-baas-expert.md` **without** frontmatter hooks; keep portable §1b warmup |
 
 See `../HOOKS.md` for why frontmatter hooks are not used.

--- a/plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh
+++ b/plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Install minimal-web-baas-demo onto the local WorkBuddy / CodeBuddy skill surface
+# so Skill("minimal-web-baas-demo") resolves before CloudBase connector Trust.
+#
+# Usage (from repo root or this pack directory):
+#   bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh
+#   bash scripts/install-skill.sh
+#
+# Destinations (created if missing):
+#   ~/.workbuddy/skills/minimal-web-baas-demo
+#   ~/.codebuddy/skills/minimal-web-baas-demo   (when that home exists)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PACK_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SRC="${PACK_ROOT}/skills/minimal-web-baas-demo"
+SKILL_ID="minimal-web-baas-demo"
+
+if [[ ! -f "${SRC}/SKILL.md" ]]; then
+  echo "ERROR: missing ${SRC}/SKILL.md" >&2
+  exit 1
+fi
+
+install_one() {
+  local dest_root="$1"
+  local label="$2"
+  local dest="${dest_root}/${SKILL_ID}"
+  mkdir -p "${dest_root}"
+  rm -rf "${dest}"
+  mkdir -p "${dest}"
+  # Prefer rsync when available; fall back to cp -R for minimal partner hosts.
+  if command -v rsync >/dev/null 2>&1; then
+    rsync -a --delete "${SRC}/" "${dest}/"
+  else
+    cp -R "${SRC}/." "${dest}/"
+  fi
+  echo "Installed ${SKILL_ID} → ${dest} (${label})"
+}
+
+install_one "${HOME}/.workbuddy/skills" "WorkBuddy"
+
+if [[ -d "${HOME}/.codebuddy" ]]; then
+  install_one "${HOME}/.codebuddy/skills" "CodeBuddy"
+fi
+
+echo
+echo "Verify (expect SKILL.md):"
+echo "  ls ~/.workbuddy/skills/${SKILL_ID}/SKILL.md"
+echo "Then start a new WorkBuddy session and call Skill(\"${SKILL_ID}\")."

--- a/plugin/xdf-workbuddy-expert-pack/skills/minimal-web-baas-demo/SKILL.md
+++ b/plugin/xdf-workbuddy-expert-pack/skills/minimal-web-baas-demo/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: minimal-web-baas-demo
+description: "Fast path for a minimal CloudBase Web + database demo (最小前后端 / 最小可用 fullstack / Lovable-like BaaS). Defaults to @cloudbase/js-sdk client CRUD (NoSQL app.database / PG app.rdb), MCP-only schema, preview-first, and forbids cloud functions unless secrets, cron/background jobs, or logic that security rules/RLS cannot express. Use for 搭一套 demo、留言板、Todo、Notes、Kanban, or when users say 带云函数+云数据库 but only need CRUD. NOT for production multi-service backends, CloudRun, WeChat Mini Programs, or tasks that truly need server secrets."
+version: 2.25.8
+alwaysApply: false
+---
+
+## Sibling skills (local only)
+
+Sibling CloudBase skills ship beside this skill. Use local relative paths such as `../web-development/SKILL.md`.
+
+If a referenced sibling skill file is missing from this environment, ask the user to install the full CloudBase plugin (or the missing skill). Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
+
+# Minimal Web BaaS Demo (fast path)
+
+Goal: **minutes to an interactive Web + database preview**, not a cloud-function middleware stack.
+
+This skill is the product equivalent of CloudBase Sites SessionStart **Rule 5** (BaaS-first data persistence).
+
+## Activation Contract
+
+### Use this first when
+
+- The user asks for a **minimal fullstack / 前后端 demo**, message board, Todo, Notes, Kanban, or Lovable/Supabase-like quick app on CloudBase Web.
+- The user says "带云函数+云数据库" but the real need is CRUD + preview (reinterpret as Web SDK → database).
+
+### Do NOT use for
+
+- WeChat Mini Programs (`wx.cloud`) — use `../miniprogram-development/SKILL.md`.
+- True server workloads: payments callbacks, SMS providers, secret third-party keys, cron/ETL, WebSockets — use `../cloud-functions/SKILL.md` or `../cloudrun-development/SKILL.md`.
+- Large multi-module products that need `../spec-workflow/SKILL.md`.
+
+## Hard rules (align with Sites SessionStart Rule 5)
+
+1. **BaaS-first data path**
+   - **Schema / admin:** MCP only. Do not ask the user to create collections/tables in the console.
+     - NoSQL: `writeNoSqlDatabaseStructure` (create collection / indexes) + permission tools as needed.
+     - PostgreSQL: follow `../postgresql-development-cloudbase/SKILL.md` (`queryPgDatabase` / `managePgDatabase` / migrations).
+   - **Reads / writes:** `@cloudbase/js-sdk` in the browser.
+     - NoSQL: `app.database()` → `db.collection(...).get()/add()/update()/watch(...)`.
+     - PG: `app.rdb().from(...)`.
+   - Prefer the template helper (often `src/utils/cloudbase.ts`). Do not invent a second SDK wrapper.
+
+2. **Cloud functions are forbidden by default**
+   - Todo / Notes / Chat / Kanban / "最小前后端 demo" → **zero** cloud functions.
+   - Even if the user says "带云函数", deliver Web SDK → DB and explain in one sentence that cloud functions are not required for CRUD.
+   - Create a cloud function **only when**:
+     - (a) the logic cannot be expressed as database security rules / RLS, **and**
+     - (b) it needs server-side secrets / third-party API keys, **or** it is a scheduled / background job not triggered by a user click.
+
+3. **Package discipline**
+   - Browser: `@cloudbase/js-sdk` only.
+   - Never install `@cloudbase/node-sdk` (or random stubs) in frontend code.
+
+4. **Preview first, deploy second**
+   - Ship local list + add (or equivalent CRUD) before static hosting / CloudApp deploy.
+   - Custom domains, DNS, rollback runbooks → only if the user explicitly asks.
+   - Skip Playwright / agent-browser unless the user asks to test.
+
+5. **UI ceremony for this path**
+   - Reuse the template look. **Do not** load `ui-design` four-part specs for a minimal demo unless the user asks for visual redesign.
+   - "Make me a X app" = X **is** the homepage (`HomePage` / `App`), not a nested demo route beside the welcome page.
+
+## Capability sniff order (partners + agents)
+
+Use this order for every minimal Web + DB demo. **Do not reorder.** Cloud functions stay off the critical path.
+
+```text
+0. Connector pre-enabled (or shortest Trust path)     ← host / partner packaging
+1. Template warmup // parallel with credential wait   ← downloadTemplate + install
+2. envQuery(action="info")                            ← sniff env + RuntimeBackends
+3. Lock ONE DB plane (NoSQL | PG | MySQL)             ← no mid-flight thrash
+4. MCP schema + minimal permissions                   ← writeNoSql* / PG migrate / MySQL manage
+5. Browser @cloudbase/js-sdk CRUD                     ← app.database() / app.rdb()
+6. Local preview (list + add)                         ← then ask before deploy
+7. Cloud functions                                    ← skip (count = 0) unless secrets/cron/rules-cannot-express
+```
+
+Stack priority for this path: **Web SDK CRUD > MCP schema > template warmup > cloud functions**.
+
+## Standard playbook
+
+1. **Warm template in parallel with credentials** (see partner notes below): `downloadTemplate` (`react` default, `vue` if requested) → `npm install` / `pnpm install`.
+2. `envQuery(action="info")` → lock **one** DB plane (NoSQL **or** PG **or** MySQL). Do not thrash between them.
+3. MCP: create the collection/table + minimal permissions.
+4. Frontend: wire list + create with `@cloudbase/js-sdk`.
+5. Start / report preview URL; ask before deploy.
+6. **Cloud function count for this path = 0.**
+
+### On-demand skills (fetch only when needed)
+
+| Need | Skill |
+| --- | --- |
+| Web scaffold / hosting | `../web-development/SKILL.md` |
+| NoSQL browser CRUD | `../cloudbase-document-database-web-sdk/SKILL.md` |
+| PG browser CRUD + MCP schema | `../postgresql-development-cloudbase/SKILL.md` |
+| Auth provider readiness | `../auth-tool-cloudbase/SKILL.md` then `../auth-web-cloudbase/SKILL.md` |
+
+Prefer `searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo")` (or the sibling dir id) when local skill files are unavailable. **Do not** dump every CloudBase skill at session start.
+
+## WorkBuddy / partner packaging notes (XDF and beyond)
+
+Any partner host (WorkBuddy, CodeBuddy connectors, vertical expert prompts, ISV wrappers) should treat this skill as the **compact fast-path brief**. Reuse the sniff order above; do not invent a cloud-function-first demo path.
+
+| Host capability | Recommended packaging |
+| --- | --- |
+| Full CloudBase Sites plugin | Rely on SessionStart Rule 5 injection + this skill on demand for non-Sites cwd demos. |
+| WorkBuddy with SessionStart (supported) | Prefer `plugin/workbuddy-template-prewarm` (or enable Sites with `CLOUDBASE_SITES_AUTO_INIT=1`): background React zip + install + Sites `preview` (ports 17173..17272) overlaps credential/Trust wait; inject this skill pointer via `additionalContext`. Never guess 5173 — read `.cloudbase-sites/preview.json`. |
+| WorkBuddy / connector without hooks | **Pre-enable** the CloudBase MCP connector for the tenant when possible; inject a short system brief that points here; warm `downloadTemplate` + `npm install` **during** credential/Trust wait (do not idle). |
+| Expert / vertical prompts (XDF or other ISVs) | Ship a thin pack: expert Agent markdown (**no** frontmatter hooks) + settings/hooks merge for SessionStart prewarm. Reference example: `plugin/xdf-workbuddy-expert-pack` + sibling prewarm plugin. Replace any "必须云函数中转 / 前端绝不直连库" language with this BaaS-first contract. |
+
+WorkBuddy SessionStart: https://www.workbuddy.ai/docs/cli/hooks (same `additionalContext` schema as CodeBuddy/Claude Code). Empty-dir Sites auto-init stays passive unless opted in — do not assume enabling Sites alone warms templates during credential wait.
+
+**Do not** block first preview on custom domains or org DNS health. DNS issues are a post-preview concern.
+
+### One-screen partner paste (optional)
+
+```text
+For 最小前后端 / Lovable-like demos: FIRST call
+searchKnowledgeBase(mode="skill", skillName="minimal-web-baas-demo"), then Read.
+Do not rely only on ad-hoc expert-prompt brief text.
+Order: connector ready → template warmup during credential wait → envQuery →
+lock one DB → MCP schema → @cloudbase/js-sdk CRUD → preview.
+Do not dump all CloudBase skills. Do not create cloud functions for CRUD.
+```

--- a/scripts/sync-codebuddy-plugin.ts
+++ b/scripts/sync-codebuddy-plugin.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env npx tsx
 /**
- * Sync the generated all-in-one CloudBase skill into config/codebuddy-plugin.
+ * Sync the generated all-in-one CloudBase skill into config/codebuddy-plugin,
+ * plus any top-level skills that must be Skill()-addressable by id
+ * (e.g. minimal-web-baas-demo for WorkBuddy expert Step0 before Trust).
  *
  * Usage:
  *   npx tsx scripts/sync-codebuddy-plugin.ts
@@ -16,13 +18,16 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
 const ROOT = path.resolve(__dirname, '..');
-const DEFAULT_DEST = path.join(
-  ROOT,
-  'config',
-  'codebuddy-plugin',
-  'skills',
-  'cloudbase',
-);
+const DEFAULT_SKILLS_ROOT = path.join(ROOT, 'config', 'codebuddy-plugin', 'skills');
+const DEFAULT_DEST = path.join(DEFAULT_SKILLS_ROOT, 'cloudbase');
+const SOURCE_SKILLS_DIR = path.join(ROOT, 'config', 'source', 'skills');
+
+/**
+ * Skills that must also be published as top-level plugin skills so hosts
+ * that resolve Skill("<name>") (WorkBuddy / CodeBuddy) can load them without
+ * digging into cloudbase/references/. Keep in sync with plugin.json "skills".
+ */
+export const TOP_LEVEL_SKILL_IDS = ['minimal-web-baas-demo'] as const;
 
 function copyDir(src: string, dest: string): void {
   fs.mkdirSync(dest, { recursive: true });
@@ -45,11 +50,37 @@ function countFiles(dir: string): number {
   return count;
 }
 
+function syncTopLevelSkills(skillsRoot: string): string[] {
+  const synced: string[] = [];
+  for (const skillId of TOP_LEVEL_SKILL_IDS) {
+    const src = path.join(SOURCE_SKILLS_DIR, skillId);
+    const entry = path.join(src, 'SKILL.md');
+    if (!fs.existsSync(entry)) {
+      throw new Error(`Missing top-level skill source: ${entry}`);
+    }
+    const dest = path.join(skillsRoot, skillId);
+    if (fs.existsSync(dest)) {
+      fs.rmSync(dest, { recursive: true, force: true });
+    }
+    copyDir(src, dest);
+    synced.push(skillId);
+  }
+  return synced;
+}
+
 export function syncCodeBuddyPlugin(options: {
   destinationDir?: string;
+  skillsRootDir?: string;
   tempRootDir?: string;
-} = {}): { sourceDir: string; destinationDir: string; fileCount: number } {
+} = {}): {
+  sourceDir: string;
+  destinationDir: string;
+  fileCount: number;
+  topLevelSkills: string[];
+} {
   const destinationDir = options.destinationDir || DEFAULT_DEST;
+  const skillsRootDir =
+    options.skillsRootDir || path.dirname(destinationDir);
   const tempRootDir = options.tempRootDir || fs.mkdtempSync(
     path.join(os.tmpdir(), 'cloudbase-codebuddy-plugin-'),
   );
@@ -69,10 +100,18 @@ export function syncCodeBuddyPlugin(options: {
 
     copyDir(sourceDir, destinationDir);
 
+    const topLevelSkills = syncTopLevelSkills(skillsRootDir);
+
+    let fileCount = countFiles(destinationDir);
+    for (const skillId of topLevelSkills) {
+      fileCount += countFiles(path.join(skillsRootDir, skillId));
+    }
+
     return {
       sourceDir,
       destinationDir,
-      fileCount: countFiles(destinationDir),
+      fileCount,
+      topLevelSkills,
     };
   } finally {
     if (shouldCleanupTemp) {
@@ -85,6 +124,7 @@ function main(): void {
   const result = syncCodeBuddyPlugin();
   console.log(`SRC : ${result.sourceDir}`);
   console.log(`DEST: ${result.destinationDir}`);
+  console.log(`TOP : ${result.topLevelSkills.join(', ') || '(none)'}`);
   console.log(`Done: ${result.fileCount} files copied`);
 }
 

--- a/tests/sync-codebuddy-plugin.test.js
+++ b/tests/sync-codebuddy-plugin.test.js
@@ -2,17 +2,22 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import { expect, test } from 'vitest';
-import { syncCodeBuddyPlugin } from '../scripts/sync-codebuddy-plugin.ts';
+import {
+  syncCodeBuddyPlugin,
+  TOP_LEVEL_SKILL_IDS,
+} from '../scripts/sync-codebuddy-plugin.ts';
 
 test('sync-codebuddy-plugin copies generated all-in-one skill into the plugin skill directory', () => {
   const tempRootDir = fs.mkdtempSync(
     path.join(os.tmpdir(), 'cloudbase-codebuddy-sync-root-'),
   );
-  const destinationDir = path.join(tempRootDir, 'plugin-skills', 'cloudbase');
+  const skillsRootDir = path.join(tempRootDir, 'plugin-skills');
+  const destinationDir = path.join(skillsRootDir, 'cloudbase');
 
   try {
     const result = syncCodeBuddyPlugin({
       destinationDir,
+      skillsRootDir,
       tempRootDir,
     });
 
@@ -22,11 +27,28 @@ test('sync-codebuddy-plugin copies generated all-in-one skill into the plugin sk
     expect(
       fs.existsSync(path.join(destinationDir, 'references', 'auth-web-cloudbase', 'SKILL.md')),
     ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(destinationDir, 'references', 'minimal-web-baas-demo', 'SKILL.md'),
+      ),
+    ).toBe(true);
 
     const mainSkill = fs.readFileSync(path.join(destinationDir, 'SKILL.md'), 'utf8');
     expect(mainSkill).toContain('name: cloudbase');
     expect(mainSkill).toContain('## Activation Contract');
     expect(mainSkill).toContain('Native App / Flutter / React Native');
+    expect(mainSkill).toContain('minimal-web-baas-demo');
+
+    expect(TOP_LEVEL_SKILL_IDS).toContain('minimal-web-baas-demo');
+    expect(result.topLevelSkills).toContain('minimal-web-baas-demo');
+    expect(
+      fs.existsSync(path.join(skillsRootDir, 'minimal-web-baas-demo', 'SKILL.md')),
+    ).toBe(true);
+    const topLevel = fs.readFileSync(
+      path.join(skillsRootDir, 'minimal-web-baas-demo', 'SKILL.md'),
+      'utf8',
+    );
+    expect(topLevel).toContain('name: minimal-web-baas-demo');
   } finally {
     fs.rmSync(tempRootDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- Drop unused `state` assignments in `workbuddy-template-prewarm` prewarm flow (clears code-quality review noise from #886).
- Ship installable `minimal-web-baas-demo` under the expert pack + CodeBuddy top-level skill sync so WorkBuddy can `Skill()` before connector Trust.
- Fix `Sync Derived Branches` / `chore/codebuddy_plugin`: `git add -f` for gitignored `config/codebuddy-plugin/skills/` after reset onto main (pre-existing main CI failure, re-triggered by #886 merge).

## Context
- #886 was squash-merged while follow-up commits landed on the feature branch; this PR cherry-picks those onto main.
- Main run failure example: https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/actions/runs/30988338535

## Test plan
- [ ] CI green on this PR (compat / spec-check / build-and-publish)
- [ ] After merge, `Sync Derived Branches` → Sync chore/codebuddy_plugin succeeds (or re-run workflow_dispatch)
- [ ] `npx tsx scripts/sync-codebuddy-plugin.ts` copies `minimal-web-baas-demo` as top-level skill
- [ ] `bash plugin/xdf-workbuddy-expert-pack/scripts/install-skill.sh` installs skill locally


Made with [Cursor](https://cursor.com)