### PR TITLE
feat(cloudrun): ✨ add queryCloudRun getProcessLog for runtime deploy logs

### DIFF
--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -152,9 +152,29 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `queryCloudRun(action="list")` -> list services
 - `queryCloudRun(action="detail")` -> inspect one service and its latest deploy status when available
 - `queryCloudRun(action="templates")` -> see available starters
-- `queryCloudRun(action="getDeployLog")` -> retrieve the latest deploy log or a specified `buildId`
+- `queryCloudRun(action="getDeployLog")` -> **构建日志**（CODING / `DescribeCloudRunBuildLog`）。**仅云端源码构建有意义**；已有镜像部署（`imageUrl`）没有构建过程，不要用它诊断镜像部署失败。未登录 CODING 的账号会报错（如 `User not created or may not qcloud user`）
+- `queryCloudRun(action="getProcessLog")` -> **运行日志**（`tcbr/DescribeCloudRunProcessLog`）。返回部署阶段步骤（如 `create_version_check_vpc` / `create_eks_virtual_service` / `check_eks_virtual_service`）+ 容器启动/运行日志（s6-overlay、应用进程、readiness probe 失败原因）。**镜像部署与源码构建均可用，不依赖 CODING**。参数：`detailServerName`/`serverName` + 可选 `runId`（不传则取最新部署的 `RunId`；`RunId` 也可从 `detail` / `getDeployRecords` 的 `latestDeploy.RunId` 取得）
 - `queryCloudRun(action="getDeployRecords")` -> list deploy records (newest first; includes `BuildId` / `RunId` / `FlowRatio` / `Status`) — use to review release history and rollback context before a traffic operation
 - `queryCloudRun(action="envStatus")` -> check whether the environment's CloudRun is opened and its provisioning status (`Status=creating` opening / `normal` opened) — use after `initEnv` to poll progress or before `deploy` to confirm readiness
+
+### Log query SOP（构建日志 vs 运行日志）
+
+部署失败排查时**必须区分**两类日志，不要只用 `getDeployLog`：
+
+1. **云端源码构建**（传 `targetPath`、走 CODING 构建）  
+   - 先 `queryCloudRun(action="getDeployLog", detailServerName=..., buildId=...)` 查**构建日志**（编译/打包失败）  
+   - 再 `queryCloudRun(action="getProcessLog", detailServerName=..., runId=...)` 查**运行日志**（部署步骤 + 容器启动/健康检查）
+2. **已有镜像部署**（传 `imageUrl`、`DeployType=image`）  
+   - **跳过** `getDeployLog`（无构建过程；且依赖 CODING，未登录会直接失败）  
+   - 直接 `queryCloudRun(action="detail")` 或 `getDeployRecords` 取 `latestDeploy.RunId`，再 `getProcessLog` 查运行日志
+
+```json
+{
+  "action": "getProcessLog",
+  "detailServerName": "my-svc",
+  "runId": "<from latestDeploy.RunId>"
+}
+```
 
 ### Write operations
 
@@ -162,7 +182,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step`. **Source builds**: poll `queryCloudRun(action="getDeployLog", buildId=...)` then `getProcessLog`. **Image deploys** (`imageUrl`): skip build log; poll status via `detail` and diagnose with `getProcessLog` (RunId from `latestDeploy`). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -204,7 +224,18 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 }
 ```
 
-部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。
+部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。镜像部署失败排查：**不要**调用 `getDeployLog`；用 `detail`/`getDeployRecords` 取 `latestDeploy.RunId` 后调用 `getProcessLog`。
+
+## InitialDelaySeconds（端口健康检查初始延迟）
+
+`serverConfig.InitialDelaySeconds` 的真实语义：
+
+1. **部署流程完成后**，先等待 **N 秒**，才开始对服务端口做健康检查（readiness）
+2. 之后大约 **每 5 秒检查一次**，连续约 **30 次**
+3. **30 次全部失败** 才判定本次部署失败（探测窗口大约 **150 秒**）
+4. **不是**「等 N 秒后立即失败」——把 N 设小并不会让失败更快判定到「秒级」
+
+容器启动耗时长的应用（JVM 预热、拉配置、迁移等）应把 `InitialDelaySeconds` 调到 **60–120**，避免还在启动就被判定失败。
 
 ## Access guidance
 
@@ -284,7 +315,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 - **Access failure** -> check ingress access type, domain setup, and whether the instance scaled to zero.
 - **Deployment blocked with "尚未初始化云托管 / not initialized"** -> the environment needs CloudRun enabled first: call `manageCloudRun(action="initEnv", envId=...)` (异步开通) and poll `queryCloudRun(action="envStatus")` until `Status=normal`; or open the console `环境 → 云托管 → 开通`. For stateless HTTP services, consider an HTTP cloud function instead of CloudRun entirely.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> follow the **Log query SOP** above: source builds check `getDeployLog` then `getProcessLog`; image deploys skip build log and use `getProcessLog` only. Also inspect Dockerfile (source), CPU/memory ratio, and `InitialDelaySeconds` if readiness fails after slow startup.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -152,9 +152,29 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `queryCloudRun(action="list")` -> list services
 - `queryCloudRun(action="detail")` -> inspect one service and its latest deploy status when available
 - `queryCloudRun(action="templates")` -> see available starters
