### PR TITLE
docs(skills): sync cloud-functions layer naming convention {layerName}_{envId} (a743309b)

### DIFF
--- a/config/source/skills/cloud-functions/SKILL.md
+++ b/config/source/skills/cloud-functions/SKILL.md
@@ -72,6 +72,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Making code or configuration changes without first following the Change Safety Protocol (`cloudbase-platform/references/protocols/change-safety-protocol.md`).
 - Exposing functions publicly or deploying without first completing the checks in `cloudbase-platform/references/protocols/deployment-gate.md`.
 - **Returning `req.headers`, `process.env`, `event`, or `context` wholesale** — gateways may inject `x-cloudbase-context` (base64 temporary credentials). Never echo that header or dump credential env vars to clients. Follow `../cloudbase-platform/references/protocols/sensitive-runtime-data-protection.md`.
+- **Using a bare layer name (e.g. `common`) across environments.** SCF LayerName is an account-scoped shared namespace: same name → shared version sequence. Create new layers with fixed format `{layerName}_{当前envId}` (e.g. `common_cloud1-d9ghadgak3edf6b36`). Pass the full name as `layerName` — do not invent automatic suffixes. Treat MCP layer `warnings` as soft advisories (operation still succeeds). Details: `./references/operations-and-config.md`.
 - **Defaulting new CRUD to TCP DB clients** (`DATABASE_URL` / `mysql2` / `pg` / Redis) instead of native `app.rdb()` / `app.database()` or MCP SQL. TCP is exception-only for existing ORM migrations — see `references/vpc-and-tcp-database.md` only then.
 
 ### Minimal checklist
@@ -167,7 +168,7 @@ Use these rules whenever you are writing the function code itself:
    - HTTP Function details -> `./references/http-functions.md`
    - HTTP Function CloudBase SDK credentials -> `./references/http-function-credentials.md`
    - HTTP Function from a container image (`Runtime: CustomImage`, TCR image pipeline) -> `./references/http-functions-custom-image.md`
-   - Logs, gateway, env vars, and legacy mappings -> `./references/operations-and-config.md`
+   - Logs, gateway, env vars, layers (`{layerName}_{当前envId}`), and legacy mappings -> `./references/operations-and-config.md`
 
 ## Database write reminder
 
@@ -301,6 +302,17 @@ The `scf_bootstrap` binary path must match the runtime — see the full mapping 
 - `manageFunctions(action="createFunction")`
 - `manageFunctions(action="updateFunctionCode")`
 - `manageFunctions(action="updateFunctionConfig")`
+
+### Layers (SCF Layer)
+
+Layers are **account-scoped**, not env-scoped. Align with MCP `manageFunctions` / `queryFunctions` layer guidance:
+
+- **Naming (required for new layers):** `{layerName}_{当前envId}` — example `common_cloud1-d9ghadgak3edf6b36`. Do not reuse a bare name like `common` in another env.
+- **Create:** `manageFunctions(action="createLayerVersion", layerName="…_{envId}", …)` after `queryFunctions(action="listLayers")` to check duplicates. MCP may return a soft `warnings` entry if the name lacks the current `envId`; it does **not** rewrite the name.
+- **Read:** `queryFunctions(action="listLayers"|"listLayerVersions"|"getLayerVersionDetail"|"listFunctionLayers")` — list results are an account-level view and may include layers created in other envs.
+- **Bind / unbind / replace:** `manageFunctions(action="attachLayer"|"detachLayer"|"updateFunctionLayers")`
+- **Delete version:** `manageFunctions(action="deleteLayerVersion")` — deleting a version can affect every env that binds that version.
+- Full contract and warning semantics → `./references/operations-and-config.md`
 
 ### Logs
 

--- a/config/source/skills/cloud-functions/checklist.md
+++ b/config/source/skills/cloud-functions/checklist.md
@@ -19,7 +19,12 @@ Use this checklist before creating or updating a CloudBase function.
 6. Confirm the function root path points to the parent directory, not the function directory itself. (Not needed for Custom Image deploys — the code lives in the image.)
 7. For Custom Image deploys, confirm TCR, the CloudApp build, and SCF are in the same region, and the image tag is unique (not `:latest`). Remember Stage A (CloudApp custom build → TCR push) is a raw Tencent Cloud API path, not covered by MCP tools.
 8. For HTTP Functions that need public access, configure the function security rule with `managePermissions(action="updateResourcePermission", resourceType="function")` after creation. Default rules reject unauthenticated callers with `EXCEED_AUTHORITY`. Note: anonymous login is disabled by default — use `rule: "true"` for public endpoints.
-9. If the request is really for a long-running container service, reroute to `cloudrun-development`.
+9. If creating or mutating a function **layer**, follow the account-scoped naming contract (same as MCP tool descriptions):
+   - New layer names must use `{layerName}_{当前envId}` (e.g. `common_cloud1-d9ghadgak3edf6b36`). Pass that full string as `layerName`; do not auto-append suffixes in client code.
+   - Before `createLayerVersion`, call `queryFunctions(action="listLayers")` to avoid colliding with another env's bare name.
+   - Treat envelope `warnings` as soft advisories (success still means the call ran). Deleting a layer version or rebinding layers can impact every env that shares that LayerName.
+   - Details: `references/operations-and-config.md`.
+10. If the request is really for a long-running container service, reroute to `cloudrun-development`.
 
 ## Common failure patterns
 
