### PR TITLE
feat(permissions): add gateway OPA policy list/get/set actions

### DIFF
--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -747,7 +747,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "role",
       type: "string",
-      description: `可选的 PostgreSQL role，会传给 Manager SDK executePGSql；例如需要管理策略时可传 postgres。`,
+      description: `可选的 PostgreSQL role，传给 Manager SDK executePGSql 的 Role（平台会 SET ROLE）。默认 cloudbase_admin。推荐取值：cloudbase_admin / anon / authenticated / service_role。不要传 postgres、postgres_pgdb_* 或从环境名臆造的角色；不确定时省略本字段，或先用 cloudbase_admin 执行 SELECT rolname FROM pg_roles。`,
     },
     {
       name: "objectName",
@@ -2831,14 +2831,16 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 ---
 
 ### `queryPermissions`
-查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情。
+查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情，以及网关 OPA 授权策略（对齐 CLI `tcb policy list/get`）。
 
 示例：
 - 查询存储桶权限：`action="getResourcePermission", resourceType="storage", resourceId="bucket-name"`
+- 列出旧网关策略：`action="listPolicy"`（PG / OPA 引擎环境返回空列表，与 CLI 一致）
+- 读取用户 Rego：`action="getPolicy"`；平台扩展策略：`action="getPolicy", extension=true`
 
 📌 跨后端边界提示：调用前先用 `envQuery(action="info", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType="noSqlDatabase"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action="sql", sql="SELECT * FROM pg_policies WHERE tablename=...")`。本工具不涉及 MySQL 权限。
 
-⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。
+⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。显式 OPA 策略请用 `listPolicy` / `getPolicy`。
 
 #### 参数
 
@@ -2848,7 +2850,7 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
       name: "action",
       type: "string",
       required: true,
-      description: ` 可填写的值: "getResourcePermission", "listResourcePermissions", "listRoles", "getRole", "listUsers", "getUser"`,
+      description: ` 可填写的值: "getResourcePermission", "listResourcePermissions", "listRoles", "getRole", "listUsers", "getUser", "listPolicy", "getPolicy"`,
     },
     {
       name: "resourceType",
@@ -2890,6 +2892,16 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
     {
       name: "pageSize",
       type: "number",
+    },
+    {
+      name: "extension",
+      type: "boolean",
+      description: `仅 action=getPolicy。true=读取平台为该环境单独配置的策略（authz.platform.extension.rego），默认 false=用户策略（authz.user.rego），对齐 CLI \`tcb policy get --extension\`。`,
+    },
+    {
+      name: "policyResourceType",
+      type: "string",
+      description: `仅 action=listPolicy。按资源类型过滤，当前仅支持 \`policy\`，对齐 CLI \`tcb policy list --resource-type policy\`。 可填写的值: "policy"`,
     }
   ]}
 />
@@ -2897,12 +2909,13 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 ---
 
 ### `managePermissions`
-管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD。
+管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD，以及设置网关 OPA Rego 策略（对齐 CLI `tcb policy set`）。
 
 示例：
 - 设置存储桶为私有：`action="updateResourcePermission", resourceType="storage", resourceId="bucket-name", permission="PRIVATE"`
 - 创建角色：`action="createRole", roleName="admin", roleIdentity="admin"`
 - 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action="updateResourcePermission", resourceType="function", resourceId="myFn", permission="CUSTOM", securityRule='\{"invoke":true\}'`
+- 直接设置用户 Rego：`action="setPolicy", regoContent="package authz.user\n\ndefault allow := false\n", confirm=true`（⚠️ 立即禁用旧网关鉴权）
 
 注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp(\{ username, password \})`，登录应使用 `auth.signInWithPassword(\{ username, password \})`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType="noSqlDatabase"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。
 
