### PR TITLE
fix(ci): make ClawHub/SkillHub publish idempotent

### DIFF
--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -83,6 +83,8 @@ jobs:
         # Exact version pin for supply-chain reproducibility (do not use bare @latest).
         # 0.23.3 upload-ticket regression was fixed server-side in openclaw/clawhub#3395
         # and verified with a real publish after production backend deploy (2026-08-05).
+        # Historical CI (Actions run 30894334622) failed all six targets with
+        # "Uploaded file does not match its skill upload ticket" under clawhub@latest.
         # Client-side: publish-to-clawhub.mjs treats version-exists / already-published as
         # idempotent success, and retries upload-ticket mismatches for all targets
         # (all-in-one gets more attempts; openclaw/clawhub#3394 / #3397).

--- a/.github/workflows/publish-clawhub-registry.yml
+++ b/.github/workflows/publish-clawhub-registry.yml
@@ -83,8 +83,11 @@ jobs:
         # Exact version pin for supply-chain reproducibility (do not use bare @latest).
         # 0.23.3 upload-ticket regression was fixed server-side in openclaw/clawhub#3395
         # and verified with a real publish after production backend deploy (2026-08-05).
-        # Client-side: publish-to-clawhub.mjs still retries all-in-one on residual
-        # "upload ticket does not match" races (openclaw/clawhub#3394 / #3397).
+        # Client-side: publish-to-clawhub.mjs treats version-exists / already-published as
+        # idempotent success, and retries upload-ticket mismatches for all targets
+        # (all-in-one gets more attempts; openclaw/clawhub#3394 / #3397).
+        # SkillHub: publish-to-skillhub.mjs treats version-already-exists as success and
+        # only bump-retries on monotonicity ("must be higher") conflicts.
         run: npm install -g clawhub@0.23.3
 
       - name: Login to ClawHub

--- a/scripts/publish-to-clawhub.mjs
+++ b/scripts/publish-to-clawhub.mjs
@@ -8,9 +8,15 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const AUTO_CHANGELOG_LIMIT = 5;
 
-/** all-in-one uploads are large and historically hit intermittent upload-ticket races. */
+/**
+ * Upload-ticket mismatches are intermittent ClawHub races (openclaw/clawhub#3394 / #3397).
+ * all-in-one packages are large and hit them most often; smaller skills can still race.
+ */
 export const ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS = 3;
+export const DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS = 2;
 export const ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS = 2000;
