### PR TITLE
fix(functions): 🔧 guide and bounded-wait on SCF Updating state

### DIFF
--- a/mcp/src/tools/function-updating.test.ts
+++ b/mcp/src/tools/function-updating.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  FUNCTION_BUSY_STATUSES,
+  FUNCTION_UPDATING_ERROR_CODE,
+  FUNCTION_UPDATING_RETRY_AFTER_SECONDS,
+  buildFunctionUpdatingPayload,
+  functionUpdatingRuntime,
+  isFunctionBusyStatus,
+  isFunctionUpdatingError,
+  waitUntilFunctionActive,
+} from "./function-updating.js";
+
+describe("function updating helpers", () => {
+  const originalSleep = functionUpdatingRuntime.sleep;
+
+  afterEach(() => {
+    functionUpdatingRuntime.sleep = originalSleep;
+  });
+
+  it("detects the SCF UpdateFunctionConfiguration Updating copy from beacons", () => {
+    expect(
+      isFunctionUpdatingError(
+        new Error("[scf/UpdateFunctionConfiguration] 当前函数处于 Updating"),
+      ),
+    ).toBe(true);
+    expect(
+      isFunctionUpdatingError("[scf/UpdateFunctionCode] 当前函数处于 Updating"),
+    ).toBe(true);
+    expect(
+      isFunctionUpdatingError("ResourceInUse: function is currently updating"),
+    ).toBe(true);
+    expect(isFunctionUpdatingError("函数状态异常，检查超时")).toBe(true);
+  });
+
+  it("does not treat unrelated SCF errors as Updating", () => {
+    expect(isFunctionUpdatingError("Function not found")).toBe(false);
+    expect(isFunctionUpdatingError("invalid parameter value")).toBe(false);
+    expect(isFunctionUpdatingError("依赖安装失败")).toBe(false);
+  });
+
+  it("treats Creating/Updating/Publishing/Deleting as busy", () => {
+    for (const status of FUNCTION_BUSY_STATUSES) {
+      expect(isFunctionBusyStatus(status)).toBe(true);
+    }
+    expect(isFunctionBusyStatus("Active")).toBe(false);
+    expect(isFunctionBusyStatus("UpdateFailed")).toBe(false);
+    expect(isFunctionBusyStatus(undefined)).toBe(false);
+  });
+
+  it("builds a guided payload with retryAfterSeconds and executable nextActions", () => {
+    const payload = buildFunctionUpdatingPayload({
+      action: "updateFunctionConfig",
+      functionName: "hello",
+      status: "Updating",
+      rawMessage: "[scf/UpdateFunctionConfiguration] 当前函数处于 Updating",
+    });
+
+    expect(payload.success).toBe(false);
+    expect(payload.errorCode).toBe(FUNCTION_UPDATING_ERROR_CODE);
+    expect(payload.retryAfterSeconds).toBe(FUNCTION_UPDATING_RETRY_AFTER_SECONDS);
+    expect(payload.message).toContain("不要立即重试");
+    expect(payload.message).toContain("getFunctionDetail");
+    expect(payload.message).toContain("当前函数处于 Updating");
+    expect(payload.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tool: "queryFunctions",
+          action: "getFunctionDetail",
+          suggested_args: expect.objectContaining({
+            functionName: "hello",
+          }),
+        }),
+        expect.objectContaining({
+          tool: "manageFunctions",
+          action: "updateFunctionConfig",
+        }),
+      ]),
+    );
+  });
+
+  it("returns immediately when initial Status is already Active", async () => {
+    const getStatus = vi.fn();
+    const result = await waitUntilFunctionActive(getStatus, {
+      initialStatus: "Active",
+    });
+    expect(result).toEqual({
+      ready: true,
+      status: "Active",
+      attempts: 0,
+      timedOut: false,
+    });
+    expect(getStatus).not.toHaveBeenCalled();
+  });
+
+  it("polls until Status leaves Updating, with a sleep between attempts", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const getStatus = vi
+      .fn()
+      .mockResolvedValueOnce("Updating")
+      .mockResolvedValueOnce("Updating")
+      .mockResolvedValueOnce("Active");
+
+    const result = await waitUntilFunctionActive(getStatus, {
+      initialStatus: "Updating",
+      intervalMs: 50,
+      maxAttempts: 5,
+      timeoutMs: 1000,
+      sleep,
+    });
+
+    expect(result.ready).toBe(true);
+    expect(result.status).toBe("Active");
+    expect(result.attempts).toBe(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+    expect(sleep).toHaveBeenCalledWith(50);
+  });
+
+  it("stops at maxAttempts without spinning forever", async () => {
+    const sleep = vi.fn(async () => undefined);
+    const getStatus = vi.fn().mockResolvedValue("Updating");
+
+    const result = await waitUntilFunctionActive(getStatus, {
+      initialStatus: "Updating",
+      intervalMs: 10,
+      maxAttempts: 3,
+      timeoutMs: 10_000,
+      sleep,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.attempts).toBe(3);
+    expect(result.timedOut).toBe(false);
+    expect(getStatus).toHaveBeenCalledTimes(3);
+    expect(sleep).toHaveBeenCalledTimes(2);
+  });
+
+  it("honors timeoutMs and does not start another poll after the deadline", async () => {
+    let now = 0;
+    const sleep = vi.fn(async (ms: number) => {
+      now += ms;
+    });
+    const getStatus = vi.fn().mockResolvedValue("Updating");
+
+    const result = await waitUntilFunctionActive(getStatus, {
+      initialStatus: "Updating",
+      intervalMs: 100,
+      maxAttempts: 50,
+      timeoutMs: 250,
+      sleep,
+      now: () => now,
+    });
+
+    expect(result.ready).toBe(false);
+    expect(result.timedOut).toBe(true);
+    expect(result.attempts).toBeLessThanOrEqual(3);
+    expect(getStatus.mock.calls.length).toBeLessThanOrEqual(3);
+  });
+});