-- `queryCloudRun(action="getDeployLog")` -> retrieve the latest deploy log or a specified `buildId`
+- `queryCloudRun(action="getDeployLog")` -> **构建日志**（CODING / `DescribeCloudRunBuildLog`）。**仅云端源码构建有意义**；已有镜像部署（`imageUrl`）没有构建过程，不要用它诊断镜像部署失败。未登录 CODING 的账号会报错（如 `User not created or may not qcloud user`）
+- `queryCloudRun(action="getProcessLog")` -> **运行日志**（`tcbr/DescribeCloudRunProcessLog`）。返回部署阶段步骤（如 `create_version_check_vpc` / `create_eks_virtual_service` / `check_eks_virtual_service`）+ 容器启动/运行日志（s6-overlay、应用进程、readiness probe 失败原因）。**镜像部署与源码构建均可用，不依赖 CODING**。参数：`detailServerName`/`serverName` + 可选 `runId`（不传则取最新部署的 `RunId`；`RunId` 也可从 `detail` / `getDeployRecords` 的 `latestDeploy.RunId` 取得）
 - `queryCloudRun(action="getDeployRecords")` -> list deploy records (newest first; includes `BuildId` / `RunId` / `FlowRatio` / `Status`) — use to review release history and rollback context before a traffic operation
 - `queryCloudRun(action="envStatus")` -> check whether the environment's CloudRun is opened and its provisioning status (`Status=creating` opening / `normal` opened) — use after `initEnv` to poll progress or before `deploy` to confirm readiness
+
+### Log query SOP（构建日志 vs 运行日志）
+
+部署失败排查时**必须区分**两类日志，不要只用 `getDeployLog`：
+
+1. **云端源码构建**（传 `targetPath`、走 CODING 构建）  
+   - 先 `queryCloudRun(action="getDeployLog", detailServerName=..., buildId=...)` 查**构建日志**（编译/打包失败）  
+   - 再 `queryCloudRun(action="getProcessLog", detailServerName=..., runId=...)` 查**运行日志**（部署步骤 + 容器启动/健康检查）
+2. **已有镜像部署**（传 `imageUrl`、`DeployType=image`）  
+   - **跳过** `getDeployLog`（无构建过程；且依赖 CODING，未登录会直接失败）  
+   - 直接 `queryCloudRun(action="detail")` 或 `getDeployRecords` 取 `latestDeploy.RunId`，再 `getProcessLog` 查运行日志
+
+```json
+{
+  "action": "getProcessLog",
+  "detailServerName": "my-svc",
+  "runId": "<from latestDeploy.RunId>"
+}
+```
 
 ### Write operations
 
@@ -162,7 +182,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step`. **Source builds**: poll `queryCloudRun(action="getDeployLog", buildId=...)` then `getProcessLog`. **Image deploys** (`imageUrl`): skip build log; poll status via `detail` and diagnose with `getProcessLog` (RunId from `latestDeploy`). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -204,7 +224,18 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 }
 ```
 
-部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。
+部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。镜像部署失败排查：**不要**调用 `getDeployLog`；用 `detail`/`getDeployRecords` 取 `latestDeploy.RunId` 后调用 `getProcessLog`。
+
+## InitialDelaySeconds（端口健康检查初始延迟）
+
+`serverConfig.InitialDelaySeconds` 的真实语义：
+
+1. **部署流程完成后**，先等待 **N 秒**，才开始对服务端口做健康检查（readiness）
+2. 之后大约 **每 5 秒检查一次**，连续约 **30 次**
+3. **30 次全部失败** 才判定本次部署失败（探测窗口大约 **150 秒**）
+4. **不是**「等 N 秒后立即失败」——把 N 设小并不会让失败更快判定到「秒级」
+
+容器启动耗时长的应用（JVM 预热、拉配置、迁移等）应把 `InitialDelaySeconds` 调到 **60–120**，避免还在启动就被判定失败。
 
 ## Access guidance
 
@@ -284,7 +315,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 - **Access failure** -> check ingress access type, domain setup, and whether the instance scaled to zero.
 - **Deployment blocked with "尚未初始化云托管 / not initialized"** -> the environment needs CloudRun enabled first: call `manageCloudRun(action="initEnv", envId=...)` (异步开通) and poll `queryCloudRun(action="envStatus")` until `Status=normal`; or open the console `环境 → 云托管 → 开通`. For stateless HTTP services, consider an HTTP cloud function instead of CloudRun entirely.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> follow the **Log query SOP** above: source builds check `getDeployLog` then `getProcessLog`; image deploys skip build log and use `getProcessLog` only. Also inspect Dockerfile (source), CPU/memory ratio, and `InitialDelaySeconds` if readiness fails after slow startup.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -2107,7 +2107,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
 ---
 
 ### `queryCloudRun`