@@ -2911,7 +2924,7 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
 - `resourceType="storage"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。
 - 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。
 
-⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'\{"invoke":true\}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。
+⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType="function"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'\{"invoke":true\}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。显式 OPA 策略请优先用 `action="setPolicy"`。
 
 #### 参数
 
@@ -2921,7 +2934,7 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
       name: "action",
       type: "string",
       required: true,
-      description: ` 可填写的值: "updateResourcePermission", "createRole", "updateRole", "deleteRoles", "addRoleMembers", "removeRoleMembers", "addRolePolicies", "removeRolePolicies", "createUser", "updateUser", "deleteUsers"`,
+      description: ` 可填写的值: "updateResourcePermission", "createRole", "updateRole", "deleteRoles", "addRoleMembers", "removeRoleMembers", "addRolePolicies", "removeRolePolicies", "createUser", "updateUser", "deleteUsers", "setPolicy"`,
     },
     {
       name: "resourceType",
@@ -2996,6 +3009,16 @@ action=deployApp 上传源码 ZIP 并触发远端构建部署管道：
       name: "userStatus",
       type: "string",
       description: ` 可填写的值: "ACTIVE", "BLOCKED"`,
+    },
+    {
+      name: "regoContent",
+      type: "string",
+      description: `仅 action=setPolicy。用户 OPA Rego 全文，必须以 \`package authz.user\` 开头，对齐 CLI \`tcb policy set <regoContent>\`。`,
+    },
+    {
+      name: "confirm",
+      type: "boolean",
+      description: `仅 action=setPolicy。设置 Rego 后会立即禁用旧网关鉴权，必须显式传 confirm=true（对齐 CLI 确认提示）。`,
     }
   ]}
 />

