### PR TITLE
feat(cloudrun): 🧭 branch manageCloudRun deploy next_step for image vs source

### DIFF
--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -182,7 +182,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - `manageCloudRun(action="init")` -> create local project
 - `manageCloudRun(action="download")` -> pull remote code
 - `manageCloudRun(action="run")` -> local run for Function mode
-- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for BuildId registration** (does not hang for full build). Returns `buildId` / `taskId` + `next_step`. **Source builds**: poll `queryCloudRun(action="getDeployLog", buildId=...)` then `getProcessLog`. **Image deploys** (`imageUrl`): skip build log; poll status via `detail` and diagnose with `getProcessLog` (RunId from `latestDeploy`). Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
+- `manageCloudRun(action="deploy")` -> trigger deploy + **lightweight wait for registration** (does not hang for full build). Returns `buildId` / `runId` / `taskId` + **DeployType-aware `next_step`**: **source** → `getDeployLog` then `getProcessLog`; **image** (`imageUrl`, BuildId often `0`) → **skip `getDeployLog`**, use `getDeployRecords`/`detail` for `RunId` then `getProcessLog`. Follow the returned `next_step` — do not always poll build logs. Existing services: RMW preserves remote VpcConf / EnvParams keys / OpenAccessTypes; **new services automatically validate that the environment's CloudRun is initialized** — if not, deploy is blocked with guidance to call `initEnv` first
 - `manageCloudRun(action="updateConfig")` -> config-only update (no code upload; VPC / EnvParams / scaling / access types)
 - `manageCloudRun(action="traffic")` -> **traffic management / canary release** (aligns with `tcb cloudrun traffic`): `trafficOp="set"` adjusts the stable/canary traffic ratio (`stablePercent` + `canaryPercent` must equal 100, e.g. 90/10); `trafficOp="promote"` promotes the canary version to full release (100%, closes gray release, irreversible); `trafficOp="rollback"` rolls back to the previous stable version (stops the releasing canary). Check `queryCloudRun(action="getDeployRecords")` first to understand current versions and traffic
 - `manageCloudRun(action="delete")` -> delete service
