### PR TITLE
fix(env): detect RuntimeBackends.nosql from flexdb tnt InstanceId

### DIFF
--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1115,12 +1115,109 @@ describe("env tools - envQuery", () => {
       },
     });
     expect(payload.EnvInfo.Storages).toEqual([{ Bucket: "bucket-1" }]);
+    // Storages alone must NOT imply NoSQL (flexdb); CreateEnv treats them separately.
+    expect(payload.EnvInfo.RuntimeBackends).toEqual({
+      postgresql: false,
+      nosql: false,
+      mysql: false,
+    });
     expect(commonServiceCall).toHaveBeenCalledWith({
       Action: "DescribeBillingInfo",
       Param: {
         EnvId: "env-test",
       },
     });
+  });
+
+  it("envQuery(info) RuntimeBackends.nosql should require usable Databases InstanceId", async () => {
+    const cases: Array<{
+      name: string;
+      envInfo: Record<string, unknown>;
+      expected: { postgresql: boolean; nosql: boolean; mysql: boolean };
+      runtimeMode: "postgresql" | "nosql";
+    }> = [
+      {
+        name: "running flexdb",
+        envInfo: {
+          EnvId: "env-test",
+          Databases: [{ InstanceId: "tnt-1", Status: "RUNNING" }],
+        },
+        expected: { postgresql: false, nosql: true, mysql: false },
+        runtimeMode: "nosql",
+      },
+      {
+        name: "storages-only must not set nosql",
+        envInfo: {
+          EnvId: "env-test",
+          Storages: [{ Bucket: "bucket-only" }],
+        },
+        expected: { postgresql: false, nosql: false, mysql: false },
+        runtimeMode: "nosql",
+      },
+      {
+        name: "empty InstanceId ignored",
+        envInfo: {
+          EnvId: "env-test",
+          Databases: [{ InstanceId: "", Status: "RUNNING" }],
+          Storages: [{ Bucket: "bucket-1" }],
+        },
+        expected: { postgresql: false, nosql: false, mysql: false },
+        runtimeMode: "nosql",
+      },
+      {
+        name: "non-RUNNING Databases ignored",
+        envInfo: {
+          EnvId: "env-test",
+          Databases: [{ InstanceId: "tnt-pending", Status: "CREATING" }],
+        },
+        expected: { postgresql: false, nosql: false, mysql: false },
+        runtimeMode: "nosql",
+      },
+      {
+        name: "PG + flexdb coexist",
+        envInfo: {
+          EnvId: "env-test",
+          PostgreSQL: [{ InstanceId: "pg-1" }],
+          Databases: [{ InstanceId: "tnt-1", Status: "RUNNING" }],
+          Storages: [{ Bucket: "legacy-bucket" }],
+        },
+        expected: { postgresql: true, nosql: true, mysql: false },
+        runtimeMode: "postgresql",
+      },
+      {
+        name: "PG + storage without flexdb",
+        envInfo: {
+          EnvId: "env-test",
+          PostgreSQL: [{ InstanceId: "pg-1" }],
+          Storages: [{ Bucket: "legacy-bucket" }],
+        },
+        expected: { postgresql: true, nosql: false, mysql: false },
+        runtimeMode: "postgresql",
+      },
+    ];
+
+    for (const testCase of cases) {
+      mockGetCloudBaseManager.mockResolvedValue({
+        env: {
+          getEnvInfo: vi.fn().mockResolvedValue({ EnvInfo: testCase.envInfo }),
+        },
+        commonService: vi.fn(() => ({
+          call: vi.fn().mockResolvedValue({}),
+        })),
+      });
+
+      const { tools } = createMockServer();
+      const payload = JSON.parse(
+        (await tools.queryEnv.handler({ action: "info" })).content[0].text,
+      );
+
+      expect(payload.EnvInfo.RuntimeBackends, testCase.name).toEqual(
+        testCase.expected,
+      );
+      expect(payload.EnvInfo.RuntimeMode, testCase.name).toBe(
+        testCase.runtimeMode,
+      );
+    }
   });
 
   it("envQuery(info) should prefer explicit envId over cached binding", async () => {

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { registerEnvTools } from "./env.js";
+import { isUsableNoSqlDatabaseEntry, registerEnvTools } from "./env.js";
 import type { ExtendedMcpServer } from "../server.js";
 
 const {
@@ -1194,6 +1194,15 @@ describe("env tools - envQuery", () => {
         expected: { postgresql: true, nosql: false, mysql: false },
         runtimeMode: "postgresql",
       },
+      {
+        name: "empty Databases array is nosql=false",
+        envInfo: {
+          EnvId: "env-test",
+          Databases: [],
+        },
+        expected: { postgresql: false, nosql: false, mysql: false },
+        runtimeMode: "nosql",
+      },
     ];
 
     for (const testCase of cases) {
@@ -1218,6 +1227,56 @@ describe("env tools - envQuery", () => {
         testCase.runtimeMode,
       );
     }
+  });
+
+  it("isUsableNoSqlDatabaseEntry accepts live DescribeEnvs flexdb tnt InstanceIds", () => {
+    // Captured 2026-08-05 via tcb DescribeEnvs for this account.
+    // ListTables(Tag=<InstanceId>) succeeded for each of these tnt values.
+    const liveDatabases = [
+      {
+        envId: "ai-9gra12b5b6a3c966",
+        entry: {
+          InstanceId: "tnt-88yexwqcw",
+          Status: "RUNNING",
+          Region: "ap-shanghai",
+        },
+      },
+      {
+        envId: "ai-native-d1ggefhgb8c27e3e8",
+        entry: {
+          InstanceId: "tnt-n8pjn7tiu",
+          Status: "RUNNING",
+          Region: "ap-shanghai",
+        },
+      },
+      {
+        envId: "ai-share-d2guukyxybb63b206",
+        entry: {
+          InstanceId: "tnt-0svnxv8c6",
+          Status: "RUNNING",
+          Region: "ap-shanghai",
+        },
+      },
+    ];
+
+    for (const { envId, entry } of liveDatabases) {
+      expect(isUsableNoSqlDatabaseEntry(entry), envId).toBe(true);
+    }
+
+    // Negative: stripping Databases (CreateEnv without flexdb) must not count
+    // as NoSQL even when Storages remains — storage is unrelated to flexdb.
+    expect(isUsableNoSqlDatabaseEntry(undefined)).toBe(false);
+    expect(isUsableNoSqlDatabaseEntry({ InstanceId: "", Status: "RUNNING" })).toBe(
+      false,
+    );
+    expect(
+      [{}, { Bucket: "6169-ai-native-d1ggefhgb8c27e3e8-1251119057" }].some(
+        isUsableNoSqlDatabaseEntry,
+      ),
+    ).toBe(false);
+    expect(
+      ([] as unknown[]).some(isUsableNoSqlDatabaseEntry),
+    ).toBe(false);
   });
 
   it("envQuery(info) should prefer explicit envId over cached binding", async () => {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -755,9 +755,12 @@ async function enrichEnvInfoWithBilling(params: {
  * CloudBase environment can have any combination of:
  * - PostgreSQL (CloudBase PG / pgstore): signaled by `EnvInfo.PostgreSQL[]`
  *   non-empty and/or `EnvInfo.Meta` containing `postgresql=enable`.
- * - NoSQL document database + the matching legacy COS-style bucket:
- *   signaled by `EnvInfo.Databases[]` (with InstanceId / RUNNING) and the
- *   bucket exposed in `EnvInfo.Storages[]`.
+ * - NoSQL document database (flexdb): signaled by a usable entry in
+ *   `EnvInfo.Databases[]` — non-empty `InstanceId`, and `Status` either
+ *   missing or `RUNNING`. Do NOT treat `EnvInfo.Storages[]` as NoSQL:
+ *   cloud storage (`storage`) is a separate CreateEnv resource and can
+ *   exist without flexdb.
+ * - Legacy COS cloud storage: `EnvInfo.Storages[]` (orthogonal to NoSQL).
  * - MySQL: signaled by a non-empty `EnvInfo.MysqlInstances[]` (or similar
  *   field, name varies). In a pure PG environment this is absent.
  *
@@ -780,6 +783,23 @@ async function enrichEnvInfoWithBilling(params: {
  *   for new code, including an explicit `MysqlNotAvailable` line when
  *   MySQL is absent — that one IS a hard "do not use" signal.
  */
+function isUsableNoSqlDatabaseEntry(db: unknown): boolean {
+  if (!db || typeof db !== "object") {
+    return false;
+  }
+  const entry = db as { InstanceId?: unknown; Status?: unknown };
+  const instanceId =
+    typeof entry.InstanceId === "string" ? entry.InstanceId.trim() : "";
+  if (!instanceId) {
+    return false;
+  }
+  // Some API versions omit Status; when present, only RUNNING counts as usable.
+  if (entry.Status != null && String(entry.Status).toUpperCase() !== "RUNNING") {
+    return false;
+  }
+  return true;
+}
+
 async function enrichEnvInfoWithRuntimeMode(result: any, manager?: any) {
   const envInfo = result?.EnvInfo;
   if (!envInfo || typeof envInfo !== "object") {
@@ -797,14 +817,12 @@ async function enrichEnvInfoWithRuntimeMode(result: any, manager?: any) {
   );
   const hasPostgresql = pgList.length > 0 || metaPostgresEnabled;
 
-  // NoSQL document DB shows up under Databases[]; the matching legacy bucket
-  // shows up under Storages[]. Treat NoSQL as available when either side is
-  // non-empty (an old env may keep one without the other).
+  // NoSQL document DB is flexdb, exposed under Databases[]. Storages[] is the
+  // independent cloud-storage resource and must NOT flip nosql=true.
   const databasesList = Array.isArray(envInfo.Databases)
     ? envInfo.Databases
     : [];
-  const storagesList = Array.isArray(envInfo.Storages) ? envInfo.Storages : [];
-  const hasNoSql = databasesList.length > 0 || storagesList.length > 0;
+  const hasNoSql = databasesList.some(isUsableNoSqlDatabaseEntry);
 
   // MySQL field name has been seen as MysqlInstances / MySQLInstances /
   // MySQL across API versions; check any of them.
@@ -858,8 +876,8 @@ async function enrichEnvInfoWithRuntimeMode(result: any, manager?: any) {
         Storage:
           "PG-mode browser uploads should use `app.storage.from().upload(<bucket>/<key>, file)` against an explicitly-created `pgstore` bucket (same model as Supabase Storage; the v3 SDK does not auto-create one). `EnvInfo.Storages[]` here is the legacy NoSQL bucket — it is still usable for the legacy `app.uploadFile()` flow but is NOT a valid pgstore target.",
         CoexistingNoSQL: hasNoSql
-          ? "This env also has the legacy NoSQL Database + Storage running. Existing collections, existing `app.uploadFile()` calls, existing `managePermissions(resourceType=\"noSqlDatabase\")` rules all remain valid for legacy data."
-          : "No legacy NoSQL Database/Storage observed in this env.",
+          ? "This env also has a usable NoSQL (flexdb) instance in EnvInfo.Databases[]. Existing collections and `managePermissions(resourceType=\"noSqlDatabase\")` rules remain valid for that data. EnvInfo.Storages[] is independent cloud storage, not proof of NoSQL."
+          : "No usable NoSQL (flexdb) instance observed in EnvInfo.Databases[] — do not assume app.database() / NoSQL MCP tools work. EnvInfo.Storages[] alone does not mean NoSQL is provisioned.",
         MysqlNotAvailable: hasMysql
           ? "MySQL instance(s) detected — see EnvInfo.MysqlInstances."
           : "No MySQL instance is provisioned for this env. Do NOT use `manageMysqlDatabase` / `queryMysqlDatabase` (those are MySQL-specific) and do NOT read the `relational-database-mcp-cloudbase` skill — that family targets MySQL, not CloudBase PG.",

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -755,22 +755,21 @@ async function enrichEnvInfoWithBilling(params: {
  * CloudBase environment can have any combination of:
  * - PostgreSQL (CloudBase PG / pgstore): signaled by `EnvInfo.PostgreSQL[]`
  *   non-empty and/or `EnvInfo.Meta` containing `postgresql=enable`.
- * - NoSQL document database (flexdb): signaled by a usable entry in
- *   `EnvInfo.Databases[]` — non-empty `InstanceId`, and `Status` either
- *   missing or `RUNNING`. Do NOT treat `EnvInfo.Storages[]` as NoSQL:
- *   cloud storage (`storage`) is a separate CreateEnv resource and can
- *   exist without flexdb.
- * - Legacy COS cloud storage: `EnvInfo.Storages[]` (orthogonal to NoSQL).
+ * - NoSQL document database (flexdb): signaled ONLY by a usable entry in
+ *   `EnvInfo.Databases[]`. The usable signal is a non-empty `InstanceId`
+ *   (FlexDB Tag, typically `tnt-...` — same value `getDatabaseInstanceId`
+ *   / ListTables `Tag` consume) with `Status` missing or `RUNNING`.
+ *   Cloud storage (`EnvInfo.Storages[]` / CreateEnv `storage`) is unrelated
+ *   and must never flip `RuntimeBackends.nosql`.
  * - MySQL: signaled by a non-empty `EnvInfo.MysqlInstances[]` (or similar
  *   field, name varies). In a pure PG environment this is absent.
  *
- * In particular: a CloudBase PG environment commonly STILL has the NoSQL
- * Database + Storage running in parallel. NoSQL is therefore "co-present"
- * — its collection APIs, NoSQL `securityRule`s, and the legacy
- * `app.uploadFile()` upload flow remain valid for collections / files
- * that already live there. The thing that is NOT a substitute for the new
- * PG surface is using NoSQL collections to model a brand-new business
- * table that the task explicitly puts in PG.
+ * In particular: a CloudBase PG environment commonly STILL has flexdb
+ * provisioned in parallel (`Databases[].InstanceId = tnt-...`). NoSQL is
+ * therefore "co-present" — its collection APIs and NoSQL `securityRule`s
+ * remain valid for collections that already live there. The thing that is
+ * NOT a substitute for the new PG surface is using NoSQL collections to
+ * model a brand-new business table that the task explicitly puts in PG.
  *
  * What this enrichment does:
  * - Adds `EnvInfo.RuntimeMode = "postgresql" | "nosql"` based on whether
@@ -778,18 +777,21 @@ async function enrichEnvInfoWithBilling(params: {
  *   business data when set to "postgresql".
  * - Adds `EnvInfo.RuntimeBackends`, a structured snapshot of which
  *   backends are actually available (postgresql / nosql / mysql), so the
- *   agent does not have to re-read `Databases`/`Storages`/`PostgreSQL`.
+ *   agent does not have to re-read `Databases`/`PostgreSQL`.
  * - Adds `EnvInfo.RuntimeModeHints` summarizing which API/tool to prefer
  *   for new code, including an explicit `MysqlNotAvailable` line when
  *   MySQL is absent — that one IS a hard "do not use" signal.
  */
-function isUsableNoSqlDatabaseEntry(db: unknown): boolean {
+/** Exported for unit tests / live-fixture checks against FlexDB InstanceId. */
+export function isUsableNoSqlDatabaseEntry(db: unknown): boolean {
   if (!db || typeof db !== "object") {
     return false;
   }
   const entry = db as { InstanceId?: unknown; Status?: unknown };
   const instanceId =
     typeof entry.InstanceId === "string" ? entry.InstanceId.trim() : "";
+  // Empty InstanceId means no flexdb tenant — same failure mode as
+  // getDatabaseInstanceId() throwing "无法获取数据库实例ID".
   if (!instanceId) {
     return false;
   }
@@ -817,8 +819,8 @@ async function enrichEnvInfoWithRuntimeMode(result: any, manager?: any) {
   );
   const hasPostgresql = pgList.length > 0 || metaPostgresEnabled;
 
-  // NoSQL document DB is flexdb, exposed under Databases[]. Storages[] is the
-  // independent cloud-storage resource and must NOT flip nosql=true.
+  // NoSQL = flexdb tenant id on Databases[].InstanceId (typically tnt-...).
+  // Aligns with getDatabaseInstanceId() / ListTables Tag. Storage is unrelated.
   const databasesList = Array.isArray(envInfo.Databases)
     ? envInfo.Databases
     : [];
@@ -876,8 +878,8 @@ async function enrichEnvInfoWithRuntimeMode(result: any, manager?: any) {
         Storage:
           "PG-mode browser uploads should use `app.storage.from().upload(<bucket>/<key>, file)` against an explicitly-created `pgstore` bucket (same model as Supabase Storage; the v3 SDK does not auto-create one). `EnvInfo.Storages[]` here is the legacy NoSQL bucket — it is still usable for the legacy `app.uploadFile()` flow but is NOT a valid pgstore target.",
         CoexistingNoSQL: hasNoSql
-          ? "This env also has a usable NoSQL (flexdb) instance in EnvInfo.Databases[]. Existing collections and `managePermissions(resourceType=\"noSqlDatabase\")` rules remain valid for that data. EnvInfo.Storages[] is independent cloud storage, not proof of NoSQL."
-          : "No usable NoSQL (flexdb) instance observed in EnvInfo.Databases[] — do not assume app.database() / NoSQL MCP tools work. EnvInfo.Storages[] alone does not mean NoSQL is provisioned.",
+          ? "This env also has a usable NoSQL (flexdb) InstanceId in EnvInfo.Databases[] (FlexDB Tag, typically tnt-...). Existing collections and `managePermissions(resourceType=\"noSqlDatabase\")` rules remain valid for that data."
+          : "No usable NoSQL (flexdb) InstanceId in EnvInfo.Databases[] — do not assume app.database() / NoSQL MCP tools work. Cloud storage does not imply flexdb.",
         MysqlNotAvailable: hasMysql
           ? "MySQL instance(s) detected — see EnvInfo.MysqlInstances."
           : "No MySQL instance is provisioned for this env. Do NOT use `manageMysqlDatabase` / `queryMysqlDatabase` (those are MySQL-specific) and do NOT read the `relational-database-mcp-cloudbase` skill — that family targets MySQL, not CloudBase PG.",


### PR DESCRIPTION
## Summary
- `RuntimeBackends.nosql` is derived only from usable `EnvInfo.Databases[]` entries — non-empty `InstanceId` (FlexDB Tag, typically `tnt-...`, same source as `getDatabaseInstanceId` / `ListTables` `Tag`) with `Status` missing or `RUNNING`.
- Cloud storage (`EnvInfo.Storages[]`) is unrelated and does not flip `nosql`.
- Live check (2026-08-05): all three account envs expose `tnt-*` InstanceIds; `ListTables(Tag=<tnt>)` succeeds; invalid Tag fails. Unit fixtures cover empty / missing Databases (no flexdb).

## Test plan
- [x] `pnpm exec vitest run src/tools/env.test.ts` (56 passed)
- [x] Live DescribeEnvs + ListTables Tag cross-check
- [ ] CI green on this PR