### PR TITLE
feat(skills): publish minimal-web-baas-demo to WorkBuddy skill surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -28,6 +28,16 @@
       "dependencies": [
         "cloudbase-sites"
       ]
+    },
+    {
+      "name": "xdf-workbuddy-expert-pack",
+      "displayName": "CloudBase XDF WorkBuddy Expert Pack",
+      "source": "./plugin/xdf-workbuddy-expert-pack",
+      "description": "XDF / WorkBuddy expert prompt + loadable minimal-web-baas-demo skill for BaaS-first demos without local repo checkout.",
+      "category": "Developer Tools",
+      "dependencies": [
+        "workbuddy-template-prewarm"
+      ]
     }
   ]
 }

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -83,6 +83,27 @@
         "codebuddy",
         "cursor"
       ]
+    },
+    {
+      "name": "xdf-workbuddy-expert-pack",
+      "source": "plugin/xdf-workbuddy-expert-pack",
+      "description": "XDF / WorkBuddy expert prompt + loadable minimal-web-baas-demo skill for BaaS-first demos without local repo checkout.",
+      "version": "0.1.1",
+      "author": {
+        "name": "CloudBase AI Toolkit"
+      },
+      "homepage": "https://github.com/TencentCloudBase/CloudBase-MCP/tree/main/plugin/xdf-workbuddy-expert-pack",
+      "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
+      "license": "MIT",
+      "category": "Developer Tools",
+      "keywords": [
+        "cloudbase",
+        "workbuddy",
+        "xdf",
+        "baas",
+        "minimal-web-baas-demo",
+        "cursor"
+      ]
     }
   ]
 }

--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -16,7 +16,7 @@ on:
   workflow_dispatch:
     inputs:
       targets:
-        description: 'Comma-separated publish targets: miniprogram-development, cloudbase-wechat-integration, all-in-one, ui-design, web-development, spec-workflow'
+        description: 'Comma-separated publish targets: miniprogram-development, cloudbase-wechat-integration, all-in-one, ui-design, web-development, spec-workflow, minimal-web-baas-demo'
         required: true
         type: string
       bump:
@@ -55,7 +55,7 @@ jobs:
     permissions:
       contents: read
     env:
-      TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.targets || 'miniprogram-development,cloudbase-wechat-integration,all-in-one,ui-design,web-development,spec-workflow' }}
+      TARGETS: ${{ github.event_name == 'workflow_dispatch' && inputs.targets || 'miniprogram-development,cloudbase-wechat-integration,all-in-one,ui-design,web-development,spec-workflow,minimal-web-baas-demo' }}
       BUMP: ${{ github.event_name == 'workflow_dispatch' && inputs.bump || 'minor' }}
       CHANGELOG: ${{ github.event_name == 'workflow_dispatch' && inputs.changelog || '' }}
       TAGS: ${{ github.event_name == 'workflow_dispatch' && inputs.tags || 'latest' }}

--- a/plugin/cloudbase/.codebuddy-plugin/plugin.json
+++ b/plugin/cloudbase/.codebuddy-plugin/plugin.json
@@ -1,0 +1,66 @@
+{
+  "name": "cloudbase",
+  "version": "0.2.0",
+  "description": "Tencent CloudBase — AI models, authentication, NoSQL/PostgreSQL databases, cloud functions, cloud storage, CloudRun backend services, and WeChat Mini Program integration. Powered by cloudbase-mcp.",
+  "author": {
+    "name": "Tencent CloudBase",
+    "url": "https://cloudbase.net"
+  },
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-plugin",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
+  "license": "MIT",
+  "keywords": [
+    "cloudbase",
+    "tencent-cloud",
+    "baas",
+    "codebuddy",
+    "workbuddy",
+    "ai-model",
+    "database",
+    "cloud-function",
+    "authentication",
+    "storage",
+    "cloudrun"
+  ],
+  "skills": [
+    "./skills/ai-model-nodejs/",
+    "./skills/ai-model-web/",
+    "./skills/ai-model-wechat/",
+    "./skills/auth-nodejs-cloudbase/",
+    "./skills/auth-tool-cloudbase/",
+    "./skills/auth-web-cloudbase/",
+    "./skills/auth-wechat-miniprogram/",
+    "./skills/cloud-functions/",
+    "./skills/cloud-storage-web/",
+    "./skills/cloudbase/",
+    "./skills/cloudbase-agent/",
+    "./skills/cloudbase-cli/",
+    "./skills/cloudbase-code-review/",
+    "./skills/cloudbase-document-database-in-wechat-miniprogram/",
+    "./skills/cloudbase-document-database-web-sdk/",
+    "./skills/cloudbase-platform/",
+    "./skills/cloudbase-wechat-integration/",
+    "./skills/cloudrun-development/",
+    "./skills/data-model-creation/",
+    "./skills/http-api-cloudbase/",
+    "./skills/minimal-web-baas-demo/",
+    "./skills/miniprogram-development/",
+    "./skills/ops-inspector/",
+    "./skills/postgresql-development-cloudbase/",
+    "./skills/relational-database-mcp-cloudbase/",
+    "./skills/relational-database-web-cloudbase/",
+    "./skills/spec-workflow/",
+    "./skills/ui-design/",
+    "./skills/web-development/"
+  ],
+  "commands": [
+    "./commands/cloudbase-env.md",
+    "./commands/cloudbase-deploy.md",
+    "./commands/cloudbase-init.md",
+    "./commands/cloudbase-status.md"
+  ],
+  "agents": [
+    "./agents/cloudbase-architect.md",
+    "./agents/cloudbase-deployment-expert.md"
+  ]
+}

