### PR TITLE
docs(readme): ✨ simplify quick start & externalize images

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-<div align="center"><a name="readme-top"></a>
+<div align="center">
 
-<img src="mcp/icon.png" width="96" height="96" alt="CloudBase AI Toolkit" />
+<img src="https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/mcp/icon.png" width="96" height="96" alt="CloudBase AI Toolkit" />
 
 # CloudBase AI Toolkit
 
@@ -71,7 +71,18 @@ Prefer Plugin for the full stack; Skills alone when you only need knowledge cons
 
 ## Quick start
 
-Pick one default path for your tool.
+### Fastest way to get started
+
+Copy this AI prompt into your AI IDE. The agent reads `skill.md` and completes the setup:
+
+```
+Set up CloudBase for me:
+1. Open https://docs.cloudbase.net/skill.md and complete the setup following its instructions.
+2. Tell me when you're done, and suggest the most relevant next step.
+```
+
+<details>
+<summary>Pick one default path for your tool (Plugin / CLI / MCP)</summary>
 
 | Your tool | Suggested path |
 |----------|----------|
@@ -81,7 +92,7 @@ Pick one default path for your tool.
 | CodeBuddy / WorkBuddy / ZCode (built-in) | Use the IDE’s built-in CloudBase plugin or connector; for CodeBuddy you can also [install via plugin marketplace](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ide-setup/codebuddy) |
 | Other MCP-capable IDEs | MCP config only (below) |
 
-### Plugin
+#### Plugin
 
 ```bash
 npx plugins add TencentCloudBase/cloudbase-plugin
@@ -89,7 +100,7 @@ npx plugins add TencentCloudBase/cloudbase-plugin
 
 Details and IDE differences: [AI plugin docs](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ai-agent-plugins).
 
-### MCP only
+#### MCP only
 
 ```json
 {
@@ -103,6 +114,8 @@ Details and IDE differences: [AI plugin docs](https://docs.cloudbase.net/ai/clou
 ```
 
 Hosted HTTP, self-hosted Cloud Mode, and plugin scoping: [Install & connect](#install--connect).
+
+</details>
 
 ### First prompts
 
@@ -118,7 +131,7 @@ Skills shape structure and practice; MCP handles environment and resources. You 
 
 ### Supported AI IDEs
 
-<img width="1200" alt="Supported AI IDEs" src="scripts/assets/ide-support-grid.png" />
+<img width="1200" alt="Supported AI IDEs" src="https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/scripts/assets/ide-support-grid.png" />
 
 | Tool | Platform | Guide |
 |------|------|------|

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
-<div align="center"><a name="readme-top"></a>
+<div align="center">
 
-<img src="mcp/icon.png" width="96" height="96" alt="CloudBase AI Toolkit" />
+<img src="https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/mcp/icon.png" width="96" height="96" alt="CloudBase AI Toolkit" />
 
 # CloudBase AI Toolkit
 
@@ -71,7 +71,18 @@ AI IDE（Cursor、Claude Code、Codex、CodeBuddy 等）擅长生成代码。真
 
 ## 快速开始
 
-按你的工具选一条默认路径即可。
+### 最快上手（推荐）
+
+复制下面的 AI Prompt，粘贴到你的 AI IDE。Agent 会读取 skill.md 完成接入：
+
+```
+帮我把 CloudBase 接好，按下面做：
+1. 打开 https://docs.cloudbase.net/skill.md，按说明完成接入。
+2. 接入完成后告诉我，并建议最相关的下一步。
+```
+
+<details>
+<summary>按你的工具选一条默认路径（Plugin / CLI / MCP）</summary>
 
 | 你的工具 | 建议做法 |
 |----------|----------|
@@ -81,7 +92,7 @@ AI IDE（Cursor、Claude Code、Codex、CodeBuddy 等）擅长生成代码。真
 | CodeBuddy / WorkBuddy / ZCode（已内置） | 使用 IDE 内置的 CloudBase 插件或连接器；CodeBuddy 也可通过[插件市场安装](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ide-setup/codebuddy) |
 | 其他支持 MCP 的 IDE | 仅配置 MCP（见下方） |
 
-### Plugin
+#### Plugin
 
 ```bash
 npx plugins add TencentCloudBase/cloudbase-plugin
@@ -89,7 +100,7 @@ npx plugins add TencentCloudBase/cloudbase-plugin
 
 说明与各 IDE 差异见 [AI 插件文档](https://docs.cloudbase.net/ai/cloudbase-ai-toolkit/ai-agent-plugins)。
 
-### 仅配置 MCP
+#### 仅配置 MCP
 
 ```json
 {
@@ -103,6 +114,8 @@ npx plugins add TencentCloudBase/cloudbase-plugin
 ```
 
 托管 HTTP、自建 Cloud Mode、按插件裁剪工具集见 [安装与连接](#安装与连接)。
+
+</details>
 
 ### 首次对话
 
@@ -118,7 +131,7 @@ Skills 负责写法与结构；MCP 负责环境与资源操作。完成后应能
 
 ### 支持的 AI IDE
 
-<img width="1200" alt="Supported AI IDEs" src="scripts/assets/ide-support-grid.png" />
+<img width="1200" alt="Supported AI IDEs" src="https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/scripts/assets/ide-support-grid.png" />
 
 | 工具 | 平台 | 指引 |
 |------|------|------|


### PR DESCRIPTION
## 变更说明

README 优化（英文 + 中文同步修改）：

1. **去掉 HTML 空标签** — 移除头部 `<a name="readme-top"></a>` 空锚点
2. **图片改外链** — `mcp/icon.png` 与 `scripts/assets/ide-support-grid.png` 改用 `raw.githubusercontent.com/.../main/...` 绝对 URL，复制 markdown 到别处后图片仍可正常显示
3. **快速开始简化** — 新增「最快上手」AI Prompt（复制到 AI IDE，Agent 读取 `https://docs.cloudbase.net/skill.md` 自动完成接入）；原有按工具决策链 + Plugin / 仅配置 MCP 细节折叠进 `<details>` 标签，保留完整详情

## 验证

- `node scripts/check-readme-sync.js` 中英文同步检查通过
- 两个 raw.githubusercontent.com 图片 URL 均返回 200
- `https://docs.cloudbase.net/skill.md` 真实存在