--- a/mcp/src/tools/function-updating.ts
+++ b/mcp/src/tools/function-updating.ts
@@ -1,0 +1,231 @@
+/**
+ * Guidance + bounded wait when a cloud function is not Active.
+ * SCF rejects UpdateFunctionConfiguration / UpdateFunctionCode while Status=Updating.
+ */
+
+export const FUNCTION_UPDATING_ERROR_CODE = "FUNCTION_UPDATING";
+
+/** Agents must wait at least this long before retrying the same write. */
+export const FUNCTION_UPDATING_RETRY_AFTER_SECONDS = 10;
+
+export const FUNCTION_BUSY_STATUSES = [
+  "Updating",
+  "Creating",
+  "Publishing",
+  "Deleting",
+] as const;
+
+export type FunctionBusyStatus = (typeof FUNCTION_BUSY_STATUSES)[number];
+
+export const FUNCTION_UPDATING_WAIT = {
+  intervalMs: 2000,
+  maxAttempts: 5,
+  timeoutMs: 12_000,
+} as const;
+
+export type FunctionUpdatingNextAction = {
+  tool: string;
+  action: string;
+  reason: string;
+  suggested_args?: Record<string, unknown>;
+};
+
+export type FunctionUpdatingPayload = {
+  success: false;
+  errorCode: typeof FUNCTION_UPDATING_ERROR_CODE;
+  retryAfterSeconds: number;
+  message: string;
+  data: Record<string, unknown>;
+  nextActions: FunctionUpdatingNextAction[];
+};
+
+/**
+ * Injectable sleep for unit tests. Production uses setTimeout.
+ * Tests must restore the original function in afterEach.
+ */
+export const functionUpdatingRuntime = {
+  sleep: (ms: number) =>
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, ms);
+    }),
+};
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
+
+export function isFunctionBusyStatus(status: unknown): status is FunctionBusyStatus {
+  if (typeof status !== "string") {
+    return false;
+  }
+  return (FUNCTION_BUSY_STATUSES as readonly string[]).includes(status);
+}
+
+const UPDATING_ERROR_PATTERNS = [
+  /当前函数处于\s*Updating/i,
+  /函数处于\s*Updating/i,
+  /currently\s+(?:in\s+)?updating/i,
+  /function\s+is\s+(?:currently\s+)?updating/i,
+  /Status\s*(?:is|=|:)?\s*Updating/i,
+  /scf\/UpdateFunction(?:Configuration|Code).{0,80}Updating/i,
+  /函数状态异常，检查超时/,
+];
+
+export function isFunctionUpdatingError(error: unknown): boolean {
+  const message = getErrorMessage(error);
+  return UPDATING_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function buildFunctionUpdatingMessage(params: {
+  action: string;
+  functionName?: string;
+  status?: string;
+  rawMessage?: string;
+}): string {
+  const namePart = params.functionName
+    ? `函数 \`${params.functionName}\``
+    : "目标函数";
+  const statusPart = params.status ? `（当前 Status=${params.status}）` : "";
+  const lines = [
+    `${namePart} 尚未就绪${statusPart}，无法执行 manageFunctions(action="${params.action}")。`,
+    `不要立即重试同一写操作（SCF 会在 Updating 期间连续拒绝 UpdateFunctionConfiguration / UpdateFunctionCode）。`,
+    `请等待 ${FUNCTION_UPDATING_RETRY_AFTER_SECONDS} 秒后重试，或先调用 queryFunctions(action="getFunctionDetail") 确认 Status 为 Active。`,
+  ];
+  if (params.rawMessage) {
+    lines.push(`原始错误: ${params.rawMessage}`);
+  }
+  return lines.join("\n");
+}
+
+export function buildFunctionUpdatingNextActions(params: {
+  action: string;
+  functionName?: string;
+}): FunctionUpdatingNextAction[] {
+  const functionName = params.functionName;
+  return [
+    {
+      tool: "queryFunctions",
+      action: "getFunctionDetail",
+      reason: "查看函数 Status，等到 Active 后再写配置/代码",
+      suggested_args: {
+        action: "getFunctionDetail",
+        ...(functionName ? { functionName } : {}),
+      },
+    },
+    {
+      tool: "manageFunctions",
+      action: params.action,
+      reason: `等待 ${FUNCTION_UPDATING_RETRY_AFTER_SECONDS} 秒且 Status=Active 后，用相同参数重试；禁止立刻连打`,
+      suggested_args: {
+        action: params.action,
+        ...(functionName ? { functionName } : {}),
+      },
+    },
+  ];
+}
+
+export function buildFunctionUpdatingPayload(params: {
+  action: string;
+  functionName?: string;
+  status?: string;
+  rawMessage?: string;
+  waitedAttempts?: number;
+  timedOut?: boolean;
+}): FunctionUpdatingPayload {
+  return {
+    success: false,
+    errorCode: FUNCTION_UPDATING_ERROR_CODE,
+    retryAfterSeconds: FUNCTION_UPDATING_RETRY_AFTER_SECONDS,
+    message: buildFunctionUpdatingMessage(params),
+    data: {
+      action: params.action,
+      ...(params.functionName ? { functionName: params.functionName } : {}),
+      ...(params.status ? { status: params.status } : {}),
+      retryAfterSeconds: FUNCTION_UPDATING_RETRY_AFTER_SECONDS,
+      doNotRetryImmediately: true,
+      ...(typeof params.waitedAttempts === "number"
+        ? { waitedAttempts: params.waitedAttempts }
+        : {}),
+      ...(params.timedOut ? { waitTimedOut: true } : {}),
+      ...(params.rawMessage ? { rawError: params.rawMessage.slice(0, 500) } : {}),
+    },
+    nextActions: buildFunctionUpdatingNextActions(params),
+  };
+}
+
+export type WaitUntilFunctionActiveResult = {
+  ready: boolean;
+  status?: string;
+  attempts: number;
+  timedOut: boolean;
+};
+
+/**
+ * Poll function Status until it leaves a busy state.
+ * Always bounded: maxAttempts AND timeoutMs; never spins without a sleep between polls.
+ */
+export async function waitUntilFunctionActive(
+  getStatus: () => Promise<string | undefined>,
+  options: {
+    initialStatus?: string;
+    intervalMs?: number;
+    maxAttempts?: number;
+    timeoutMs?: number;
+    sleep?: (ms: number) => Promise<void>;
+    now?: () => number;
+  } = {},
+): Promise<WaitUntilFunctionActiveResult> {
+  const intervalMs = options.intervalMs ?? FUNCTION_UPDATING_WAIT.intervalMs;
+  const maxAttempts = options.maxAttempts ?? FUNCTION_UPDATING_WAIT.maxAttempts;
+  const timeoutMs = options.timeoutMs ?? FUNCTION_UPDATING_WAIT.timeoutMs;
+  const sleep = options.sleep ?? ((ms: number) => functionUpdatingRuntime.sleep(ms));
+  const now = options.now ?? Date.now;
+
+  if (maxAttempts < 1) {
+    throw new Error("waitUntilFunctionActive maxAttempts must be >= 1");
+  }
+  if (intervalMs < 0 || timeoutMs < 0) {
+    throw new Error("waitUntilFunctionActive intervalMs/timeoutMs must be >= 0");
+  }
+
+  if (
+    options.initialStatus !== undefined &&
+    !isFunctionBusyStatus(options.initialStatus)
+  ) {
+    return {
+      ready: true,
+      status: options.initialStatus,
+      attempts: 0,
+      timedOut: false,
+    };
+  }
+
+  const startedAt = now();
+  let attempts = 0;
+  let status = options.initialStatus;
+
+  while (attempts < maxAttempts) {
+    if (now() - startedAt >= timeoutMs) {
+      return { ready: false, status, attempts, timedOut: true };
+    }
+
+    attempts += 1;
+    status = await getStatus();
+    if (!isFunctionBusyStatus(status)) {
+      return { ready: true, status, attempts, timedOut: false };
+    }
+
+    if (attempts >= maxAttempts) {
+      break;
+    }
+    if (now() - startedAt + intervalMs >= timeoutMs) {
+      return { ready: false, status, attempts, timedOut: true };
+    }
+    await sleep(intervalMs);
+  }
+
+  return { ready: false, status, attempts, timedOut: false };
+}

--- a/mcp/src/tools/function-updating.ts
+++ b/mcp/src/tools/function-updating.ts
@@ -205,7 +205,7 @@ export async function waitUntilFunctionActive(
 
   const startedAt = now();
   let attempts = 0;
-  let status = options.initialStatus;
+  let status: string | undefined = options.initialStatus;
 
   while (attempts < maxAttempts) {
     if (now() - startedAt >= timeoutMs) {

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   buildCreateLayerNameWarning,
   buildFunctionOperationErrorMessage,
@@ -10,11 +10,18 @@ import {
   resolveEventFunctionRuntime,
   shouldInstallDependencyForFunction,
 } from "./functions.js";
+import {
+  FUNCTION_UPDATING_ERROR_CODE,
+  FUNCTION_UPDATING_RETRY_AFTER_SECONDS,
+  functionUpdatingRuntime,
+} from "./function-updating.js";
 import type { ExtendedMcpServer } from "../server.js";
 
 const {
   mockCreateFunction,
   mockUpdateFunctionCode,
+  mockUpdateFunctionConfig,
+  mockGetFunctionDetail,
   mockCreateAccess,
   mockGetCloudBaseManager,
   mockGetEnvId,
@@ -23,6 +30,8 @@ const {
 } = vi.hoisted(() => ({
   mockCreateFunction: vi.fn(),
   mockUpdateFunctionCode: vi.fn(),
+  mockUpdateFunctionConfig: vi.fn(),
+  mockGetFunctionDetail: vi.fn(),
   mockCreateAccess: vi.fn(),
   mockGetCloudBaseManager: vi.fn(),
   mockGetEnvId: vi.fn(),
@@ -70,9 +79,11 @@ function createMockServer() {
 
 describe("functions tool helpers", () => {
   let tools: ReturnType<typeof createMockServer>["tools"];
+  const originalSleep = functionUpdatingRuntime.sleep;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    functionUpdatingRuntime.sleep = async () => undefined;
     mockIsCloudMode.mockReturnValue(false);
     mockGetEnvId.mockResolvedValue("env-test");
     mockCreateFunction.mockResolvedValue({
@@ -85,10 +96,21 @@ describe("functions tool helpers", () => {
     mockUpdateFunctionCode.mockResolvedValue({
       RequestId: "req-update-code",
     });
+    mockUpdateFunctionConfig.mockResolvedValue({
+      RequestId: "req-update-config",
+    });
+    mockGetFunctionDetail.mockResolvedValue({
+      Status: "Active",
+      Timeout: 20,
+      Environment: { Variables: [] },
+      VpcConfig: {},
+    });
     mockGetCloudBaseManager.mockResolvedValue({
       functions: {
         createFunction: mockCreateFunction,
         updateFunctionCode: mockUpdateFunctionCode,
+        updateFunctionConfig: mockUpdateFunctionConfig,
+        getFunctionDetail: mockGetFunctionDetail,
       },
       access: {
         createAccess: mockCreateAccess,
@@ -96,6 +118,10 @@ describe("functions tool helpers", () => {
     });
 
     ({ tools } = createMockServer());
+  });
+
+  afterEach(() => {
+    functionUpdatingRuntime.sleep = originalSleep;
   });
 
   it("soft-warns bare layer names and accepts env-suffixed names", () => {
@@ -387,5 +413,152 @@ describe("functions tool helpers", () => {
         func: expect.objectContaining({ name: "imageDemo" }),
       }),
     );
+  });
+
+  it("guides updateFunctionConfig when Status stays Updating instead of throwing raw SCF copy", async () => {
+    mockGetFunctionDetail.mockResolvedValue({
+      Status: "Updating",
+      Timeout: 20,
+      Environment: { Variables: [] },
+      VpcConfig: {},
+    });
+
+    const result = await tools.manageFunctions.handler({
+      action: "updateFunctionConfig",
+      functionName: "hello",
+      timeout: 30,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(false);
+    expect(payload.errorCode).toBe(FUNCTION_UPDATING_ERROR_CODE);
+    expect(payload.retryAfterSeconds).toBe(FUNCTION_UPDATING_RETRY_AFTER_SECONDS);
+    expect(payload.message).toContain("不要立即重试");
+    expect(payload.message).toContain("getFunctionDetail");
+    expect(payload.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tool: "queryFunctions",
+          action: "getFunctionDetail",
+        }),
+        expect.objectContaining({
+          tool: "manageFunctions",
+          action: "updateFunctionConfig",
+        }),
+      ]),
+    );
+    expect(mockUpdateFunctionConfig).not.toHaveBeenCalled();
+  });
+
+  it("returns nextActions when UpdateFunctionConfiguration reports Updating after Status was Active", async () => {
+    mockUpdateFunctionConfig.mockRejectedValue(
+      new Error("[scf/UpdateFunctionConfiguration] 当前函数处于 Updating"),
+    );
+
+    const result = await tools.manageFunctions.handler({
+      action: "updateFunctionConfig",
+      functionName: "hello",
+      envVariables: { FOO: "bar" },
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(false);
+    expect(payload.errorCode).toBe(FUNCTION_UPDATING_ERROR_CODE);
+    expect(payload.message).toContain("当前函数处于 Updating");
+    expect(payload.message).not.toBe(
+      "[scf/UpdateFunctionConfiguration] 当前函数处于 Updating",
+    );
+    expect(payload.nextActions[0]).toMatchObject({
+      tool: "queryFunctions",
+      action: "getFunctionDetail",
+    });
+    expect(mockUpdateFunctionConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns Updating guidance for updateFunctionCode instead of only wrapping the SCF message", async () => {
+    mockUpdateFunctionCode.mockRejectedValue(
+      new Error("[scf/UpdateFunctionCode] 当前函数处于 Updating"),
+    );
+
+    const result = await tools.manageFunctions.handler({
+      action: "updateFunctionCode",
+      functionName: "imageDemo",
+      imageConfig: {
+        imageType: "personal",
+        imageUri: "ccr.ccs.tencentyun.com/your-ns/demo-app:demo-app-004",
+      },
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(false);
+    expect(payload.errorCode).toBe(FUNCTION_UPDATING_ERROR_CODE);
+    expect(payload.message).toContain("不要立即重试");
+    expect(payload.nextActions).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tool: "manageFunctions",
+          action: "updateFunctionCode",
+        }),
+      ]),
+    );
+  });
+
+  it("adds Updating wait guidance on wrapped create/update code errors", () => {
+    const message = buildFunctionOperationErrorMessage(
+      "updateFunctionCode",
+      "hello",
+      "/tmp/cloudfunctions",
+      new Error("[scf/UpdateFunctionCode] 当前函数处于 Updating"),
+    );
+
+    expect(message).toContain("Updating");
+    expect(message).toContain("getFunctionDetail");
+    expect(message).toContain("不要立即重试");
+  });
+
+  it("updates function config when Status is Active", async () => {
+    const result = await tools.manageFunctions.handler({
+      action: "updateFunctionConfig",
+      functionName: "hello",
+      timeout: 60,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(true);
+    expect(mockUpdateFunctionConfig).toHaveBeenCalledTimes(1);
+    expect(payload.message).toContain("hello");
+  });
+
+  it("retries updateFunctionConfig after Status leaves Updating within the wait budget", async () => {
+    mockGetFunctionDetail
+      .mockResolvedValueOnce({
+        Status: "Updating",
+        Timeout: 20,
+        Environment: { Variables: [] },
+        VpcConfig: {},
+      })
+      .mockResolvedValueOnce({
+        Status: "Updating",
+        Timeout: 20,
+        Environment: { Variables: [] },
+        VpcConfig: {},
+      })
+      .mockResolvedValue({
+        Status: "Active",
+        Timeout: 20,
+        Environment: { Variables: [] },
+        VpcConfig: {},
+      });
+
+    const result = await tools.manageFunctions.handler({
+      action: "updateFunctionConfig",
+      functionName: "hello",
+      timeout: 30,
+    });
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.success).toBe(true);
+    expect(mockUpdateFunctionConfig).toHaveBeenCalledTimes(1);
+    expect(mockGetFunctionDetail.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -9,6 +9,13 @@ import { isCloudMode } from "../utils/cloud-mode.js";
 import { resolveGatewayAccessUrls } from "../utils/gateway-access-urls.js";
 import { jsonContent } from "../utils/json-content.js";
 import { debug } from "../utils/logger.js";
+import { isToolPayloadError } from "../utils/tool-result.js";
+import {
+  buildFunctionUpdatingPayload,
+  getErrorMessage,
+  isFunctionUpdatingError,
+  waitUntilFunctionActive,
+} from "./function-updating.js";
 
 import { IEnvVariable } from "@cloudbase/manager-node/types/function/types.js";
 import { existsSync } from "fs";
@@ -139,10 +146,13 @@ type FunctionToolEnvelope = {
   success: boolean;
   data: Record<string, unknown>;
   message: string;
+  errorCode?: string;
+  retryAfterSeconds?: number;
   nextActions?: Array<{
     tool: string;
     action: string;
     reason: string;
+    suggested_args?: Record<string, unknown>;
   }>;
   /** Soft advisory messages; never blocks the operation. */
   warnings?: string[];
@@ -528,6 +538,13 @@ export function buildFunctionOperationErrorMessage(
     );
   }
 
+  if (isFunctionUpdatingError(error)) {
+    suggestions.push(
+      `函数当前处于 Updating/非 Active，不要立即重试 ${operation}。` +
+        `请等待约 10 秒，或先 queryFunctions(action="getFunctionDetail") 确认 Status 为 Active 后再重试。`,
+    );
+  }
+
   // Handle invalid parameter value errors from CloudBase API
   if (/invalid parameter value/i.test(baseMessage)) {
     suggestions.push(
@@ -588,6 +605,38 @@ function wrapFunctionOperationError(
   return wrappedError;
 }
 
+async function waitForManageWriteOrGuide(
+  action: "updateFunctionCode" | "updateFunctionConfig",
+  functionName: string,
+  getFunctionDetail: (
+    name: string,
+  ) => Promise<{ Status?: string } | null | undefined>,
+  initialDetail?: { Status?: string } | null,
+): Promise<ReturnType<typeof buildFunctionUpdatingPayload> | undefined> {
+  const waitResult = await waitUntilFunctionActive(
+    async () => {
+      const latest = await getFunctionDetail(functionName);
+      return typeof latest?.Status === "string" ? latest.Status : undefined;
+    },
+    {
+      initialStatus:
+        typeof initialDetail?.Status === "string" ? initialDetail.Status : undefined,
+    },
+  );
+
+  if (waitResult.ready) {
+    return undefined;
+  }
+
+  return buildFunctionUpdatingPayload({
+    action,
+    functionName,
+    status: waitResult.status,
+    waitedAttempts: waitResult.attempts,
+    timedOut: waitResult.timedOut,
+  });
+}
+
 export function registerFunctionTools(server: ExtendedMcpServer) {
   const cloudBaseOptions = server.cloudBaseOptions;
   const deployOverrides = server.pluginOptions?.functions;
@@ -620,6 +669,17 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
     try {
       return jsonContent(await handler());
     } catch (error) {
+      if (isToolPayloadError(error)) {
+        return jsonContent(error.payload);
+      }
+      if (isFunctionUpdatingError(error)) {
+        return jsonContent(
+          buildFunctionUpdatingPayload({
+            action: "manageFunctions",
+            rawMessage: getErrorMessage(error),
+          }),
+        );
+      }
       return jsonContent(buildErrorEnvelope(error));
     }
   };
@@ -1341,6 +1401,31 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       }
       const cloudbase = await getManager();
 
+      if (typeof cloudbase.functions.getFunctionDetail === "function") {
+        try {
+          const currentDetail = await cloudbase.functions.getFunctionDetail(
+            input.functionName,
+          );
+          const waited = await waitForManageWriteOrGuide(
+            "updateFunctionCode",
+            input.functionName,
+            (name) => cloudbase.functions.getFunctionDetail(name),
+            currentDetail,
+          );
+          if (waited) {
+            return waited;
+          }
+        } catch (error) {
+          if (isFunctionUpdatingError(error)) {
+            return buildFunctionUpdatingPayload({
+              action: "updateFunctionCode",
+              functionName: input.functionName,
+              rawMessage: getErrorMessage(error),
+            });
+          }
+        }
+      }
+
       // 镜像更新分支：后续迭代只需用新镜像 tag 更新函数。
       const updateImageConfig =
         input.imageConfig ??
@@ -1361,6 +1446,13 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
             deployMode: "image",
           } as any);
         } catch (error) {
+          if (isFunctionUpdatingError(error)) {
+            return buildFunctionUpdatingPayload({
+              action: "updateFunctionCode",
+              functionName: input.functionName,
+              rawMessage: getErrorMessage(error),
+            });
+          }
           throw wrapFunctionOperationError(
             "updateFunctionCode",
             input.functionName,
@@ -1432,6 +1524,13 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
       try {
         result = await cloudbase.functions.updateFunctionCode(updateParams as any);
       } catch (error) {
+        if (isFunctionUpdatingError(error)) {
+          return buildFunctionUpdatingPayload({
+            action: "updateFunctionCode",
+            functionName: input.functionName,
+            rawMessage: getErrorMessage(error),
+          });
+        }
         throw wrapFunctionOperationError(
           "updateFunctionCode",
           input.functionName,
@@ -1491,6 +1590,16 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         throw new Error(`函数 ${input.functionName} 不存在或无法获取详情`);
       }
 
+      const configBusy = await waitForManageWriteOrGuide(
+        "updateFunctionConfig",
+        input.functionName,
+        (name) => cloudbase.functions.getFunctionDetail(name),
+        functionDetail,
+      );
+      if (configBusy) {
+        return configBusy;
+      }
+
       const currentVpc =
         typeof functionDetail.VpcConfig === "object" &&
         functionDetail.VpcConfig !== null &&
@@ -1502,42 +1611,53 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
             }
           : undefined;
 
-      const result = await cloudbase.functions.updateFunctionConfig({
-        name: input.functionName,
-        envVariables: Object.assign(
-          {},
-          (functionDetail.Environment?.Variables || []).reduce(
-            (
-              acc: Record<string, string | number | boolean>,
-              curr: IEnvVariable,
-            ) => {
-              acc[curr.Key] = curr.Value;
-              return acc;
-            },
+      try {
+        const result = await cloudbase.functions.updateFunctionConfig({
+          name: input.functionName,
+          envVariables: Object.assign(
             {},
+            (functionDetail.Environment?.Variables || []).reduce(
+              (
+                acc: Record<string, string | number | boolean>,
+                curr: IEnvVariable,
+              ) => {
+                acc[curr.Key] = curr.Value;
+                return acc;
+              },
+              {},
+            ),
+            input.envVariables ?? {},
           ),
-          input.envVariables ?? {},
-        ),
-        timeout: input.timeout ?? functionDetail.Timeout,
-        vpc: Object.assign({}, currentVpc, input.vpc ?? {}),
-      });
+          timeout: input.timeout ?? functionDetail.Timeout,
+          vpc: Object.assign({}, currentVpc, input.vpc ?? {}),
+        });
 
-      logCloudBaseResult(server.logger, result);
-      return buildEnvelope(
-        {
-          action: input.action,
-          functionName: input.functionName,
-          raw: result,
-        },
-        `已更新函数 ${input.functionName} 的配置`,
-        [
+        logCloudBaseResult(server.logger, result);
+        return buildEnvelope(
           {
-            tool: "queryFunctions",
-            action: "getFunctionDetail",
-            reason: "确认配置变更结果",
+            action: input.action,
+            functionName: input.functionName,
+            raw: result,
           },
-        ],
-      );
+          `已更新函数 ${input.functionName} 的配置`,
+          [
+            {
+              tool: "queryFunctions",
+              action: "getFunctionDetail",
+              reason: "确认配置变更结果",
+            },
+          ],
+        );
+      } catch (error) {
+        if (isFunctionUpdatingError(error)) {
+          return buildFunctionUpdatingPayload({
+            action: "updateFunctionConfig",
+            functionName: input.functionName,
+            rawMessage: getErrorMessage(error),
+          });
+        }
+        throw error;
+      }
     }
     case "invokeFunction": {
       if (!input.functionName) {


### PR DESCRIPTION
## Summary
- When `manageFunctions` hits SCF `Updating` / non-Active status, wait a bounded 5 attempts / 12s instead of immediately retrying `UpdateFunctionConfiguration`.
- If the function stays busy, return `FUNCTION_UPDATING` with `retryAfterSeconds` and nextActions (`queryFunctions(getFunctionDetail)` then retry) instead of the raw SCF error copy.
- Adds unit tests covering the lighthouse Updating copy and wait/retry guidance.

## Test plan
- [x] `npx vitest run src/tools/function-updating.test.ts src/tools/functions.test.ts` (33 passed)
- [ ] Confirm CI on this PR is green
- [ ] Optional: update a live function while Status=Updating and confirm the tool waits then returns `FUNCTION_UPDATING` rather than looping UpdateFunctionConfiguration


Made with [Cursor](https://cursor.com)