--- a/mcp/src/tools/permissions.test.ts
+++ b/mcp/src/tools/permissions.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { registerPermissionTools } from "./permissions.js";
+import { registerPermissionTools, validateUserRegoContent } from "./permissions.js";
 import type { ExtendedMcpServer } from "../server.js";
 
 const {
@@ -14,6 +14,7 @@ const {
   mockCreateUser,
   mockDescribeEnvAuthzConfig,
   mockModifyEnvAuthzConfig,
+  mockDescribeResourcePolicyList,
 } = vi.hoisted(() => ({
   mockGetCloudBaseManager: vi.fn(),
   mockGetEnvId: vi.fn(),
@@ -26,6 +27,7 @@ const {
   mockCreateUser: vi.fn(),
   mockDescribeEnvAuthzConfig: vi.fn(),
   mockModifyEnvAuthzConfig: vi.fn(),
+  mockDescribeResourcePolicyList: vi.fn(),
 }));
 
 vi.mock("../cloudbase-manager.js", () => ({
@@ -124,6 +126,7 @@ describe("permission tools", () => {
         createRole: mockCreateRole,
         describeEnvAuthzConfig: mockDescribeEnvAuthzConfig,
         modifyEnvAuthzConfig: mockModifyEnvAuthzConfig,
+        describeResourcePolicyList: mockDescribeResourcePolicyList,
       },
       user: {
         describeUserList: mockDescribeUserList,
@@ -540,5 +543,168 @@ describe("permission tools", () => {
       },
     });
     expect(payload.data.rego).toContain("package authz.user");
+  });
+
+  it("queryPermissions schema includes listPolicy/getPolicy enums", () => {
+    const actionSchema = tools.queryPermissions.meta.inputSchema.action;
+    expect(actionSchema._def.values).toEqual(
+      expect.arrayContaining(["listPolicy", "getPolicy"]),
+    );
+    const policyResourceType = tools.queryPermissions.meta.inputSchema.policyResourceType;
+    expect(policyResourceType._def.innerType._def.values).toEqual(["policy"]);
+  });
+
+  it("managePermissions schema includes setPolicy and confirm", () => {
+    const actionSchema = tools.managePermissions.meta.inputSchema.action;
+    expect(actionSchema._def.values).toEqual(expect.arrayContaining(["setPolicy"]));
+    expect(tools.managePermissions.meta.inputSchema.confirm).toBeDefined();
+    expect(tools.managePermissions.meta.inputSchema.regoContent).toBeDefined();
+  });
+
+  it("validateUserRegoContent rejects empty and non-user packages", () => {
+    expect(() => validateUserRegoContent("")).toThrow(/非空/);
+    expect(() => validateUserRegoContent("package other\n")).toThrow(/package authz\.user/);
+    expect(() => validateUserRegoContent("package authz.user\nallow if {\n")).toThrow(/花括号/);
+    expect(
+      validateUserRegoContent("package authz.user\n\ndefault allow := false\n"),
+    ).toContain("package authz.user");
+  });
+
+  it("queryPermissions(action=listPolicy) calls describeResourcePolicyList", async () => {
+    mockDescribeResourcePolicyList.mockResolvedValueOnce({
+      Data: { PolicyList: [], Total: "0" },
+      RequestId: "req-list-policy",
+    });
+
+    const result = await tools.queryPermissions.handler({
+      action: "listPolicy",
+      policyResourceType: "policy",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDescribeResourcePolicyList).toHaveBeenCalledWith({
+      resourceType: "policy",
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "listPolicy",
+        policies: [],
+        total: "0",
+        policyResourceType: "policy",
+      },
+    });
+  });
+
+  it("queryPermissions(action=getPolicy) reads authz.user.rego by default", async () => {
+    mockDescribeEnvAuthzConfig.mockResolvedValueOnce({
+      Item: {
+        Key: "authz.user.rego",
+        Value: "package authz.user\n\ndefault allow := false\n",
+      },
+      RequestId: "req-get-policy",
+    });
+
+    const result = await tools.queryPermissions.handler({ action: "getPolicy" });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDescribeEnvAuthzConfig).toHaveBeenCalledWith({
+      key: "authz.user.rego",
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "getPolicy",
+        key: "authz.user.rego",
+        extension: false,
+        rego: expect.stringContaining("package authz.user"),
+      },
+    });
+  });
+
+  it("queryPermissions(action=getPolicy, extension=true) reads platform extension key", async () => {
+    mockDescribeEnvAuthzConfig.mockResolvedValueOnce({
+      Item: {
+        Key: "authz.platform.extension.rego",
+        Value: "package authz.platform.extension\n",
+      },
+    });
+
+    const result = await tools.queryPermissions.handler({
+      action: "getPolicy",
+      extension: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDescribeEnvAuthzConfig).toHaveBeenCalledWith({
+      key: "authz.platform.extension.rego",
+    });
+    expect(payload.data.key).toBe("authz.platform.extension.rego");
+    expect(payload.data.extension).toBe(true);
+  });
+
+  it("managePermissions(action=setPolicy) requires confirm=true", async () => {
+    const result = await tools.managePermissions.handler({
+      action: "setPolicy",
+      regoContent: "package authz.user\n\ndefault allow := false\n",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("confirm=true");
+    expect(mockModifyEnvAuthzConfig).not.toHaveBeenCalled();
+  });
+
+  it("managePermissions(action=setPolicy) validates Rego then calls modifyEnvAuthzConfig", async () => {
+    mockModifyEnvAuthzConfig.mockResolvedValueOnce({
+      AffectedRows: 1,
+      RequestId: "req-set-policy",
+    });
+
+    const rego = [
+      "package authz.user",
+      "",
+      "default allow := false",
+      "",
+      "allow if {",
+      '  input.cloudbase.resource_type == "functions"',
+      '  input.subject.auth_type == "anonymous"',
+      "}",
+      "",
+    ].join("\n");
+
+    const result = await tools.managePermissions.handler({
+      action: "setPolicy",
+      regoContent: rego,
+      confirm: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockModifyEnvAuthzConfig).toHaveBeenCalledWith({
+      key: "authz.user.rego",
+      value: rego.trim(),
+    });
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "setPolicy",
+        key: "authz.user.rego",
+        rego: expect.stringContaining("package authz.user"),
+        sideEffect: expect.stringContaining("disables legacy gateway"),
+      },
+    });
+  });
+
+  it("managePermissions(action=setPolicy) rejects invalid Rego before API call", async () => {
+    const result = await tools.managePermissions.handler({
+      action: "setPolicy",
+      regoContent: "package wrong\n",
+      confirm: true,
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload.success).toBe(false);
+    expect(payload.message).toContain("package authz.user");
+    expect(mockModifyEnvAuthzConfig).not.toHaveBeenCalled();
   });
 });

--- a/mcp/src/tools/permissions.ts
+++ b/mcp/src/tools/permissions.ts
@@ -10,6 +10,9 @@ const QUERY_PERMISSION_ACTIONS = [
   "getRole",
   "listUsers",
   "getUser",
+  // Align with CLI `tcb policy list/get` (OPA gateway authz)
+  "listPolicy",
+  "getPolicy",
 ] as const;
 
 const MANAGE_PERMISSION_ACTIONS = [
@@ -24,7 +27,17 @@ const MANAGE_PERMISSION_ACTIONS = [
   "createUser",
   "updateUser",
   "deleteUsers",
+  // Align with CLI `tcb policy set` (OPA Rego; disables legacy gateway auth)
+  "setPolicy",
 ] as const;
+
+/** Keys accepted by Manager SDK describeEnvAuthzConfig / modifyEnvAuthzConfig. */
+const AUTHZ_USER_REGO_KEY = "authz.user.rego" as const;
+const AUTHZ_PLATFORM_EXTENSION_REGO_KEY = "authz.platform.extension.rego" as const;
+type AuthzConfigKey = typeof AUTHZ_USER_REGO_KEY | typeof AUTHZ_PLATFORM_EXTENSION_REGO_KEY;
+
+/** CLI `tcb policy list --resource-type` only documents `policy`. */
+const POLICY_LIST_RESOURCE_TYPES = ["policy"] as const;
 
 type QueryPermissionAction = (typeof QUERY_PERMISSION_ACTIONS)[number];
 type ManagePermissionAction = (typeof MANAGE_PERMISSION_ACTIONS)[number];
@@ -121,10 +134,39 @@ function isPostgresqlPermissionApiUnsupported(error: unknown): boolean {
   return /does not support PostgreSQL type environments/i.test(message);
 }
 
-const AUTHZ_USER_REGO_KEY = "authz.user.rego" as const;
-
 function looksLikeUserRego(value: string): boolean {
   return /^\s*package\s+authz\.user\b/m.test(value);
+}
+
+/**
+ * Validate user Rego before setPolicy / modifyEnvAuthzConfig.
+ * Aligns with CLI docs (must start with `package authz.user`) and CLI non-empty check.
+ * Does not run a full OPA compiler; backend still owns deep syntax validation.
+ */
+export function validateUserRegoContent(value: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(
+      "action=setPolicy 需要非空 regoContent（对齐 CLI `tcb policy set <regoContent>`）。",
+    );
+  }
+  const trimmed = value.trim();
+  if (!looksLikeUserRego(trimmed)) {
+    throw new Error(
+      "Rego 策略必须以 `package authz.user` 开头（对齐 https://docs.cloudbase.net/cli-v1/policy/management ）。",
+    );
+  }
+  const open = (trimmed.match(/\{/g) || []).length;
+  const close = (trimmed.match(/\}/g) || []).length;
+  if (open !== close) {
+    throw new Error(
+      `Rego 策略花括号不匹配（{=${open}, }=${close}）。请检查语法后再调用 setPolicy。`,
+    );
+  }
+  return trimmed;
+}
+
+function resolveAuthzConfigKey(extension?: boolean): AuthzConfigKey {
+  return extension ? AUTHZ_PLATFORM_EXTENSION_REGO_KEY : AUTHZ_USER_REGO_KEY;
 }
 
 /** Detect legacy function securityRule shapes that mean "public invoke". */
@@ -208,24 +250,30 @@ function resolveFunctionAuthzRegoInput(
   );
 }
 
-async function describeEnvAuthzUserRego(
+async function describeEnvAuthzConfigByKey(
   cloudbase: any,
-): Promise<{ value: string; raw: unknown }> {
+  key: AuthzConfigKey = AUTHZ_USER_REGO_KEY,
+): Promise<{ key: AuthzConfigKey; value: string; raw: unknown }> {
   if (!cloudbase?.permission?.describeEnvAuthzConfig) {
     throw new Error(
       "Current @cloudbase/manager-node does not expose permission.describeEnvAuthzConfig. Upgrade manager-node (>= 5.5.5) to align with CLI tcb policy get.",
     );
   }
-  const result = await cloudbase.permission.describeEnvAuthzConfig({
-    key: AUTHZ_USER_REGO_KEY,
-  });
+  const result = await cloudbase.permission.describeEnvAuthzConfig({ key });
   const value =
     typeof result?.Item?.Value === "string"
       ? result.Item.Value
       : typeof result?.Value === "string"
         ? result.Value
         : "";
-  return { value, raw: result };
+  return { key, value, raw: result };
+}
+
+async function describeEnvAuthzUserRego(
+  cloudbase: any,
+): Promise<{ value: string; raw: unknown }> {
+  const result = await describeEnvAuthzConfigByKey(cloudbase, AUTHZ_USER_REGO_KEY);
+  return { value: result.value, raw: result.raw };
 }
 
 async function modifyEnvAuthzUserRego(
@@ -237,10 +285,25 @@ async function modifyEnvAuthzUserRego(
       "Current @cloudbase/manager-node does not expose permission.modifyEnvAuthzConfig. Upgrade manager-node (>= 5.5.5) to align with CLI tcb policy set.",
     );
   }
+  const validated = validateUserRegoContent(value);
   return cloudbase.permission.modifyEnvAuthzConfig({
     key: AUTHZ_USER_REGO_KEY,
-    value,
+    value: validated,
   });
+}
+
+async function describeResourcePolicyListAligned(
+  cloudbase: any,
+  policyResourceType?: (typeof POLICY_LIST_RESOURCE_TYPES)[number],
+): Promise<unknown> {
+  if (!cloudbase?.permission?.describeResourcePolicyList) {
+    throw new Error(
+      "Current @cloudbase/manager-node does not expose permission.describeResourcePolicyList. Upgrade manager-node (>= 5.5.5) to align with CLI tcb policy list.",
+    );
+  }
+  return cloudbase.permission.describeResourcePolicyList(
+    policyResourceType ? { resourceType: policyResourceType } : undefined,
+  );
 }
 
 async function describeResourcePermissionWithFunctionPgFallback(options: {
@@ -558,7 +621,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
     "queryPermissions",
     {
       title: "查询 CloudBase 权限与用户配置",
-      description: "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。\n\n⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。",
+      description: "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情，以及网关 OPA 授权策略（对齐 CLI `tcb policy list/get`）。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n- 列出旧网关策略：`action=\"listPolicy\"`（PG / OPA 引擎环境返回空列表，与 CLI 一致）\n- 读取用户 Rego：`action=\"getPolicy\"`；平台扩展策略：`action=\"getPolicy\", extension=true`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。\n\n⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。显式 OPA 策略请用 `listPolicy` / `getPolicy`。",
       inputSchema: {
         action: z.enum(QUERY_PERMISSION_ACTIONS),
         resourceType: z
@@ -573,6 +636,18 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
         username: z.string().optional(),
         pageNo: z.number().optional(),
         pageSize: z.number().optional(),
+        extension: z
+          .boolean()
+          .optional()
+          .describe(
+            "仅 action=getPolicy。true=读取平台为该环境单独配置的策略（authz.platform.extension.rego），默认 false=用户策略（authz.user.rego），对齐 CLI `tcb policy get --extension`。",
+          ),
+        policyResourceType: z
+          .enum(POLICY_LIST_RESOURCE_TYPES)
+          .optional()
+          .describe(
+            "仅 action=listPolicy。按资源类型过滤，当前仅支持 `policy`，对齐 CLI `tcb policy list --resource-type policy`。",
+          ),
       },
       annotations: {
         readOnlyHint: true,
@@ -592,6 +667,8 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username,
       pageNo,
       pageSize,
+      extension,
+      policyResourceType,
     }: {
       action: QueryPermissionAction;
       resourceType?: LegacyResourceType;
@@ -604,6 +681,8 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username?: string;
       pageNo?: number;
       pageSize?: number;
+      extension?: boolean;
+      policyResourceType?: (typeof POLICY_LIST_RESOURCE_TYPES)[number];
     }) =>
       withEnvelope(async () => {
         const envId = await getEnvId(cloudBaseOptions);
@@ -780,6 +859,48 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
               "应用用户详情查询成功",
             );
           }
+          case "listPolicy": {
+            const result = await describeResourcePolicyListAligned(
+              cloudbase,
+              policyResourceType,
+            );
+            logCloudBaseResult(server.logger, result);
+            const data = (result as { Data?: { PolicyList?: unknown[]; Total?: string | number } })
+              ?.Data;
+            const policyList = data?.PolicyList ?? [];
+            const total = data?.Total ?? policyList.length;
+            return buildEnvelope(
+              {
+                action,
+                envId,
+                policyResourceType: policyResourceType ?? null,
+                policies: policyList,
+                total,
+                note:
+                  "PG 环境与 authz_engine=opa 的环境会返回空列表（与 CLI `tcb policy list` / SDK describeResourcePolicyList 一致）。读取用户 Rego 请用 action=getPolicy。",
+                raw: result,
+              },
+              "网关授权策略列表查询成功",
+            );
+          }
+          case "getPolicy": {
+            const key = resolveAuthzConfigKey(extension);
+            const result = await describeEnvAuthzConfigByKey(cloudbase, key);
+            logCloudBaseResult(server.logger, result.raw);
+            return buildEnvelope(
+              {
+                action,
+                envId,
+                key: result.key,
+                extension: Boolean(extension),
+                rego: result.value,
+                raw: result.raw,
+              },
+              extension
+                ? "平台扩展 OPA 策略查询成功（authz.platform.extension.rego）"
+                : "用户 OPA 策略查询成功（authz.user.rego）",
+            );
+          }
         }
       }),
   );