@@ -32,6 +37,7 @@ Use this checklist before creating or updating a CloudBase function.
 - For Custom Image functions: using `:latest`, mismatched regions across TCR/CloudApp/SCF, or assuming MCP covers the CloudApp build → TCR push stage (it does not).
 - Forgetting to configure function security rules for HTTP Functions that need public access.
 - Treating Cloud Functions as the default answer for Web authentication.
+- Creating layers with a bare name (e.g. `common`) so multiple envs share one version sequence, or ignoring MCP layer `warnings` about account-scoped sharing.
 
 ## Done criteria
 
@@ -39,4 +45,5 @@ Use this checklist before creating or updating a CloudBase function.
 - Packaging constraints are checked.
 - HTTP Function SDK credentials are explicit and a real SDK operation was verified after deployment.
 - No response echoes `x-cloudbase-context`, full headers, or credential env vars.
+- If layers were created, names follow `{layerName}_{当前envId}` and duplicate checks were done via `listLayers`.
 - The task is confirmed to be a function workflow rather than CloudRun.

--- a/config/source/skills/cloud-functions/references.md
+++ b/config/source/skills/cloud-functions/references.md
@@ -56,6 +56,7 @@ Read this when the task is about:
 - timer cron format
 - VPC field shape only (examples) — for TCP DB policy see `vpc-and-tcp-database.md` (exception-only)
 - gateway exposure for Event Functions
+- SCF layers: account-scoped naming `{layerName}_{当前envId}`, soft `warnings`, list/create/bind/delete actions
 - legacy tool-name translation
 - `callCloudApi` fallback for Cloud Functions
 

--- a/config/source/skills/cloud-functions/references/operations-and-config.md
+++ b/config/source/skills/cloud-functions/references/operations-and-config.md
@@ -145,6 +145,57 @@ When a function already needs VPC egress (exception path: existing TCP DB client
 }
 ```
 
+## Layers (SCF Layer)
+
+SCF LayerName is an **account-scoped shared namespace** (not per CloudBase env). Different envs that create the same layer name share one version sequence; deleting a version can break every function in every env that binds that version.
+
+This section mirrors the MCP `queryFunctions` / `manageFunctions` **层（Layer）说明** so skill guidance and tool descriptions stay aligned.
+
+### Naming contract (new layers)
+
+- Fixed format: `{layerName}_{当前envId}`
+- Example: `common_cloud1-d9ghadgak3edf6b36`
+- Pass the full string as `layerName`. MCP / Manager SDK pass the name through as-is — they do **not** auto-append `envId`.
+- Do not reuse a bare name (e.g. `common`) in another env.
+- Before create: `queryFunctions(action="listLayers")` (optionally with `searchKey`) to check for collisions.
+
+### Preferred tools
+
+| Goal | Tool |
+| --- | --- |
+| List layers / versions / detail (account-level view) | `queryFunctions(action="listLayers"\|"listLayerVersions"\|"getLayerVersionDetail")` |
+| List layers bound to a function | `queryFunctions(action="listFunctionLayers")` |
+| Create a layer version | `manageFunctions(action="createLayerVersion")` |
+| Delete a layer version | `manageFunctions(action="deleteLayerVersion")` |
+| Bind / unbind / replace function layers | `manageFunctions(action="attachLayer"\|"detachLayer"\|"updateFunctionLayers")` |
+
+```javascript
+// Create — name already includes current envId
+manageFunctions({
+  action: "createLayerVersion",
+  layerName: "common_cloud1-d9ghadgak3edf6b36",
+  runtimes: ["Nodejs18.15"],
+  contentPath: "/abs/path/to/layer-content"
+});
+```
+
+### Soft `warnings` (non-blocking)
+
+Layer actions may return envelope `warnings: string[]` while `success` remains `true`. Surface them to the user; do not treat them as hard failures and do not invent a different tool path because of them.
+
+Typical advisories (wording may vary slightly):
+
+- create without `envId` in the name → suggest `{layerName}_{envId}` because the name may share a version sequence with other envs
+- list layers / versions / detail → account-level view may include layers from other envs
+- delete version → account-shared; affects all envs bound to that version
+- attach / detach / updateFunctionLayers → account-shared bind/unbind impact
+
+### Do not
+
+- Auto-rewrite or suffix existing bare layer names in tooling (breaks callers that still use the bare name).
+- Tell the user to switch to `tcb` CLI solely to avoid layer conflicts — stay on MCP when tools are available.
+- Assume `listLayers` is filtered to the current env only.
+
 ## Legacy tool-name translation
 
 Prefer the converged entrances below, but translate historical names when they appear in old prompts or old docs.


### PR DESCRIPTION
## 背景
父任务 #904（6bd691b1）已为 MCP manageFunctions 补充层账号级共享语义与固定命名格式引导（`{layerName}_{envId}`）。本 PR 同步更新 `config/source/skills/cloud-functions/` 相关 SKILL/checklist，避免 skill 与 MCP 工具描述不一致。

## 改动
- `SKILL.md`: Common mistakes 增加裸层名跨环境告警；新增 Layers 专节（命名格式、list/create/bind/delete 工具映射、soft warnings 语义）
- `checklist.md`: 层创建/变更检查项 + done criteria
- `references.md`: routing 补 layer 场景
- `references/operations-and-config.md`: 新增 Layer 专节（账号级命名空间、固定命名格式、warning 软校验、工具映射）

## 不做
- 不自动拼 envId 后缀、不推荐 CLI、不启用 SearchSrc（与父任务决策一致）
- 只改 source skills，.claude/plugin 镜像交给 CI 同步

## 验证
- 分支基于 origin/main cherry-pick 原提交并解决与 sensitive-runtime 改动的冲突
- 保留 main 已有 sensitive-runtime 内容，层命名新增内容完整