@@ -224,7 +224,7 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 }
 ```
 
-部署后可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。镜像部署失败排查：**不要**调用 `getDeployLog`；用 `detail`/`getDeployRecords` 取 `latestDeploy.RunId` 后调用 `getProcessLog`。
+部署后：`manageCloudRun(deploy)` 对镜像返回的 `next_step` 默认指向 `getProcessLog`（或先 `getDeployRecords` 取 `RunId`），**不要**改去调 `getDeployLog`。也可用 `queryCloudRun(action="detail")` 查看 `imageInfo`（镜像地址与部署类型）。镜像部署失败排查同样走 `getProcessLog`。
 
 ## InitialDelaySeconds（端口健康检查初始延迟）
 

--- a/mcp/src/tools/cloudrun-deploy-registration.test.ts
+++ b/mcp/src/tools/cloudrun-deploy-registration.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 import {
+  buildCloudRunDeployNextStep,
   isValidCloudRunBuildId,
+  isValidCloudRunRunId,
   waitForCloudRunDeployRegistration,
 } from "./cloudrun.js";
 
@@ -13,6 +15,61 @@ describe("isValidCloudRunBuildId", () => {
     expect(isValidCloudRunBuildId(undefined)).toBe(false);
     expect(isValidCloudRunBuildId("12")).toBe(false);
     expect(isValidCloudRunBuildId(Number.NaN)).toBe(false);
+  });
+});
+
+describe("isValidCloudRunRunId", () => {
+  it("accepts non-empty strings only", () => {
+    expect(isValidCloudRunRunId("run-1")).toBe(true);
+    expect(isValidCloudRunRunId("  run-2  ")).toBe(true);
+    expect(isValidCloudRunRunId("")).toBe(false);
+    expect(isValidCloudRunRunId("   ")).toBe(false);
+    expect(isValidCloudRunRunId(undefined)).toBe(false);
+    expect(isValidCloudRunRunId(12)).toBe(false);
+  });
+});
+
+describe("buildCloudRunDeployNextStep", () => {
+  it("routes image deploy to getProcessLog when RunId is ready", () => {
+    expect(
+      buildCloudRunDeployNextStep({
+        deployType: "image",
+        serverName: "svc",
+        runId: "run-abc",
+        registered: true,
+      }),
+    ).toMatchObject({
+      action: "getProcessLog",
+      suggested_args: {
+        action: "getProcessLog",
+        detailServerName: "svc",
+        runId: "run-abc",
+      },
+    });
+  });
+
+  it("routes image deploy without RunId to getDeployRecords", () => {
+    expect(
+      buildCloudRunDeployNextStep({
+        deployType: "image",
+        serverName: "svc",
+        registered: true,
+      }),
+    ).toMatchObject({
+      action: "getDeployRecords",
+    });
+  });
+
+  it("routes source deploy to getDeployLog and mentions getProcessLog", () => {
+    const step = buildCloudRunDeployNextStep({
+      deployType: "source",
+      serverName: "svc",
+      buildId: 88,
+      registered: true,
+    });
+    expect(step.action).toBe("getDeployLog");
+    expect(step.suggested_args.buildId).toBe(88);
+    expect(step.note).toMatch(/getProcessLog/);
   });
 });
 
@@ -53,6 +110,36 @@ describe("waitForCloudRunDeployRegistration", () => {
         TaskId: 0,
       },
     });
+  });
+
+  it("image mode returns on RunId even when BuildId is 0", async () => {
+    const call = vi.fn().mockResolvedValue({
+      Task: { Id: 11, Status: "running" },
+    });
+    const getDeployRecords = vi.fn().mockResolvedValue({
+      DeployRecords: [{ BuildId: 0, RunId: "run-img-9", Status: "creating" }],
+    });
+    const sleepFn = vi.fn().mockResolvedValue(undefined);
+
+    const result = await waitForCloudRunDeployRegistration({
+      manager: { commonService: () => ({ call }) },
+      cloudrunService: { getDeployRecords },
+      envId: "env-test",
+      serverName: "svc-img",
+      mode: "image",
+      maxWaitMs: 30_000,
+      intervalMs: 3_000,
+      sleepFn,
+    });
+
+    expect(result).toMatchObject({
+      registered: true,
+      timedOut: false,
+      taskId: 11,
+      runId: "run-img-9",
+    });
+    expect(result.buildId).toBeUndefined();
+    expect(sleepFn).not.toHaveBeenCalled();
   });
 
   it("keeps polling until BuildId > 0 even if Task.Id appears first", async () => {

--- a/mcp/src/tools/cloudrun-image-deploy.test.ts
+++ b/mcp/src/tools/cloudrun-image-deploy.test.ts
@@ -51,6 +51,7 @@ function makeManager(options: {
   detailImpl?: (params: { serverName: string }) => Promise<any>;
   deployImpl?: (params: any) => Promise<any>;
   buildId?: number;
+  runId?: string;
 } = {}): ManagerMock {
   const {
     envStatus = "normal",
@@ -60,6 +61,7 @@ function makeManager(options: {
     },
     deployImpl = async () => ({}),
     buildId = 9001,
+    runId = "run-image-1",
   } = options;
   return {
     commonService: vi.fn().mockReturnValue({
@@ -88,7 +90,13 @@ function makeManager(options: {
       deploy: vi.fn(deployImpl),
       detail: vi.fn(detailImpl),
       getDeployRecords: vi.fn(async () => ({
-        DeployRecords: [{ BuildId: buildId, Status: "building" }],
+        DeployRecords: [
+          {
+            BuildId: buildId,
+            RunId: runId,
+            Status: buildId > 0 ? "building" : "creating",
+          },
+        ],
       })),
     },
   };
@@ -112,7 +120,8 @@ describe("manageCloudRun deploy imageUrl branch", () => {
   });
 
   it("forwards imageUrl to SDK deploy params (DeployType=image) and allows omitting targetPath", async () => {
-    const manager = makeManager();
+    // Image deploys typically have BuildId=0; registration waits for RunId instead.
+    const manager = makeManager({ buildId: 0, runId: "run-hermes-1" });
     mockGetCloudBaseManager.mockReturnValue(manager);
     const { tools } = await createCloudRunTools();
 
@@ -136,7 +145,8 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     expect(parsed.data.deployPath).toBeUndefined();
     expect(parsed.data.cloudbasercGenerated).toBe(false);
     expect(parsed.data.status).toBe("deploying");
-    expect(parsed.data.buildId).toBe(9001);
+    expect(parsed.data.buildId).toBeUndefined();
+    expect(parsed.data.runId).toBe("run-hermes-1");
     expect(parsed.data.taskId).toBe(42);
     expect(parsed.data.registration).toMatchObject({
       registered: true,
@@ -144,13 +154,16 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     });
     expect(parsed.data.next_step).toMatchObject({
       tool: "queryCloudRun",
-      action: "getDeployLog",
+      action: "getProcessLog",
       suggested_args: {
-        action: "getDeployLog",
+        action: "getProcessLog",
         detailServerName: "hermes-agent",
-        buildId: 9001,
+        runId: "run-hermes-1",
       },
     });
+    expect(parsed.data.next_step.note).toMatch(/skip getDeployLog/i);
+    expect(parsed.message).toMatch(/getProcessLog/);
+    expect(parsed.message).not.toMatch(/getDeployLog.*build progress/);
     expect(manager.cloudrun.getDeployRecords).toHaveBeenCalled();
 
     const deployCall = manager.cloudrun.deploy.mock.calls[0][0];
@@ -173,8 +186,8 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     const schema = tools.manageCloudRun.meta.inputSchema;
     expect(schema.imageUrl.description).toMatch(/必须传 imageUrl|不要回退到源码构建/);
     expect(schema.targetPath.description).toMatch(/优先传 imageUrl|不等于必须走源码构建/);
-    expect(schema.action.description).toMatch(/轻量等待|getDeployLog/);
-    expect(tools.manageCloudRun.meta.description).toMatch(/轻量等待任务注册|buildId/);
+    expect(schema.action.description).toMatch(/getProcessLog|跳过 getDeployLog/);
+    expect(tools.manageCloudRun.meta.description).toMatch(/getProcessLog|跳过 getDeployLog/);
   });
 
   it("auto-fills vpcInfo from env DescribeEnvBaseInfo when VpcConf is omitted", async () => {
@@ -217,7 +230,7 @@ describe("manageCloudRun deploy imageUrl branch", () => {
   });
 
   it("keeps source-build behavior when imageUrl is absent (targetPath required)", async () => {
-    const manager = makeManager();
+    const manager = makeManager({ buildId: 9001, runId: "run-src-1" });
     mockGetCloudBaseManager.mockReturnValue(manager);
     const { tools } = await createCloudRunTools();
 
@@ -233,6 +246,17 @@ describe("manageCloudRun deploy imageUrl branch", () => {
     expect(parsed.success).toBe(true);
     expect(parsed.data.deployType).toBe("source");
     expect(parsed.data.imageUrl).toBeUndefined();
+    expect(parsed.data.buildId).toBe(9001);
+    expect(parsed.data.next_step).toMatchObject({
+      tool: "queryCloudRun",
+      action: "getDeployLog",
+      suggested_args: {
+        action: "getDeployLog",
+        detailServerName: "my-svc",
+        buildId: 9001,
+      },
+    });
+    expect(parsed.data.next_step.note).toMatch(/getProcessLog/);
 
     const deployCall = manager.cloudrun.deploy.mock.calls[0][0];
     expect(deployCall.imageUrl).toBeUndefined();

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -48,7 +48,7 @@ const queryCloudRunInputSchema = {
 
 // Input schema for manageCloudRun tool
 const ManageCloudRunInputSchema = {
-  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent', 'updateConfig', 'initEnv', 'traffic']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=触发部署并轻量等待任务注册（返回 buildId；不会 hang 等构建完成；构建进度请用 queryCloudRun(action=getDeployLog, buildId=...) 轮询）。支持函数型/容器型；传 imageUrl 时改为已有镜像部署（DeployType=image，targetPath 可省略）；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）'),
+  action: z.enum(['init', 'download', 'run', 'deploy', 'delete', 'createAgent', 'updateConfig', 'initEnv', 'traffic']).describe('云托管服务管理操作类型：init=从模板初始化新的云托管项目代码（在targetPath目录下创建以serverName命名的子目录，支持多种语言和框架模板），download=从云端下载现有服务的代码到本地进行开发，run=在本地运行函数型云托管服务（用于开发和调试，仅支持函数型服务），deploy=触发部署并轻量等待任务注册（不会 hang 等完整构建）。源码构建（targetPath）返回 buildId，用 getDeployLog 轮询后再 getProcessLog；已有镜像部署（imageUrl，DeployType=image，BuildId 常为 0）跳过 getDeployLog，用 detail/getDeployRecords 取 RunId 后 getProcessLog。传 imageUrl 时 targetPath 可省略；已存在服务会 Read-Merge-Write 保留远程 VpcConf/EnvParams/OpenAccessTypes），updateConfig=仅更新服务配置不重新上传代码（对齐控制台服务设置，走 SubmitServerConfigChangeDiff；不需要 targetPath），delete=删除指定的云托管服务（不可恢复，需要确认），createAgent=创建函数型Agent（基于函数型云托管开发AI智能体），initEnv=开通当前环境的云托管（异步创建云托管环境，幂等：已开通直接返回；适合新环境首次部署前使用），traffic=流量管理与灰度发布（set=调整稳定版/灰度版流量比例，promote=将灰度版本升级为全量，rollback=回滚到上一个稳定版本；对应 tcb cloudrun traffic 命令）'),
   serverName: z.string().describe('云托管服务名称，用于标识和管理服务。命名规则：支持大小写字母、数字、连字符和下划线，必须以字母开头，长度3-45个字符。在init操作中会作为在targetPath下创建的子目录名，在其他操作中作为目标服务名。initEnv 操作不需要此参数'),
 
   // Traffic management operation parameters (action=traffic)
@@ -280,21 +280,33 @@ export function buildManageCloudRunErrorMessage(action: ManageCloudRunInput["act
 
 /**
  * Lightweight wait after manageCloudRun deploy: poll until the platform has
- * registered the manage task / assigned a BuildId so getDeployLog works.
- * Does NOT wait for the full build (that can take 5–30 minutes).
+ * registered the manage task / assigned identifiers for follow-up log queries.
+ * - source builds: prefer BuildId > 0 (getDeployLog)
+ * - image deploys: prefer RunId (getProcessLog; BuildId is often 0)
+ * Does NOT wait for the full build/deploy (that can take 5–30 minutes).
  * Aligns with tcb CLI's DescribeServerManageTask polling entrypoint, but with
  * a short timeout suitable for MCP tool calls.
  */
 export const CLOUDRUN_DEPLOY_REGISTRATION_MAX_WAIT_MS = 45_000;
 export const CLOUDRUN_DEPLOY_REGISTRATION_INTERVAL_MS = 3_000;
 
+export type CloudRunDeployRegistrationMode = "source" | "image";
+
 export type CloudRunDeployRegistration = {
   registered: boolean;
   timedOut: boolean;
   taskId?: number;
   buildId?: number;
+  runId?: string;
   taskStatus?: string;
   waitMs: number;
+};
+
+export type CloudRunDeployNextStep = {
+  tool: "queryCloudRun";
+  action: "getDeployLog" | "getProcessLog" | "getDeployRecords";
+  suggested_args: Record<string, string | number>;
+  note?: string;
 };
 
 function sleepMs(ms: number): Promise<void> {
@@ -303,6 +315,10 @@ function sleepMs(ms: number): Promise<void> {
 
 export function isValidCloudRunBuildId(value: unknown): value is number {
   return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
+export function isValidCloudRunRunId(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
 }
 
 function extractServerManageTaskInfo(resp: unknown): {
@@ -330,9 +346,11 @@ function extractServerManageTaskInfo(resp: unknown): {
 }
 
 /**
- * Poll DescribeServerManageTask + getDeployRecords until BuildId > 0
- * (preferred) or a manage task Id appears. Returns early on BuildId;
- * if only taskId is seen, keeps polling for BuildId until maxWaitMs.
+ * Poll DescribeServerManageTask + getDeployRecords until the preferred
+ * identifier appears:
+ * - source (default): BuildId > 0 for getDeployLog
+ * - image: RunId for getProcessLog (BuildId is often 0)
+ * If only taskId is seen, keeps polling for the preferred id until maxWaitMs.
  */
 export async function waitForCloudRunDeployRegistration(options: {
   manager: {
@@ -346,10 +364,12 @@ export async function waitForCloudRunDeployRegistration(options: {
   };
   envId: string;
   serverName: string;
+  mode?: CloudRunDeployRegistrationMode;
   maxWaitMs?: number;
   intervalMs?: number;
   sleepFn?: (ms: number) => Promise<void>;
 }): Promise<CloudRunDeployRegistration> {
+  const mode = options.mode ?? "source";
   const maxWaitMs = options.maxWaitMs ?? CLOUDRUN_DEPLOY_REGISTRATION_MAX_WAIT_MS;
   const intervalMs = options.intervalMs ?? CLOUDRUN_DEPLOY_REGISTRATION_INTERVAL_MS;
   const sleepFn = options.sleepFn ?? sleepMs;
@@ -358,6 +378,7 @@ export async function waitForCloudRunDeployRegistration(options: {
   let lastTaskId: number | undefined;
   let lastTaskStatus: string | undefined;
   let lastBuildId: number | undefined;
+  let lastRunId: string | undefined;
 
   // Immediate first probe, then interval retries until timeout.
   for (;;) {
@@ -389,22 +410,31 @@ export async function waitForCloudRunDeployRegistration(options: {
       try {
         const recordsResult = (await options.cloudrunService.getDeployRecords({
           serverName: options.serverName,
-        })) as { DeployRecords?: Array<{ BuildId?: number }> };
+        })) as { DeployRecords?: Array<{ BuildId?: number; RunId?: string }> };
         const latest = recordsResult?.DeployRecords?.[0];
         if (isValidCloudRunBuildId(latest?.BuildId)) {
           lastBuildId = latest.BuildId;
+        }
+        if (isValidCloudRunRunId(latest?.RunId)) {
+          lastRunId = latest.RunId.trim();
         }
       } catch {
         // Deploy record may lag behind task registration; retry.
       }
     }
 
-    if (isValidCloudRunBuildId(lastBuildId)) {
+    const preferredReady =
+      mode === "image"
+        ? isValidCloudRunRunId(lastRunId)
+        : isValidCloudRunBuildId(lastBuildId);
+
+    if (preferredReady) {
       return {
         registered: true,
         timedOut: false,
         taskId: lastTaskId,
-        buildId: lastBuildId,
+        ...(isValidCloudRunBuildId(lastBuildId) ? { buildId: lastBuildId } : {}),
+        ...(isValidCloudRunRunId(lastRunId) ? { runId: lastRunId } : {}),
         taskStatus: lastTaskStatus,
         waitMs: Date.now() - startAt,
       };
@@ -418,16 +448,116 @@ export async function waitForCloudRunDeployRegistration(options: {
 
   const registered =
     isValidCloudRunBuildId(lastBuildId) ||
+    isValidCloudRunRunId(lastRunId) ||
     (typeof lastTaskId === "number" && lastTaskId > 0);
 
   return {
     registered,
     timedOut: true,
     taskId: lastTaskId,
-    buildId: lastBuildId,
+    ...(isValidCloudRunBuildId(lastBuildId) ? { buildId: lastBuildId } : {}),
+    ...(isValidCloudRunRunId(lastRunId) ? { runId: lastRunId } : {}),
     taskStatus: lastTaskStatus,
     waitMs: Date.now() - startAt,
   };
+}
+
+/**
+ * Build manageCloudRun(deploy) next_step by DeployType:
+ * - source: getDeployLog (+ follow-up getProcessLog)
+ * - image: skip getDeployLog; getProcessLog via RunId (or getDeployRecords first)
+ */
+export function buildCloudRunDeployNextStep(options: {
+  deployType: CloudRunDeployRegistrationMode;
+  serverName: string;
+  buildId?: number;
+  runId?: string;
+  registered: boolean;
+}): CloudRunDeployNextStep {
+  const { deployType, serverName, registered } = options;
+
+  if (deployType === "image") {
+    if (isValidCloudRunRunId(options.runId)) {
+      return {
+        tool: "queryCloudRun",
+        action: "getProcessLog",
+        suggested_args: {
+          action: "getProcessLog",
+          detailServerName: serverName,
+          runId: options.runId.trim(),
+        },
+        note: "Image deploy has no CODING build process; skip getDeployLog. Poll getProcessLog for deploy-step and container runtime logs.",
+      };
+    }
+    return {
+      tool: "queryCloudRun",
+      action: "getDeployRecords",
+      suggested_args: {
+        action: "getDeployRecords",
+        detailServerName: serverName,
+      },
+      note: registered
+        ? "Image deploy: read latestDeploy.RunId, then queryCloudRun(action=\"getProcessLog\", runId=...). Skip getDeployLog."
+        : "Image deploy registration still queueing; retry getDeployRecords for RunId, then getProcessLog. Skip getDeployLog.",
+    };
+  }
+
+  if (isValidCloudRunBuildId(options.buildId)) {
+    return {
+      tool: "queryCloudRun",
+      action: "getDeployLog",
+      suggested_args: {
+        action: "getDeployLog",
+        detailServerName: serverName,
+        buildId: options.buildId,
+      },
+      note: "Source build: poll getDeployLog for build progress, then getProcessLog (RunId from detail/getDeployRecords) for runtime/deploy-step logs.",
+    };
+  }
+
+  return {
+    tool: "queryCloudRun",
+    action: "getDeployLog",
+    suggested_args: {
+      action: "getDeployLog",
+      detailServerName: serverName,
+    },
+    note: registered
+      ? "BuildId not yet available; omit buildId to use the latest deploy record. After build, use getProcessLog for runtime logs."
+      : "Registration timed out; wait a moment then retry getDeployLog, or open consoleUrl. After build, use getProcessLog for runtime logs.",
+  };
+}
+
+export function buildCloudRunDeployProgressHint(options: {
+  deployType: CloudRunDeployRegistrationMode;
+  serverName: string;
+  buildId?: number;
+  runId?: string;
+  registered: boolean;
+  timedOut: boolean;
+  waitMs: number;
+  consoleUrl: string;
+  taskId?: number;
+}): string {
+  const { deployType, serverName, consoleUrl } = options;
+
+  if (deployType === "image") {
+    if (isValidCloudRunRunId(options.runId)) {
+      return ` Image deploy: use queryCloudRun(action="getProcessLog", detailServerName="${serverName}", runId="${options.runId.trim()}") for runtime/deploy-step logs (skip getDeployLog).`;
+    }
+    if (options.registered) {
+      return ` Image deploy registered${typeof options.taskId === "number" ? ` (taskId=${options.taskId})` : ""}; RunId not yet available — use queryCloudRun(action="getDeployRecords", detailServerName="${serverName}") then getProcessLog (skip getDeployLog), or check ${consoleUrl}.`;
+    }
+    return ` Image deploy registration timed out after ${Math.round(options.waitMs / 1000)}s — retry getDeployRecords for RunId then getProcessLog (skip getDeployLog), or check ${consoleUrl}.`;
+  }
+
+  if (isValidCloudRunBuildId(options.buildId)) {
+    return ` Use queryCloudRun(action="getDeployLog", detailServerName="${serverName}", buildId=${options.buildId}) to poll build progress, then getProcessLog for runtime logs.`;
+  }
+  if (options.registered) {
+    return ` Task registered (taskId=${options.taskId ?? "unknown"}); BuildId not yet available — retry queryCloudRun(action="getDeployLog", detailServerName="${serverName}") shortly, then getProcessLog, or check ${consoleUrl}.`;
+  }
+  return ` Build registration timed out after ${Math.round(options.waitMs / 1000)}s — deployment may still be queueing. Check ${consoleUrl} or retry queryCloudRun(action="getDeployLog", detailServerName="${serverName}") later.`;
 }
 
 const CLOUDRUN_DB_ENV_KEY_PATTERN =
@@ -1287,7 +1417,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
     "manageCloudRun",
     {
       title: "管理 CloudRun 服务",
-      description: "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 语义为「触发部署 + 轻量等待任务注册」（最多约 45s，对齐 tcb CLI 的 DescribeServerManageTask 轮询起点），返回 buildId；不会 hang 等待完整构建（5–30min）。拿到 buildId 后请用 queryCloudRun(action=\"getDeployLog\", buildId=...) 轮询构建进度。若用户明确指定镜像或无需重新构建，必须传 imageUrl，不要仅因本地有源码目录就回退到源码构建。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
+      description: "管理云托管服务，按开发顺序支持：开通云托管环境（initEnv）、初始化项目（可从模板开始，模板列表可通过 queryCloudRun 查询）、下载服务代码、本地运行（仅函数型服务）、部署代码、仅更新配置（updateConfig，无需重新上传代码）、删除服务。deploy 支持两种方式：1) 源码构建（传入 targetPath，本地代码打包上传，默认路径）；2) 已有镜像部署（传入 imageUrl，如 ccr.ccs.tencentyun.com/ns/img:v1，走 DeployType=image 容器型部署，targetPath 可省略）。deploy 语义为「触发部署 + 轻量等待任务注册」（最多约 45s）。源码构建返回 buildId，用 getDeployLog 轮询构建进度后再 getProcessLog；镜像部署（imageUrl）BuildId 常为 0，跳过 getDeployLog，返回 runId/next_step 引导 getProcessLog（或先 getDeployRecords 取 RunId）。若用户明确指定镜像或无需重新构建，必须传 imageUrl，不要仅因本地有源码目录就回退到源码构建。deploy 对已存在服务会先读取远程配置再合并（保留 VpcConf/EnvParams/OpenAccessTypes）。updateConfig 对齐控制台服务设置页。删除操作需要确认，建议设置force=true。新环境首次部署前若提示未开通云托管，先调用 initEnv 开通（异步、幂等）。",
       inputSchema: ManageCloudRunInputSchema,
       annotations: {
         readOnlyHint: false,
@@ -1849,13 +1979,17 @@ for await (let x of res.textStream) {
             // Generate cloudbaserc.json configuration file (source-build only; image deploy has no local project dir)
             const currentEnvId = await getEnvId(cloudBaseOptions);
 
-            // Lightweight wait for task/BuildId registration (not full build completion).
-            // Prevents immediate getDeployLog "build not found" after deploy returns.
+            // Lightweight wait for task / BuildId (source) or RunId (image) registration.
+            // Does not wait for full build/deploy completion.
+            const deployType: CloudRunDeployRegistrationMode = input.imageUrl
+              ? "image"
+              : "source";
             const registration = await waitForCloudRunDeployRegistration({
               manager,
               cloudrunService,
               envId: currentEnvId,
               serverName: input.serverName,
+              mode: deployType,
             });
 
             let cloudbasercGenerated = false;
@@ -1939,33 +2073,25 @@ for await (let x of res.textStream) {
               ? ` Warning: ${dbNetworkRisk.message} Set serverConfig.VpcConf before relying on DB connectivity.`
               : "";
 
-            const buildIdHint = isValidCloudRunBuildId(registration.buildId)
-              ? ` Use queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}", buildId=${registration.buildId}) to poll build progress.`
-              : registration.registered
-                ? ` Task registered (taskId=${registration.taskId ?? "unknown"}); BuildId not yet available — retry queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}") shortly, or check ${consoleUrl}.`
-                : ` Build registration timed out after ${Math.round(registration.waitMs / 1000)}s — deployment may still be queueing. Check ${consoleUrl} or retry queryCloudRun(action="getDeployLog", detailServerName="${input.serverName}") later.`;
+            const progressHint = buildCloudRunDeployProgressHint({
+              deployType,
+              serverName: input.serverName,
+              buildId: registration.buildId,
+              runId: registration.runId,
+              registered: registration.registered,
+              timedOut: registration.timedOut,
+              waitMs: registration.waitMs,
+              consoleUrl,
+              taskId: registration.taskId,
+            });
 