@@ -789,7 +910,7 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
     {
       title: "管理 CloudBase 权限与用户配置",
       description:
-        "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action=\"updateResourcePermission\", resourceType=\"function\", resourceId=\"myFn\", permission=\"CUSTOM\", securityRule='{\"invoke\":true}'`\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。\n\n⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'{\"invoke\":true}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。",
+        "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD，以及设置网关 OPA Rego 策略（对齐 CLI `tcb policy set`）。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action=\"updateResourcePermission\", resourceType=\"function\", resourceId=\"myFn\", permission=\"CUSTOM\", securityRule='{\"invoke\":true}'`\n- 直接设置用户 Rego：`action=\"setPolicy\", regoContent=\"package authz.user\\n\\ndefault allow := false\\n\", confirm=true`（⚠️ 立即禁用旧网关鉴权）\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。\n\n⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'{\"invoke\":true}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。显式 OPA 策略请优先用 `action=\"setPolicy\"`。",
       inputSchema: {
         action: z.enum(MANAGE_PERMISSION_ACTIONS),
         resourceType: z
@@ -822,6 +943,18 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
         username: z.string().optional(),
         password: z.string().optional(),
         userStatus: z.enum(["ACTIVE", "BLOCKED"]).optional(),
+        regoContent: z
+          .string()
+          .optional()
+          .describe(
+            "仅 action=setPolicy。用户 OPA Rego 全文，必须以 `package authz.user` 开头，对齐 CLI `tcb policy set <regoContent>`。",
+          ),
+        confirm: z
+          .boolean()
+          .optional()
+          .describe(
+            "仅 action=setPolicy。设置 Rego 后会立即禁用旧网关鉴权，必须显式传 confirm=true（对齐 CLI 确认提示）。",
+          ),
       },
       annotations: {
         readOnlyHint: false,
@@ -850,6 +983,8 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username,
       password,
       userStatus,
+      regoContent,
+      confirm,
     }: {
       action: ManagePermissionAction;
       resourceType?: LegacyResourceType;
@@ -869,6 +1004,8 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
       username?: string;
       password?: string;
       userStatus?: "ACTIVE" | "BLOCKED";
+      regoContent?: string;
+      confirm?: boolean;
     }) =>
       withEnvelope(async () => {
         const envId = await getEnvId(cloudBaseOptions);
@@ -1078,6 +1215,32 @@ export function registerPermissionTools(server: ExtendedMcpServer) {
                 raw: result,
               },
               "应用用户删除成功",
+            );
+          }
+          case "setPolicy": {
+            if (confirm !== true) {
+              throw new Error(
+                "action=setPolicy 会立即禁用旧网关鉴权（对齐 CLI `tcb policy set`），必须显式传 confirm=true。",
+              );
+            }
+            const validated = validateUserRegoContent(regoContent ?? "");
+            const result = await modifyEnvAuthzUserRego(cloudbase, validated);
+            logCloudBaseResult(server.logger, result);
+            return buildEnvelope(
+              {
+                action,
+                envId,
+                key: AUTHZ_USER_REGO_KEY,
+                rego: validated,
+                sideEffect:
+                  "Setting authz.user.rego immediately disables legacy gateway authorization.",
+                nextSteps: [
+                  'queryPermissions(action="getPolicy")',
+                  'queryPermissions(action="listPolicy")',
+                ],
+                raw: result,
+              },
+              "用户 OPA Rego 策略设置成功（旧网关鉴权已失效）",
             );
           }
         }

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -751,7 +751,7 @@
           },
           "role": {
             "type": "string",
-            "description": "可选的 PostgreSQL role，会传给 Manager SDK executePGSql；例如需要管理策略时可传 postgres。"
+            "description": "可选的 PostgreSQL role，传给 Manager SDK executePGSql 的 Role（平台会 SET ROLE）。默认 cloudbase_admin。推荐取值：cloudbase_admin / anon / authenticated / service_role。不要传 postgres、postgres_pgdb_* 或从环境名臆造的角色；不确定时省略本字段，或先用 cloudbase_admin 执行 SELECT rolname FROM pg_roles。"
           },
           "objectName": {
             "type": "string",
@@ -2998,7 +2998,7 @@
     },
     {
       "name": "queryPermissions",
-      "description": "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。\n\n⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。",
+      "description": "查询 CloudBase 权限与用户配置，支持查询资源权限（数据库/云函数/存储桶等）、角色列表/详情、应用用户列表/详情，以及网关 OPA 授权策略（对齐 CLI `tcb policy list/get`）。\n\n示例：\n- 查询存储桶权限：`action=\"getResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\"`\n- 列出旧网关策略：`action=\"listPolicy\"`（PG / OPA 引擎环境返回空列表，与 CLI 一致）\n- 读取用户 Rego：`action=\"getPolicy\"`；平台扩展策略：`action=\"getPolicy\", extension=true`\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`。`resourceType=\"noSqlDatabase\"` 查询的是 CloudBase NoSQL 集合规则，与 CloudBase PostgreSQL（PG）表的行级安全（RLS）是两套独立机制——同一个 PG 环境里 NoSQL 集合若仍在使用，对那些集合查询本工具结果**仍然有效**。要查 PG 表 RLS，请改用 `queryPgDatabase(action=\"sql\", sql=\"SELECT * FROM pg_policies WHERE tablename=...\")`。本工具不涉及 MySQL 权限。\n\n⚠️ PostgreSQL 环境：平台 `DescribeResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `describeEnvAuthzConfig`（与 CLI `tcb policy get` 一致，读取 `authz.user.rego`）。显式 OPA 策略请用 `listPolicy` / `getPolicy`。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3010,7 +3010,9 @@
               "listRoles",
               "getRole",
               "listUsers",
-              "getUser"
+              "getUser",
+              "listPolicy",
+              "getPolicy"
             ]
           },
           "resourceType": {
@@ -3051,6 +3053,17 @@
           },
           "pageSize": {
             "type": "number"
+          },
+          "extension": {
+            "type": "boolean",
+            "description": "仅 action=getPolicy。true=读取平台为该环境单独配置的策略（authz.platform.extension.rego），默认 false=用户策略（authz.user.rego），对齐 CLI `tcb policy get --extension`。"
+          },
+          "policyResourceType": {
+            "type": "string",
+            "enum": [
+              "policy"
+            ],
+            "description": "仅 action=listPolicy。按资源类型过滤，当前仅支持 `policy`，对齐 CLI `tcb policy list --resource-type policy`。"
           }
         },
         "required": [
@@ -3062,7 +3075,7 @@
     },
     {
       "name": "managePermissions",
-      "description": "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action=\"updateResourcePermission\", resourceType=\"function\", resourceId=\"myFn\", permission=\"CUSTOM\", securityRule='{\"invoke\":true}'`\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。\n\n⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'{\"invoke\":true}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。",
+      "description": "管理 CloudBase 权限与用户配置，支持修改资源权限（数据库/云函数/存储桶等）、角色管理、成员与策略增删、应用用户 CRUD，以及设置网关 OPA Rego 策略（对齐 CLI `tcb policy set`）。\n\n示例：\n- 设置存储桶为私有：`action=\"updateResourcePermission\", resourceType=\"storage\", resourceId=\"bucket-name\", permission=\"PRIVATE\"`\n- 创建角色：`action=\"createRole\", roleName=\"admin\", roleIdentity=\"admin\"`\n- 放开云函数匿名/未登录访问（PG 会走 OPA，对齐 CLI `tcb policy set`）：`action=\"updateResourcePermission\", resourceType=\"function\", resourceId=\"myFn\", permission=\"CUSTOM\", securityRule='{\"invoke\":true}'`\n- 直接设置用户 Rego：`action=\"setPolicy\", regoContent=\"package authz.user\\n\\ndefault allow := false\\n\", confirm=true`（⚠️ 立即禁用旧网关鉴权）\n\n注意：`createUser` / `updateUser` 是环境侧应用用户管理能力，适合测试账号、管理员或预置用户，不应替代浏览器里的 Web SDK 注册表单；前端用户名密码注册应使用 `auth.signUp({ username, password })`，登录应使用 `auth.signInWithPassword({ username, password })`。直接在浏览器里用 `auth.signUp` 创建用户名密码用户取决于 SDK/provider 支持，使用前必须验证；不支持时应走后端或管理端边界，不能在浏览器暴露密钥。`securityRule` 的详细语义取决于 `resourceType`：`doc._openid`、`auth.openid`、查询条件子集校验，以及 `create` / `update` / `delete` JSON 模板仅适用于 `resourceType=\"noSqlDatabase\"` 的文档数据库安全规则；配置 `function` 或 `storage` 时，请参考各自官方安全规则文档，而不是复用 NoSQL 模板。\n\n📌 跨后端边界提示：调用前先用 `envQuery(action=\"info\", envId=...)` 看 `EnvInfo.RuntimeBackends`：\n- `resourceType=\"noSqlDatabase\"` 仅作用于 CloudBase NoSQL 文档数据库的集合；CloudBase PostgreSQL（PG）表的行级权限**不**受它控制——PG 表请改用 RLS：`managePgDatabase(action=\"execute\", confirm=true)` 跑 `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` 与 `CREATE POLICY ...`。同一个 PG 环境里如果还有 NoSQL 集合在用，对那些**集合**继续使用 `noSqlDatabase` 规则是正确的——不是\"PG 环境就禁用本工具\"。\n- `resourceType=\"storage\"` 控制的是 NoSQL/COS 存储桶 ACL；PG 的 `pgstore` bucket 不在此 `resourceType` 覆盖范围内。\n- 本工具不涉及 MySQL；MySQL 数据库权限请走 MySQL 自身的 GRANT/REVOKE 语句（通过 `manageMysqlDatabase`）。\n\n⚠️ PostgreSQL 环境：平台 `ModifyResourcePermission` 对 PG 环境会直接拒绝。当 `resourceType=\"function\"` 时，本工具会自动回退到 Manager SDK `modifyEnvAuthzConfig`（与 CLI `tcb policy set` 一致，写入 `authz.user.rego`）。`securityRule` 可传完整 Rego（`package authz.user`）或 `'{\"invoke\":true}'`（自动生成放通 anonymous/unauthenticated 调 functions 的策略）。设置 Rego 后旧网关鉴权会失效，行为与 CLI 相同。显式 OPA 策略请优先用 `action=\"setPolicy\"`。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3079,7 +3092,8 @@
               "removeRolePolicies",
               "createUser",
               "updateUser",
-              "deleteUsers"
+              "deleteUsers",
+              "setPolicy"
             ]
           },
           "resourceType": {
@@ -3169,6 +3183,14 @@
               "ACTIVE",
               "BLOCKED"
             ]
