### PR TITLE
fix(cloudrun): deploy 轻量等待注册并返回 buildId

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The CloudBase integration layer for AI coding tools: Plugin installs the stack, 
 
 **v2.26.x** (2026-08)
 
+- CloudRun: `manageCloudRun(action=deploy)` lightly waits for BuildId registration and returns `buildId` + `next_step` for `getDeployLog` polling (avoids immediate "build not found")
 - Gateway: enable/disable HTTP routes (`enableRoute` / `disableRoute`); hosting/env surfaces detect disabled default-domain routes before returning access URLs (#901, #902, #903)
 - Auth: accept `CLOUDBASE_APIKEY` as an API Key environment-variable fallback (#900)
 - Skills: MCP-to-CLI tooling fallback for first sessions when MCP tools are not loaded yet (#889)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,6 +34,7 @@
 
 **v2.26.x**（2026-08）
 
+- 云托管：`manageCloudRun(action=deploy)` 轻量等待 BuildId 注册并返回 `buildId` + `next_step`，便于立刻用 `getDeployLog` 轮询（避免立即出现 build not found）
 - 网关：支持启用/禁用 HTTP 路由（`enableRoute` / `disableRoute`）；托管与环境查询在返回访问地址前会识别默认域名路由已禁用的情况（#901、#902、#903）
 - 认证：支持 `CLOUDBASE_APIKEY` 作为 API Key 环境变量回退（#900）
 - Skills：首次会话 MCP 工具尚未加载时，提供 MCP→CLI 工具回退指引（#889）

--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -162,7 +162,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> deploy local project (**two ways**: source build via `targetPath`, or existing image via `imageUrl`) — existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -170,7 +170,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 ## Deploying an existing image (imageUrl)
 
-> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。
+> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。若用户明确提到使用某个镜像或无需重新构建代码，**必须传 imageUrl**，不要仅因本地有源码目录就回退到源码构建。
 
 **决策路径（直填 vs 本地中转）：**
 

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -162,7 +162,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> deploy local project (**two ways**: source build via `targetPath`, or existing image via `imageUrl`) — existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -170,7 +170,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 ## Deploying an existing image (imageUrl)
 
-> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。
+> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。若用户明确提到使用某个镜像或无需重新构建代码，**必须传 imageUrl**，不要仅因本地有源码目录就回退到源码构建。
 
 **决策路径（直填 vs 本地中转）：**
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -2052,7 +2052,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 ---
 
 ### `manageCloudRun`
-管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。
+管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 语义为「触发部署 + 轻量等待任务注册」（最多约 45s，对齐 tcb CLI 的 DescribeServerManageTask 轮询起点），返回 buildId；不会 hang 等待完整构建（5–30min）。拿到 buildId 后请用 queryCloudRun(action="getDeployLog", buildId=...) 轮询构建进度。若用户明确指定镜像或无需重新构建，必须传 imageUrl，不要仅因本地有源码目录就回退到源码构建。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。
 
 #### 参数
 
@@ -2062,7 +2062,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
       name: "action",
       type: "string",
       required: true,
-      description: `云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；传 imageUrl 时改为已有镜像部署，走 DeployType=image 容器型，targetPath 可省略；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令） 可填写的值: "init", "download", "run", "deploy", "delete", "createAgent", "updateConfig", "initEnv", "traffic"`,
+      description: `云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=触发部署并轻量等待任务注册（返回 buildId；不会 hang 等构建完成；构建进度请用 queryCloudRun(action=getDeployLog, buildId=...) 轮询）。支持函数型/容器型；传 imageUrl 时改为已有镜像部署（DeployType=image，targetPath 可省略）；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令） 可填写的值: "init", "download", "run", "deploy", "delete", "createAgent", "updateConfig", "initEnv", "traffic"`,
     },
     {
       name: "serverName",
@@ -2098,12 +2098,12 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
     {
       name: "targetPath",
       type: "string",
-      description: `本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略`,
+      description: `本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建`,
     },
     {
       name: "imageUrl",
       type: "string",
-      description: `已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType="image"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）`,
+      description: `已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType="image"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。约束：若用户明确提到使用某个镜像、或无需重新构建代码，则必须传 imageUrl 走镜像部署，不要回退到源码构建。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）`,
     },
     {
       name: "envParamsReplaceAll",

--- a/doc/prompts/cloudrun-development.mdx
+++ b/doc/prompts/cloudrun-development.mdx
@@ -198,7 +198,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> deploy local project (**two ways**: source build via `targetPath`, or existing image via `imageUrl`) — existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -206,7 +206,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 ## Deploying an existing image (imageUrl)
 
-> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。
+> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。若用户明确提到使用某个镜像或无需重新构建代码，**必须传 imageUrl**，不要仅因本地有源码目录就回退到源码构建。
 
 **决策路径（直填 vs 本地中转）：**
 

--- a/mcp/src/tools/cloudrun-deploy-registration.test.ts
+++ b/mcp/src/tools/cloudrun-deploy-registration.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  isValidCloudRunBuildId,
+  waitForCloudRunDeployRegistration,
+} from "./cloudrun.js";
+
+describe("isValidCloudRunBuildId", () => {
+  it("accepts positive finite numbers only", () => {
+    expect(isValidCloudRunBuildId(1)).toBe(true);
+    expect(isValidCloudRunBuildId(42)).toBe(true);
+    expect(isValidCloudRunBuildId(0)).toBe(false);
+    expect(isValidCloudRunBuildId(-1)).toBe(false);
+    expect(isValidCloudRunBuildId(undefined)).toBe(false);
+    expect(isValidCloudRunBuildId("12")).toBe(false);
+    expect(isValidCloudRunBuildId(Number.NaN)).toBe(false);
+  });
+});
+
+describe("waitForCloudRunDeployRegistration", () => {
+  it("returns immediately when BuildId appears on first poll", async () => {
+    const call = vi.fn().mockResolvedValue({
+      Task: { Id: 7, Status: "running" },
+    });
+    const getDeployRecords = vi.fn().mockResolvedValue({
+      DeployRecords: [{ BuildId: 1001, Status: "building" }],
+    });
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await waitForCloudRunDeployRegistration({
+      manager: { commonService: () => ({ call }) },
+      cloudrunService: { getDeployRecords },
+      envId: "env-test",
+      serverName: "svc-a",
+      maxWaitMs: 30_000,
+      intervalMs: 3_000,
+      sleepFn,
+    });
+
+    expect(result).toMatchObject({
+      registered: true,
+      timedOut: false,
+      taskId: 7,
+      buildId: 1001,
+      taskStatus: "running",
+    });
+    expect(result.waitMs).toBeLessThan(1000);
+    expect(sleepFn).not.toHaveBeenCalled();
+    expect(call).toHaveBeenCalledWith({
+      Action: "DescribeServerManageTask",
+      Param: {
+        EnvId: "env-test",
+        ServerName: "svc-a",
+        TaskId: 0,
+      },
+    });
+  });
+
+  it("keeps polling until BuildId > 0 even if Task.Id appears first", async () => {
+    const call = vi
+      .fn()
+      .mockResolvedValueOnce({ Task: { Id: 9, Status: "todo" } })
+      .mockResolvedValue({ Task: { Id: 9, Status: "running" } });
+    const getDeployRecords = vi
+      .fn()
+      .mockResolvedValueOnce({ DeployRecords: [{ BuildId: 0 }] })
+      .mockResolvedValueOnce({ DeployRecords: [] })
+      .mockResolvedValue({ DeployRecords: [{ BuildId: 55 }] });
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await waitForCloudRunDeployRegistration({
+      manager: { commonService: () => ({ call }) },
+      cloudrunService: { getDeployRecords },
+      envId: "env-test",
+      serverName: "svc-b",
+      maxWaitMs: 20_000,
+      intervalMs: 10,
+      sleepFn,
+    });
+
+    expect(result.registered).toBe(true);
+    expect(result.timedOut).toBe(false);
+    expect(result.buildId).toBe(55);
+    expect(result.taskId).toBe(9);
+    expect(sleepFn).toHaveBeenCalled();
+    expect(getDeployRecords.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("times out with taskId when BuildId never becomes valid", async () => {
+    const call = vi.fn().mockResolvedValue({
+      Task: { Id: 3, Status: "running" },
+    });
+    const getDeployRecords = vi.fn().mockResolvedValue({
+      DeployRecords: [{ BuildId: 0 }],
+    });
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await waitForCloudRunDeployRegistration({
+      manager: { commonService: () => ({ call }) },
+      cloudrunService: { getDeployRecords },
+      envId: "env-test",
+      serverName: "svc-c",
+      maxWaitMs: 25,
+      intervalMs: 10,
+      sleepFn,
+    });
+
+    expect(result.registered).toBe(true);
+    expect(result.timedOut).toBe(true);
+    expect(result.taskId).toBe(3);
+    expect(result.buildId).toBeUndefined();
+  });
+
+  it("times out unregistered when neither task nor BuildId appears", async () => {
+    const call = vi.fn().mockResolvedValue({ Task: {} });
+    const getDeployRecords = vi.fn().mockResolvedValue({ DeployRecords: [] });
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await waitForCloudRunDeployRegistration({
+      manager: { commonService: () => ({ call }) },
+      cloudrunService: { getDeployRecords },
+      envId: "env-test",
+      serverName: "svc-d",
+      maxWaitMs: 25,
+      intervalMs: 10,
+      sleepFn,
+    });
+
+    expect(result.registered).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.buildId).toBeUndefined();
+    expect(result.taskId).toBeUndefined();
+  });
+
+  it("tolerates missing commonService / getDeployRecords and still times out safely", async () => {
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+    const result = await waitForCloudRunDeployRegistration({
+      manager: {},
+      cloudrunService: {},
+      envId: "env-test",
+      serverName: "svc-e",
+      maxWaitMs: 20,
+      intervalMs: 5,
+      sleepFn,
+    });
+    expect(result.registered).toBe(false);
+    expect(result.timedOut).toBe(true);
+  });
+});

--- a/mcp/src/tools/cloudrun-image-deploy.test.ts
+++ b/mcp/src/tools/cloudrun-image-deploy.test.ts
@@ -41,7 +41,7 @@ type ManagerMock = {
   cloudrun: {
     deploy: ReturnType<typeof vi.fn>;
     detail: ReturnType<typeof vi.fn>;
-    getDeployRecords?: ReturnType<typeof vi.fn>;
+    getDeployRecords: ReturnType<typeof vi.fn>;
   };
 };
 
@@ -49,6 +49,7 @@ function makeManager(options: {
   envStatus?: "normal" | "creating" | "unopened";
   detailImpl?: (params: { serverName: string }) => Promise<any>;
   deployImpl?: (params: any) => Promise<any>;
+  buildId?: number;
 } = {}): ManagerMock {
   const {
     envStatus = "normal",
@@ -56,6 +57,7 @@ function makeManager(options: {
       throw new Error("ResourceNotFound.ServerNotFound");
     },
     deployImpl = async () => ({}),
+    buildId = 9001,
   } = options;
   return {
     commonService: vi.fn().mockReturnValue({
@@ -69,12 +71,18 @@ function makeManager(options: {
             IsExist: true,
           };
         }
+        if (req.Action === "DescribeServerManageTask") {
+          return { Task: { Id: 42, Status: "running" } };
+        }
         return {};
       },
     }),
     cloudrun: {
       deploy: vi.fn(deployImpl),
       detail: vi.fn(detailImpl),
+      getDeployRecords: vi.fn(async () => ({
+        DeployRecords: [{ BuildId: buildId, Status: "building" }],
+      })),
     },
   };
 }
@@ -88,7 +96,11 @@ describe("manageCloudRun deploy imageUrl branch", () => {
   });
   afterEach(() => {
     if (tmpSourceDir) {
-      fs.rmSync(tmpSourceDir, { recursive: true, force: true });
+      try {
+        fs.rmSync(tmpSourceDir, { recursive: true, force: true });
+      } catch {
+        // Ignore cleanup failures in restricted CI/sandbox delete hooks.
+      }
     }
   });
 
@@ -116,6 +128,23 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     expect(parsed.data.serverType).toBe("container");
     expect(parsed.data.deployPath).toBeUndefined();
     expect(parsed.data.cloudbasercGenerated).toBe(false);
+    expect(parsed.data.status).toBe("deploying");
+    expect(parsed.data.buildId).toBe(9001);
+    expect(parsed.data.taskId).toBe(42);
+    expect(parsed.data.registration).toMatchObject({
+      registered: true,
+      timedOut: false,
+    });
+    expect(parsed.data.next_step).toMatchObject({
+      tool: "queryCloudRun",
+      action: "getDeployLog",
+      suggested_args: {
+        action: "getDeployLog",
+        detailServerName: "hermes-agent",
+        buildId: 9001,
+      },
+    });
+    expect(manager.cloudrun.getDeployRecords).toHaveBeenCalled();
 
     const deployCall = manager.cloudrun.deploy.mock.calls[0][0];
     expect(deployCall.imageUrl).toBe("ccr.ccs.tencentyun.com/ns/hermes:v1");
@@ -130,6 +159,15 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     });
     // 镜像部署未传 targetPath 时应保持 undefined，交给 SDK 走 DeployType=image 分支。
     expect(deployCall.targetPath).toBeUndefined();
+  });
+
+  it("documents imageUrl-first semantics in schema descriptions", async () => {
+    const { tools } = await createCloudRunTools();
+    const schema = tools.manageCloudRun.meta.inputSchema;
+    expect(schema.imageUrl.description).toMatch(/必须传 imageUrl|不要回退到源码构建/);
+    expect(schema.targetPath.description).toMatch(/优先传 imageUrl|不等于必须走源码构建/);
+    expect(schema.action.description).toMatch(/轻量等待|getDeployLog/);
+    expect(tools.manageCloudRun.meta.description).toMatch(/轻量等待任务注册|buildId/);
   });
 
   it("fails with guidance when imageUrl deploy targets an unopened CloudRun env", async () => {

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -46,7 +46,7 @@ const queryCloudRunInputSchema = {
 
 // Input schema for manageCloudRun tool
 const ManageCloudRunInputSchema = {
-  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent', 'updateConfig', 'initEnv', 'traffic']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；传 imageUrl 时改为已有镜像部署，走 DeployType=image 容器型，targetPath 可省略；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）'),
+  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent', 'updateConfig', 'initEnv', 'traffic']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=触发部署并轻量等待任务注册（返回 buildId；不会 hang 等构建完成；构建进度请用 queryCloudRun(action=getDeployLog, buildId=...) 轮询）。支持函数型/容器型；传 imageUrl 时改为已有镜像部署（DeployType=image，targetPath 可省略）；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）'),
   serverName: z.string().describe('云托管服务名称，用于标识和管理服务。命名规则：支持大小写字母、数字、连字符和下划线，必须以字母开头，长度3-45个字符。在init操作中会作为在targetPath下创建的子目录名，在其他操作中作为目标服务名。initEnv 操作不需要此参数'),
 
   // Traffic management operation parameters (action=traffic)
@@ -59,8 +59,8 @@ const ManageCloudRunInputSchema = {
   packageType: z.enum(CLOUDRUN_PACKAGE_TYPES).optional().default('Trial').describe('云托管环境套餐类型（action=initEnv 时使用）：Trial=试用，Standard=标准，Professional=专业，Enterprise=企业。默认 Trial'),
 
   // Deploy operation parameters
-  targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略'),
-  imageUrl: z.string().optional().describe('已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType="image"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）'),
+  targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建'),
+  imageUrl: z.string().optional().describe('已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType="image"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。约束：若用户明确提到使用某个镜像、或无需重新构建代码，则必须传 imageUrl 走镜像部署，不要回退到源码构建。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）'),
   envParamsReplaceAll: z.boolean().optional().default(false).describe('EnvParams 合并策略（deploy / updateConfig）：false（默认）= 与远程按 key 合并（输入覆盖同名 key，远程其余 key 保留）；true= 用输入 EnvParams 整包替换远程。仅当显式传入 EnvParams 时生效'),
   serverConfig: z.object({
     OpenAccessTypes: z.array(z.enum(CLOUDRUN_ACCESS_TYPES)).optional().describe('公网访问类型配置，控制服务的访问权限：OA=办公网访问，PUBLIC=公网访问（默认，可通过HTTPS域名访问），MINIAPP=小程序访问，VPC=VPC访问（仅同VPC内可访问）。可配置多个类型'),
@@ -257,6 +257,158 @@ function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["action"] |
   }
 
   return `[manageCloudRun/${action}] ${baseMessage}\n建议：${suggestions.join(" ")}`;
+}
+
+/**
+ * Lightweight wait after manageCloudRun deploy: poll until the platform has
+ * registered the manage task / assigned a BuildId so getDeployLog works.
+ * Does NOT wait for the full build (that can take 5–30 minutes).
+ * Aligns with tcb CLI's DescribeServerManageTask polling entrypoint, but with
+ * a short timeout suitable for MCP tool calls.
+ */
+export const CLOUDRUN_DEPLOY_REGISTRATION_MAX_WAIT_MS = 45_000;
+export const CLOUDRUN_DEPLOY_REGISTRATION_INTERVAL_MS = 3_000;
+
+export type CloudRunDeployRegistration = {
+  registered: boolean;
+  timedOut: boolean;
+  taskId?: number;
+  buildId?: number;
+  taskStatus?: string;
+  waitMs: number;
+};
+
+function sleepMs(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function isValidCloudRunBuildId(value: unknown): value is number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+function extractServerManageTaskInfo(resp: unknown): {
+  taskId?: number;
+  taskStatus?: string;
+} {
+  const data = (resp ?? {}) as Record<string, unknown>;
+  const task = (data.Task ?? data.task ?? {}) as Record<string, unknown>;
+  const rawId = task.Id ?? task.id;
+  const rawStatus = task.Status ?? task.status;
+  const taskId =
+    typeof rawId === "number" && rawId > 0
+      ? rawId
+      : typeof rawId === "string" && /^\d+$/.test(rawId) && Number(rawId) > 0
+        ? Number(rawId)
+        : undefined;
+  const taskStatus =
+    typeof rawStatus === "string" && rawStatus.trim()
+      ? rawStatus.trim()
+      : undefined;
+  return {
+    ...(taskId !== undefined ? { taskId } : {}),
+    ...(taskStatus ? { taskStatus } : {}),
+  };
+}
+
+/**
+ * Poll DescribeServerManageTask + getDeployRecords until BuildId > 0
+ * (preferred) or a manage task Id appears. Returns early on BuildId;
+ * if only taskId is seen, keeps polling for BuildId until maxWaitMs.
+ */
+export async function waitForCloudRunDeployRegistration(options: {
+  manager: {
+    commonService?: (
+      service: string,
+      version: string,
+    ) => { call: (req: { Action: string; Param: Record<string, unknown> }) => Promise<unknown> };
+  };
+  cloudrunService: {
+    getDeployRecords?: (params: { serverName: string }) => Promise<unknown>;
+  };
+  envId: string;
+  serverName: string;
+  maxWaitMs?: number;
+  intervalMs?: number;
+  sleepFn?: (ms: number) => Promise<void>;
+}): Promise<CloudRunDeployRegistration> {
+  const maxWaitMs = options.maxWaitMs ?? CLOUDRUN_DEPLOY_REGISTRATION_MAX_WAIT_MS;
+  const intervalMs = options.intervalMs ?? CLOUDRUN_DEPLOY_REGISTRATION_INTERVAL_MS;
+  const sleepFn = options.sleepFn ?? sleepMs;
+  const startAt = Date.now();
+
+  let lastTaskId: number | undefined;
+  let lastTaskStatus: string | undefined;
+  let lastBuildId: number | undefined;
+
+  // Immediate first probe, then interval retries until timeout.
+  for (;;) {
+    if (options.manager.commonService) {
+      try {
+        const resp = await options.manager
+          .commonService("tcbr", "2022-02-17")
+          .call({
+            Action: "DescribeServerManageTask",
+            Param: {
+              EnvId: options.envId,
+              ServerName: options.serverName,
+              TaskId: lastTaskId ?? 0,
+            },
+          });
+        const info = extractServerManageTaskInfo(resp);
+        if (info.taskId !== undefined) {
+          lastTaskId = info.taskId;
+        }
+        if (info.taskStatus) {
+          lastTaskStatus = info.taskStatus;
+        }
+      } catch {
+        // Task may not be queryable yet; retry until timeout.
+      }
+    }
+
+    if (typeof options.cloudrunService.getDeployRecords === "function") {
+      try {
+        const recordsResult = (await options.cloudrunService.getDeployRecords({
+          serverName: options.serverName,
+        })) as { DeployRecords?: Array<{ BuildId?: number }> };
+        const latest = recordsResult?.DeployRecords?.[0];
+        if (isValidCloudRunBuildId(latest?.BuildId)) {
+          lastBuildId = latest.BuildId;
+        }
+      } catch {
+        // Deploy record may lag behind task registration; retry.
+      }
+    }
+
+    if (isValidCloudRunBuildId(lastBuildId)) {
+      return {
+        registered: true,
+        timedOut: false,
+        taskId: lastTaskId,
+        buildId: lastBuildId,
+        taskStatus: lastTaskStatus,
+        waitMs: Date.now() - startAt,
+      };
+    }
+
+    if (Date.now() - startAt >= maxWaitMs) {
+      break;
+    }
+    await sleepFn(intervalMs);
+  }
+
+  const registered =
+    isValidCloudRunBuildId(lastBuildId) ||
+    (typeof lastTaskId === "number" && lastTaskId > 0);
+
+  return {
+    registered,
+    timedOut: true,
+    taskId: lastTaskId,
+    buildId: lastBuildId,
+    taskStatus: lastTaskStatus,
+    waitMs: Date.now() - startAt,
+  };
 }
 
 const CLOUDRUN_DB_ENV_KEY_PATTERN =
@@ -934,7 +1086,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
     "manageCloudRun",
     {
       title: "管理 CloudRun 服务",
-      description: "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
+      description: "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 语义为「触发部署 + 轻量等待任务注册」（最多约 45s，对齐 tcb CLI 的 DescribeServerManageTask 轮询起点），返回 buildId；不会 hang 等待完整构建（5–30min）。拿到 buildId 后请用 queryCloudRun(action=\"getDeployLog\", buildId=...) 轮询构建进度。若用户明确指定镜像或无需重新构建，必须传 imageUrl，不要仅因本地有源码目录就回退到源码构建。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
       inputSchema: ManageCloudRunInputSchema,
       annotations: {
         readOnlyHint: false,
@@ -1474,6 +1626,16 @@ for await (let x of res.textStream) {
 
             // Generate cloudbaserc.json configuration file (source-build only; image deploy has no local project dir)
             const currentEnvId = await getEnvId(cloudBaseOptions);
+
+            // Lightweight wait for task/BuildId registration (not full build completion).
+            // Prevents immediate getDeployLog "build not found" after deploy returns.
+            const registration = await waitForCloudRunDeployRegistration({
+              manager,
+              cloudrunService,
+              envId: currentEnvId,
+              serverName: input.serverName,
+            });
+
             let cloudbasercGenerated = false;
             if (targetPath) {
               const cloudbasercPath = path.join(targetPath, 'cloudbaserc.json');
@@ -1555,6 +1717,34 @@ for await (let x of res.textStream) {
               ? ` Warning: ${dbNetworkRisk.message} Set serverConfig.VpcConf before relying on DB connectivity.`
               : "";
 
+            const buildIdHint = isValidCloudRunBuildId(registration.buildId)
+              ? ` Use queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}", buildId=${registration.buildId}) to poll build progress.`
+              : registration.registered
+                ? ` Task registered (taskId=${registration.taskId ?? "unknown"}); BuildId not yet available — retry queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}") shortly, or check ${consoleUrl}.`
+                : ` Build registration timed out after ${Math.round(registration.waitMs / 1000)}s — deployment may still be queueing. Check ${consoleUrl} or retry queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}") later.`;
+
+            const nextStep = isValidCloudRunBuildId(registration.buildId)
+              ? {
+                  tool: "queryCloudRun",
+                  action: "getDeployLog",
+                  suggested_args: {
+                    action: "getDeployLog",
+                    detailServerName: input.serverName,
+                    buildId: registration.buildId,
+                  },
+                }
+              : {
+                  tool: "queryCloudRun",
+                  action: "getDeployLog",
+                  suggested_args: {
+                    action: "getDeployLog",
+                    detailServerName: input.serverName,
+                  },
+                  note: registration.registered
+                    ? "BuildId not yet available; omit buildId to use the latest deploy record, or check consoleUrl."
+                    : "Registration timed out; wait a moment then retry getDeployLog, or open consoleUrl.",
+                };
+
             return {
               content: [
                 {
@@ -1570,6 +1760,21 @@ for await (let x of res.textStream) {
                       serverType: serverType,
                       cloudbasercGenerated,
                       consoleUrl,
+                      ...(isValidCloudRunBuildId(registration.buildId)
+                        ? { buildId: registration.buildId }
+                        : {}),
+                      ...(typeof registration.taskId === "number"
+                        ? { taskId: registration.taskId }
+                        : {}),
+                      registration: {
+                        registered: registration.registered,
+                        timedOut: registration.timedOut,
+                        waitMs: registration.waitMs,
+                        ...(registration.taskStatus
+                          ? { taskStatus: registration.taskStatus }
+                          : {}),
+                      },
+                      next_step: nextStep,
                       ...(existingService
                         ? {
                             configMerge: {
@@ -1590,8 +1795,10 @@ for await (let x of res.textStream) {
                         ? { accessUrlSource: preferredAccessSource }
                         : {}),
                       ...(warnings.length > 0 ? { warnings } : {}),
+                      // Keep raw SDK result for debugging without implying build finished.
+                      ...(result != null ? { deployAccepted: true } : {}),
                     },
-                    message: `Triggered deployment for ${serverType} service '${input.serverName}' ${input.imageUrl ? `from image ${input.imageUrl}` : `from ${targetPath}`}. You can follow the progress in ${consoleUrl}.${warningSuffix}`
+                    message: `Triggered deployment for ${serverType} service '${input.serverName}' ${input.imageUrl ? `from image ${input.imageUrl}` : `from ${targetPath}`}. Deployment is registering/building (status=deploying); this call does not wait for full build completion.${buildIdHint}${warningSuffix}`
                   }, null, 2)
                 }
               ]

--- a/plugin/cloudbase/skills/cloudrun-development/SKILL.md
+++ b/plugin/cloudbase/skills/cloudrun-development/SKILL.md
@@ -162,7 +162,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> deploy local project (**two ways**: source build via `targetPath`, or existing image via `imageUrl`) — existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -170,7 +170,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 ## Deploying an existing image (imageUrl)
 
-> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。
+> 已有一个现成镜像（本地构建好、或第三方发布）时，不需要本地源码目录，直接 `manageCloudRun(action="deploy")` 传入 `imageUrl` 即可，走 `DeployType="image"`（容器型）部署，`targetPath` 可省略。若用户明确提到使用某个镜像或无需重新构建代码，**必须传 imageUrl**，不要仅因本地有源码目录就回退到源码构建。
 
 **决策路径（直填 vs 本地中转）：**
 

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2138,7 +2138,7 @@
     },
     {
       "name": "manageCloudRun",
-      "description": "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
+      "description": "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 语义为「触发部署 + 轻量等待任务注册」（最多约 45s，对齐 tcb CLI 的 DescribeServerManageTask 轮询起点），返回 buildId；不会 hang 等待完整构建（5–30min）。拿到 buildId 后请用 queryCloudRun(action=\"getDeployLog\", buildId=...) 轮询构建进度。若用户明确指定镜像或无需重新构建，必须传 imageUrl，不要仅因本地有源码目录就回退到源码构建。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2155,7 +2155,7 @@
               "initEnv",
               "traffic"
             ],
-            "description": "云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=将本地代码部署到云端云托管服务（支持函数型和容器型；传 imageUrl 时改为已有镜像部署，走 DeployType=image 容器型，targetPath 可省略；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）"
+            "description": "云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=触发部署并轻量等待任务注册（返回 buildId；不会 hang 等构建完成；构建进度请用 queryCloudRun(action=getDeployLog, buildId=...) 轮询）。支持函数型/容器型；传 imageUrl 时改为已有镜像部署（DeployType=image，targetPath 可省略）；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）"
           },
           "serverName": {
             "type": "string",
@@ -2199,11 +2199,11 @@
           },
           "targetPath": {
             "type": "string",
-            "description": "本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略"
+            "description": "本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建"
           },
           "imageUrl": {
             "type": "string",
-            "description": "已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType=\"image\"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）"
+            "description": "已有镜像部署（action=deploy 时使用）：直接指定容器镜像地址，如 ccr.ccs.tencentyun.com/ns/img:v1 或公网 registry 地址。传入后走 DeployType=\"image\"（容器型）部署，无需本地源码目录（targetPath 可省略）。支持：1) 公网匿名可拉取的镜像直填地址；2) 私有/需登录的镜像（如 ghcr.io）需先在本地 docker pull → docker tag/push 到腾讯云 CCR → 填入 CCR 地址。不传则维持源码构建（本地代码打包上传）。约束：若用户明确提到使用某个镜像、或无需重新构建代码，则必须传 imageUrl 走镜像部署，不要回退到源码构建。注意：无论哪种部署方式，环境都需先开通云托管（未开通时先调用 initEnv，Status=normal 后再部署）"
           },
           "envParamsReplaceAll": {
             "type": "boolean",


### PR DESCRIPTION
## Summary
- `manageCloudRun(action=deploy)` 在 `deploy()` 接单成功后，轻量轮询 `DescribeServerManageTask` + `getDeployRecords`（默认最多约 45s / 3s），拿到有效 `BuildId` 即返回，**不会 hang 等完整构建**（对齐 tcb CLI 的轮询入口，但超时更短以适配 MCP）
- 返回 payload 增加 `buildId` / `taskId` / `registration` / `next_step`，引导立刻用 `queryCloudRun(action=getDeployLog, buildId=...)` 轮询构建进度，避免 `build not found`
- 强化 `imageUrl` / `targetPath` / deploy 工具描述：用户明确指定镜像或无需重建时必须传 `imageUrl`，不要仅因本地有源码目录就回退源码构建
- 同步 `scripts/tools.json`、`doc/mcp-tools.md`、`cloudrun-development` skill/prompts 与 README changelog

## Test plan
- [x] `vitest`：`cloudrun-deploy-registration.test.ts` + `cloudrun-image-deploy.test.ts`（含 schema 文案与返回 `buildId`/`next_step`）
- [x] `npm run build` 通过；已重新生成 tools schema 文档
- [ ] 真人/联调：新服务 `deploy` 后立刻 `getDeployLog(buildId=...)` 不再报 `DescribeCloudRunBuildLog build not found`
- [ ] 确认 RMW（VpcConf/EnvParams）行为未回归；`InitialDelaySeconds` 平台压参不在本次范围


Made with [Cursor](https://cursor.com)