### PR TITLE
fix(cloudrun): initEnv EnvType/VPC, envStatus case, deploy VPC autofill, CAM guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file. Follow the 
 
 ### Bug Fixes
 
-* **cloudrun**: fix `manageCloudRun(initEnv)` missing `EnvType=tcbr`, add optional `vpcId`/`subnetIds` for Tencent internal accounts, normalize uppercase `NORMAL`/`CREATING` in `envStatus`, auto-fill deploy `vpcInfo` from env VPC, and guide CAM/API Key failures to device-code or SecretKey auth
+* **cloudrun**: fix `manageCloudRun(initEnv)` missing `EnvType=tcbr`, add optional `vpcId`/`subnetIds` when an explicit VPC is required, normalize uppercase `NORMAL`/`CREATING` in `envStatus`, auto-fill deploy `vpcInfo` from env VPC, and guide CAM/API Key failures to device-code or SecretKey auth
 
 ## [1.7.0](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/compare/v1.6.0...v1.7.0) (2025-06-10)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file. Follow the repository's conventional commit guidelines and release workflow documentation when preparing releases.
 
+## Unreleased
+
+### Bug Fixes
+
+* **cloudrun**: fix `manageCloudRun(initEnv)` missing `EnvType=tcbr`, add optional `vpcId`/`subnetIds` for Tencent internal accounts, normalize uppercase `NORMAL`/`CREATING` in `envStatus`, auto-fill deploy `vpcInfo` from env VPC, and guide CAM/API Key failures to device-code or SecretKey auth
+
 ## [1.7.0](https://github.com/TencentCloudBase/CloudBase-AI-ToolKit/compare/v1.6.0...v1.7.0) (2025-06-10)
 
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -189,9 +189,11 @@ CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即�
 ---
 
 ### `queryEnv`
-查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名与资源用量。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
+查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
 
 📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。
+
+📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。
 
 🔍 action=info 还会派生三个用于后端选型的字段：
 - `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。
@@ -210,7 +212,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "action",
       type: "string",
       required: true,
-      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量/指标（必须传入 envId，对齐 tcb env usage/info） 可填写的值: "list", "info", "domains", "usage"`,
+      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
     },
     {
       name: "alias",
@@ -225,7 +227,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "envId",
       type: "string",
-      description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage 时必填。usage 对齐 DescribeEnvAccountCircle / DescribeCreditsUsageDetail，缺少 EnvId 会导致云 API 参数错误。`,
+      description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。`,
     },
     {
       name: "limit",
@@ -261,6 +263,36 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "needUsageDetails",
       type: "boolean",
       description: `是否返回每日用量明细。仅 action=usage 时有效；默认 true。`,
+    },
+    {
+      name: "metricName",
+      type: "string",
+      description: `监控指标名。仅 action=metrics 时有效且必填。GatewayTraceEnvQPS/EnvQPSAll=环境与网关 QPS；FunctionInvocation/FunctionError/FunctionTimeout/FunctionThrottle=云函数调用、错误、超时、限流；DbRead/DbWrite/DbSizepkg=文档库读写与容量；MysqlCpuUsageRate/MysqlMemoryUse/MysqlStorageUsage=SQL 库 CPU/内存/磁盘；TkeCpuUsedService/TkeQPSService/TkeHttpErrorService=云托管 CPU/QPS/错误。 可填写的值: "GatewayTraceEnvQPS", "EnvQPSAll", "FunctionInvocation", "FunctionError", "FunctionTimeout", "FunctionThrottle", "FunctionDuration", "FunctionConcurrentExecutions", "DbRead", "DbWrite", "DbSizepkg", "MysqlCpuUsageRate", "MysqlMemoryUse", "MysqlStorageUsage", "MysqlQps", "MysqlSlowQueries", "MysqlDbConnections", "TkeCpuUsedService", "TkeMemUsedService", "TkeQPSService", "TkeHttpErrorService", "TkeInvokeNumService"`,
+    },
+    {
+      name: "startTime",
+      type: "string",
+      description: `监控开始时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 endTime 成对传入。不传则默认最近 24 小时。结束时间须晚于开始时间至少五分钟。`,
+    },
+    {
+      name: "endTime",
+      type: "string",
+      description: `监控结束时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 startTime 成对传入。不传则默认最近 24 小时。`,
+    },
+    {
+      name: "period",
+      type: "number",
+      description: `统计周期（秒）。仅 action=metrics 时有效；仅支持 300、3600、86400。不传则由后端按时间范围自动选择。时间范围 ≤1 天不可用 86400；>3 天不可用 300。 可填写的值: 300, 3600, 86400`,
+    },
+    {
+      name: "resourceID",
+      type: "string",
+      description: `资源 ID。仅 action=metrics 时有效。云函数传函数名，文档库传集合名，云托管必须传服务名；GatewayTraceEnvQPS 不传则使用环境级 all|:|all|:|all|:|all。`,
+    },
+    {
+      name: "subresourceID",
+      type: "string",
+      description: `子资源 ID。仅 action=metrics 时有效；查询云托管某版本监控时传入版本名。`,
     }
   ]}
 />
@@ -268,9 +300,11 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
 ---
 
 ### `envQuery`
-查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名与资源用量。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
+查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
 
 📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。