--- a/plugin/cloudbase/.workbuddy-plugin/plugin.json
+++ b/plugin/cloudbase/.workbuddy-plugin/plugin.json
@@ -1,0 +1,66 @@
+{
+  "name": "cloudbase",
+  "version": "0.2.0",
+  "description": "Tencent CloudBase — AI models, authentication, NoSQL/PostgreSQL databases, cloud functions, cloud storage, CloudRun backend services, and WeChat Mini Program integration. Powered by cloudbase-mcp.",
+  "author": {
+    "name": "Tencent CloudBase",
+    "url": "https://cloudbase.net"
+  },
+  "homepage": "https://github.com/TencentCloudBase/cloudbase-plugin",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
+  "license": "MIT",
+  "keywords": [
+    "cloudbase",
+    "tencent-cloud",
+    "baas",
+    "workbuddy",
+    "codebuddy",
+    "ai-model",
+    "database",
+    "cloud-function",
+    "authentication",
+    "storage",
+    "cloudrun"
+  ],
+  "skills": [
+    "./skills/ai-model-nodejs/",
+    "./skills/ai-model-web/",
+    "./skills/ai-model-wechat/",
+    "./skills/auth-nodejs-cloudbase/",
+    "./skills/auth-tool-cloudbase/",
+    "./skills/auth-web-cloudbase/",
+    "./skills/auth-wechat-miniprogram/",
+    "./skills/cloud-functions/",
+    "./skills/cloud-storage-web/",
+    "./skills/cloudbase/",
+    "./skills/cloudbase-agent/",
+    "./skills/cloudbase-cli/",
+    "./skills/cloudbase-code-review/",
+    "./skills/cloudbase-document-database-in-wechat-miniprogram/",
+    "./skills/cloudbase-document-database-web-sdk/",
+    "./skills/cloudbase-platform/",
+    "./skills/cloudbase-wechat-integration/",
+    "./skills/cloudrun-development/",
+    "./skills/data-model-creation/",
+    "./skills/http-api-cloudbase/",
+    "./skills/minimal-web-baas-demo/",
+    "./skills/miniprogram-development/",
+    "./skills/ops-inspector/",
+    "./skills/postgresql-development-cloudbase/",
+    "./skills/relational-database-mcp-cloudbase/",
+    "./skills/relational-database-web-cloudbase/",
+    "./skills/spec-workflow/",
+    "./skills/ui-design/",
+    "./skills/web-development/"
+  ],
+  "commands": [
+    "./commands/cloudbase-env.md",
+    "./commands/cloudbase-deploy.md",
+    "./commands/cloudbase-init.md",
+    "./commands/cloudbase-status.md"
+  ],
+  "agents": [
+    "./agents/cloudbase-architect.md",
+    "./agents/cloudbase-deployment-expert.md"
+  ]
+}