-查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取部署日志以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。
+查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取构建日志（getDeployLog，仅云端源码构建/依赖 CODING）、获取运行日志（getProcessLog，镜像与源码部署均可/不依赖 CODING）、获取部署记录以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。
 
 #### 参数
 
@@ -2117,7 +2117,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
       name: "action",
       type: "string",
       required: true,
-      description: `查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取指定服务最近一次或指定构建的部署日志，getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪 可填写的值: "list", "detail", "templates", "getDeployLog", "getDeployRecords", "envStatus"`,
+      description: `查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取构建日志（仅云端源码构建有意义，走 CODING/DescribeCloudRunBuildLog；已有镜像部署无构建过程；未登录 CODING 的账号会报错），getProcessLog=获取运行日志（部署阶段步骤+容器启动/运行日志，走 tcbr/DescribeCloudRunProcessLog；镜像部署与源码构建均可用，不依赖 CODING；RunId 来自 detail/getDeployRecords 的 latestDeploy.RunId），getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪 可填写的值: "list", "detail", "templates", "getDeployLog", "getProcessLog", "getDeployRecords", "envStatus"`,
     },
     {
       name: "pageSize",
@@ -2147,12 +2147,17 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
     {
       name: "detailServerName",
       type: "string",
-      description: `要查询详细信息、部署记录或部署日志的服务名称。当action为detail、getDeployLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表`,
+      description: `要查询详细信息、部署记录、构建日志或运行日志的服务名称。当action为detail、getDeployLog、getProcessLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表`,
     },
     {
       name: "buildId",
       type: "number",
-      description: `构建ID，仅在action=getDeployLog时使用。不传时默认返回最近一次部署的构建日志`,
+      description: `构建ID，仅在action=getDeployLog时使用（构建日志，仅云端源码构建）。不传时默认返回最近一次部署的构建日志`,
+    },
+    {
+      name: "runId",
+      type: "string",
+      description: `运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志`,
     }
   ]}
 />
