### PR TITLE
fix(ci): 🔁 retry all-in-one clawhub upload-ticket mismatches

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -83,6 +83,8 @@ jobs:
         # Exact version pin for supply-chain reproducibility (do not use bare @latest).
         # 0.23.3 upload-ticket regression was fixed server-side in openclaw/clawhub#3395
         # and verified with a real publish after production backend deploy (2026-08-05).
+        # Client-side: publish-to-clawhub.mjs still retries all-in-one on residual
+        # "upload ticket does not match" races (openclaw/clawhub#3394 / #3397).
         run: npm install -g clawhub@0.23.3
 
       - name: Login to ClawHub

--- a/scripts/publish-to-clawhub.mjs
+++ b/scripts/publish-to-clawhub.mjs
@@ -8,6 +8,26 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const AUTO_CHANGELOG_LIMIT = 5;
 
+/** all-in-one uploads are large and historically hit intermittent upload-ticket races. */
+export const ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS = 3;
+export const ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS = 2000;
+
+function clawhubErrorText(error) {
+  const message = String(error?.message || error || "");
+  const stderr = String(error?.stderr || "");
+  const stdout = String(error?.stdout || "");
+  return `${message}\n${stderr}\n${stdout}`;
+}
+
+function defaultSleepMs(ms) {
+  if (!ms || ms <= 0) {
+    return;
+  }
+
+  // Sync sleep keeps publishToClawhub synchronous (execFileSync-based).
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
 function parseArgs(argv) {
   let manifestPath = "";
   let dryRun = false;
@@ -160,14 +180,39 @@ export function buildPublishCommand(target, options) {
  * and this detector never matches.
  */
 export function isClawhubVersionExistsError(error) {
-  const message = String(error?.message || error || "");
-  const stderr = String(error?.stderr || "");
-  const stdout = String(error?.stdout || "");
-  const combined = `${message}\n${stderr}\n${stdout}`;
+  const combined = clawhubErrorText(error);
   return (
     /Version\s+\S+\s+already exists/i.test(combined) ||
     /is already published/i.test(combined)
   );
+}
+
+/**
+ * Detect intermittent ClawHub upload-ticket mismatches
+ * (openclaw/clawhub#3394 / #3397). These are retryable for large packages.
+ */
+export function isClawhubUploadTicketError(error) {
+  const combined = clawhubErrorText(error);
+  return (
+    /upload ticket does not match/i.test(combined) ||
+    /Uploaded file does not match its skill upload ticket/i.test(combined) ||
+    /skill upload ticket/i.test(combined)
+  );
+}
+
+export function supportsClawhubUploadTicketRetry(target) {
+  return target?.targetKey === "all-in-one";
+}
+
+export function formatClawhubUploadTicketFailure(target, error, attempts) {
+  const lastError = String(error?.message || error || "")
+    .trim()
+    .replace(/\s+/g, " ");
+  return [
+    `upload-ticket mismatch after ${attempts} attempt(s) for ${target.targetKey} (${target.registrySlug})`,
+    `last error: ${lastError}`,
+    "hint: intermittent ClawHub issue (openclaw/clawhub#3394 / #3397); re-run workflow_dispatch if it persists",
+  ].join(" | ");
 }
 
 /**
@@ -211,6 +256,8 @@ export function publishToClawhub({
   changelog = "",
   tags = "latest",
   bump = "minor",
+  runPublish = runClawhubPublish,
+  sleepMs = defaultSleepMs,
 }) {
   const manifest = readManifest(manifestPath);
   const gitRoot = resolveGitRoot(manifestPath);
@@ -247,31 +294,75 @@ export function publishToClawhub({
       continue;
     }
 
-    try {
-      runClawhubPublish(publishCommand.command, publishCommand.args, process.env);
+    const maxAttempts = supportsClawhubUploadTicketRetry(target)
+      ? ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS
+      : 1;
+    let settled = false;
 
-      results.push({
-        targetKey: target.targetKey,
-        registrySlug: target.registrySlug,
-        status: "published",
-      });
-    } catch (error) {
-      if (isClawhubVersionExistsError(error)) {
-        console.log(
-          `版本已存在，视为已发布 / Version already exists, treating as published: ${target.registrySlug}`,
-        );
+    for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+      try {
+        runPublish(publishCommand.command, publishCommand.args, process.env);
+
         results.push({
           targetKey: target.targetKey,
           registrySlug: target.registrySlug,
-          status: "already-published",
+          status: "published",
+          attempts: attempt,
         });
-        continue;
-      }
+        settled = true;
+        break;
+      } catch (error) {
+        if (isClawhubVersionExistsError(error)) {
+          console.log(
+            `版本已存在，视为已发布 / Version already exists, treating as published: ${target.registrySlug}`,
+          );
+          results.push({
+            targetKey: target.targetKey,
+            registrySlug: target.registrySlug,
+            status: "already-published",
+            attempts: attempt,
+          });
+          settled = true;
+          break;
+        }
 
+        const canRetryUploadTicket =
+          attempt < maxAttempts && isClawhubUploadTicketError(error);
+
+        if (canRetryUploadTicket) {
+          console.warn(
+            `upload-ticket 不匹配，准备重试 / Upload-ticket mismatch, retrying ${target.targetKey} (${target.registrySlug}) attempt ${attempt}/${maxAttempts}: ${String(error.message || error).trim()}`,
+          );
+          sleepMs(ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS);
+          continue;
+        }
+
+        const message = isClawhubUploadTicketError(error)
+          ? formatClawhubUploadTicketFailure(target, error, attempt)
+          : error.message;
+
+        if (isClawhubUploadTicketError(error) && maxAttempts > 1) {
+          console.error(
+            `upload-ticket 重试耗尽 / Upload-ticket retries exhausted for ${target.targetKey} (${target.registrySlug}) after ${attempt} attempt(s)`,
+          );
+        }
+
+        failures.push({
+          targetKey: target.targetKey,
+          registrySlug: target.registrySlug,
+          message,
+          attempts: attempt,
+        });
+        settled = true;
+        break;
+      }
+    }
+
+    if (!settled) {
       failures.push({
         targetKey: target.targetKey,
         registrySlug: target.registrySlug,
-        message: error.message,
+        message: `unexpected publish loop exit for ${target.targetKey}`,
       });
     }
   }

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -1,9 +1,42 @@
-import { describe, expect, test } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, test } from 'vitest';
 import {
+  ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS,
   buildPublishCommand,
+  formatClawhubUploadTicketFailure,
+  isClawhubUploadTicketError,
   isClawhubVersionExistsError,
   normalizeClawhubChangelog,
+  publishToClawhub,
+  supportsClawhubUploadTicketRetry,
 } from '../scripts/publish-to-clawhub.mjs';
+
+const tempDirs = [];
+
+function createManifest(targets) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'clawhub-publish-test-'));
+  tempDirs.push(dir);
+  const manifestPath = path.join(dir, 'manifest.json');
+  fs.writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      targets: targets.map((target) => ({
+        artifactDir: path.join(dir, target.targetKey),
+        ...target,
+      })),
+    }),
+  );
+  return manifestPath;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('publish-to-clawhub command construction', () => {
   test('normalizes multiline changelog for clawhub CLI arguments', () => {
@@ -75,5 +108,154 @@ describe('publish-to-clawhub command construction', () => {
     const error = new Error('Command failed: clawhub skill publish ...');
     error.stdout = 'OK. cloudbase@1.92.48 is already published\n';
     expect(isClawhubVersionExistsError(error)).toBe(true);
+  });
+
+  test('detects upload-ticket mismatch errors as retryable', () => {
+    expect(
+      isClawhubUploadTicketError(
+        new Error('Skill upload ticket does not match this publish'),
+      ),
+    ).toBe(true);
+
+    const stderrOnly = new Error('Command failed: clawhub skill publish ...');
+    stderrOnly.stderr = 'Error: Uploaded file does not match its skill upload ticket\n';
+    expect(isClawhubUploadTicketError(stderrOnly)).toBe(true);
+    expect(isClawhubUploadTicketError(new Error('Version 1.92.48 already exists'))).toBe(false);
+  });
+
+  test('only all-in-one supports upload-ticket retry', () => {
+    expect(supportsClawhubUploadTicketRetry({ targetKey: 'all-in-one' })).toBe(true);
+    expect(supportsClawhubUploadTicketRetry({ targetKey: 'web-development' })).toBe(false);
+  });
+
+  test('formats upload-ticket exhaustion with attempt count and issue hint', () => {
+    const message = formatClawhubUploadTicketFailure(
+      { targetKey: 'all-in-one', registrySlug: 'cloudbase' },
+      new Error('Skill upload ticket does not match this publish'),
+      3,
+    );
+
+    expect(message).toContain('after 3 attempt(s)');
+    expect(message).toContain('all-in-one');
+    expect(message).toContain('cloudbase');
+    expect(message).toContain('openclaw/clawhub#3394');
+    expect(message).toContain('Skill upload ticket does not match this publish');
+  });
+});
+
+describe('publish-to-clawhub all-in-one upload-ticket retry', () => {
+  test('retries all-in-one on upload-ticket mismatch then succeeds', () => {
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const manifestPath = createManifest([
+        { targetKey: 'all-in-one', registrySlug: 'cloudbase' },
+      ]);
+      let calls = 0;
+      const sleepCalls = [];
+
+      const results = publishToClawhub({
+        manifestPath,
+        changelog: 'retry test',
+        runPublish: () => {
+          calls += 1;
+          if (calls < 2) {
+            const error = new Error('Skill upload ticket does not match this publish');
+            error.stderr = 'Skill upload ticket does not match this publish\n';
+            throw error;
+          }
+          return { status: 'ok', output: '' };
+        },
+        sleepMs: (ms) => {
+          sleepCalls.push(ms);
+        },
+      });
+
+      expect(calls).toBe(2);
+      expect(sleepCalls).toEqual([2000]);
+      expect(results).toEqual([
+        {
+          targetKey: 'all-in-one',
+          registrySlug: 'cloudbase',
+          status: 'published',
+          attempts: 2,
+        },
+      ]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
+  });
+
+  test('exhausts all-in-one upload-ticket retries with clear failure message', () => {
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const manifestPath = createManifest([
+        { targetKey: 'all-in-one', registrySlug: 'cloudbase' },
+      ]);
+      let calls = 0;
+
+      expect(() =>
+        publishToClawhub({
+          manifestPath,
+          changelog: 'retry exhaust',
+          runPublish: () => {
+            calls += 1;
+            const error = new Error('Skill upload ticket does not match this publish');
+            error.stderr = 'Skill upload ticket does not match this publish\n';
+            throw error;
+          },
+          sleepMs: () => {},
+        }),
+      ).toThrow(/Failed to publish 1 target/);
+
+      expect(calls).toBe(ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
+  });
+
+  test('does not retry upload-ticket errors for non all-in-one targets', () => {
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const manifestPath = createManifest([
+        { targetKey: 'web-development', registrySlug: 'cloudbase-web-development' },
+      ]);
+      let calls = 0;
+
+      expect(() =>
+        publishToClawhub({
+          manifestPath,
+          changelog: 'no retry',
+          runPublish: () => {
+            calls += 1;
+            throw new Error('Skill upload ticket does not match this publish');
+          },
+          sleepMs: () => {
+            throw new Error('sleep should not be called');
+          },
+        }),
+      ).toThrow(/Failed to publish 1 target/);
+
+      expect(calls).toBe(1);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- After #893 (version-exists idempotency), add a client-side safety net for residual ClawHub `upload ticket does not match` races on **all-in-one** (openclaw/clawhub#3394 / #3397).
- Retry up to 3 attempts with a 2s delay; exhaust with a failure message that includes attempt count and issue hints.
- Non–all-in-one targets still fail immediately on the same error (no retry).

## Test plan
- [x] `npx vitest run tests/publish-to-clawhub.test.js` (11 passed)
- [ ] After merge, if Publish ClawHub hits upload-ticket again, confirm all-in-one retries in logs before failing or succeeding


Made with [Cursor](https://cursor.com)