### PR TITLE
fix(cloudrun): set CreateCloudRunEnv EnvType to baas

### DIFF
--- a/mcp/src/tools/cloudrun-init.test.ts
+++ b/mcp/src/tools/cloudrun-init.test.ts
@@ -411,7 +411,7 @@ describe("manageCloudRun initEnv action", () => {
     expect((calls[1] as any).Param).toEqual({
       EnvId: "env-test",
       PackageType: "Professional",
-      EnvType: "tcbr",
+      EnvType: "baas",
     });
   });
 
@@ -432,7 +432,7 @@ describe("manageCloudRun initEnv action", () => {
     const tools = await createCloudRunTools();
     await tools.manageCloudRun.handler({ action: "initEnv", envId: "env-test" });
     expect((calls[1] as any).Param.PackageType).toBe("Trial");
-    expect((calls[1] as any).Param.EnvType).toBe("tcbr");
+    expect((calls[1] as any).Param.EnvType).toBe("baas");
   });
 
   it("passes optional vpcId/subnetIds through to CreateCloudRunEnv", async () => {
@@ -459,7 +459,7 @@ describe("manageCloudRun initEnv action", () => {
     expect((calls[1] as any).Param).toEqual({
       EnvId: "env-test",
       PackageType: "Trial",
-      EnvType: "tcbr",
+      EnvType: "baas",
       VpcId: "vpc-26vsxozo",
       SubNetIds: ["subnet-hyiwt4ut"],
     });
@@ -618,14 +618,14 @@ describe("queryCloudRun envStatus action", () => {
 });
 
 describe("cloudrun VPC helpers", () => {
-  it("buildCreateCloudRunEnvParam always sets EnvType=tcbr", async () => {
+  it("buildCreateCloudRunEnvParam always sets EnvType=baas", async () => {
     const { buildCreateCloudRunEnvParam } = await import("./cloudrun.js");
     expect(
       buildCreateCloudRunEnvParam({ envId: "env-x", packageType: "Trial" }),
     ).toEqual({
       EnvId: "env-x",
       PackageType: "Trial",
-      EnvType: "tcbr",
+      EnvType: "baas",
     });
   });
 

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -629,8 +629,8 @@ export async function describeCloudRunEnvStatus(
   return { isExist: true, status, baseInfo };
 }
 
-/** CloudRun EnvType for CreateCloudRunEnv (tcbr DescribeEnvBaseInfo enum). */
-export const CLOUDRUN_ENV_TYPE = "tcbr" as const;
+/** CloudRun EnvType for CreateCloudRunEnv (baas DescribeEnvBaseInfo enum). */
+export const CLOUDRUN_ENV_TYPE = "baas" as const;
 
 export type CloudRunVpcInfo = {
   VpcId: string;
@@ -689,7 +689,7 @@ export function resolveCloudRunDeployVpcInfo(options: {
 }
 
 /**
- * Build CreateCloudRunEnv Param, always including EnvType=tcbr.
+ * Build CreateCloudRunEnv Param, always including EnvType=baas.
  * Optional vpcId/subnetIds are used when the platform requires an explicit VPC.
  */
 export function buildCreateCloudRunEnvParam(options: {
@@ -1515,7 +1515,7 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
             }
 
             // 未开通 → 发起异步开通（CreateCloudRunEnv 异步，不阻塞等待）。
-            // Always pass EnvType=tcbr; optional vpcId/subnetIds when an explicit VPC is required.
+            // Always pass EnvType=baas; optional vpcId/subnetIds when an explicit VPC is required.
             let createResult: any;
             try {
               createResult = await manager


### PR DESCRIPTION
## Summary
- Change `CLOUDRUN_ENV_TYPE` in `mcp/src/tools/cloudrun.ts` from `\"tcbr\"` to `\"baas\"` for `CreateCloudRunEnv` payloads.
- Update related inline comments to match the new `EnvType=baas` behavior.
- Update `mcp/src/tools/cloudrun-init.test.ts` assertions and test title to expect `EnvType: \"baas\"`.

## Changelog
- `fix(cloudrun): set CreateCloudRunEnv EnvType to baas (eb463dae)`

## Test plan
- [x] Run `npm exec vitest run "src/tools/cloudrun-init.test.ts"` in `mcp/`.
- [x] Verify `buildCreateCloudRunEnvParam` test now asserts `EnvType=baas`.

Made with [Cursor](https://cursor.com)