+          },
+          "regoContent": {
+            "type": "string",
+            "description": "仅 action=setPolicy。用户 OPA Rego 全文，必须以 `package authz.user` 开头，对齐 CLI `tcb policy set <regoContent>`。"
+          },
+          "confirm": {
+            "type": "boolean",
+            "description": "仅 action=setPolicy。设置 Rego 后会立即禁用旧网关鉴权，必须显式传 confirm=true（对齐 CLI 确认提示）。"
           }
         },
         "required": [


### PR DESCRIPTION
## Summary
- Extend `queryPermissions` / `managePermissions` with OPA policy actions aligned to `tcb policy` and Manager SDK resource policy APIs
- Add Rego validation helpers and schema coverage for `listPolicy` / `getPolicy` / `setPolicy`
- Update `scripts/tools.json` and `doc/mcp-tools.md`

## Test plan
- [ ] `cd mcp && npm test -- permissions.test.ts` passes
- [ ] `queryPermissions(action="listPolicy", policyResourceType="policy")` returns policy list payload
- [ ] `managePermissions(action="setPolicy", …)` requires confirm and validates Rego package

**Note:** This PR and `feature/query-env-usage` both touch `doc/mcp-tools.md` / `scripts/tools.json`; merge one first, then rebase the other if needed.


Made with [Cursor](https://cursor.com)