@@ -2325,7 +2330,7 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
         {
           name: "InitialDelaySeconds",
           type: "number",
-          description: `延迟检测时间（秒），用于配置服务启动后的健康检查延迟。在此期间内不会将请求路由到该实例，适用于启动时间较长的服务`,
+          description: `端口健康检查初始延迟（秒）。部署完成后先等待 N 秒才开始端口探测，之后约每 5s 检查一次、连续约 30 次；30 次全失败才判定部署失败（约 150s 探测窗口），不是「N 秒后立即失败」。启动耗时长的应用建议调到 60–120`,
         },
         {
           name: "LogType",

--- a/mcp/src/tools/cloudrun-process-log.test.ts
+++ b/mcp/src/tools/cloudrun-process-log.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockGetCloudBaseManager, mockGetEnvId } = vi.hoisted(() => ({
+  mockGetCloudBaseManager: vi.fn(),
+  mockGetEnvId: vi.fn(),
+}));
+
+vi.mock("../cloudbase-manager.js", () => ({
+  getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
+}));
+
+type RegisteredTool = { meta: any; handler: (args: any) => Promise<any> };
+
+async function createCloudRunTools() {
+  const tools: Record<string, RegisteredTool> = {};
+  const server: any = {
+    cloudBaseOptions: {},
+    ide: "CodeBuddy",
+    server: {
+      sendLoggingMessage: vi.fn(),
+    },
+    registerTool: vi.fn((name: string, meta: any, handler: (args: any) => Promise<any>) => {
+      tools[name] = { meta, handler };
+    }),
+  };
+  const { registerCloudRunTools } = await import("./cloudrun.js");
+  registerCloudRunTools(server);
+  return { tools, server };
+}
+
+function parseToolResult(res: any) {
+  return JSON.parse(res.content[0].text);
+}
+
+function makeManager(overrides: {
+  getProcessLog?: ReturnType<typeof vi.fn>;
+  getBuildLog?: ReturnType<typeof vi.fn>;
+  getDeployRecords?: ReturnType<typeof vi.fn>;
+} = {}) {
+  return {
+    commonService: vi.fn().mockReturnValue({ call: vi.fn() }),
+    cloudrun: {
+      getDeployRecords: overrides.getDeployRecords ?? vi.fn().mockResolvedValue({
+        DeployRecords: [
+          {
+            DeployId: "d1",
+            DeployTime: "2026-08-17 10:00:00",
+            Status: "normal",
+            RunId: "run-latest",
+            BuildId: 200,
+            FlowRatio: 100,
+          },
+        ],
+      }),
+      getBuildLog: overrides.getBuildLog ?? vi.fn().mockResolvedValue({
+        Log: { Text: "build ok", More: false },
+        RequestId: "req-build",
+      }),
+      getProcessLog: overrides.getProcessLog ?? vi.fn().mockResolvedValue({
+        Logs: [
+          "create_version_check_vpc: success",
+          "create_eks_virtual_service: success",
+          "check_eks_virtual_service: success",
+          "s6-overlay: starting app",
+        ],
+        RequestId: "req-process",
+      }),
+    },
+  };
+}
+
+describe("queryCloudRun getProcessLog schema", () => {
+  it("exposes getProcessLog in the action enum (z.enum)", async () => {
+    const { tools } = await createCloudRunTools();
+    const actionEnum = tools.queryCloudRun.meta.inputSchema.action;
+    expect(actionEnum._def.values).toContain("getProcessLog");
+  });
+
+  it("documents getDeployLog as build log and getProcessLog as runtime log", async () => {
+    const { tools } = await createCloudRunTools();
+    const actionDesc = tools.queryCloudRun.meta.inputSchema.action.description as string;
+    expect(actionDesc).toMatch(/getDeployLog=.*构建日志/);
+    expect(actionDesc).toMatch(/getProcessLog=.*运行日志/);
+    expect(actionDesc).toMatch(/CODING/);
+    expect(tools.queryCloudRun.meta.inputSchema.runId).toBeDefined();
+    expect(tools.queryCloudRun.meta.description).toMatch(/getProcessLog/);
+  });
+
+  it("documents InitialDelaySeconds real readiness semantics", async () => {
+    const { tools } = await createCloudRunTools();
+    const serverConfig = tools.manageCloudRun.meta.inputSchema.serverConfig.unwrap();
+    const delayField = serverConfig.shape.InitialDelaySeconds;
+    // .describe() is attached to the optional wrapper
+    const delayDesc = (delayField.description ?? delayField.unwrap?.()?.description) as string;
+    expect(delayDesc).toMatch(/每 5s|每 5 秒/);
+    expect(delayDesc).toMatch(/30/);
+    expect(delayDesc).toMatch(/150/);
+    expect(delayDesc).toMatch(/不是/);
+  });
+});
+
+describe("queryCloudRun getProcessLog handler", () => {
+  it("calls SDK getProcessLog with explicit runId", async () => {
+    const manager = makeManager();
+    mockGetCloudBaseManager.mockReturnValue(manager);
+    const { tools } = await createCloudRunTools();
+
+    const res = await tools.queryCloudRun.handler({
+      action: "getProcessLog",
+      detailServerName: "my-svc",
+      runId: "run-explicit",
+    });
+    const parsed = parseToolResult(res);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.runId).toBe("run-explicit");
+    expect(parsed.data.processLogs).toHaveLength(4);
+    expect(parsed.data.processLogText).toContain("create_eks_virtual_service");
+    expect(manager.cloudrun.getProcessLog).toHaveBeenCalledWith({ RunId: "run-explicit" });
+  });
+
+  it("falls back to latest deploy RunId when runId is omitted", async () => {
+    const manager = makeManager();
+    mockGetCloudBaseManager.mockReturnValue(manager);
+    const { tools } = await createCloudRunTools();
+
+    const res = await tools.queryCloudRun.handler({
+      action: "getProcessLog",
+      detailServerName: "my-svc",
+    });
+    const parsed = parseToolResult(res);
+
+    expect(parsed.success).toBe(true);
+    expect(parsed.data.runId).toBe("run-latest");
+    expect(manager.cloudrun.getDeployRecords).toHaveBeenCalledWith({ serverName: "my-svc" });
+    expect(manager.cloudrun.getProcessLog).toHaveBeenCalledWith({ RunId: "run-latest" });
+  });
+
+  it("does not call getBuildLog (CODING) for getProcessLog", async () => {
+    const manager = makeManager();
+    mockGetCloudBaseManager.mockReturnValue(manager);
+    const { tools } = await createCloudRunTools();
+
+    await tools.queryCloudRun.handler({
+      action: "getProcessLog",
+      detailServerName: "my-svc",
+      runId: "run-1",
+    });
+
+    expect(manager.cloudrun.getBuildLog).not.toHaveBeenCalled();
+  });
+
+  it("returns a clear error when RunId cannot be resolved", async () => {
+    const manager = makeManager({
+      getDeployRecords: vi.fn().mockResolvedValue({ DeployRecords: [] }),
+    });
+    mockGetCloudBaseManager.mockReturnValue(manager);
+    const { tools } = await createCloudRunTools();
+
+    const res = await tools.queryCloudRun.handler({
+      action: "getProcessLog",
+      detailServerName: "empty-svc",
+    });
+    const parsed = parseToolResult(res);
+
+    expect(parsed.success).toBe(false);
+    expect(parsed.error).toMatch(/RunId/);
+    expect(manager.cloudrun.getProcessLog).not.toHaveBeenCalled();
+  });
+});

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -31,7 +31,7 @@ export type CloudRunPackageType = typeof CLOUDRUN_PACKAGE_TYPES[number];
 
 // Input schema for queryCloudRun tool
 const queryCloudRunInputSchema = {
-  action: z.enum(['list', 'detail', 'templates', 'getDeployLog', 'getDeployRecords', 'envStatus']).describe('查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取指定服务最近一次或指定构建的部署日志，getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪'),
+  action: z.enum(['list', 'detail', 'templates', 'getDeployLog', 'getProcessLog', 'getDeployRecords', 'envStatus']).describe('查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取构建日志（仅云端源码构建有意义，走 CODING/DescribeCloudRunBuildLog；已有镜像部署无构建过程；未登录 CODING 的账号会报错），getProcessLog=获取运行日志（部署阶段步骤+容器启动/运行日志，走 tcbr/DescribeCloudRunProcessLog；镜像部署与源码构建均可用，不依赖 CODING；RunId 来自 detail/getDeployRecords 的 latestDeploy.RunId），getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪'),
 
   // List operation parameters
   pageSize: z.number().min(1).max(100).optional().default(10).describe('分页大小，控制每页返回的服务数量。取值范围：1-100，默认值：10。建议根据网络性能和显示需求调整'),
@@ -41,8 +41,9 @@ const queryCloudRunInputSchema = {
   envId: z.string().optional().describe('环境 ID（action=envStatus 时使用；不传则使用当前配置的环境）。格式如 env-xxxxxx'),
 
   // Detail and log operation parameters
-  detailServerName: z.string().optional().describe('要查询详细信息、部署记录或部署日志的服务名称。当action为detail、getDeployLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表'),
-  buildId: z.number().optional().describe('构建ID，仅在action=getDeployLog时使用。不传时默认返回最近一次部署的构建日志'),
+  detailServerName: z.string().optional().describe('要查询详细信息、部署记录、构建日志或运行日志的服务名称。当action为detail、getDeployLog、getProcessLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表'),
+  buildId: z.number().optional().describe('构建ID，仅在action=getDeployLog时使用（构建日志，仅云端源码构建）。不传时默认返回最近一次部署的构建日志'),
+  runId: z.string().optional().describe('运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志'),
 };
 
 // Input schema for manageCloudRun tool
@@ -84,7 +85,7 @@ const ManageCloudRunInputSchema = {
     InternalDomain: z.string().optional().describe('内网域名配置，用于配置服务的内网访问域名。仅在启用内网访问时有效'),
     EntryPoint: z.array(z.string()).optional().describe('Dockerfile EntryPoint参数配置，仅容器型服务需要。指定容器启动时的入口程序数组，如["node","app.js"]'),
     Cmd: z.array(z.string()).optional().describe('Dockerfile Cmd参数配置，仅容器型服务需要。指定容器启动时的默认命令数组，如["npm","start"]'),
-    InitialDelaySeconds: z.number().min(0).optional().describe('延迟检测时间（秒），用于配置服务启动后的健康检查延迟。在此期间内不会将请求路由到该实例，适用于启动时间较长的服务'),
+    InitialDelaySeconds: z.number().min(0).optional().describe('端口健康检查初始延迟（秒）。部署完成后先等待 N 秒才开始端口探测，之后约每 5s 检查一次、连续约 30 次；30 次全失败才判定部署失败（约 150s 探测窗口），不是「N 秒后立即失败」。启动耗时长的应用建议调到 60–120'),
     LogType: z.string().optional().describe('日志类型配置，指定服务的日志收集类型。影响日志的采集方式和存储格式'),
     LogSetId: z.string().optional().describe('CLS日志集ID配置，指定日志服务（CLS）的日志集ID。需要先开通CLS日志服务'),
     LogTopicId: z.string().optional().describe('CLS日志主题ID配置，指定日志服务（CLS）的日志主题ID。需要先开通CLS日志服务'),
@@ -140,13 +141,14 @@ const ManageCloudRunInputSchema = {
 };
 
 type queryCloudRunInput = {
-  action: 'list' | 'detail' | 'templates' | 'getDeployLog' | 'getDeployRecords' | 'envStatus';
+  action: 'list' | 'detail' | 'templates' | 'getDeployLog' | 'getProcessLog' | 'getDeployRecords' | 'envStatus';
   pageSize?: number;
   pageNum?: number;
   serverName?: string;
   serverType?: CloudRunServiceType;
   detailServerName?: string;
   buildId?: number;
+  runId?: string;
   envId?: string;
 };
 
@@ -836,7 +838,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
     "queryCloudRun",
     {
       title: "查询 CloudRun 服务信息",
-      description: "查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取部署日志以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。",
+      description: "查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取构建日志（getDeployLog，仅云端源码构建/依赖 CODING）、获取运行日志（getProcessLog，镜像与源码部署均可/不依赖 CODING）、获取部署记录以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。",
       inputSchema: queryCloudRunInputSchema,
       annotations: {
         readOnlyHint: true,
@@ -939,7 +941,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
               if (!latestDeploy) {
                 message = `Retrieved details for service '${serverName}'. No deploy records found yet.`;
               } else if (typeof latestDeploy.Status === 'string' && latestDeploy.Status.includes('failed')) {
-                message = `Service '${serverName}' latest deploy failed. Please use queryCloudRun(action="getDeployLog") for details.`;
+                message = `Service '${serverName}' latest deploy failed. Use queryCloudRun(action="getProcessLog") for runtime/deploy-step logs (RunId from latestDeploy); use getDeployLog only for cloud source-build logs (CODING).`;
               } else if (typeof latestDeploy.Status === 'string' && latestDeploy.Status.includes('creating')) {
                 message = `Service '${serverName}' latest deploy is still running. Please check again later or query the deploy log for progress.`;
               } else {
@@ -1029,6 +1031,9 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
             }
 
             const buildId = input.buildId ?? latestDeploy.BuildId;
+            // Build log (CODING / DescribeCloudRunBuildLog). Meaningful only for
+            // cloud source builds; image deploys have no build process. Accounts
+            // without a CODING user may fail here — use getProcessLog for runtime logs.
             const buildLogResult: any = await cloudrunService.getBuildLog({
               serverName,
               buildId,
@@ -1062,11 +1067,101 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
                       buildId,
                       deployRecord: latestDeploy,
                       buildLog: buildLogResult?.Log || null,
+                      // Optional best-effort attach; prefer dedicated getProcessLog for runtime diagnosis
                       processLogs,
                       combinedLogText,
                       ...(processLogsWarning ? { processLogsWarning } : {})
                     },
-                    message: `Retrieved deploy log for service '${serverName}'`
+                    message: `Retrieved build log for service '${serverName}' (getDeployLog=构建日志; for 运行日志 use getProcessLog with RunId)`
+                  }, null, 2)
+                }
+              ]
+            };
+          }
+
+          case 'getProcessLog': {
+            const serverName = getCloudRunQueryServerName(input);
+
+            if (!serverName && !input.runId?.trim()) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      success: false,
+                      error: "runId is required, or provide detailServerName/serverName to resolve latest RunId",
+                      message: "Pass runId from detail/getDeployRecords latestDeploy.RunId, or provide a service name to use the latest deploy RunId."
+                    }, null, 2)
+                  }
+                ]
+              };
+            }
+
+            let runId = input.runId?.trim() || "";
+            let deployRecord: any = null;
+
+            if (serverName) {
+              const deployRecordsResult: any = await cloudrunService.getDeployRecords({ serverName });
+              const deployRecords = Array.isArray(deployRecordsResult?.DeployRecords)
+                ? deployRecordsResult.DeployRecords
+                : [];
+              deployRecord = deployRecords[0] ?? null;
+
+              if (!runId) {
+                runId = typeof deployRecord?.RunId === "string" ? deployRecord.RunId.trim() : "";
+              } else if (deployRecord?.RunId && deployRecord.RunId !== runId) {
+                // Keep latest deploy as context only; explicit runId wins
+              }
+            }
+
+            if (!runId) {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      success: false,
+                      error: serverName
+                        ? `Service '${serverName}' has no RunId on the latest deploy record.`
+                        : "runId is required for getProcessLog action",
+                      message: "Deploy the service first, then read RunId from queryCloudRun(action=\"detail\") or getDeployRecords (latestDeploy.RunId)."
+                    }, null, 2)
+                  }
+                ]
+              };
+            }
+
+            if (typeof cloudrunService.getProcessLog !== "function") {
+              throw new Error(
+                "Current CloudBase Manager SDK does not support getProcessLog; please upgrade @cloudbase/manager-node.",
+              );
+            }
+
+            const processLogResult: any = await cloudrunService.getProcessLog({
+              RunId: runId,
+            });
+            const processLogs = Array.isArray(processLogResult?.Logs)
+              ? processLogResult.Logs
+              : [];
+            const processLogText = processLogs.length > 0
+              ? normalizeProcessLogText(processLogs)
+              : "";
+
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: JSON.stringify({
+                    success: true,
+                    data: {
+                      serverName: serverName || undefined,
+                      runId,
+                      deployRecord,
+                      processLogs,
+                      processLogText,
+                      requestId: processLogResult?.RequestId,
+                    },
+                    message: `Retrieved process/runtime log for RunId='${runId}' (getProcessLog=运行日志; getDeployLog=构建日志且仅云端构建/依赖 CODING)`
                   }, null, 2)
                 }
               ]