--- a/plugin/xdf-workbuddy-expert-pack/.codebuddy-plugin/plugin.json
+++ b/plugin/xdf-workbuddy-expert-pack/.codebuddy-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "xdf-workbuddy-expert-pack",
+  "version": "0.1.1",
+  "description": "XDF / WorkBuddy expert distribution: BaaS-first agent prompt + loadable minimal-web-baas-demo skill. SessionStart prewarm via settings or sibling workbuddy-template-prewarm — not agent frontmatter hooks.",
+  "author": {
+    "name": "CloudBase AI Toolkit"
+  },
+  "homepage": "https://github.com/TencentCloudBase/CloudBase-MCP/tree/main/plugin/xdf-workbuddy-expert-pack",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
+  "license": "MIT",
+  "keywords": [
+    "cloudbase",
+    "workbuddy",
+    "xdf",
+    "baas",
+    "minimal-web-baas-demo"
+  ],
+  "skills": [
+    "./skills/minimal-web-baas-demo"
+  ],
+  "agents": [
+    "./agents/cloudbase-baas-expert.md"
+  ],
+  "dependencies": [
+    "workbuddy-template-prewarm"
+  ]
+}

--- a/plugin/xdf-workbuddy-expert-pack/.workbuddy-plugin/plugin.json
+++ b/plugin/xdf-workbuddy-expert-pack/.workbuddy-plugin/plugin.json
@@ -1,0 +1,27 @@
+{
+  "name": "xdf-workbuddy-expert-pack",
+  "version": "0.1.1",
+  "description": "XDF / WorkBuddy expert distribution: BaaS-first agent prompt + loadable minimal-web-baas-demo skill. SessionStart prewarm via settings or sibling workbuddy-template-prewarm — not agent frontmatter hooks.",
+  "author": {
+    "name": "CloudBase AI Toolkit"
+  },
+  "homepage": "https://github.com/TencentCloudBase/CloudBase-MCP/tree/main/plugin/xdf-workbuddy-expert-pack",
+  "repository": "https://github.com/TencentCloudBase/CloudBase-MCP",
+  "license": "MIT",
+  "keywords": [
+    "cloudbase",
+    "workbuddy",
+    "xdf",
+    "baas",
+    "minimal-web-baas-demo"
+  ],
+  "skills": [
+    "./skills/minimal-web-baas-demo"
+  ],
+  "agents": [
+    "./agents/cloudbase-baas-expert.md"
+  ],
+  "dependencies": [
+    "workbuddy-template-prewarm"
+  ]
+}

--- a/plugin/xdf-workbuddy-expert-pack/PARTNER-CHECKLIST.md
+++ b/plugin/xdf-workbuddy-expert-pack/PARTNER-CHECKLIST.md
@@ -37,7 +37,7 @@
 > - `state.json` → `ready`（~20s）；`preview.json.port=17177` ∈ 17173..17272  
 > - `sitesBin` = marketplace `vendor/cloudbase-sites`（无 monorepo 绝对路径）  
 > - settings **仅**保留 `[teamai]` SessionStart；`enabledPlugins["workbuddy-template-prewarm@tencent-cloudbase"]=true`  