+
+📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。
 
 🔍 action=info 还会派生三个用于后端选型的字段：
 - `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。
@@ -289,7 +323,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "action",
       type: "string",
       required: true,
-      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量/指标（必须传入 envId，对齐 tcb env usage/info） 可填写的值: "list", "info", "domains", "usage"`,
+      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
     },
     {
       name: "alias",
@@ -304,7 +338,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "envId",
       type: "string",
-      description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage 时必填。usage 对齐 DescribeEnvAccountCircle / DescribeCreditsUsageDetail，缺少 EnvId 会导致云 API 参数错误。`,
+      description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。`,
     },
     {
       name: "limit",
@@ -340,6 +374,36 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "needUsageDetails",
       type: "boolean",
       description: `是否返回每日用量明细。仅 action=usage 时有效；默认 true。`,
+    },
+    {
+      name: "metricName",
+      type: "string",
+      description: `监控指标名。仅 action=metrics 时有效且必填。GatewayTraceEnvQPS/EnvQPSAll=环境与网关 QPS；FunctionInvocation/FunctionError/FunctionTimeout/FunctionThrottle=云函数调用、错误、超时、限流；DbRead/DbWrite/DbSizepkg=文档库读写与容量；MysqlCpuUsageRate/MysqlMemoryUse/MysqlStorageUsage=SQL 库 CPU/内存/磁盘；TkeCpuUsedService/TkeQPSService/TkeHttpErrorService=云托管 CPU/QPS/错误。 可填写的值: "GatewayTraceEnvQPS", "EnvQPSAll", "FunctionInvocation", "FunctionError", "FunctionTimeout", "FunctionThrottle", "FunctionDuration", "FunctionConcurrentExecutions", "DbRead", "DbWrite", "DbSizepkg", "MysqlCpuUsageRate", "MysqlMemoryUse", "MysqlStorageUsage", "MysqlQps", "MysqlSlowQueries", "MysqlDbConnections", "TkeCpuUsedService", "TkeMemUsedService", "TkeQPSService", "TkeHttpErrorService", "TkeInvokeNumService"`,
+    },
+    {
+      name: "startTime",
+      type: "string",
+      description: `监控开始时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 endTime 成对传入。不传则默认最近 24 小时。结束时间须晚于开始时间至少五分钟。`,
+    },
+    {
+      name: "endTime",
+      type: "string",
+      description: `监控结束时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 startTime 成对传入。不传则默认最近 24 小时。`,
+    },
+    {
+      name: "period",
+      type: "number",
+      description: `统计周期（秒）。仅 action=metrics 时有效；仅支持 300、3600、86400。不传则由后端按时间范围自动选择。时间范围 ≤1 天不可用 86400；>3 天不可用 300。 可填写的值: 300, 3600, 86400`,
+    },
+    {
+      name: "resourceID",
+      type: "string",
+      description: `资源 ID。仅 action=metrics 时有效。云函数传函数名，文档库传集合名，云托管必须传服务名；GatewayTraceEnvQPS 不传则使用环境级 all|:|all|:|all|:|all。`,
+    },
+    {
+      name: "subresourceID",
+      type: "string",
+      description: `子资源 ID。仅 action=metrics 时有效；查询云托管某版本监控时传入版本名。`,
     }
   ]}
 />

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -2140,6 +2140,16 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
       description: `云托管环境套餐类型（action=initEnv 时使用）：Trial=试用，Standard=标准，Professional=专业，Enterprise=企业。默认 Trial 可填写的值: "Trial", "Standard", "Professional", "Enterprise"`,
     },
     {
+      name: "vpcId",
+      type: "string",
+      description: `VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）`,
+    },
+    {
+      name: "subnetIds",
+      type: "array of string",
+      description: `子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds`,
+    },
+    {
       name: "targetPath",
       type: "string",
       description: `本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建`,

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -2206,12 +2206,12 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
     {
       name: "vpcId",
       type: "string",
-      description: `VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）`,
+      description: `VPC 网络 ID（action=initEnv 时可选）。当平台拒绝系统创建网络时必填，格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。多数场景可不传（由系统创建网络）`,
     },
     {
       name: "subnetIds",
       type: "array of string",
-      description: `子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds`,
+      description: `子网 ID 列表（action=initEnv 时可选）。当需指定自有 VPC 时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds`,
     },
     {
       name: "targetPath",

--- a/mcp/src/tools/capi.test.ts
+++ b/mcp/src/tools/capi.test.ts
@@ -40,6 +40,18 @@ describe("buildCapiErrorMessage", () => {
 
     expect(message).not.toContain("可能的 tcb Action");
   });
+
+  it("guides device code / SecretKey on CAM auth failures", () => {
+    const message = buildCapiErrorMessage(
+      "tcbr",
+      "CreateCloudRunEnv",
+      new Error("UnauthorizedOperation: [CAM] not authorized to perform: tcbr:CreateCloudRunEnv"),
+    );
+
+    expect(message).toMatch(/device code|start_auth/);
+    expect(message).toMatch(/SecretId\/SecretKey/);
+    expect(message).toMatch(/API Key/);
+  });
 });
 
 describe("assertTcbCloudRunActionAllowed", () => {

--- a/mcp/src/tools/capi.ts
+++ b/mcp/src/tools/capi.ts
@@ -157,6 +157,27 @@ function buildCapiDocGuidance(service: AllowedService) {
     return `请优先核对对应官方云 API 文档；若你的场景其实是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode="openapi")，不要继续猜测管控面 Action。`;
 }
 
+/** Match CAM / authorization failures from Tencent Cloud control-plane APIs. */
+export const CAM_AUTH_ERROR_PATTERN =
+    /UnauthorizedOperation|AuthFailure|not authorized|cam.*denied|Forbidden/i;
+
+/**
+ * Guidance when control-plane calls fail due to CAM / API Key scope limits.
+ * Shared by callCloudApi and manageCloudRun error builders.
+ */
+export function buildCamAuthGuidance(): string {
+    return (
+        "这通常是 CAM 权限不足（常见于 API Key 登录仅授权数据面：DB/函数/存储）。请任选其一：" +
+        "1) 改用 device code 登录管控面：auth(action=\"start_auth\", authMode=\"device\")；" +
+        "2) 或使用腾讯云 SecretId/SecretKey（确认子账号已授 CAM 策略，如 QcloudTCBFullAccess、QcloudVPCReadOnlyAccess）；" +
+        "3) 确认目标资源属于当前登录账号。"
+    );
+}
+
+export function isCamAuthError(message: string): boolean {
+    return CAM_AUTH_ERROR_PATTERN.test(message);
+}
+
 export function buildCapiErrorMessage(service: AllowedService, action: string, error: unknown): string {
     const baseMessage = error instanceof Error ? error.message : String(error);
     const suggestions: string[] = [];
@@ -164,6 +185,11 @@ export function buildCapiErrorMessage(service: AllowedService, action: string, e
     const hasInvalidActionError = /invalid or not found|does not exist|not recognized/i.test(baseMessage);
     const hasParameterError = /parameter\s+`?.+?`?\s+is not recognized|MissingParameter|missing parameter|missing required/i.test(baseMessage);
     const hasInvalidParameterValueError = /invalid parameter value/i.test(baseMessage);
+    const hasCamAuthError = isCamAuthError(baseMessage);
+
+    if (hasCamAuthError) {
+        suggestions.push(buildCamAuthGuidance());
+    }
 
     if (hasInvalidActionError) {
         suggestions.push(

--- a/mcp/src/tools/cloudrun-image-deploy.test.ts
+++ b/mcp/src/tools/cloudrun-image-deploy.test.ts
@@ -47,12 +47,14 @@ type ManagerMock = {
 
 function makeManager(options: {
   envStatus?: "normal" | "creating" | "unopened";
+  envBaseInfoExtras?: Record<string, unknown>;
   detailImpl?: (params: { serverName: string }) => Promise<any>;
   deployImpl?: (params: any) => Promise<any>;
   buildId?: number;
 } = {}): ManagerMock {
   const {
     envStatus = "normal",
+    envBaseInfoExtras = {},
     detailImpl = async () => {
       throw new Error("ResourceNotFound.ServerNotFound");
     },
@@ -67,7 +69,12 @@ function makeManager(options: {
             return { EnvBaseInfo: {}, IsExist: false };
           }
           return {
-            EnvBaseInfo: { EnvId: "env-test", Status: envStatus, PackageType: "Trial" },
+            EnvBaseInfo: {
+              EnvId: "env-test",
+              Status: envStatus,
+              PackageType: "Trial",
+              ...envBaseInfoExtras,
+            },
             IsExist: true,
           };
         }
@@ -168,6 +175,30 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     expect(schema.targetPath.description).toMatch(/优先传 imageUrl|不等于必须走源码构建/);
     expect(schema.action.description).toMatch(/轻量等待|getDeployLog/);
     expect(tools.manageCloudRun.meta.description).toMatch(/轻量等待任务注册|buildId/);
+  });
+
+  it("auto-fills vpcInfo from env DescribeEnvBaseInfo when VpcConf is omitted", async () => {
+    const manager = makeManager({
+      envBaseInfoExtras: {
+        VpcId: "vpc-26vsxozo",
+        SubNetIds: ["subnet-hyiwt4ut"],
+      },
+    });
+    mockGetCloudBaseManager.mockReturnValue(manager);
+    const { tools } = await createCloudRunTools();
+
+    await tools.manageCloudRun.handler({
+      action: "deploy",
+      serverName: "hermes-agent",
+      imageUrl: "ccr.ccs.tencentyun.com/ns/hermes:v1",
+    });
+
+    const deployCall = manager.cloudrun.deploy.mock.calls[0][0];
+    expect(deployCall.vpcInfo).toEqual({
+      VpcId: "vpc-26vsxozo",
+      CreateType: 2,
+      SubnetIds: ["subnet-hyiwt4ut"],
+    });
   });
 
   it("fails with guidance when imageUrl deploy targets an unopened CloudRun env", async () => {

--- a/mcp/src/tools/cloudrun-init.test.ts
+++ b/mcp/src/tools/cloudrun-init.test.ts
@@ -411,6 +411,7 @@ describe("manageCloudRun initEnv action", () => {
     expect((calls[1] as any).Param).toEqual({
       EnvId: "env-test",
       PackageType: "Professional",
+      EnvType: "tcbr",
     });
   });
 
@@ -431,6 +432,80 @@ describe("manageCloudRun initEnv action", () => {
     const tools = await createCloudRunTools();
     await tools.manageCloudRun.handler({ action: "initEnv", envId: "env-test" });
     expect((calls[1] as any).Param.PackageType).toBe("Trial");
+    expect((calls[1] as any).Param.EnvType).toBe("tcbr");
+  });
+
+  it("passes optional vpcId/subnetIds through to CreateCloudRunEnv", async () => {
+    const calls: unknown[] = [];
+    mockGetCloudBaseManager.mockReturnValue({
+      commonService: vi.fn().mockReturnValue({
+        call: async (req: any) => {
+          calls.push(req);
+          if (req.Action === "DescribeEnvBaseInfo") {
+            return { EnvBaseInfo: {}, IsExist: false };
+          }
+          return { EnvId: "env-test", TranId: "tran-vpc" };
+        },
+      }),
+      cloudrun: {},
+    });
+    const tools = await createCloudRunTools();
+    await tools.manageCloudRun.handler({
+      action: "initEnv",
+      envId: "env-test",
+      vpcId: "vpc-26vsxozo",
+      subnetIds: ["subnet-hyiwt4ut"],
+    });
+    expect((calls[1] as any).Param).toEqual({
+      EnvId: "env-test",
+      PackageType: "Trial",
+      EnvType: "tcbr",
+      VpcId: "vpc-26vsxozo",
+      SubNetIds: ["subnet-hyiwt4ut"],
+    });
+  });
+
+  it("treats uppercase NORMAL as already-opened (idempotent)", async () => {
+    const calls: unknown[] = [];
+    mockGetCloudBaseManager.mockReturnValue({
+      commonService: vi.fn().mockReturnValue({
+        call: async (req: any) => {
+          calls.push(req);
+          return {
+            EnvBaseInfo: { EnvId: "env-test", Status: "NORMAL", PackageType: "Trial" },
+            IsExist: true,
+          };
+        },
+      }),
+      cloudrun: {},
+    });
+    const tools = await createCloudRunTools();
+    const res = await tools.manageCloudRun.handler({
+      action: "initEnv",
+      envId: "env-test",
+    });
+    const parsed = parseToolResult(res);
+    expect(parsed.data.status).toBe("normal");
+    expect(parsed.data.created).toBe(false);
+    expect(calls.map((c: any) => c.Action)).toEqual(["DescribeEnvBaseInfo"]);
+  });
+
+  it("guides device code / SecretKey on CAM auth failure during initEnv", async () => {
+    mockGetCloudBaseManager.mockReturnValue({
+      commonService: vi.fn().mockReturnValue({
+        call: async (req: any) => {
+          if (req.Action === "DescribeEnvBaseInfo") {
+            return { EnvBaseInfo: {}, IsExist: false };
+          }
+          throw new Error("UnauthorizedOperation: [CAM] not authorized to perform: tcbr:CreateCloudRunEnv");
+        },
+      }),
+      cloudrun: {},
+    });
+    const tools = await createCloudRunTools();
+    await expect(
+      tools.manageCloudRun.handler({ action: "initEnv", envId: "env-test" }),
+    ).rejects.toThrow(/device code|SecretId\/SecretKey|start_auth/);
   });
 });
 
@@ -457,6 +532,22 @@ describe("queryCloudRun envStatus action", () => {
     expect(parsed.data.status).toBe("normal");
     expect(parsed.data.envBaseInfo.Status).toBe("normal");
     expect(parsed.message).toMatch(/可直接 manageCloudRun\(action="deploy"\)/);
+  });
+
+  it("normalizes uppercase NORMAL/CREATING from platform", async () => {
+    mockGetCloudBaseManager.mockReturnValue({
+      commonService: vi.fn().mockReturnValue({
+        call: async () => ({
+          EnvBaseInfo: { EnvId: "env-test", Status: "NORMAL", PackageType: "Trial" },
+          IsExist: true,
+        }),
+      }),
+      cloudrun: {},
+    });
+    const tools = await createCloudRunTools();
+    const res = await tools.queryCloudRun.handler({ action: "envStatus", envId: "env-test" });
+    const parsed = parseToolResult(res);
+    expect(parsed.data.status).toBe("normal");
   });
 
   it("returns creating with retry guidance", async () => {
@@ -523,5 +614,42 @@ describe("queryCloudRun envStatus action", () => {
     const res = await tools.queryCloudRun.handler({ action: "envStatus" });
     const parsed = parseToolResult(res);
     expect(parsed.data.envId).toBe("env-configured");
+  });
+});
+
+describe("cloudrun VPC helpers", () => {
+  it("buildCreateCloudRunEnvParam always sets EnvType=tcbr", async () => {
+    const { buildCreateCloudRunEnvParam } = await import("./cloudrun.js");
+    expect(
+      buildCreateCloudRunEnvParam({ envId: "env-x", packageType: "Trial" }),
+    ).toEqual({
+      EnvId: "env-x",
+      PackageType: "Trial",
+      EnvType: "tcbr",
+    });
+  });
+
+  it("resolveCloudRunDeployVpcInfo prefers VpcConf then env base info", async () => {
+    const { resolveCloudRunDeployVpcInfo } = await import("./cloudrun.js");
+    expect(
+      resolveCloudRunDeployVpcInfo({
+        vpcConf: { VpcId: "vpc-a", SubnetId: "subnet-a" },
+        envBaseInfo: { VpcId: "vpc-b", SubNetIds: ["subnet-b"] },
+      }),
+    ).toEqual({
+      VpcId: "vpc-a",
+      CreateType: 2,
+      SubnetIds: ["subnet-a"],
+    });
+    expect(
+      resolveCloudRunDeployVpcInfo({
+        vpcConf: null,
+        envBaseInfo: { VpcId: "vpc-b", SubNetIds: ["subnet-b"] },
+      }),
+    ).toEqual({
+      VpcId: "vpc-b",
+      CreateType: 2,
+      SubnetIds: ["subnet-b"],
+    });
   });
 });

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -58,8 +58,8 @@ const ManageCloudRunInputSchema = {
   // InitEnv operation parameters
   envId: z.string().optional().describe('环境 ID（action=initEnv 时使用；不传则使用当前配置的环境）。格式如 env-xxxxxx'),
   packageType: z.enum(CLOUDRUN_PACKAGE_TYPES).optional().default('Trial').describe('云托管环境套餐类型（action=initEnv 时使用）：Trial=试用，Standard=标准，Professional=专业，Enterprise=企业。默认 Trial'),
-  vpcId: z.string().optional().describe('VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）'),
-  subnetIds: z.array(z.string()).optional().describe('子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds'),
+  vpcId: z.string().optional().describe('VPC 网络 ID（action=initEnv 时可选）。当平台拒绝系统创建网络时必填，格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。多数场景可不传（由系统创建网络）'),
+  subnetIds: z.array(z.string()).optional().describe('子网 ID 列表（action=initEnv 时可选）。当需指定自有 VPC 时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds'),
 
   // Deploy operation parameters
   targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建'),
@@ -261,11 +261,11 @@ export function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["act
     suggestions.push("如果你确认要覆盖当前流程，可在合适时机使用 `force=true` 再次发起。");
   }
 
-  if (/云托管资源未开通|无法使用系统创建网络|VpcInfo|内部帐号|内部账号/i.test(baseMessage)) {
+  if (/云托管资源未开通|无法使用系统创建网络|VpcInfo/i.test(baseMessage)) {
     suggestions.push(
       "CreateCloudRunServer 需要有效 VPC：请传 serverConfig.VpcConf（VpcId+SubnetId），" +
         "或在 initEnv 时传入 vpcId/subnetIds（环境开通后 deploy 会自动从 EnvBaseInfo 回填）。" +
-        "腾讯内部账号必须指定上海地域 VPC，不能依赖系统创建网络。",
+        "若平台拒绝系统创建网络，必须指定上海地域 VPC。",
     );
   }
 
@@ -508,7 +508,7 @@ export type CloudRunVpcInfo = {
 
 /**
  * Extract VPC binding from DescribeEnvBaseInfo.EnvBaseInfo when the env was
- * opened with an explicit VPC (common for Tencent internal accounts).
+ * opened with an explicit VPC.
  */
 export function extractEnvBaseInfoVpc(
   baseInfo: Record<string, unknown> | null | undefined,
@@ -558,7 +558,7 @@ export function resolveCloudRunDeployVpcInfo(options: {
 
 /**
  * Build CreateCloudRunEnv Param, always including EnvType=tcbr.
- * Optional vpcId/subnetIds are required for Tencent internal accounts.
+ * Optional vpcId/subnetIds are used when the platform requires an explicit VPC.
  */
 export function buildCreateCloudRunEnvParam(options: {
   envId: string;
@@ -1283,7 +1283,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
             }
 
             // 未开通 → 发起异步开通（CreateCloudRunEnv 异步，不阻塞等待）。
-            // Always pass EnvType=tcbr; optional vpcId/subnetIds for internal accounts.
+            // Always pass EnvType=tcbr; optional vpcId/subnetIds when an explicit VPC is required.
             let createResult: any;
             try {
               createResult = await manager
@@ -1733,7 +1733,7 @@ for await (let x of res.textStream) {
                   envBaseInfoForVpc = envStatusForVpc.baseInfo;
                 }
               } catch {
-                // Best-effort: deploy may still succeed without vpcInfo for non-internal accounts.
+                // Best-effort: deploy may still succeed without vpcInfo when the platform creates the network.
               }
             }
             const resolvedVpcInfo = resolveCloudRunDeployVpcInfo({

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -8,6 +8,7 @@ import type { CloudBaseOptions } from '../types.js';
 import { debug } from '../utils/logger.js';
 import { preferGatewayOrFallback, resolveGatewayAccessUrls } from '../utils/gateway-access-urls.js';
 import { sendDeployNotification } from '../utils/notification.js';
+import { buildCamAuthGuidance, isCamAuthError } from './capi.js';
 import {
   listLikelyRedeployFields,
   mergeCloudRunServerConfig,
@@ -57,6 +58,8 @@ const ManageCloudRunInputSchema = {
   // InitEnv operation parameters
   envId: z.string().optional().describe('环境 ID（action=initEnv 时使用；不传则使用当前配置的环境）。格式如 env-xxxxxx'),
   packageType: z.enum(CLOUDRUN_PACKAGE_TYPES).optional().default('Trial').describe('云托管环境套餐类型（action=initEnv 时使用）：Trial=试用，Standard=标准，Professional=专业，Enterprise=企业。默认 Trial'),
+  vpcId: z.string().optional().describe('VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）'),
+  subnetIds: z.array(z.string()).optional().describe('子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 ["subnet-xxxxxxxx"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds'),
 
   // Deploy operation parameters
   targetPath: z.string().optional().describe('本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建'),
@@ -159,6 +162,8 @@ type ManageCloudRunInput = {
   serverType?: CloudRunServiceType;
   envId?: string;
   packageType?: CloudRunPackageType;
+  vpcId?: string;
+  subnetIds?: string[];
   trafficOp?: 'set' | 'promote' | 'rollback';
   stablePercent?: number;
   canaryPercent?: number;
@@ -243,13 +248,25 @@ function validateAndNormalizePath(inputPath: string): string {
   return normalizedPath;
 }
 
-function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["action"] | string, serverName: string, error: unknown): string {
+export function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["action"] | string, serverName: string, error: unknown): string {
   const baseMessage = error instanceof Error ? error.message : String(error);
   const suggestions: string[] = [];
+
+  if (isCamAuthError(baseMessage)) {
+    suggestions.push(buildCamAuthGuidance());
+  }
 
   if (/已有部署发布任务运行中|部署发布任务运行中/i.test(baseMessage)) {
     suggestions.push(`服务 \`${serverName}\` 当前已有部署任务在执行，请等待现有任务完成后再重试。`);
     suggestions.push("如果你确认要覆盖当前流程，可在合适时机使用 `force=true` 再次发起。");
+  }
+
+  if (/云托管资源未开通|无法使用系统创建网络|VpcInfo|内部帐号|内部账号/i.test(baseMessage)) {
+    suggestions.push(
+      "CreateCloudRunServer 需要有效 VPC：请传 serverConfig.VpcConf（VpcId+SubnetId），" +
+        "或在 initEnv 时传入 vpcId/subnetIds（环境开通后 deploy 会自动从 EnvBaseInfo 回填）。" +
+        "腾讯内部账号必须指定上海地域 VPC，不能依赖系统创建网络。",
+    );
   }
 
   if (suggestions.length === 0) {
@@ -471,11 +488,100 @@ export async function describeCloudRunEnvStatus(
     return { isExist: false, status: "unopened", baseInfo };
   }
   const rawStatus = typeof baseInfo.Status === "string" ? baseInfo.Status : "";
+  // Platform may return NORMAL/CREATING (uppercase); normalize before matching.
+  const normalizedStatus = rawStatus.toLowerCase();
   const status =
-    rawStatus === "creating" || rawStatus === "normal"
-      ? (rawStatus as "creating" | "normal")
+    normalizedStatus === "creating" || normalizedStatus === "normal"
+      ? (normalizedStatus as "creating" | "normal")
       : "unknown";
   return { isExist: true, status, baseInfo };
+}
+
+/** CloudRun EnvType for CreateCloudRunEnv (tcbr DescribeEnvBaseInfo enum). */
+export const CLOUDRUN_ENV_TYPE = "tcbr" as const;
+
+export type CloudRunVpcInfo = {
+  VpcId: string;
+  CreateType: number;
+  SubnetIds: string[];
+};
+
+/**
+ * Extract VPC binding from DescribeEnvBaseInfo.EnvBaseInfo when the env was
+ * opened with an explicit VPC (common for Tencent internal accounts).
+ */
+export function extractEnvBaseInfoVpc(
+  baseInfo: Record<string, unknown> | null | undefined,
+): { VpcId: string; SubnetIds: string[] } | undefined {
+  if (!baseInfo) {
+    return undefined;
+  }
+  const vpcId = typeof baseInfo.VpcId === "string" ? baseInfo.VpcId.trim() : "";
+  const rawSubnets = baseInfo.SubNetIds ?? baseInfo.SubnetIds;
+  const subnetIds = Array.isArray(rawSubnets)
+    ? rawSubnets
+        .filter((item): item is string => typeof item === "string" && item.trim().length > 0)
+        .map((item) => item.trim())
+    : [];
+  if (!vpcId || subnetIds.length === 0) {
+    return undefined;
+  }
+  return { VpcId: vpcId, SubnetIds: subnetIds };
+}
+
+/**
+ * Resolve CreateCloudRunServer.VpcInfo: prefer explicit serverConfig.VpcConf,
+ * otherwise fall back to env-level VPC from DescribeEnvBaseInfo.
+ */
+export function resolveCloudRunDeployVpcInfo(options: {
+  vpcConf?: { VpcId?: string; SubnetId?: string } | null;
+  envBaseInfo?: Record<string, unknown> | null;
+}): CloudRunVpcInfo | undefined {
+  const conf = options.vpcConf;
+  if (conf?.VpcId?.trim() && conf?.SubnetId?.trim()) {
+    return {
+      VpcId: conf.VpcId.trim(),
+      CreateType: 2,
+      SubnetIds: [conf.SubnetId.trim()],
+    };
+  }
+  const fromEnv = extractEnvBaseInfoVpc(options.envBaseInfo);
+  if (!fromEnv) {
+    return undefined;
+  }
+  return {
+    VpcId: fromEnv.VpcId,
+    CreateType: 2,
+    SubnetIds: fromEnv.SubnetIds,
+  };
+}
+
+/**
+ * Build CreateCloudRunEnv Param, always including EnvType=tcbr.
+ * Optional vpcId/subnetIds are required for Tencent internal accounts.
+ */
+export function buildCreateCloudRunEnvParam(options: {
+  envId: string;
+  packageType: string;
+  vpcId?: string;
+  subnetIds?: string[];
+}): Record<string, unknown> {
+  const param: Record<string, unknown> = {
+    EnvId: options.envId,
+    PackageType: options.packageType,
+    EnvType: CLOUDRUN_ENV_TYPE,
+  };
+  const vpcId = options.vpcId?.trim();
+  const subnetIds = (options.subnetIds ?? [])
+    .filter((id): id is string => typeof id === "string" && id.trim().length > 0)
+    .map((id) => id.trim());
+  if (vpcId) {
+    param.VpcId = vpcId;
+  }
+  if (subnetIds.length > 0) {
+    param.SubNetIds = subnetIds;
+  }
+  return param;
 }
 
 /**
@@ -1177,13 +1283,19 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
             }
 
             // 未开通 → 发起异步开通（CreateCloudRunEnv 异步，不阻塞等待）。
+            // Always pass EnvType=tcbr; optional vpcId/subnetIds for internal accounts.
             let createResult: any;
             try {
               createResult = await manager
                 .commonService("tcbr", "2022-02-17")
                 .call({
                   Action: "CreateCloudRunEnv",
-                  Param: { EnvId: envId, PackageType: packageType },
+                  Param: buildCreateCloudRunEnvParam({
+                    envId,
+                    packageType,
+                    vpcId: input.vpcId,
+                    subnetIds: input.subnetIds,
+                  }),
                 });
             } catch (error) {
               throw new Error(buildManageCloudRunErrorMessage('initEnv', envId, error));
@@ -1605,16 +1717,31 @@ for await (let x of res.textStream) {
             }
 
             // Manager SDK create path prefers top-level vpcInfo (CreateCloudRunServer.VpcInfo).
-            // Map serverConfig.VpcConf → vpcInfo so first-time create actually binds VPC.
+            // Prefer serverConfig.VpcConf; if missing, auto-fill from env DescribeEnvBaseInfo
+            // (envs opened with vpcId/subnetIds already carry VpcId/SubNetIds).
             const vpcConf = effectiveServerConfig?.VpcConf as
               | { VpcId?: string; SubnetId?: string }
               | undefined;
-            if (vpcConf?.VpcId?.trim() && vpcConf?.SubnetId?.trim()) {
-              deployParams.vpcInfo = {
-                VpcId: vpcConf.VpcId.trim(),
-                CreateType: 2,
-                SubnetIds: [vpcConf.SubnetId.trim()],
-              };
+            let envBaseInfoForVpc: Record<string, unknown> | null = null;
+            const explicitVpcId = vpcConf?.VpcId?.trim() ?? "";
+            const explicitSubnetId = vpcConf?.SubnetId?.trim() ?? "";
+            if (!explicitVpcId || !explicitSubnetId) {
+              try {
+                const envIdForVpc = await getEnvId(cloudBaseOptions);
+                const envStatusForVpc = await describeCloudRunEnvStatus(manager, envIdForVpc);
+                if (envStatusForVpc.isExist) {
+                  envBaseInfoForVpc = envStatusForVpc.baseInfo;
+                }
+              } catch {
+                // Best-effort: deploy may still succeed without vpcInfo for non-internal accounts.
+              }
+            }
+            const resolvedVpcInfo = resolveCloudRunDeployVpcInfo({
+              vpcConf,
+              envBaseInfo: envBaseInfoForVpc,
+            });
+            if (resolvedVpcInfo) {
+              deployParams.vpcInfo = resolvedVpcInfo;
             }
 
             let result: unknown;

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
+  ENV_METRIC_NAME_VALUES,
+  ENV_METRIC_PERIOD_VALUES,
   ENV_USAGE_MODULE_VALUES,
+  GATEWAY_ENV_QPS_DEFAULT_RESOURCE_ID,
   extractAccountCircleDate,
+  formatEnvMetricTime,
   isUsableNoSqlDatabaseEntry,
   registerEnvTools,
+  resolveEnvMetricName,
+  resolveEnvMetricPeriod,
+  resolveEnvMetricResourceId,
+  resolveEnvMetricTimeRange,
   resolveEnvUsageDateRange,
   resolveEnvUsageModules,
+  summarizeEnvMetricCurve,
 } from "./env.js";
 import type { ExtendedMcpServer } from "../server.js";
 
@@ -1645,11 +1654,26 @@ describe("env tools - envQuery", () => {
       "info",
       "domains",
       "usage",
+      "metrics",
     ]);
     expect(tools.queryEnv.meta.inputSchema.type.unwrap().element.options).toEqual([
       ...ENV_USAGE_MODULE_VALUES,
     ]);
     expect(tools.envQuery.meta.inputSchema.action.options).toContain("usage");
+  });
+
+  it("queryEnv schema should expose metrics action and metric enum", async () => {
+    const { tools } = createMockServer();
+    expect(tools.queryEnv.meta.inputSchema.action.options).toContain("metrics");
+    expect(tools.queryEnv.meta.inputSchema.metricName.unwrap().options).toEqual([
+      ...ENV_METRIC_NAME_VALUES,
+    ]);
+    expect(
+      tools.queryEnv.meta.inputSchema.period.unwrap().options.map((item: { value: number }) => item.value),
+    ).toEqual([...ENV_METRIC_PERIOD_VALUES]);
+    expect(tools.envQuery.meta.inputSchema.action.options).toContain("metrics");
+    expect(tools.queryEnv.meta.description).toContain("action=metrics");
+    expect(tools.queryEnv.meta.description).toContain("DescribeCurveData");
   });
 
   it("envQuery(usage) should require envId", async () => {
@@ -1760,6 +1784,121 @@ describe("env tools - envQuery", () => {
     expect(payload.DateSource).toBe("params");
     expect(payload.Modules).toEqual([...ENV_USAGE_MODULE_VALUES]);
   });
+
+  it("envQuery(metrics) should require envId and metricName", async () => {
+    const { tools } = createMockServer();
+    const missingEnv = await tools.queryEnv.handler({ action: "metrics" });
+    expect(missingEnv.content[0].text).toContain("envId 为必填参数");
+    expect(missingEnv.content[0].text).toContain("queryEnv");
+
+    const missingMetric = await tools.queryEnv.handler({
+      action: "metrics",
+      envId: "env-test",
+    });
+    expect(missingMetric.content[0].text).toContain("metricName 为必填参数");
+  });
+
+  it("envQuery(metrics) should call monitor.describeCurveData and summarize the curve", async () => {
+    const describeCurveData = vi.fn().mockResolvedValue({
+      StartTime: "2026-08-16 16:00:00",
+      EndTime: "2026-08-17 16:00:00",
+      MetricName: "FunctionInvocation",
+      Period: 300,
+      Values: [0, 12, 3],
+      Time: [1786900000, 1786900300, 1786900600],
+      NewValues: [0, 12, 3],
+      Statistics: "sum",
+      RequestId: "req-metrics",
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      monitor: { describeCurveData },
+    });
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse(
+      (
+        await tools.queryEnv.handler({
+          action: "metrics",
+          envId: "ai-native-d1ggefhgb8c27e3e8",
+          metricName: "FunctionInvocation",
+          startTime: "2026-08-16 16:00:00",
+          endTime: "2026-08-17 16:00:00",
+          period: 300,
+          resourceID: "hello-word-test",
+        })
+      ).content[0].text,
+    );
+
+    expect(describeCurveData).toHaveBeenCalledWith({
+      MetricName: "FunctionInvocation",
+      StartTime: "2026-08-16 16:00:00",
+      EndTime: "2026-08-17 16:00:00",
+      Period: 300,
+      ResourceID: "hello-word-test",
+    });
+    expect(payload).toMatchObject({
+      EnvId: "ai-native-d1ggefhgb8c27e3e8",
+      MetricName: "FunctionInvocation",
+      TimeSource: "params",
+      Period: 300,
+      ResourceID: "hello-word-test",
+      Summary: {
+        sampleCount: 3,
+        max: 12,
+        min: 0,
+        latest: 3,
+        peakTimestamp: 1786900300,
+        allZero: false,
+      },
+    });
+    expect(payload.Curve.RequestId).toBe("req-metrics");
+  });
+
+  it("envQuery(metrics) should default GatewayTraceEnvQPS resourceID and last 24h range", async () => {
+    const describeCurveData = vi.fn().mockResolvedValue({
+      MetricName: "GatewayTraceEnvQPS",
+      Period: 300,
+      Values: [8, 42, 10],
+      Time: [1, 2, 3],
+      NewValues: [8, 42, 10],
+      RequestId: "req-qps",
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      monitor: { describeCurveData },
+    });
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse(
+      (
+        await tools.queryEnv.handler({
+          action: "metrics",
+          envId: "env-test",
+          metricName: "GatewayTraceEnvQPS",
+        })
+      ).content[0].text,
+    );
+
+    expect(describeCurveData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        MetricName: "GatewayTraceEnvQPS",
+        ResourceID: GATEWAY_ENV_QPS_DEFAULT_RESOURCE_ID,
+      }),
+    );
+    expect(payload.TimeSource).toBe("defaultLast24h");
+    expect(payload.Summary.max).toBe(42);
+    expect(payload.Summary.allZero).toBe(false);
+  });
+
+  it("envQuery(metrics) should require resourceID for CloudRun metrics", async () => {
+    const { tools } = createMockServer();
+    const result = await tools.queryEnv.handler({
+      action: "metrics",
+      envId: "env-test",
+      metricName: "TkeCpuUsedService",
+    });
+    expect(result.content[0].text).toContain("resourceID 为必填");
+    expect(result.content[0].text).toContain("TkeCpuUsedService");
+  });
 });
 
 describe("env usage helpers", () => {
@@ -1782,6 +1921,89 @@ describe("env usage helpers", () => {
       startDate: "2026-08-01",
       endDate: "2026-08-31",
       dateSource: "accountCircle",
+    });
+  });
+});
+
+describe("env metrics helpers", () => {
+  it("resolveEnvMetricName should accept catalog names and reject unknowns", () => {
+    expect(resolveEnvMetricName("FunctionInvocation")).toBe("FunctionInvocation");
+    expect(() => resolveEnvMetricName(undefined)).toThrow(/metricName 为必填/);
+    expect(() => resolveEnvMetricName("GetMonitorData")).toThrow(/无效的 metricName/);
+  });
+
+  it("resolveEnvMetricPeriod should allow SDK periods only", () => {
+    expect(resolveEnvMetricPeriod(undefined)).toBeUndefined();
+    expect(resolveEnvMetricPeriod(300)).toBe(300);
+    expect(resolveEnvMetricPeriod("3600")).toBe(3600);
+    expect(() => resolveEnvMetricPeriod(60)).toThrow(/period 仅支持/);
+  });
+
+  it("resolveEnvMetricTimeRange should default to last 24h and validate pairs", () => {
+    const now = new Date("2026-08-17T16:00:00");
+    expect(resolveEnvMetricTimeRange({ now })).toEqual({
+      startTime: formatEnvMetricTime(new Date(now.getTime() - 24 * 60 * 60 * 1000)),
+      endTime: formatEnvMetricTime(now),
+      timeSource: "defaultLast24h",
+    });
+    expect(
+      resolveEnvMetricTimeRange({
+        startTime: "2026-08-16 10:00:00",
+        endTime: "2026-08-16 12:00:00",
+      }),
+    ).toEqual({
+      startTime: "2026-08-16 10:00:00",
+      endTime: "2026-08-16 12:00:00",
+      timeSource: "params",
+    });
+    expect(() =>
+      resolveEnvMetricTimeRange({ startTime: "2026-08-16 10:00:00" }),
+    ).toThrow(/必须同时提供/);
+    expect(() =>
+      resolveEnvMetricTimeRange({
+        startTime: "2026-08-16",
+        endTime: "2026-08-17",
+      }),
+    ).toThrow(/YYYY-MM-DD HH:mm:ss/);
+    expect(() =>
+      resolveEnvMetricTimeRange({
+        startTime: "2026-08-16 10:00:00",
+        endTime: "2026-08-16 10:03:00",
+      }),
+    ).toThrow(/至少五分钟/);
+  });
+
+  it("resolveEnvMetricResourceId should fill gateway QPS and require CloudRun service name", () => {
+    expect(resolveEnvMetricResourceId("GatewayTraceEnvQPS")).toBe(
+      GATEWAY_ENV_QPS_DEFAULT_RESOURCE_ID,
+    );
+    expect(resolveEnvMetricResourceId("FunctionInvocation")).toBeUndefined();
+    expect(resolveEnvMetricResourceId("FunctionInvocation", "hello")).toBe("hello");
+    expect(() => resolveEnvMetricResourceId("TkeQPSService")).toThrow(/resourceID 为必填/);
+  });
+
+  it("summarizeEnvMetricCurve should report peak and all-zero invocation", () => {
+    expect(
+      summarizeEnvMetricCurve({
+        Values: [0, 0, 0],
+        NewValues: [0, 0, 0],
+        Time: [1, 2, 3],
+      }),
+    ).toMatchObject({
+      sampleCount: 3,
+      max: 0,
+      allZero: true,
+    });
+    expect(
+      summarizeEnvMetricCurve({
+        Values: [1, 9, 4],
+        NewValues: [1.5, 9.2, 4.1],
+        Time: [10, 20, 30],
+      }),
+    ).toMatchObject({
+      max: 9.2,
+      peakTimestamp: 20,
+      allZero: false,
     });
   });
 });

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -169,6 +169,229 @@ export function resolveEnvUsageDateRange(options: {
 }
 
 /**
+ * Monitor metric names for queryEnv(action=metrics).
+ * Subset of TCB DescribeCurveData MetricName from the CloudBase monitor catalog
+ * (gateway/env QPS, functions, NoSQL, MySQL, CloudRun).
+ */
+export const ENV_METRIC_NAME_VALUES = [
+  "GatewayTraceEnvQPS",
+  "EnvQPSAll",
+  "FunctionInvocation",
+  "FunctionError",
+  "FunctionTimeout",
+  "FunctionThrottle",
+  "FunctionDuration",
+  "FunctionConcurrentExecutions",
+  "DbRead",
+  "DbWrite",
+  "DbSizepkg",
+  "MysqlCpuUsageRate",
+  "MysqlMemoryUse",
+  "MysqlStorageUsage",
+  "MysqlQps",
+  "MysqlSlowQueries",
+  "MysqlDbConnections",
+  "TkeCpuUsedService",
+  "TkeMemUsedService",
+  "TkeQPSService",
+  "TkeHttpErrorService",
+  "TkeInvokeNumService",
+] as const;
+
+export type EnvMetricName = (typeof ENV_METRIC_NAME_VALUES)[number];
+
+export const ENV_METRIC_PERIOD_VALUES = [300, 3600, 86400] as const;
+
+export type EnvMetricPeriod = (typeof ENV_METRIC_PERIOD_VALUES)[number];
+
+/** Console default ResourceID for environment-level gateway QPS. */
+export const GATEWAY_ENV_QPS_DEFAULT_RESOURCE_ID = "all|:|all|:|all|:|all";
+
+const ENV_METRIC_NAME_SET = new Set<string>(ENV_METRIC_NAME_VALUES);
+const ENV_METRIC_PERIOD_SET = new Set<number>(ENV_METRIC_PERIOD_VALUES);
+const ENV_METRICS_REQUIRING_RESOURCE_ID = new Set<string>([
+  "TkeCpuUsedService",
+  "TkeMemUsedService",
+  "TkeQPSService",
+  "TkeHttpErrorService",
+  "TkeInvokeNumService",
+]);
+const ENV_METRIC_TIME_RE = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/;
+const ENV_METRIC_MIN_RANGE_MS = 5 * 60 * 1000;
+
+function padMetricTimeUnit(value: number): string {
+  return value.toString().padStart(2, "0");
+}
+
+export function formatEnvMetricTime(date: Date): string {
+  return `${date.getFullYear()}-${padMetricTimeUnit(date.getMonth() + 1)}-${padMetricTimeUnit(date.getDate())} ${padMetricTimeUnit(date.getHours())}:${padMetricTimeUnit(date.getMinutes())}:${padMetricTimeUnit(date.getSeconds())}`;
+}
+
+export function resolveEnvMetricName(metricName: unknown): EnvMetricName {
+  const normalized =
+    typeof metricName === "string" && metricName.trim().length > 0
+      ? metricName.trim()
+      : undefined;
+  if (!normalized) {
+    throw new Error(
+      `查询监控指标时 metricName 为必填参数。可选值：${ENV_METRIC_NAME_VALUES.join(", ")}`,
+    );
+  }
+  if (!ENV_METRIC_NAME_SET.has(normalized)) {
+    throw new Error(
+      `无效的 metricName: ${normalized}。可选值：${ENV_METRIC_NAME_VALUES.join(", ")}`,
+    );
+  }
+  return normalized as EnvMetricName;
+}
+
+export function resolveEnvMetricPeriod(period: unknown): EnvMetricPeriod | undefined {
+  if (period === undefined || period === null || period === "") {
+    return undefined;
+  }
+  const numericPeriod =
+    typeof period === "number"
+      ? period
+      : typeof period === "string" && /^\d+$/.test(period.trim())
+        ? Number(period.trim())
+        : Number.NaN;
+  if (!ENV_METRIC_PERIOD_SET.has(numericPeriod)) {
+    throw new Error(
+      `period 仅支持 300、3600、86400（秒）。当前值：${String(period)}`,
+    );
+  }
+  return numericPeriod as EnvMetricPeriod;
+}
+
+export function resolveEnvMetricTimeRange(options: {
+  startTime?: string;
+  endTime?: string;
+  now?: Date;
+}): { startTime: string; endTime: string; timeSource: "params" | "defaultLast24h" } {
+  const startFromParams =
+    typeof options.startTime === "string" && options.startTime.trim().length > 0
+      ? options.startTime.trim()
+      : undefined;
+  const endFromParams =
+    typeof options.endTime === "string" && options.endTime.trim().length > 0
+      ? options.endTime.trim()
+      : undefined;
+
+  if (startFromParams || endFromParams) {
+    if (!startFromParams || !endFromParams) {
+      throw new Error(
+        "查询监控指标时 startTime 与 endTime 必须同时提供，格式为 YYYY-MM-DD HH:mm:ss。",
+      );
+    }
+    if (!ENV_METRIC_TIME_RE.test(startFromParams) || !ENV_METRIC_TIME_RE.test(endFromParams)) {
+      throw new Error("startTime / endTime 格式必须为 YYYY-MM-DD HH:mm:ss。");
+    }
+    const startMs = Date.parse(startFromParams.replace(" ", "T"));
+    const endMs = Date.parse(endFromParams.replace(" ", "T"));
+    if (Number.isNaN(startMs) || Number.isNaN(endMs)) {
+      throw new Error("startTime / endTime 无法解析为有效时间。");
+    }
+    if (endMs - startMs < ENV_METRIC_MIN_RANGE_MS) {
+      throw new Error("结束时间需要晚于开始时间至少五分钟（监控最小粒度为 5 分钟）。");
+    }
+    return {
+      startTime: startFromParams,
+      endTime: endFromParams,
+      timeSource: "params",
+    };
+  }
+
+  const now = options.now ?? new Date();
+  const start = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+  return {
+    startTime: formatEnvMetricTime(start),
+    endTime: formatEnvMetricTime(now),
+    timeSource: "defaultLast24h",
+  };
+}
+
+export function resolveEnvMetricResourceId(
+  metricName: EnvMetricName,
+  resourceID?: string,
+): string | undefined {
+  const normalized =
+    typeof resourceID === "string" && resourceID.trim().length > 0
+      ? resourceID.trim()
+      : undefined;
+  if (normalized) {
+    return normalized;
+  }
+  if (metricName === "GatewayTraceEnvQPS") {
+    return GATEWAY_ENV_QPS_DEFAULT_RESOURCE_ID;
+  }
+  if (ENV_METRICS_REQUIRING_RESOURCE_ID.has(metricName)) {
+    throw new Error(
+      `查询 ${metricName} 时 resourceID 为必填（云托管服务名）。请先 queryCloudRun(action="list") 获取服务名后再查询。`,
+    );
+  }
+  return undefined;
+}
+
+export function summarizeEnvMetricCurve(curve: {
+  Values?: unknown;
+  NewValues?: unknown;
+  Time?: unknown;
+}): {
+  sampleCount: number;
+  max: number | null;
+  min: number | null;
+  avg: number | null;
+  latest: number | null;
+  peakTimestamp: number | null;
+  allZero: boolean;
+} {
+  const newValues = Array.isArray(curve.NewValues) ? curve.NewValues : [];
+  const values = Array.isArray(curve.Values) ? curve.Values : [];
+  const times = Array.isArray(curve.Time) ? curve.Time : [];
+  const series = (newValues.length > 0 ? newValues : values).filter(
+    (item): item is number => typeof item === "number" && Number.isFinite(item),
+  );
+
+  if (series.length === 0) {
+    return {
+      sampleCount: 0,
+      max: null,
+      min: null,
+      avg: null,
+      latest: null,
+      peakTimestamp: null,
+      allZero: true,
+    };
+  }
+
+  let max = series[0];
+  let min = series[0];
+  let sum = 0;
+  let peakIndex = 0;
+  for (let i = 0; i < series.length; i++) {
+    const value = series[i];
+    sum += value;
+    if (value > max) {
+      max = value;
+      peakIndex = i;
+    }
+    if (value < min) {
+      min = value;
+    }
+  }
+
+  return {
+    sampleCount: series.length,
+    max,
+    min,
+    avg: sum / series.length,
+    latest: series[series.length - 1],
+    peakTimestamp: typeof times[peakIndex] === "number" ? times[peakIndex] : null,
+    allZero: series.every((value) => value === 0),
+  };
+}
+
+/**
  * Simplify environment list data by keeping only essential fields for AI assistant
  * This reduces token consumption when returning environment lists via MCP tools
  * @param envList - Full environment list from API
@@ -1244,6 +1467,16 @@ function buildEnvQueryErrorMessage(error: unknown, action: string): string {
     );
   }
 
+  if (action === "metrics" && suggestions.length === 0) {
+    suggestions.push("查询环境监控指标失败，建议：");
+    suggestions.push("1. 先调用 auth(action=\"status\") 确认登录状态；未登录则 auth(action=\"start_auth\")");
+    suggestions.push("2. 使用 queryEnv(action=\"list\") 确认 envId 正确且可访问");
+    suggestions.push(
+      `3. 再调用 queryEnv(action=\"metrics\", envId=\"<EnvId>\", metricName=\"GatewayTraceEnvQPS\")；metricName 可选值：${ENV_METRIC_NAME_VALUES.join(", ")}`,
+    );
+    suggestions.push("4. startTime/endTime 格式为 YYYY-MM-DD HH:mm:ss，须成对传入；period 仅 300/3600/86400");
+  }
+
   // If no specific pattern matched, provide general guidance
   if (suggestions.length === 0) {
     suggestions.push("查询环境信息时出错，建议：");
@@ -2317,7 +2550,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   );
   } // end: wxide guard for auth tool
 
-  // queryEnv - 环境查询（合并 listEnvs + getEnvInfo + getEnvAuthDomains + usage）
+  // queryEnv - 环境查询（合并 listEnvs + getEnvInfo + getEnvAuthDomains + usage + metrics）
   const queryEnvHandler: (args: any) => Promise<any> = async ({
     action,
     alias,
@@ -2330,8 +2563,14 @@ export function registerEnvTools(server: ExtendedMcpServer) {
     startDate,
     endDate,
     needUsageDetails,
+    metricName,
+    startTime,
+    endTime,
+    period,
+    resourceID,
+    subresourceID,
   }: {
-      action: "list" | "info" | "domains" | "usage";
+      action: "list" | "info" | "domains" | "usage" | "metrics";
       alias?: string;
       aliasExact?: boolean;
       envId?: string;
@@ -2342,6 +2581,12 @@ export function registerEnvTools(server: ExtendedMcpServer) {
       startDate?: string;
       endDate?: string;
       needUsageDetails?: boolean;
+      metricName?: string;
+      startTime?: string;
+      endTime?: string;
+      period?: number;
+      resourceID?: string;
+      subresourceID?: string;
     }) => {
       try {
         let result;
@@ -2557,6 +2802,65 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             break;
           }
 
+          case "metrics": {
+            const metricsEnvId = normalizeOptionalToolString(envId);
+            if (!metricsEnvId) {
+              throw new Error(
+                '查询监控指标时 envId 为必填参数。请先调用 queryEnv(action="list") 获取 EnvId，再调用 queryEnv(action="metrics", envId="<EnvId>", metricName="GatewayTraceEnvQPS")。',
+              );
+            }
+            const resolvedMetricName = resolveEnvMetricName(metricName);
+            const timeRange = resolveEnvMetricTimeRange({ startTime, endTime });
+            const resolvedPeriod = resolveEnvMetricPeriod(period);
+            const resolvedResourceId = resolveEnvMetricResourceId(
+              resolvedMetricName,
+              resourceID,
+            );
+            const resolvedSubresourceId = normalizeOptionalToolString(subresourceID);
+            const cloudbaseMetrics = await getManagerForEnvQuery(metricsEnvId);
+            if (typeof cloudbaseMetrics?.monitor?.describeCurveData !== "function") {
+              throw new Error(
+                "当前 CloudBase Manager 不支持 monitor.describeCurveData。请升级 @cloudbase/manager-node。",
+              );
+            }
+            const curveParams: {
+              MetricName: EnvMetricName;
+              StartTime: string;
+              EndTime: string;
+              Period?: EnvMetricPeriod;
+              ResourceID?: string;
+              SubresourceID?: string;
+            } = {
+              MetricName: resolvedMetricName,
+              StartTime: timeRange.startTime,
+              EndTime: timeRange.endTime,
+            };
+            if (resolvedPeriod !== undefined) {
+              curveParams.Period = resolvedPeriod;
+            }
+            if (resolvedResourceId) {
+              curveParams.ResourceID = resolvedResourceId;
+            }
+            if (resolvedSubresourceId) {
+              curveParams.SubresourceID = resolvedSubresourceId;
+            }
+            const curve = await cloudbaseMetrics.monitor.describeCurveData(curveParams);
+            logCloudBaseResult(server.logger, curve);
+            result = {
+              EnvId: metricsEnvId,
+              MetricName: resolvedMetricName,
+              StartTime: timeRange.startTime,
+              EndTime: timeRange.endTime,
+              TimeSource: timeRange.timeSource,
+              Period: resolvedPeriod ?? curve?.Period,
+              ResourceID: resolvedResourceId,
+              SubresourceID: resolvedSubresourceId,
+              Curve: curve,
+              Summary: summarizeEnvMetricCurve(curve ?? {}),
+            };
+            break;
+          }
+
           default:
             throw new Error(`不支持的查询类型: ${action}`);
         }
@@ -2592,12 +2896,12 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   const queryEnvToolSchema = {
     title: "CloudBase 环境查询",
     description:
-      "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名与资源用量。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
     inputSchema: {
       action: z
-        .enum(["list", "info", "domains", "usage"])
+        .enum(["list", "info", "domains", "usage", "metrics"])
         .describe(
-          "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量/指标（必须传入 envId，对齐 tcb env usage/info）",
+          "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）",
         ),
       alias: z.string().optional().describe("按环境别名筛选。action=list 时可选"),
       aliasExact: z.boolean().optional().describe("按环境别名精确筛选。action=list 时可选；与 alias 配合使用"),
@@ -2605,7 +2909,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         .string()
         .optional()
         .describe(
-          "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage 时必填。usage 对齐 DescribeEnvAccountCircle / DescribeCreditsUsageDetail，缺少 EnvId 会导致云 API 参数错误。",
+          "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。",
         ),
       limit: z.number().int().positive().optional().describe("返回数量上限。action=list 时可选"),
       offset: z.number().int().min(0).optional().describe("分页偏移。action=list 时可选"),
@@ -2636,6 +2940,42 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         .optional()
         .describe(
           "是否返回每日用量明细。仅 action=usage 时有效；默认 true。",
+        ),
+      metricName: z
+        .enum(ENV_METRIC_NAME_VALUES)
+        .optional()
+        .describe(
+          "监控指标名。仅 action=metrics 时有效且必填。GatewayTraceEnvQPS/EnvQPSAll=环境与网关 QPS；FunctionInvocation/FunctionError/FunctionTimeout/FunctionThrottle=云函数调用、错误、超时、限流；DbRead/DbWrite/DbSizepkg=文档库读写与容量；MysqlCpuUsageRate/MysqlMemoryUse/MysqlStorageUsage=SQL 库 CPU/内存/磁盘；TkeCpuUsedService/TkeQPSService/TkeHttpErrorService=云托管 CPU/QPS/错误。",
+        ),
+      startTime: z
+        .string()
+        .optional()
+        .describe(
+          "监控开始时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 endTime 成对传入。不传则默认最近 24 小时。结束时间须晚于开始时间至少五分钟。",
+        ),
+      endTime: z
+        .string()
+        .optional()
+        .describe(
+          "监控结束时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 startTime 成对传入。不传则默认最近 24 小时。",
+        ),
+      period: z
+        .union([z.literal(300), z.literal(3600), z.literal(86400)])
+        .optional()
+        .describe(
+          "统计周期（秒）。仅 action=metrics 时有效；仅支持 300、3600、86400。不传则由后端按时间范围自动选择。时间范围 ≤1 天不可用 86400；>3 天不可用 300。",
+        ),
+      resourceID: z
+        .string()
+        .optional()
+        .describe(
+          "资源 ID。仅 action=metrics 时有效。云函数传函数名，文档库传集合名，云托管必须传服务名；GatewayTraceEnvQPS 不传则使用环境级 all|:|all|:|all|:|all。",
+        ),
+      subresourceID: z
+        .string()
+        .optional()
+        .describe(
+          "子资源 ID。仅 action=metrics 时有效；查询云托管某版本监控时传入版本名。",
         ),
     },
     annotations: {

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -69,7 +69,7 @@
     },
     {
       "name": "queryEnv",
-      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名与资源用量。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -79,9 +79,10 @@
               "list",
               "info",
               "domains",
-              "usage"
+              "usage",
+              "metrics"
             ],
-            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量/指标（必须传入 envId，对齐 tcb env usage/info）"
+            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
           },
           "alias": {
             "type": "string",
@@ -93,7 +94,7 @@
           },
           "envId": {
             "type": "string",
-            "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage 时必填。usage 对齐 DescribeEnvAccountCircle / DescribeCreditsUsageDetail，缺少 EnvId 会导致云 API 参数错误。"
+            "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。"
           },
           "limit": {
             "type": "integer",
@@ -155,6 +156,59 @@
           "needUsageDetails": {
             "type": "boolean",
             "description": "是否返回每日用量明细。仅 action=usage 时有效；默认 true。"
+          },
+          "metricName": {
+            "type": "string",
+            "enum": [
+              "GatewayTraceEnvQPS",
+              "EnvQPSAll",
+              "FunctionInvocation",
+              "FunctionError",
+              "FunctionTimeout",
+              "FunctionThrottle",
+              "FunctionDuration",
+              "FunctionConcurrentExecutions",
+              "DbRead",
+              "DbWrite",
+              "DbSizepkg",
+              "MysqlCpuUsageRate",
+              "MysqlMemoryUse",
+              "MysqlStorageUsage",
+              "MysqlQps",
+              "MysqlSlowQueries",
+              "MysqlDbConnections",
+              "TkeCpuUsedService",
+              "TkeMemUsedService",
+              "TkeQPSService",
+              "TkeHttpErrorService",
+              "TkeInvokeNumService"
+            ],
+            "description": "监控指标名。仅 action=metrics 时有效且必填。GatewayTraceEnvQPS/EnvQPSAll=环境与网关 QPS；FunctionInvocation/FunctionError/FunctionTimeout/FunctionThrottle=云函数调用、错误、超时、限流；DbRead/DbWrite/DbSizepkg=文档库读写与容量；MysqlCpuUsageRate/MysqlMemoryUse/MysqlStorageUsage=SQL 库 CPU/内存/磁盘；TkeCpuUsedService/TkeQPSService/TkeHttpErrorService=云托管 CPU/QPS/错误。"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "监控开始时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 endTime 成对传入。不传则默认最近 24 小时。结束时间须晚于开始时间至少五分钟。"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "监控结束时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 startTime 成对传入。不传则默认最近 24 小时。"
+          },
+          "period": {
+            "type": "number",
+            "enum": [
+              300,
+              3600,
+              86400
+            ],
+            "description": "统计周期（秒）。仅 action=metrics 时有效；仅支持 300、3600、86400。不传则由后端按时间范围自动选择。时间范围 ≤1 天不可用 86400；>3 天不可用 300。"
+          },
+          "resourceID": {
+            "type": "string",
+            "description": "资源 ID。仅 action=metrics 时有效。云函数传函数名，文档库传集合名，云托管必须传服务名；GatewayTraceEnvQPS 不传则使用环境级 all|:|all|:|all|:|all。"
+          },
+          "subresourceID": {
+            "type": "string",
+            "description": "子资源 ID。仅 action=metrics 时有效；查询云托管某版本监控时传入版本名。"
           }
         },
         "required": [
@@ -166,7 +220,7 @@
     },
     {
       "name": "envQuery",
-      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名与资源用量。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -176,9 +230,10 @@
               "list",
               "info",
               "domains",
-              "usage"
+              "usage",
+              "metrics"
             ],
-            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量/指标（必须传入 envId，对齐 tcb env usage/info）"
+            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
           },
           "alias": {
             "type": "string",
@@ -190,7 +245,7 @@
           },
           "envId": {
             "type": "string",
-            "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage 时必填。usage 对齐 DescribeEnvAccountCircle / DescribeCreditsUsageDetail，缺少 EnvId 会导致云 API 参数错误。"
+            "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。"
           },
           "limit": {
             "type": "integer",
@@ -252,6 +307,59 @@
           "needUsageDetails": {
             "type": "boolean",
             "description": "是否返回每日用量明细。仅 action=usage 时有效；默认 true。"
+          },
+          "metricName": {
+            "type": "string",
+            "enum": [
+              "GatewayTraceEnvQPS",
+              "EnvQPSAll",
+              "FunctionInvocation",
+              "FunctionError",
+              "FunctionTimeout",
+              "FunctionThrottle",
+              "FunctionDuration",
+              "FunctionConcurrentExecutions",
+              "DbRead",
+              "DbWrite",
+              "DbSizepkg",
+              "MysqlCpuUsageRate",
+              "MysqlMemoryUse",
+              "MysqlStorageUsage",
+              "MysqlQps",
+              "MysqlSlowQueries",
+              "MysqlDbConnections",
+              "TkeCpuUsedService",
+              "TkeMemUsedService",
+              "TkeQPSService",
+              "TkeHttpErrorService",
+              "TkeInvokeNumService"
+            ],
+            "description": "监控指标名。仅 action=metrics 时有效且必填。GatewayTraceEnvQPS/EnvQPSAll=环境与网关 QPS；FunctionInvocation/FunctionError/FunctionTimeout/FunctionThrottle=云函数调用、错误、超时、限流；DbRead/DbWrite/DbSizepkg=文档库读写与容量；MysqlCpuUsageRate/MysqlMemoryUse/MysqlStorageUsage=SQL 库 CPU/内存/磁盘；TkeCpuUsedService/TkeQPSService/TkeHttpErrorService=云托管 CPU/QPS/错误。"
+          },
+          "startTime": {
+            "type": "string",
+            "description": "监控开始时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 endTime 成对传入。不传则默认最近 24 小时。结束时间须晚于开始时间至少五分钟。"
+          },
+          "endTime": {
+            "type": "string",
+            "description": "监控结束时间（YYYY-MM-DD HH:mm:ss）。仅 action=metrics 时有效；与 startTime 成对传入。不传则默认最近 24 小时。"
+          },
+          "period": {
+            "type": "number",
+            "enum": [
+              300,
+              3600,
+              86400
+            ],
+            "description": "统计周期（秒）。仅 action=metrics 时有效；仅支持 300、3600、86400。不传则由后端按时间范围自动选择。时间范围 ≤1 天不可用 86400；>3 天不可用 300。"
+          },
+          "resourceID": {
+            "type": "string",
+            "description": "资源 ID。仅 action=metrics 时有效。云函数传函数名，文档库传集合名，云托管必须传服务名；GatewayTraceEnvQPS 不传则使用环境级 all|:|all|:|all|:|all。"
+          },
+          "subresourceID": {
+            "type": "string",
+            "description": "子资源 ID。仅 action=metrics 时有效；查询云托管某版本监控时传入版本名。"
           }
         },
         "required": [

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2377,14 +2377,14 @@
           },
           "vpcId": {
             "type": "string",
-            "description": "VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）"
+            "description": "VPC 网络 ID（action=initEnv 时可选）。当平台拒绝系统创建网络时必填，格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。多数场景可不传（由系统创建网络）"
           },
           "subnetIds": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 [\"subnet-xxxxxxxx\"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds"
+            "description": "子网 ID 列表（action=initEnv 时可选）。当需指定自有 VPC 时必填，如 [\"subnet-xxxxxxxx\"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds"
           },
           "targetPath": {
             "type": "string",

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2267,6 +2267,17 @@
             "default": "Trial",
             "description": "云托管环境套餐类型（action=initEnv 时使用）：Trial=试用，Standard=标准，Professional=专业，Enterprise=企业。默认 Trial"
           },
+          "vpcId": {
+            "type": "string",
+            "description": "VPC 网络 ID（action=initEnv 时可选）。腾讯内部账号开通云托管时必填（平台拒绝系统创建网络），格式如 vpc-xxxxxxxx。与 subnetIds 一起透传给 CreateCloudRunEnv 的 VpcId/SubNetIds。普通账号可不传（由系统创建网络）"
+          },
+          "subnetIds": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "description": "子网 ID 列表（action=initEnv 时可选）。腾讯内部账号开通云托管时必填，如 [\"subnet-xxxxxxxx\"]。与 vpcId 一起透传给 CreateCloudRunEnv 的 SubNetIds"
+          },
           "targetPath": {
             "type": "string",
             "description": "本地代码路径，必须是绝对路径。在deploy操作中指定要部署的代码目录，在download操作中指定下载目标目录，在init操作中指定云托管服务的上级目录（会在该目录下创建以serverName命名的子目录）。updateConfig 不需要此参数。建议约定：项目根目录下的cloudrun/目录，例如：/Users/username/projects/my-project/cloudrun。使用 imageUrl 部署已有镜像时此参数可省略。注意：本地有源码目录不等于必须走源码构建；若用户指定镜像请优先传 imageUrl，不要仅因存在 targetPath 就回退到源码构建"


### PR DESCRIPTION
## Summary
- Fix `manageCloudRun(action=initEnv)` to always pass `EnvType: "tcbr"` and optional `vpcId`/`subnetIds` (required when the platform rejects system-created networks).
- Normalize uppercase `NORMAL`/`CREATING` in `queryCloudRun(action=envStatus)` and initEnv idempotency checks.
- Auto-fill deploy `vpcInfo` from `DescribeEnvBaseInfo` when `serverConfig.VpcConf` is omitted; improve CAM/API Key error guidance to device-code / SecretKey login.
- Neutralize VPC-related tool descriptions, error guidance, comments, and changelog to describe platform network constraints instead of account-type language.

## Test plan
- [x] `vitest run src/tools/cloudrun-init.test.ts src/tools/cloudrun-image-deploy.test.ts src/tools/capi.test.ts` (51 passed)
- [x] Regenerated `scripts/tools.json` + `doc/mcp-tools.md`
- [ ] Manual: initEnv with vpcId/subnetIds when platform requires explicit VPC; envStatus against NORMAL env; image deploy without VpcConf after VPC-bound initEnv

Task: 95bc8ba7