### PR TITLE
fix(ci): install archiver deps before Build Example Zips

### DIFF
--- a/.github/workflows/build-zips.yml
+++ b/.github/workflows/build-zips.yml
@@ -66,6 +66,12 @@ jobs:
           echo "=== Staged files ==="
           git diff --staged --name-only || echo "No staged files"
       
+      # Deps live in cloudbase-examples/scripts/package.json (archiver, glob); no lockfile.
+      - name: Install zip build dependencies
+        if: github.event.inputs.build_zips == 'true'
+        working-directory: cloudbase-examples/scripts
+        run: npm install --ignore-scripts
+
       - name: Build zips
         if: github.event.inputs.build_zips == 'true'
         working-directory: cloudbase-examples


### PR DESCRIPTION
## Summary
- `Build Example Zips` failed on run 30990333359 with `Cannot find module 'archiver'` because `cloudbase-examples/scripts/build-zips.js` requires `archiver`/`glob` but the workflow never installed `scripts/package.json` deps.
- Add `npm install --ignore-scripts` in `cloudbase-examples/scripts` before building zips (no lockfile in that package; sync-branch workflows do not build zips).

## Test plan
- [ ] Dispatch `Build Example Zips` with `source_branch` pointing at this branch (`--ref` this branch) and `build_zips=true`
- [ ] Confirm job installs deps and uploads `cloudbase-examples-zips`
- [ ] Download artifact and verify `web-cloudbase-project.zip` contains `.claude/skills/minimal-web-baas-demo/`