-> - **注意：** 公开 GitHub `main` 目录暂未列入本插件（PR [#886](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/pull/886) 合入前），伙伴需用含 catalog 的 ref / 已同步 marketplace  checkout；安装器读 `.claude-plugin/marketplace.json`。
+> - **注意：** `minimal-web-baas-demo` 已合入 GitHub `main`（PR [#886](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/pull/886)）。marketplace 安装 `xdf-workbuddy-expert-pack` 或 `cloudbase@tencent-cloudbase` 后即可 `Skill("minimal-web-baas-demo")`；仍推荐跑一次 `install-skill.sh` 作为 Trust 前兜底。
 
 - [x] 添加 marketplace：`TencentCloudBase/CloudBase-MCP`（或伙伴约定源）
 - [x] 安装并启用 `workbuddy-template-prewarm`

--- a/scripts/clawhub-publish-targets.mjs
+++ b/scripts/clawhub-publish-targets.mjs
@@ -105,6 +105,23 @@ export const CLAWHUB_PUBLISH_TARGETS = {
     ),
     sourceDescription: "config/source/skills/spec-workflow",
   },
+  "minimal-web-baas-demo": {
+    key: "minimal-web-baas-demo",
+    type: "local-skill",
+    registrySlug: "minimal-web-baas-demo",
+    displayName: "腾讯云 CloudBase 最小 Web BaaS Demo / Tencent CloudBase Minimal Web BaaS Demo",
+    summary:
+      "腾讯云 CloudBase 最小 Web + 数据库 Demo 快路径：浏览器 @cloudbase/js-sdk CRUD、MCP 建表/建集合、默认 0 云函数，面向 WorkBuddy / Lovable 式分钟级预览。",
+    iconUrl: CLOUDBASE_ICON_URL,
+    sourceDir: path.join(
+      projectRoot,
+      "config",
+      "source",
+      "skills",
+      "minimal-web-baas-demo",
+    ),
+    sourceDescription: "config/source/skills/minimal-web-baas-demo",
+  },
 };
 
 export const DEFAULT_CLAWHUB_TARGET_KEYS = Object.freeze(

--- a/tests/publish-targets.test.js
+++ b/tests/publish-targets.test.js
@@ -24,7 +24,7 @@ test('parseTargetInput rejects unknown publish targets', () => {
 
 test('resolvePublishTargets only returns whitelisted publish units', () => {
   const targets = resolvePublishTargets(
-    'miniprogram-development,cloudbase-wechat-integration,all-in-one,ui-design,web-development,spec-workflow',
+    'miniprogram-development,cloudbase-wechat-integration,all-in-one,ui-design,web-development,spec-workflow,minimal-web-baas-demo',
   );
 
   expect(targets.map((target) => target.key)).toEqual([
@@ -34,6 +34,7 @@ test('resolvePublishTargets only returns whitelisted publish units', () => {
     'ui-design',
     'web-development',
     'spec-workflow',
+    'minimal-web-baas-demo',
   ]);
   expect(Object.keys(CLAWHUB_PUBLISH_TARGETS)).toEqual([
     'miniprogram-development',
@@ -42,6 +43,7 @@ test('resolvePublishTargets only returns whitelisted publish units', () => {
     'ui-design',
     'web-development',
     'spec-workflow',
+    'minimal-web-baas-demo',
   ]);
   expect(
     targets.find((target) => target.key === 'cloudbase-wechat-integration')?.registrySlug,
@@ -52,6 +54,9 @@ test('resolvePublishTargets only returns whitelisted publish units', () => {
   expect(
     targets.find((target) => target.key === 'spec-workflow')?.registrySlug,
   ).toBe('spec-workflow-guide');
+  expect(
+    targets.find((target) => target.key === 'minimal-web-baas-demo')?.registrySlug,
+  ).toBe('minimal-web-baas-demo');
 });
 
 test('every target exposes SkillHub marketplace metadata (displayName, summary, iconUrl)', () => {


### PR DESCRIPTION
## Summary
- Add `minimal-web-baas-demo` to ClawHub/SkillHub publish targets (and default CI TARGETS) so the skill is installable from the registry WorkBuddy/find-skills use.
- Declare `Skill()`-addressable skills on `plugin/cloudbase` (`.codebuddy-plugin` / `.workbuddy-plugin`) including `minimal-web-baas-demo`.
- List `xdf-workbuddy-expert-pack` in Claude/Cursor marketplace catalogs with CodeBuddy/WorkBuddy plugin manifests so partners can install the expert pack + skill without a monorepo checkout.

## Already live / verified
- ClawHub publish succeeded: `minimal-web-baas-demo@1.0.0` (moderation pending.publication may briefly hide search/install).
- `searchKnowledgeBase(mode=skill, skillName=minimal-web-baas-demo)` resolves.
- GitHub `TencentCloudBase/skills` already has the skill; CNB CodeBuddy marketplace fork still carries top-level skill (upstream `codebuddy/marketplace` still on v1.0.0 — needs CNB UI PR).

## Test plan
- [x] `npx vitest run tests/publish-targets.test.js tests/sync-codebuddy-plugin.test.js`
- [x] `node scripts/check-plugin-marketplaces.mjs`
- [x] `node scripts/build-clawhub-publish-artifacts.mjs --targets minimal-web-baas-demo`
- [x] `clawhub skill publish …` → published 1.0.0
- [ ] After moderation clears: `clawhub search/install minimal-web-baas-demo`
- [ ] Partner: enable `xdf-workbuddy-expert-pack@tencent-cloudbase` or `cloudbase@tencent-cloudbase` → `Skill("minimal-web-baas-demo")`


Made with [Cursor](https://cursor.com)