+/** @deprecated Use ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS; kept for test imports. */
+export const UPLOAD_TICKET_RETRY_DELAY_MS = ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS;
 
 function clawhubErrorText(error) {
   const message = String(error?.message || error || "");
@@ -183,8 +189,15 @@ export function isClawhubVersionExistsError(error) {
   const combined = clawhubErrorText(error);
   return (
     /Version\s+\S+\s+already exists/i.test(combined) ||
-    /is already published/i.test(combined)
+    /is already published/i.test(combined) ||
+    /version\s+already\s+exists/i.test(combined) ||
+    /版本(?:号)?已存在/.test(combined)
   );
+}
+
+/** True when clawhub stdout/stderr indicates the slug@version is already on the registry. */
+export function isClawhubAlreadyPublishedOutput(output) {
+  return isClawhubVersionExistsError({ message: String(output || "") });
 }
 
 /**
@@ -200,8 +213,18 @@ export function isClawhubUploadTicketError(error) {
   );
 }
 
-export function supportsClawhubUploadTicketRetry(target) {
-  return target?.targetKey === "all-in-one";
+/**
+ * All targets may retry upload-ticket races. all-in-one gets more attempts because
+ * large packages historically fail more often after long uploads.
+ */
+export function supportsClawhubUploadTicketRetry(_target) {
+  return true;
+}
+
+export function clawhubUploadTicketMaxAttempts(target) {
+  return target?.targetKey === "all-in-one"
+    ? ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS
+    : DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS;
 }
 
 export function formatClawhubUploadTicketFailure(target, error, attempts) {
@@ -294,21 +317,39 @@ export function publishToClawhub({
       continue;
     }
 
-    const maxAttempts = supportsClawhubUploadTicketRetry(target)
-      ? ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS
-      : 1;
+    const maxAttempts = clawhubUploadTicketMaxAttempts(target);
     let settled = false;
 
     for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
       try {
-        runPublish(publishCommand.command, publishCommand.args, process.env);
+        const publishResult = runPublish(
+          publishCommand.command,
+          publishCommand.args,
+          process.env,
+        );
+        const outputText =
+          typeof publishResult === "string"
+            ? publishResult
+            : String(publishResult?.output || "");
 
-        results.push({
-          targetKey: target.targetKey,
-          registrySlug: target.registrySlug,
-          status: "published",
-          attempts: attempt,
-        });
+        if (isClawhubAlreadyPublishedOutput(outputText)) {
+          console.log(
+            `版本已存在，视为已发布 / Already published (exit success): ${target.registrySlug}`,
+          );
+          results.push({
+            targetKey: target.targetKey,
+            registrySlug: target.registrySlug,
+            status: "already-published",
+            attempts: attempt,
+          });
+        } else {
+          results.push({
+            targetKey: target.targetKey,
+            registrySlug: target.registrySlug,
+            status: "published",
+            attempts: attempt,
+          });
+        }
         settled = true;
         break;
       } catch (error) {
@@ -333,7 +374,7 @@ export function publishToClawhub({
           console.warn(
             `upload-ticket 不匹配，准备重试 / Upload-ticket mismatch, retrying ${target.targetKey} (${target.registrySlug}) attempt ${attempt}/${maxAttempts}: ${String(error.message || error).trim()}`,
           );
-          sleepMs(ALL_IN_ONE_UPLOAD_TICKET_RETRY_DELAY_MS);
+          sleepMs(UPLOAD_TICKET_RETRY_DELAY_MS);
           continue;
         }
 

--- a/scripts/publish-to-skillhub.mjs
+++ b/scripts/publish-to-skillhub.mjs
@@ -172,7 +172,7 @@ function pickHighestVersion(versions) {
  * - If local SKILL.md version is strictly newer than everything on SkillHub → publish local
  * - Otherwise → skip (do not invent betas for unchanged skills; SkillHub rejects lower/non-monotonic versions)
  */
-function resolvePublishVersion(currentVersion, skillHubVersionStrings) {
+export function resolvePublishVersion(currentVersion, skillHubVersionStrings) {
   const highest = pickHighestVersion(skillHubVersionStrings);
   if (!highest) {
     return {
@@ -193,6 +193,51 @@ function resolvePublishVersion(currentVersion, skillHubVersionStrings) {
     version: currentVersion,
     reason: `local ${currentVersion || "(none)"} <= SkillHub highest ${highest}`,
   };
+}
+
+/**
+ * Classify SkillHub upload failures so "already published" is idempotent success,
+ * while true monotonicity errors still bump-and-retry.
+ *
+ * SkillHub API errors are shaped as:
+ *   `SkillHub API error (STATUS): message`
+ */
+export function classifySkillhubUploadError(error) {
+  const text = String(error?.message || error || "");
+  const statusMatch = text.match(/SkillHub API error \((\d+)\)/i);
+  const status = statusMatch ? Number(statusMatch[1]) : null;
+  const body = statusMatch ? text.slice(statusMatch.index + statusMatch[0].length) : text;
+
+  // Exact version already on registry (concurrent publish / re-run) → success.
+  if (
+    /already exists|already published|duplicate version|版本(?:号)?已存在|版本已发布/.test(body) ||
+    (status === 409 && /exist|已存在|duplicate|冲突/.test(body))
+  ) {
+    return "already-published";
+  }
+
+  // Bare 409 with empty/opaque body: treat as already-published (idempotent).
+  if (status === 409) {
+    return "already-published";
+  }
+
+  // Must publish a strictly higher version.
+  if (
+    /must be higher|必须高于|version (?:is )?too low|版本号必须|not higher|低于/.test(body) ||
+    (status === 400 && /version|版本/.test(body))
+  ) {
+    return "version-conflict-retry";
+  }
+
+  return "fatal";
+}
+
+export function isSkillhubAlreadyPublishedError(error) {
+  return classifySkillhubUploadError(error) === "already-published";
+}
+
+export function isSkillhubVersionConflictError(error) {
+  return classifySkillhubUploadError(error) === "version-conflict-retry";
 }
 
 function bumpSemver(versionStr, bumpType) {
@@ -352,6 +397,8 @@ export async function publishToSkillhub({
   changelog = "",
   bump = "minor",
   apiBase = DEFAULT_API_BASE,
+  uploadVersion = uploadVersionToSkillhub,
+  fetchImpl = (...args) => fetch(...args),
 }) {
   const manifest = readManifest(manifestPath);
   const gitRoot = resolveGitRoot(manifestPath);
@@ -420,7 +467,7 @@ export async function publishToSkillhub({
       continue;
     }
 
-    // 拉取 SkillHub 上该技能的所有版本号，确定要发布的版本
+    // Query SkillHub versions to decide publish vs skip.
     let version = currentVersion;
     let retryCount = 0;
     const maxRetries = 10;
@@ -429,7 +476,7 @@ export async function publishToSkillhub({
 
     try {
       const versionsUrl = `${apiBase}/api/v1/orgs/${orgId}/skills/${slug}/versions`;
-      const versionsResponse = await fetch(versionsUrl, {
+      const versionsResponse = await fetchImpl(versionsUrl, {
         headers: { Authorization: `Bearer ${token}` },
       });
       if (versionsResponse.ok) {
@@ -460,7 +507,7 @@ export async function publishToSkillhub({
       }
     } catch (fetchError) {
       console.warn(`  ⚠ 版本历史查询失败 / Failed to query version history: ${fetchError instanceof Error ? fetchError.message : fetchError}`);
-      // 拉取版本历史失败，直接尝试 SKILL.md 版本
+      // Fall through and attempt SKILL.md version.
     }
 
     if (!shouldPublish) {
@@ -469,7 +516,7 @@ export async function publishToSkillhub({
 
     while (retryCount <= maxRetries) {
       try {
-        const result = await uploadVersionToSkillhub({
+        const result = await uploadVersion({
           apiBase,
           orgId,
           token,
@@ -497,7 +544,27 @@ export async function publishToSkillhub({
         });
         break;
       } catch (error) {
-        if (error.message.includes("409") || error.message.includes("400")) {
+        const classification = classifySkillhubUploadError(error);
+
+        if (classification === "already-published") {
+          console.log(
+            `  ✓ 版本已存在，视为已发布 / Version already exists, treating as published: ${slug}@${version}`,
+          );
+          results.push({
+            targetKey: target.targetKey,
+            slug,
+            version,
+            displayName,
+            summary,
+            iconUrl,
+            fileCount: files.length,
+            status: "already-published",
+            reason: String(error.message || error),
+          });
+          break;
+        }
+
+        if (classification === "version-conflict-retry") {
           retryCount++;
           if (retryCount > maxRetries) {
             console.warn(`  ⚠ 重试耗尽 / Max retries reached for ${target.targetKey} (${slug})`);
@@ -508,21 +575,22 @@ export async function publishToSkillhub({
             });
             break;
           }
-          // 冲突：把失败候选并入历史，再取严格更高的下一号（同 patch 的下一 beta，或下一 patch-beta.1）
+          // Conflict: fold the failed candidate into history, then take the next strictly higher version.
           skillHubVersionStrings = [...skillHubVersionStrings, version];
           const next = nextVersionAfter(pickHighestVersion(skillHubVersionStrings) || version);
           version = next || `${currentVersion}-beta.${retryCount}`;
           console.log(
-            `  ↻ 版本冲突 / Version conflict (${error.message.includes("409") ? "409" : "400"}), retrying with ${version} (attempt ${retryCount}/${maxRetries}): ${error.message}`,
+            `  ↻ 版本冲突 / Version conflict, retrying with ${version} (attempt ${retryCount}/${maxRetries}): ${error.message}`,
           );
-        } else {
-          failures.push({
-            targetKey: target.targetKey,
-            slug,
-            message: error.message,
-          });
-          break;
+          continue;
         }
+
+        failures.push({
+          targetKey: target.targetKey,
+          slug,
+          message: error.message,
+        });
+        break;
       }
     }
   }
@@ -563,6 +631,8 @@ function main() {
       for (const result of results) {
         if (result.status === "published") {
           console.log(`✓ ${result.targetKey} (${result.slug}): v${result.version} -> versionId=${result.versionId}`);
+        } else if (result.status === "already-published") {
+          console.log(`✓ ${result.targetKey} (${result.slug}): v${result.version} already-published (idempotent)`);
         } else if (result.status === "skipped") {
           console.log(`- ${result.targetKey} (${result.slug}): ${result.reason}`);
         } else {

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -107,6 +107,24 @@ describe('publish-to-clawhub command construction', () => {
     expect(isClawhubVersionExistsError(error)).toBe(true);
   });
 
+  // Fingerprint version-already-exists from Actions run 30897797886 (main@95a75f82):
+  // CLI printed the Version line, but failure aggregation only kept "Command failed: ...".
+  test('detects version-already-exists from Actions run 30897797886 log shape', () => {
+    const error = new Error(
+      'Command failed: clawhub skill publish /home/runner/work/CloudBase-AI-Toolkit/CloudBase-AI-Toolkit/.clawhub-publish-output/web-development/skills/web-development --slug web-development --changelog Recent commits --tags latest',
+    );
+    error.stderr = [
+      'Version 1.27.25 already exists. Increment the version number and try again.',
+      '    at handler (../../convex/skills.ts:13078:8)',
+      '    at async handler (../../node_modules/convex-helpers/server/customFunctions.js:268:27) (reset in 42s)',
+      'Error: Version 1.27.25 already exists. Increment the version number and try again.',
+      '    at handler (../../convex/skills.ts:13078:8)',
+      '    at async handler (../../node_modules/convex-helpers/server/customFunctions.js:268:27) (reset in 42s)',
+      '',
+    ].join('\n');
+    expect(isClawhubVersionExistsError(error)).toBe(true);
+  });
+
   test('detects OK already-published messages as idempotent', () => {
     const error = new Error('Command failed: clawhub skill publish ...');
     error.stdout = 'OK. cloudbase@1.92.48 is already published\n';

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -263,6 +263,110 @@ describe('publish-to-clawhub version-exists idempotency', () => {
       }
     }
   });
+
+  // Actions run 30893435418 (main@a9444bef): ATO fingerprinted already-published, but the
+  // job-killing error was all-in-one upload-ticket under stdio inherit (no retry). Peers
+  // printed "OK. … is already published" with exit 0 and were not the failure cause.
+  test('run 30893435418: peers already-published + all-in-one upload-ticket retries to success', () => {
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const manifestPath = createManifest([
+        { targetKey: 'miniprogram-development', registrySlug: 'miniprogram-development' },
+        { targetKey: 'cloudbase-wechat-integration', registrySlug: 'cloudbase-wechat-integration' },
+        { targetKey: 'all-in-one', registrySlug: 'cloudbase' },
+        { targetKey: 'ui-design', registrySlug: 'ui-design-guide' },
+        { targetKey: 'web-development', registrySlug: 'web-development' },
+        { targetKey: 'spec-workflow', registrySlug: 'spec-workflow-guide' },
+      ]);
+      const alreadyPublished = {
+        'miniprogram-development': '1.28.21',
+        'cloudbase-wechat-integration': '1.2.21',
+        'ui-design-guide': '1.18.21',
+        'web-development': '1.27.24',
+        'spec-workflow-guide': '1.18.21',
+      };
+      let allInOneCalls = 0;
+
+      const results = publishToClawhub({
+        manifestPath,
+        changelog: 'Actions run 30893435418 regression',
+        runPublish: (_command, args) => {
+          const slug = args[args.indexOf('--slug') + 1];
+          if (slug === 'cloudbase') {
+            allInOneCalls += 1;
+            if (allInOneCalls === 1) {
+              // Mimic CI: inherit left only "Command failed"; stderr held upload-ticket.
+              const error = new Error(
+                'Command failed: clawhub skill publish /home/runner/work/CloudBase-AI-Toolkit/CloudBase-AI-Toolkit/.clawhub-publish-output/all-in-one/skills/cloudbase --slug cloudbase',
+              );
+              error.stderr = [
+                'Uncaught Error: Uploaded file does not match its skill upload ticket',
+                '    at handler (../../convex/skillPublishUploads.ts:109:14)',
+                'Error: Uncaught Error: Uploaded file does not match its skill upload ticket',
+                '',
+              ].join('\n');
+              throw error;
+            }
+            return { status: 'ok', output: 'OK. cloudbase@1.92.48 published\n' };
+          }
+          const version = alreadyPublished[slug];
+          return {
+            status: 'ok',
+            output: `OK. ${slug}@${version} is already published\n`,
+          };
+        },
+        sleepMs: () => {},
+      });
+
+      expect(allInOneCalls).toBe(2);
+      expect(results).toEqual([
+        {
+          targetKey: 'miniprogram-development',
+          registrySlug: 'miniprogram-development',
+          status: 'already-published',
+          attempts: 1,
+        },
+        {
+          targetKey: 'cloudbase-wechat-integration',
+          registrySlug: 'cloudbase-wechat-integration',
+          status: 'already-published',
+          attempts: 1,
+        },
+        {
+          targetKey: 'all-in-one',
+          registrySlug: 'cloudbase',
+          status: 'published',
+          attempts: 2,
+        },
+        {
+          targetKey: 'ui-design',
+          registrySlug: 'ui-design-guide',
+          status: 'already-published',
+          attempts: 1,
+        },
+        {
+          targetKey: 'web-development',
+          registrySlug: 'web-development',
+          status: 'already-published',
+          attempts: 1,
+        },
+        {
+          targetKey: 'spec-workflow',
+          registrySlug: 'spec-workflow-guide',
+          status: 'already-published',
+          attempts: 1,
+        },
+      ]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
+  });
 });
 
 describe('publish-to-clawhub upload-ticket retry', () => {

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -4,8 +4,11 @@ import path from 'path';
 import { afterEach, describe, expect, test } from 'vitest';
 import {
   ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS,
+  DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS,
   buildPublishCommand,
+  clawhubUploadTicketMaxAttempts,
   formatClawhubUploadTicketFailure,
+  isClawhubAlreadyPublishedOutput,
   isClawhubUploadTicketError,
   isClawhubVersionExistsError,
   normalizeClawhubChangelog,
@@ -108,6 +111,7 @@ describe('publish-to-clawhub command construction', () => {
     const error = new Error('Command failed: clawhub skill publish ...');
     error.stdout = 'OK. cloudbase@1.92.48 is already published\n';
     expect(isClawhubVersionExistsError(error)).toBe(true);
+    expect(isClawhubAlreadyPublishedOutput('OK. cloudbase@1.92.48 is already published\n')).toBe(true);
   });
 
   test('detects upload-ticket mismatch errors as retryable', () => {
@@ -123,9 +127,15 @@ describe('publish-to-clawhub command construction', () => {
     expect(isClawhubUploadTicketError(new Error('Version 1.92.48 already exists'))).toBe(false);
   });
 
-  test('only all-in-one supports upload-ticket retry', () => {
+  test('all targets support upload-ticket retry; all-in-one gets more attempts', () => {
     expect(supportsClawhubUploadTicketRetry({ targetKey: 'all-in-one' })).toBe(true);
-    expect(supportsClawhubUploadTicketRetry({ targetKey: 'web-development' })).toBe(false);
+    expect(supportsClawhubUploadTicketRetry({ targetKey: 'web-development' })).toBe(true);
+    expect(clawhubUploadTicketMaxAttempts({ targetKey: 'all-in-one' })).toBe(
+      ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS,
+    );
+    expect(clawhubUploadTicketMaxAttempts({ targetKey: 'web-development' })).toBe(
+      DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS,
+    );
   });
 
   test('formats upload-ticket exhaustion with attempt count and issue hint', () => {
@@ -201,9 +211,43 @@ describe('publish-to-clawhub version-exists idempotency', () => {
       }
     }
   });
+
+  test('classifies exit-0 already-published stdout as already-published', () => {
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const manifestPath = createManifest([
+        { targetKey: 'web-development', registrySlug: 'web-development' },
+      ]);
+
+      const results = publishToClawhub({
+        manifestPath,
+        runPublish: () => ({
+          status: 'ok',
+          output: 'OK. web-development@1.27.30 is already published\n',
+        }),
+      });
+
+      expect(results).toEqual([
+        {
+          targetKey: 'web-development',
+          registrySlug: 'web-development',
+          status: 'already-published',
+          attempts: 1,
+        },
+      ]);
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
+  });
 });
 
-describe('publish-to-clawhub all-in-one upload-ticket retry', () => {
+describe('publish-to-clawhub upload-ticket retry', () => {
   test('retries all-in-one on upload-ticket mismatch then succeeds', () => {
     const previousToken = process.env.CLAWDHUB_TOKEN;
     process.env.CLAWDHUB_TOKEN = 'test-token';
@@ -285,7 +329,7 @@ describe('publish-to-clawhub all-in-one upload-ticket retry', () => {
     }
   });
 
-  test('does not retry upload-ticket errors for non all-in-one targets', () => {
+  test('retries upload-ticket errors for non all-in-one targets with default attempts', () => {
     const previousToken = process.env.CLAWDHUB_TOKEN;
     process.env.CLAWDHUB_TOKEN = 'test-token';
 
@@ -298,18 +342,16 @@ describe('publish-to-clawhub all-in-one upload-ticket retry', () => {
       expect(() =>
         publishToClawhub({
           manifestPath,
-          changelog: 'no retry',
+          changelog: 'retry small skill',
           runPublish: () => {
             calls += 1;
-            throw new Error('Skill upload ticket does not match this publish');
+            throw new Error('Uploaded file does not match its skill upload ticket');
           },
-          sleepMs: () => {
-            throw new Error('sleep should not be called');
-          },
+          sleepMs: () => {},
         }),
       ).toThrow(/Failed to publish 1 target/);
 
-      expect(calls).toBe(1);
+      expect(calls).toBe(DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS);
     } finally {
       if (previousToken === undefined) {
         delete process.env.CLAWDHUB_TOKEN;

--- a/tests/publish-to-clawhub.test.js
+++ b/tests/publish-to-clawhub.test.js
@@ -378,4 +378,56 @@ describe('publish-to-clawhub upload-ticket retry', () => {
       }
     }
   });
+
+  test('retries every target when all hit Uploaded file does not match its skill upload ticket', () => {
+    // Regression for Actions run 30894334622: clawhub@latest systemic upload-ticket
+    // failure hit all six publish targets (not only all-in-one).
+    const previousToken = process.env.CLAWDHUB_TOKEN;
+    process.env.CLAWDHUB_TOKEN = 'test-token';
+
+    try {
+      const targets = [
+        { targetKey: 'miniprogram-development', registrySlug: 'miniprogram-development' },
+        { targetKey: 'cloudbase-wechat-integration', registrySlug: 'cloudbase-wechat-integration' },
+        { targetKey: 'all-in-one', registrySlug: 'cloudbase' },
+        { targetKey: 'ui-design', registrySlug: 'ui-design-guide' },
+        { targetKey: 'web-development', registrySlug: 'web-development' },
+        { targetKey: 'spec-workflow', registrySlug: 'spec-workflow-guide' },
+      ];
+      const manifestPath = createManifest(targets);
+      const callsBySlug = Object.fromEntries(targets.map((t) => [t.registrySlug, 0]));
+
+      expect(() =>
+        publishToClawhub({
+          manifestPath,
+          changelog: 'multi-target upload-ticket regression',
+          runPublish: (_command, args) => {
+            const slug = args[args.indexOf('--slug') + 1];
+            callsBySlug[slug] += 1;
+            const error = new Error(
+              'Command failed: clawhub skill publish ...',
+            );
+            error.stderr =
+              'Uncaught Error: Uploaded file does not match its skill upload ticket\n';
+            throw error;
+          },
+          sleepMs: () => {},
+        }),
+      ).toThrow(/Failed to publish 6 target/);
+
+      expect(callsBySlug.cloudbase).toBe(ALL_IN_ONE_UPLOAD_TICKET_MAX_ATTEMPTS);
+      for (const target of targets) {
+        if (target.targetKey === 'all-in-one') {
+          continue;
+        }
+        expect(callsBySlug[target.registrySlug]).toBe(DEFAULT_UPLOAD_TICKET_MAX_ATTEMPTS);
+      }
+    } finally {
+      if (previousToken === undefined) {
+        delete process.env.CLAWDHUB_TOKEN;
+      } else {
+        process.env.CLAWDHUB_TOKEN = previousToken;
+      }
+    }
+  });
 });

--- a/tests/publish-to-skillhub.test.js
+++ b/tests/publish-to-skillhub.test.js
@@ -1,5 +1,56 @@
-import { describe, expect, test } from 'vitest';
-import { selectMarketplaceMetadata } from '../scripts/publish-to-skillhub.mjs';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, describe, expect, test } from 'vitest';
+import {
+  classifySkillhubUploadError,
+  isSkillhubAlreadyPublishedError,
+  isSkillhubVersionConflictError,
+  publishToSkillhub,
+  resolvePublishVersion,
+  selectMarketplaceMetadata,
+} from '../scripts/publish-to-skillhub.mjs';
+
+const tempDirs = [];
+
+function createSkillManifest(targets) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'skillhub-publish-test-'));
+  tempDirs.push(dir);
+
+  const resolved = targets.map((target) => {
+    const artifactDir = path.join(dir, target.targetKey);
+    fs.mkdirSync(artifactDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(artifactDir, 'SKILL.md'),
+      [
+        '---',
+        `name: ${target.registrySlug}`,
+        'description: test skill',
+        `version: ${target.version || '1.0.0'}`,
+        '---',
+        '',
+        '# Test',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    return {
+      ...target,
+      artifactDir,
+    };
+  });
+
+  const manifestPath = path.join(dir, 'manifest.json');
+  fs.writeFileSync(manifestPath, JSON.stringify({ targets: resolved }));
+  return manifestPath;
+}
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    const dir = tempDirs.pop();
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
 
 describe('selectMarketplaceMetadata', () => {
   test('uses curated displayName / summary / iconUrl from manifest target', () => {
@@ -72,5 +123,148 @@ describe('selectMarketplaceMetadata', () => {
 
     expect(result.summary).toBe(shortChinese);
     expect(result.summary).not.toMatch(/Use this skill when/);
+  });
+});
+
+describe('resolvePublishVersion', () => {
+  test('publishes local version when SkillHub is empty', () => {
+    expect(resolvePublishVersion('1.2.3', [])).toEqual({
+      action: 'publish',
+      version: '1.2.3',
+      reason: 'SkillHub empty, use local SKILL.md',
+    });
+  });
+
+  test('skips when local version is not newer than SkillHub', () => {
+    const result = resolvePublishVersion('1.2.3', ['1.2.3', '1.2.2']);
+    expect(result.action).toBe('skip');
+    expect(result.reason).toContain('<= SkillHub highest 1.2.3');
+  });
+
+  test('publishes when local version is strictly newer', () => {
+    const result = resolvePublishVersion('1.3.0', ['1.2.9']);
+    expect(result.action).toBe('publish');
+    expect(result.version).toBe('1.3.0');
+  });
+});
+
+describe('classifySkillhubUploadError', () => {
+  test('treats version-already-exists / 409 as already-published', () => {
+    expect(
+      classifySkillhubUploadError(
+        new Error('SkillHub API error (409): version already exists'),
+      ),
+    ).toBe('already-published');
+    expect(
+      isSkillhubAlreadyPublishedError(
+        new Error('SkillHub API error (409): 版本号已存在'),
+      ),
+    ).toBe(true);
+    expect(classifySkillhubUploadError(new Error('SkillHub API error (409): conflict'))).toBe(
+      'already-published',
+    );
+  });
+
+  test('treats must-be-higher 400 as version-conflict-retry', () => {
+    expect(
+      classifySkillhubUploadError(
+        new Error('SkillHub API error (400): 版本号必须高于当前最新版本'),
+      ),
+    ).toBe('version-conflict-retry');
+    expect(
+      isSkillhubVersionConflictError(
+        new Error('SkillHub API error (400): version must be higher than latest'),
+      ),
+    ).toBe(true);
+  });
+
+  test('does not treat unrelated 400 as version conflict', () => {
+    expect(
+      classifySkillhubUploadError(
+        new Error('SkillHub API error (400): invalid payload: missing files'),
+      ),
+    ).toBe('fatal');
+  });
+});
+
+describe('publishToSkillhub idempotency', () => {
+  test('treats already-published upload errors as success without bumping', async () => {
+    const previousOrg = process.env.SKILLHUB_ORG_ID;
+    const previousToken = process.env.SKILLHUB_API_TOKEN;
+    process.env.SKILLHUB_ORG_ID = 'org-test';
+    process.env.SKILLHUB_API_TOKEN = 'token-test';
+
+    try {
+      const manifestPath = createSkillManifest([
+        { targetKey: 'web-development', registrySlug: 'web-development', version: '2.0.0' },
+      ]);
+      const uploadCalls = [];
+
+      const results = await publishToSkillhub({
+        manifestPath,
+        fetchImpl: async () => ({
+          ok: true,
+          json: async () => ({ versions: [{ version: '1.9.0' }] }),
+        }),
+        uploadVersion: async (args) => {
+          uploadCalls.push(args.version);
+          throw new Error('SkillHub API error (409): version already exists');
+        },
+      });
+
+      expect(uploadCalls).toEqual(['2.0.0']);
+      expect(results).toEqual([
+        expect.objectContaining({
+          targetKey: 'web-development',
+          slug: 'web-development',
+          version: '2.0.0',
+          status: 'already-published',
+        }),
+      ]);
+    } finally {
+      if (previousOrg === undefined) delete process.env.SKILLHUB_ORG_ID;
+      else process.env.SKILLHUB_ORG_ID = previousOrg;
+      if (previousToken === undefined) delete process.env.SKILLHUB_API_TOKEN;
+      else process.env.SKILLHUB_API_TOKEN = previousToken;
+    }
+  });
+
+  test('bumps and retries only on must-be-higher conflicts', async () => {
+    const previousOrg = process.env.SKILLHUB_ORG_ID;
+    const previousToken = process.env.SKILLHUB_API_TOKEN;
+    process.env.SKILLHUB_ORG_ID = 'org-test';
+    process.env.SKILLHUB_API_TOKEN = 'token-test';
+
+    try {
+      const manifestPath = createSkillManifest([
+        { targetKey: 'web-development', registrySlug: 'web-development', version: '2.0.0' },
+      ]);
+      const uploadCalls = [];
+
+      const results = await publishToSkillhub({
+        manifestPath,
+        fetchImpl: async () => ({
+          ok: true,
+          json: async () => ({ versions: [{ version: '1.9.0' }] }),
+        }),
+        uploadVersion: async (args) => {
+          uploadCalls.push(args.version);
+          if (uploadCalls.length === 1) {
+            throw new Error('SkillHub API error (400): 版本号必须高于当前最新版本');
+          }
+          return { versionId: 'vid-1' };
+        },
+      });
+
+      expect(uploadCalls[0]).toBe('2.0.0');
+      expect(uploadCalls[1]).toBe('2.0.1-beta.1');
+      expect(results[0].status).toBe('published');
+      expect(results[0].version).toBe('2.0.1-beta.1');
+    } finally {
+      if (previousOrg === undefined) delete process.env.SKILLHUB_ORG_ID;
+      else process.env.SKILLHUB_ORG_ID = previousOrg;
+      if (previousToken === undefined) delete process.env.SKILLHUB_API_TOKEN;
+      else process.env.SKILLHUB_API_TOKEN = previousToken;
+    }
   });
 });


### PR DESCRIPTION
## Summary
- Treat ClawHub `already published` / `Version already exists` (including exit-0 stdout) as idempotent success so re-runs and races do not fail the job.
- Retry ClawHub upload-ticket mismatches for **all** targets (all-in-one: 3 attempts; others: 2).
- SkillHub: classify upload errors — version-already-exists / 409 → `already-published`; only “must be higher” 400 → bump-and-retry (no junk betas on re-run).

## Test plan
- [x] `npx vitest run tests/publish-to-clawhub.test.js tests/publish-to-skillhub.test.js` (26 passed)
- [x] Local `build-clawhub-publish-artifacts` + `--dry-run` for ClawHub/SkillHub
- [ ] `workflow_dispatch` dry_run on this branch (run triggered)
- [ ] After merge: optional real publish (`dry_run=false`) if a content bump is needed

## Notes
- Merges/supersedes duplicate pending CI-failure tasks for already-published / version-exists / upload mismatch.
- Does not replace DSH/Claude marketplace listing tasks.


Made with [Cursor](https://cursor.com)