--- a/plugin/cloudbase/skills/cloudrun-development/SKILL.md
+++ b/plugin/cloudbase/skills/cloudrun-development/SKILL.md
@@ -152,9 +152,29 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `queryCloudRun(action="list")` -> list services
 - `queryCloudRun(action="detail")` -> inspect one service and its latest deploy status when available
 - `queryCloudRun(action="templates")` -> see available starters
-- `queryCloudRun(action="getDeployLog")` -> retrieve the latest deploy log or a specified `buildId`
+- `queryCloudRun(action="getDeployLog")` -> **构建日志**（CODING / `DescribeCloudRunBuildLog`）。**仅云端源码构建有意义**；已有镜像部署（`imageUrl`）没有构建过程，不要用它诊断镜像部署失败。未登录 CODING 的账号会报错（如 `User not created or may not qcloud user`）
+- `queryCloudRun(action="getProcessLog")` -> **运行日志**（`tcbr/DescribeCloudRunProcessLog`）。返回部署阶段步骤（如 `create_version_check_vpc` / `create_eks_virtual_service` / `check_eks_virtual_service`）+ 容器启动/运行日志（s6-overlay、应用进程、readiness probe 失败原因）。**镜像部署与源码构建均可用，不依赖 CODING**。参数：`detailServerName`/`serverName` + 可选 `runId`（不传则取最新部署的 `RunId`；`RunId` 也可从 `detail` / `getDeployRecords` 的 `latestDeploy.RunId` 取得）
 - `queryCloudRun(action="getDeployRecords")` -> list deploy records (newest first; includes `BuildId` / `RunId` / `FlowRatio` / `Status`) — use to review release history and rollback context before a traffic operation
 - `queryCloudRun(action="envStatus")` -> check whether the environment's CloudRun is opened and its provisioning status (`Status=creating` opening / `normal` opened) — use after `initEnv` to poll progress or before `deploy` to confirm readiness