-            const nextStep = isValidCloudRunBuildId(registration.buildId)
-              ? {
-                  tool: "queryCloudRun",
-                  action: "getDeployLog",
-                  suggested_args: {
-                    action: "getDeployLog",
-                    detailServerName: input.serverName,
-                    buildId: registration.buildId,
-                  },
-                }
-              : {
-                  tool: "queryCloudRun",
-                  action: "getDeployLog",
-                  suggested_args: {
-                    action: "getDeployLog",
-                    detailServerName: input.serverName,
-                  },
-                  note: registration.registered
-                    ? "BuildId not yet available; omit buildId to use the latest deploy record, or check consoleUrl."
-                    : "Registration timed out; wait a moment then retry getDeployLog, or open consoleUrl.",
-                };
+            const nextStep = buildCloudRunDeployNextStep({
+              deployType,
+              serverName: input.serverName,
+              buildId: registration.buildId,
+              runId: registration.runId,
+              registered: registration.registered,
+            });
 
             return {
               content: [
@@ -1976,7 +2102,7 @@ for await (let x of res.textStream) {
                     data: {
                       serviceName: input.serverName,
                       status: 'deploying',
-                      deployType: input.imageUrl ? 'image' : 'source',
+                      deployType,
                       ...(targetPath ? { deployPath: targetPath } : {}),
                       ...(input.imageUrl ? { imageUrl: input.imageUrl } : {}),
                       serverType: serverType,
@@ -1984,6 +2110,9 @@ for await (let x of res.textStream) {
                       consoleUrl,
                       ...(isValidCloudRunBuildId(registration.buildId)
                         ? { buildId: registration.buildId }
+                        : {}),
+                      ...(isValidCloudRunRunId(registration.runId)
+                        ? { runId: registration.runId }
                         : {}),
                       ...(typeof registration.taskId === "number"
                         ? { taskId: registration.taskId }
@@ -2020,7 +2149,7 @@ for await (let x of res.textStream) {
                       // Keep raw SDK result for debugging without implying build finished.
                       ...(result != null ? { deployAccepted: true } : {}),
                     },
-                    message: `Triggered deployment for ${serverType} service '${input.serverName}' ${input.imageUrl ? `from image ${input.imageUrl}` : `from ${targetPath}`}. Deployment is registering/building (status=deploying); this call does not wait for full build completion.${buildIdHint}${warningSuffix}`
+                    message: `Triggered deployment for ${serverType} service '${input.serverName}' ${input.imageUrl ? `from image ${input.imageUrl}` : `from ${targetPath}`}. Deployment is registering/${deployType === "image" ? "starting" : "building"} (status=deploying); this call does not wait for full completion.${progressHint}${warningSuffix}`
                   }, null, 2)
                 }
               ]


### PR DESCRIPTION
## Summary
- Branch `manageCloudRun(deploy)` `next_step` by DeployType: image deploys guide `queryCloudRun(getProcessLog)` (or `getDeployRecords` when RunId is missing); source builds keep `getDeployLog` and note follow-up `getProcessLog`.
- Extend deploy registration wait so image deploys treat a valid `RunId` as registered (`BuildId` is often `0`).
- Align `cloudrun-development` skill guidance and add/update unit coverage (registration + image deploy next_step).

## Test plan
- [ ] `vitest` for `cloudrun-deploy-registration` / `cloudrun-image-deploy` related suites
- [ ] Image deploy response includes `getProcessLog` (or `getDeployRecords` → `getProcessLog`) in `next_step`
- [ ] Source deploy response still points to `getDeployLog` first


Made with [Cursor](https://cursor.com)