### PR TITLE
feat(auth): 🔑 accept CLOUDBASE_APIKEY as API Key env fallback

### DIFF
--- a/doc/connection-modes.mdx
+++ b/doc/connection-modes.mdx
@@ -34,7 +34,7 @@ CloudBase MCP 支持两种连接方式：**本地模式**（MCP 服务在本机�
 
 | 环境变量 | 说明 | 默认 / 说明 |
 |----------|------|-------------|
-| `CLOUDBASE_API_KEY` | CloudBase 环境级 API Key（推荐用于 CI/CD、MCP Server） | 与 `CLOUDBASE_ENV_ID` 配合使用，优先级高于 `TENCENTCLOUD_*` 密钥；[在控制台创建](https://tcb.cloud.tencent.com/dev) |
+| `CLOUDBASE_API_KEY` | CloudBase 环境级 API Key（推荐用于 CI/CD、MCP Server） | 与 `CLOUDBASE_ENV_ID` 配合使用，优先级高于 `TENCENTCLOUD_*` 密钥；兼容读取 `CLOUDBASE_APIKEY`（与 `@cloudbase/js-sdk` / `@cloudbase/node-sdk` 对齐，优先使用带下划线的 `CLOUDBASE_API_KEY`）；[在控制台创建](https://tcb.cloud.tencent.com/dev) |
 | `CLOUDBASE_ENV_ID` | 云开发环境 ID（可选） | 未设置时首次调用会引导登录并选择环境 |
 | `CLOUDBASE_API_ENDPOINT` | 自定义 API Key 换取凭证的 Endpoint（高级可选） | 不设则使用默认 `https://<envId>.<region>.tcb-api.tencentcloudapi.com` |
 | `TENCENTCLOUD_SECRETID` | 腾讯云 SecretId（可选） | 不设则通过登录引导获取；[获取腾讯云 API 密钥](https://console.cloud.tencent.com/cam/capi) |
@@ -66,7 +66,7 @@ CloudBase MCP 支持两种连接方式：**本地模式**（MCP 服务在本机�
 
 当多种凭证同时存在时，MCP 按以下优先级选择：
 
-1. `CLOUDBASE_API_KEY` + `CLOUDBASE_ENV_ID` — CloudBase 环境级 API Key
+1. `CLOUDBASE_API_KEY` + `CLOUDBASE_ENV_ID` — CloudBase 环境级 API Key（若未设置 `CLOUDBASE_API_KEY`，兼容读取 `CLOUDBASE_APIKEY`）
 2. `TENCENTCLOUD_SECRETID` + `TENCENTCLOUD_SECRETKEY` — 腾讯云永久/临时密钥
 3. 本地存储的 Device Flow 登录凭证（`~/.config/.cloudbase/auth.json`）
 

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -253,7 +253,7 @@ API Key 是环境级长期凭证，MCP 会自动换取临时密钥，过期后�
 }
 ```
 
-> 💡 API Key 可在 [云开发控制台](https://tcb.cloud.tencent.com/dev) 的环境设置中创建和管理。
+> 💡 API Key 可在 [云开发控制台](https://tcb.cloud.tencent.com/dev) 的环境设置中创建和管理。也兼容 SDK 常用的 `CLOUDBASE_APIKEY`（无下划线）；两者同时存在时优先使用 `CLOUDBASE_API_KEY`。
 
 **方式二：腾讯云 API 密钥**
 

--- a/mcp/src/auth.test.ts
+++ b/mcp/src/auth.test.ts
@@ -3,10 +3,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const {
   mockAuthGetLoginState,
   mockAuthLoginByWebAuth,
+  mockAuthLoginByApiKey,
   mockAuthLogout,
 } = vi.hoisted(() => ({
   mockAuthGetLoginState: vi.fn(),
   mockAuthLoginByWebAuth: vi.fn(),
+  mockAuthLoginByApiKey: vi.fn(),
   mockAuthLogout: vi.fn(),
 }));
 
@@ -15,6 +17,7 @@ vi.mock("@cloudbase/toolbox", () => ({
     getInstance: vi.fn(() => ({
       getLoginState: mockAuthGetLoginState,
       loginByWebAuth: mockAuthLoginByWebAuth,
+      loginByApiKey: mockAuthLoginByApiKey,
       logout: mockAuthLogout,
     })),
   },
@@ -40,10 +43,17 @@ describe("auth config resolution", () => {
     delete process.env.TENCENTCLOUD_SECRETKEY;
     delete process.env.TENCENTCLOUD_SESSIONTOKEN;
     delete process.env.CLOUDBASE_ENV_ID;
+    delete process.env.CLOUDBASE_API_KEY;
+    delete process.env.CLOUDBASE_APIKEY;
     mockAuthGetLoginState.mockResolvedValue(null);
     mockAuthLoginByWebAuth.mockResolvedValue({
       secretId: "sid",
       secretKey: "skey",
+    });
+    mockAuthLoginByApiKey.mockResolvedValue({
+      secretId: "api-sid",
+      secretKey: "api-skey",
+      envId: "env-from-api-key",
     });
     mockAuthLogout.mockResolvedValue(undefined);
   });
@@ -53,6 +63,9 @@ describe("auth config resolution", () => {
     delete process.env.TCB_AUTH_CLIENT_ID;
     delete process.env.TCB_AUTH_OAUTH_ENDPOINT;
     delete process.env.TCB_AUTH_OAUTH_CUSTOM;
+    delete process.env.CLOUDBASE_API_KEY;
+    delete process.env.CLOUDBASE_APIKEY;
+    delete process.env.CLOUDBASE_ENV_ID;
   });
 
   it("should use toolbox defaults when no auth overrides are configured", async () => {
@@ -169,6 +182,80 @@ describe("auth config resolution", () => {
     const loginOptions = mockAuthLoginByWebAuth.mock.calls[0][0];
     expect(loginOptions.getOAuthEndpoint("ignored")).toBe(
       "https://custom.example.com/oauth",
+    );
+  });
+});
+
+describe("CloudBase API Key env resolution", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    delete process.env.CLOUDBASE_API_KEY;
+    delete process.env.CLOUDBASE_APIKEY;
+    delete process.env.CLOUDBASE_ENV_ID;
+    delete process.env.TENCENTCLOUD_SECRETID;
+    delete process.env.TENCENTCLOUD_SECRETKEY;
+    mockAuthGetLoginState.mockResolvedValue(null);
+    mockAuthLoginByApiKey.mockResolvedValue({
+      secretId: "api-sid",
+      secretKey: "api-skey",
+      envId: "env-test",
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.CLOUDBASE_API_KEY;
+    delete process.env.CLOUDBASE_APIKEY;
+    delete process.env.CLOUDBASE_ENV_ID;
+  });
+
+  it("should prefer CLOUDBASE_API_KEY over CLOUDBASE_APIKEY", async () => {
+    process.env.CLOUDBASE_API_KEY = "primary-key";
+    process.env.CLOUDBASE_APIKEY = "fallback-key";
+
+    const { getCloudBaseApiKeyFromEnv } = await import("./auth.js");
+
+    expect(getCloudBaseApiKeyFromEnv()).toBe("primary-key");
+  });
+
+  it("should fall back to CLOUDBASE_APIKEY when CLOUDBASE_API_KEY is unset", async () => {
+    process.env.CLOUDBASE_APIKEY = "fallback-key";
+
+    const { getCloudBaseApiKeyFromEnv } = await import("./auth.js");
+
+    expect(getCloudBaseApiKeyFromEnv()).toBe("fallback-key");
+  });
+
+  it("peekLoginState should use CLOUDBASE_APIKEY fallback for API Key mode", async () => {
+    process.env.CLOUDBASE_APIKEY = "compat-api-key";
+    process.env.CLOUDBASE_ENV_ID = "env-test";
+
+    const { peekLoginState } = await import("./auth.js");
+    const loginState = await peekLoginState();
+
+    expect(mockAuthLoginByApiKey).toHaveBeenCalledWith(
+      "compat-api-key",
+      "env-test",
+      expect.objectContaining({ cwd: expect.any(String) }),
+    );
+    expect(loginState).toMatchObject({
+      secretId: "api-sid",
+      secretKey: "api-skey",
+      envId: "env-test",
+    });
+  });
+
+  it("peekLoginState should prefer CLOUDBASE_API_KEY when both are set", async () => {
+    process.env.CLOUDBASE_API_KEY = "primary-key";
+    process.env.CLOUDBASE_APIKEY = "fallback-key";
+    process.env.CLOUDBASE_ENV_ID = "env-test";
+
+    const { peekLoginState } = await import("./auth.js");
+    await peekLoginState();
+
+    expect(mockAuthLoginByApiKey).toHaveBeenCalledWith(
+      "primary-key",
+      "env-test",
+      expect.objectContaining({ cwd: expect.any(String) }),
     );
   });
 });

--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -161,6 +161,14 @@ function updateAuthProgressState(
   return getAuthProgressStateSync();
 }
 
+/**
+ * Resolve CloudBase API Key from env.
+ * Prefer CLOUDBASE_API_KEY; fall back to CLOUDBASE_APIKEY (js-sdk / node-sdk convention).
+ */
+export function getCloudBaseApiKeyFromEnv(): string | undefined {
+  return process.env.CLOUDBASE_API_KEY || process.env.CLOUDBASE_APIKEY || undefined;
+}
+
 function normalizeLoginStateFromEnvVars(options?: {
   ignoreEnvVars?: boolean;
 }) {
@@ -168,16 +176,14 @@ function normalizeLoginStateFromEnvVars(options?: {
     return null;
   }
 
-  // 优先检查 CloudBase API Key（优先级高于 TENCENTCLOUD_*）
-  const {
-    CLOUDBASE_API_KEY,
-    CLOUDBASE_ENV_ID: CLOUDBASE_ENV,
-  } = process.env;
+  // Prefer CloudBase API Key over TENCENTCLOUD_*
+  const apiKey = getCloudBaseApiKeyFromEnv();
+  const CLOUDBASE_ENV = process.env.CLOUDBASE_ENV_ID;
 
-  if (CLOUDBASE_API_KEY && CLOUDBASE_ENV) {
+  if (apiKey && CLOUDBASE_ENV) {
     return {
       _type: 'api_key' as const,
-      apiKey: CLOUDBASE_API_KEY,
+      apiKey,
       envId: CLOUDBASE_ENV,
     };
   }
@@ -405,7 +411,7 @@ export async function peekLoginState(options?: {
 
 export async function ensureLogin(options?: EnsureLoginOptions) {
   debug("TENCENTCLOUD_SECRETID", { hasSecretId: !!process.env.TENCENTCLOUD_SECRETID });
-  debug("CLOUDBASE_API_KEY", { hasApiKey: !!process.env.CLOUDBASE_API_KEY });
+  debug("CLOUDBASE_API_KEY", { hasApiKey: !!getCloudBaseApiKeyFromEnv() });
 
   const loginState = await peekLoginState({
     ignoreEnvVars: options?.ignoreEnvVars,

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -115,6 +115,8 @@ vi.mock("../auth.js", () => ({
   buildVerificationUriComplete: mockBuildVerificationUriComplete,
   ensureLogin: mockEnsureLogin,
   getAuthConfigValidationError: mockGetAuthConfigValidationError,
+  getCloudBaseApiKeyFromEnv: () =>
+    process.env.CLOUDBASE_API_KEY || process.env.CLOUDBASE_APIKEY || undefined,
   peekLoginState: mockPeekLoginState,
   getAuthProgressState: mockGetAuthProgressState,
   logout: mockLogout,
@@ -858,6 +860,49 @@ describe("env tools - auth", () => {
     // env vars should be cleaned up on exception
     expect(process.env.CLOUDBASE_API_KEY).toBeUndefined();
     expect(process.env.CLOUDBASE_ENV_ID).toBeUndefined();
+  });
+
+  it("auth(action=status) should detect api_key mode from CLOUDBASE_APIKEY fallback", async () => {
+    process.env.CLOUDBASE_APIKEY = "compat-api-key";
+    process.env.CLOUDBASE_ENV_ID = "env-test";
+    mockPeekLoginState.mockResolvedValue({
+      secretId: "sid",
+      secretKey: "skey",
+      envId: "env-test",
+    });
+    mockGetCachedEnvId.mockReturnValue("env-test");
+
+    try {
+      const result = await tools.auth.handler({ action: "status" });
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload).toHaveProperty("ok", true);
+      expect(payload).toHaveProperty("auth_mode", "api_key");
+      expect(payload).toHaveProperty("auth_status", "READY");
+    } finally {
+      delete process.env.CLOUDBASE_APIKEY;
+      delete process.env.CLOUDBASE_ENV_ID;
+    }
+  });
+
+  it("auth(action=logout) should block when only CLOUDBASE_APIKEY is set", async () => {
+    process.env.CLOUDBASE_APIKEY = "compat-api-key";
+    process.env.CLOUDBASE_ENV_ID = "env-test";
+
+    try {
+      const result = await tools.auth.handler({
+        action: "logout",
+        confirm: "yes",
+      });
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload).toHaveProperty("ok", false);
+      expect(payload).toHaveProperty("code", "LOGOUT_NOT_ALLOWED");
+      expect(payload).toHaveProperty("auth_mode", "api_key");
+    } finally {
+      delete process.env.CLOUDBASE_APIKEY;
+      delete process.env.CLOUDBASE_ENV_ID;
+    }
   });
 });
 

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -7,6 +7,7 @@ import {
   ensureLogin,
   getAuthConfigValidationError,
   getAuthProgressState,
+  getCloudBaseApiKeyFromEnv,
   logout,
   peekLoginState,
   rejectAuthProgressState,
@@ -1589,8 +1590,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
           const loginState = await peekLoginState();
           const authFlowState = await getAuthProgressState();
 
-          // 判断是否为 API Key 模式
-          const isApiKeyMode = !!(process.env.CLOUDBASE_API_KEY && process.env.CLOUDBASE_ENV_ID);
+          // Detect API Key mode (CLOUDBASE_API_KEY preferred, CLOUDBASE_APIKEY fallback)
+          const apiKeyFromEnv = getCloudBaseApiKeyFromEnv();
+          const isApiKeyMode = !!(apiKeyFromEnv && process.env.CLOUDBASE_ENV_ID);
 
           const authStatus = loginState
             ? "READY"
@@ -1647,8 +1649,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         }
 
         if (action === "start_auth") {
-          // API Key 模式：尝试换取临时密钥
-          if (process.env.CLOUDBASE_API_KEY && process.env.CLOUDBASE_ENV_ID) {
+          // API Key mode: exchange for temporary credentials
+          const apiKeyFromEnv = getCloudBaseApiKeyFromEnv();
+          if (apiKeyFromEnv && process.env.CLOUDBASE_ENV_ID) {
             try {
               const existingLoginState = await peekLoginState();
               if (existingLoginState) {
@@ -1661,23 +1664,22 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                 });
               }
             } catch (e) {
-              // peekLoginState 内部异常，记录后 fall through
+              // peekLoginState threw; log and fall through to diagnostic
               debug("start_auth: peekLoginState threw", { error: e instanceof Error ? e.message : String(e) });
             }
 
-            // API Key 换取失败：返回详细诊断信息
-            // 尝试获取更详细的错误信息
+            // API Key exchange failed: return diagnostic details
             let diagMessage = "当前配置了 API Key 认证模式，但换取临时密钥失败。";
             const endpoint = process.env.CLOUDBASE_API_ENDPOINT || `https://${process.env.CLOUDBASE_ENV_ID}.ap-shanghai.tcb-api.tencentcloudapi.com`;
             diagMessage += `\n\n诊断信息：`;
             diagMessage += `\n- CLOUDBASE_ENV_ID: ${process.env.CLOUDBASE_ENV_ID}`;
-            diagMessage += `\n- CLOUDBASE_API_KEY: ${process.env.CLOUDBASE_API_KEY.slice(0, 20)}...（已截断）`;
+            diagMessage += `\n- CLOUDBASE_API_KEY: ${apiKeyFromEnv.slice(0, 20)}...（已截断）`;
             diagMessage += `\n- Endpoint: ${endpoint}`;
             diagMessage += `\n\n可能原因：`;
             diagMessage += `\n1. API Key 已过期或被删除`;
             diagMessage += `\n2. Endpoint 不可达（网络/DNS 问题）`;
             diagMessage += `\n3. CLOUDBASE_ENV_ID 与 API Key 所属环境不匹配`;
-            diagMessage += `\n\n建议：检查 MCP 配置中的 CLOUDBASE_API_KEY 和 CLOUDBASE_ENV_ID 环境变量是否正确。`;
+            diagMessage += `\n\n建议：检查 MCP 配置中的 CLOUDBASE_API_KEY（或兼容的 CLOUDBASE_APIKEY）和 CLOUDBASE_ENV_ID 环境变量是否正确。`;
 
             return buildJsonToolResult({
               ok: false,
@@ -1991,12 +1993,12 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         }
 
         if (action === "logout") {
-          // API Key 模式下不允许 logout
-          if (process.env.CLOUDBASE_API_KEY && process.env.CLOUDBASE_ENV_ID) {
+          // Disallow logout in API Key mode
+          if (getCloudBaseApiKeyFromEnv() && process.env.CLOUDBASE_ENV_ID) {
             return buildJsonToolResult({
               ok: false,
               code: "LOGOUT_NOT_ALLOWED",
-              message: "当前使用 API Key 认证模式，不支持退出登录。如需切换认证方式，请移除 CLOUDBASE_API_KEY 环境变量后重启。",
+              message: "当前使用 API Key 认证模式，不支持退出登录。如需切换认证方式，请移除 CLOUDBASE_API_KEY（或兼容的 CLOUDBASE_APIKEY）环境变量后重启。",
               auth_mode: "api_key",
             });
           }


### PR DESCRIPTION
Prefer CLOUDBASE_API_KEY and fall back to the SDK-standard CLOUDBASE_APIKEY so MCP auth works with shared env configs.