+
+### Log query SOP（构建日志 vs 运行日志）
+
+部署失败排查时**必须区分**两类日志，不要只用 `getDeployLog`：
+
+1. **云端源码构建**（传 `targetPath`、走 CODING 构建）  
+   - 先 `queryCloudRun(action="getDeployLog", detailServerName=..., buildId=...)` 查**构建日志**（编译/打包失败）  
+   - 再 `queryCloudRun(action="getProcessLog", detailServerName=..., runId=...)` 查**运行日志**（部署步骤 + 容器启动/健康检查）
+2. **已有镜像部署**（传 `imageUrl`、`DeployType=image`）  
+   - **跳过** `getDeployLog`（无构建过程；且依赖 CODING，未登录会直接失败）  
+   - 直接 `queryCloudRun(action="detail")` 或 `getDeployRecords` 取 `latestDeploy.RunId`，再 `getProcessLog` 查运行日志
+
+```json
+{
+  "action": "getProcessLog",
+  "detailServerName": "my-svc",
+  "runId": "<from latestDeploy.RunId>"
+}
+```
 
 ### Write operations
 
@@ -162,7 +182,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step` to poll with `queryCloudRun(action="getDeployLog", buildId=...)`. **Two ways**: source build via `targetPath`, or existing image via `imageUrl` — if the user specifies an image or says no rebuild is needed, **must pass `imageUrl`** (do not fall back to source build just because a local source dir exists). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step`. **Source builds**: poll `queryCloudRun(action="getDeployLog", buildId=...)` then `getProcessLog`. **Image deploys** (`imageUrl`): skip build log; poll status via `detail` and diagnose with `getProcessLog` (RunId from `latestDeploy`). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -204,7 +224,18 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 }
 ```
 
-部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。
+部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。镜像部署失败排查：**不要**调用 `getDeployLog`；用 `detail`/`getDeployRecords` 取 `latestDeploy.RunId` 后调用 `getProcessLog`。
+
+## InitialDelaySeconds（端口健康检查初始延迟）
+
+`serverConfig.InitialDelaySeconds` 的真实语义：
+
+1. **部署流程完成后**，先等待 **N 秒**，才开始对服务端口做健康检查（readiness）
+2. 之后大约 **每 5 秒检查一次**，连续约 **30 次**
+3. **30 次全部失败** 才判定本次部署失败（探测窗口大约 **150 秒**）
+4. **不是**「等 N 秒后立即失败」——把 N 设小并不会让失败更快判定到「秒级」
+
+容器启动耗时长的应用（JVM 预热、拉配置、迁移等）应把 `InitialDelaySeconds` 调到 **60–120**，避免还在启动就被判定失败。
 
 ## Access guidance
 
@@ -284,7 +315,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 
 - **Access failure** -> check ingress access type, domain setup, and whether the instance scaled to zero.
 - **Deployment blocked with "尚未初始化云托管 / not initialized"** -> the environment needs CloudRun enabled first: call `manageCloudRun(action="initEnv", envId=...)` (异步开通) and poll `queryCloudRun(action="envStatus")` until `Status=normal`; or open the console `环境 → 云托管 → 开通`. For stateless HTTP services, consider an HTTP cloud function instead of CloudRun entirely.
-- **Deployment failure** -> inspect Dockerfile, build logs, and CPU/memory ratio.
+- **Deployment failure** -> follow the **Log query SOP** above: source builds check `getDeployLog` then `getProcessLog`; image deploys skip build log and use `getProcessLog` only. Also inspect Dockerfile (source), CPU/memory ratio, and `InitialDelaySeconds` if readiness fails after slow startup.
 - **Local run failure** -> remember only Function mode is supported by local-run tools.
 - **Performance issues** -> reduce dependencies, optimize initialization, and tune minimum instances.
 - **DB / Redis connection failure after a successful deploy** -> almost always missing or wrong `VpcConf`, wrong private host, or security group. Follow `references/vpc-and-database.md` before rewriting application code.

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2253,7 +2253,7 @@
     },
     {
       "name": "queryCloudRun",
-      "description": "查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取部署日志以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。",
+      "description": "查询云托管服务信息，支持获取服务列表、查询服务详情、获取可用模板列表、获取构建日志（getDeployLog，仅云端源码构建/依赖 CODING）、获取运行日志（getProcessLog，镜像与源码部署均可/不依赖 CODING）、获取部署记录以及查询环境云托管开通状态（envStatus）。返回的服务信息包括服务名称、状态、访问类型、配置详情以及最近部署上下文。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2264,10 +2264,11 @@
               "detail",
               "templates",
               "getDeployLog",
+              "getProcessLog",
               "getDeployRecords",
               "envStatus"
             ],
-            "description": "查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取指定服务最近一次或指定构建的部署日志，getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪"
+            "description": "查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取构建日志（仅云端源码构建有意义，走 CODING/DescribeCloudRunBuildLog；已有镜像部署无构建过程；未登录 CODING 的账号会报错），getProcessLog=获取运行日志（部署阶段步骤+容器启动/运行日志，走 tcbr/DescribeCloudRunProcessLog；镜像部署与源码构建均可用，不依赖 CODING；RunId 来自 detail/getDeployRecords 的 latestDeploy.RunId），getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪"
           },
           "pageSize": {
             "type": "number",
@@ -2300,11 +2301,15 @@
           },
           "detailServerName": {
             "type": "string",
-            "description": "要查询详细信息、部署记录或部署日志的服务名称。当action为detail、getDeployLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表"
+            "description": "要查询详细信息、部署记录、构建日志或运行日志的服务名称。当action为detail、getDeployLog、getProcessLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表"
           },
           "buildId": {
             "type": "number",
-            "description": "构建ID，仅在action=getDeployLog时使用。不传时默认返回最近一次部署的构建日志"
+            "description": "构建ID，仅在action=getDeployLog时使用（构建日志，仅云端源码构建）。不传时默认返回最近一次部署的构建日志"
+          },
+          "runId": {
+            "type": "string",
+            "description": "运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志"
           }
         },
         "required": [
@@ -2511,7 +2516,7 @@
               "InitialDelaySeconds": {
                 "type": "number",
                 "minimum": 0,
-                "description": "延迟检测时间（秒），用于配置服务启动后的健康检查延迟。在此期间内不会将请求路由到该实例，适用于启动时间较长的服务"
+                "description": "端口健康检查初始延迟（秒）。部署完成后先等待 N 秒才开始端口探测，之后约每 5s 检查一次、连续约 30 次；30 次全失败才判定部署失败（约 150s 探测窗口），不是「N 秒后立即失败」。启动耗时长的应用建议调到 60–120"
               },
               "LogType": {
                 "type": "string",


### PR DESCRIPTION
## Summary
- Add `queryCloudRun` action `getProcessLog` to query CloudRun **runtime/deploy process logs** (distinct from `getBuildLog` build logs).
- Update `cloudrun-development` skill SOP for dual-log troubleshooting and clarify `InitialDelaySeconds` semantics.
- Sync MCP schema/docs (`scripts/tools.json`, `doc/mcp-tools.md`) and add unit tests for the new action.

## Context
Image/container deploys often have no build log (`getBuildLog` → build not exist). Agents need `getProcessLog` to inspect deploy steps such as `create_version_check_vpc`.

## Test plan
- [ ] Unit tests for `getProcessLog` handler/schema pass
- [ ] Schema documents distinguish `getBuildLog` vs `getProcessLog`
- [ ] Skill SOP instructs: build failure → `getBuildLog`; runtime/deploy failure or image deploy → `getProcessLog`
- [ ] Manual: image deploy can return process steps via `getProcessLog`


Made with [Cursor](https://cursor.com)