### PR TITLE
feat(kimi): pack Kimi plugin zip and attach to release assets

### DIFF
--- a/.github/workflows/release-plugin-zips.yml
+++ b/.github/workflows/release-plugin-zips.yml
@@ -1,0 +1,52 @@
+name: Release Plugin Zips
+
+on:
+  # Attach plugin zips to every published release.
+  release:
+    types: [published]
+  # Manual backfill: attach plugin zips to an existing release.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to attach plugin zips (e.g. v2.28.1)"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  pack-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve release tag
+        id: tag
+        run: |
+          if [[ -n "${{ github.event.release.tag_name }}" ]]; then
+            echo "tag=${{ github.event.release.tag_name }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.2.2
+        with:
+          ref: ${{ steps.tag.outputs.tag }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
+      - name: Pack Kimi plugin zip
+        run: node scripts/pack-kimi-plugin.mjs
+
+      - name: Verify release exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release view "${{ steps.tag.outputs.tag }}" --json tagName >/dev/null
+
+      - name: Upload plugin zips to release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload "${{ steps.tag.outputs.tag }}" dist/*.zip --clobber

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "sync:codebuddy-marketplace": "node scripts/sync-codebuddy-marketplace.mjs",
     "pack:qoder-plugin": "node scripts/pack-qoder-plugin.mjs",
     "pack:qoder-skill": "node scripts/pack-qoder-skill.mjs",
+    "pack:kimi-plugin": "node scripts/pack-kimi-plugin.mjs",
     "prepare": "husky"
   },
   "devDependencies": {

--- a/scripts/pack-kimi-plugin.mjs
+++ b/scripts/pack-kimi-plugin.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+/**
+ * Pack plugin/cloudbase as a Kimi Code / Kimi Work plugin zip.
+ *
+ * Zip root contains `kimi.plugin.json` (Open Plugin Spec style manifest),
+ * skills, MCP config, agents, commands, hooks — the same layout Qoder packs.
+ *
+ * Usage:
+ *   node scripts/pack-kimi-plugin.mjs
+ *   node scripts/pack-kimi-plugin.mjs --out /tmp/cloudbase-kimi.zip
+ *   node scripts/pack-kimi-plugin.mjs --version 0.2.0   # override manifest version
+ *
+ * Release flow (CI): .github/workflows/release-plugin-zips.yml packs this zip
+ * on `release: published` and uploads it to the release assets.
+ */
+
+import { execFileSync } from "child_process";
+import fs from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, "..");
+const PLUGIN_DIR = path.join(ROOT, "plugin", "cloudbase");
+const MANIFEST_PATH = path.join(PLUGIN_DIR, "kimi.plugin.json");
+
+function parseArgs(argv = process.argv.slice(2)) {
+  const args = { out: null, version: null };
+  for (let i = 0; i < argv.length; i += 1) {
+    const a = argv[i];
+    if (a === "--") continue;
+    if (a === "--out") {
+      args.out = argv[++i];
+      if (!args.out) throw new Error("--out requires a path");
+    } else if (a === "--version") {
+      args.version = argv[++i];
+      if (!args.version) throw new Error("--version requires a value");
+    } else if (a === "--help" || a === "-h") args.help = true;
+    else throw new Error(`Unknown argument: ${a}`);
+  }
+  return args;
+}
+
+function assertReady() {
+  const required = [
+    MANIFEST_PATH,
+    path.join(PLUGIN_DIR, ".mcp.json"),
+    path.join(PLUGIN_DIR, "skills"),
+  ];
+  for (const p of required) {
+    if (!fs.existsSync(p)) {
+      throw new Error(`Missing required path for Kimi pack: ${p}`);
+    }
+  }
+}
+
+function main() {
+  const args = parseArgs();
+  if (args.help) {
+    console.log(`Pack CloudBase plugin for Kimi Code / Kimi Work.
+
+Usage:
+  node scripts/pack-kimi-plugin.mjs
+  node scripts/pack-kimi-plugin.mjs --out ./dist/cloudbase-kimi.zip
+  node scripts/pack-kimi-plugin.mjs --version 0.2.0
+`);
+    return;
+  }
+
+  assertReady();
+
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+  const version = args.version || manifest.version || "0.0.0";
+  const outPath =
+    args.out ||
+    path.join(ROOT, "dist", `cloudbase-kimi-v${version}.zip`);
+
+  fs.mkdirSync(path.dirname(outPath), { recursive: true });
+  if (fs.existsSync(outPath)) fs.rmSync(outPath);
+
+  // zip from inside plugin dir so archive root is the plugin contents
+  execFileSync(
+    "zip",
+    [
+      "-r",
+      outPath,
+      ".",
+      "-x",
+      "*.DS_Store",
+      "./.git/*",
+      "./.sync-metadata.json",
+      "./generated/*",
+    ],
+    { cwd: PLUGIN_DIR, stdio: "inherit" },
+  );
+
+  const size = fs.statSync(outPath).size;
+  console.log("");
+  console.log(`Packed: ${outPath}`);
+  console.log(`Size:   ${(size / 1024 / 1024).toFixed(2)} MiB`);
+  console.log(`Name:   ${manifest.name}@${version}`);
+  console.log("");
+  console.log("Next:");
+  console.log("  1. Upload this zip to the GitHub release assets");
+  console.log("     (CI does this automatically on release: published)");
+  console.log("  2. Or install locally: put it under ~/.kimi-code/plugins/managed/<id>/");
+}
+
+try {
+  main();
+} catch (err) {
+  console.error(err instanceof Error ? err.message : err);
+  process.exit(1);
+}


### PR DESCRIPTION
## 背景
KimiCode 插件市场接入需要 CloudBase 插件 zip 通过 release 分发（qer 上架需要 zip-url）。当前最近 5 个 release 均无 assets。

## 改动
1. **scripts/pack-kimi-plugin.mjs**：将 `plugin/cloudbase/` 打包为 `dist/cloudbase-kimi-v<version>.zip`（zip 根含 kimi.plugin.json，结构与 Qoder pack 一致，排除 .git/.sync-metadata.json/generated）
2. **.github/workflows/release-plugin-zips.yml**：release 发布时自动打包并 `gh release upload` 到 release assets；支持 workflow_dispatch 对历史 release 补传

## 验证
- 本地打包跑通：`cloudbase-kimi-v0.2.0.zip`（0.56 MiB，247 文件，kimi.plugin.json/.mcp.json/skills 均在 zip 根）
- action 引用已 pin 完整 commit SHA（供应链规则）