### PR TITLE
feat(mcp): support cross-region env query and expose credential boundary

### DIFF
--- a/doc/connection-modes.mdx
+++ b/doc/connection-modes.mdx
@@ -77,8 +77,8 @@ CloudBase MCP 支持两种连接方式：**本地模式**（MCP 服务在本机�
 
 | 登录方式 | `auth(status)` 字段 | 能看到什么 |
 |----------|---------------------|------------|
-| 账号级（device / web / 腾讯云 SecretId） | `login_mode=account`，`credential_scope=account` | 当前地域下账号有权的环境；其他地域需显式查询 |
-| 环境级 API Key（`CLOUDBASE_API_KEY` + `CLOUDBASE_ENV_ID`） | `login_mode=api_key`，`credential_scope=single_env` | **仅绑定的那一个 envId**，无法列出其他环境或其他地域 |
+| 账号级（device / web / 腾讯云 SecretId） | `credential_scope=account` | 当前地域下账号有权的环境；其他地域需显式查询 |
+| 环境级 API Key（`CLOUDBASE_API_KEY` + `CLOUDBASE_ENV_ID`） | `credential_scope=single_env` | **仅绑定的那一个 envId**，无法列出其他环境或其他地域 |
 
 跨地域查询（仅账号级凭据）：
 

--- a/doc/connection-modes.mdx
+++ b/doc/connection-modes.mdx
@@ -71,6 +71,23 @@ CloudBase MCP 支持两种连接方式：**本地模式**（MCP 服务在本机�
 2. `TENCENTCLOUD_SECRETID` + `TENCENTCLOUD_SECRETKEY` — 腾讯云永久/临时密钥
 3. 本地存储的 Device Flow 登录凭证（`~/.config/.cloudbase/auth.json`）
 
+#### 登录模式与查询范围
+
+两种登录的**可见环境范围不同**，这是凭据权限边界，不是环境丢失：
+
+| 登录方式 | `auth(status)` 字段 | 能看到什么 |
+|----------|---------------------|------------|
+| 账号级（device / web / 腾讯云 SecretId） | `login_mode=account`，`credential_scope=account` | 当前地域下账号有权的环境；其他地域需显式查询 |
+| 环境级 API Key（`CLOUDBASE_API_KEY` + `CLOUDBASE_ENV_ID`） | `login_mode=api_key`，`credential_scope=single_env` | **仅绑定的那一个 envId**，无法列出其他环境或其他地域 |
+
+跨地域查询（仅账号级凭据）：
+
+- MCP：`queryEnv(action="list", region="ap-singapore")`（`envQuery` 同义）
+- MCP 管控面：`callCloudApi(service="tcb", action="DescribeEnvs", region="ap-singapore")`。**不要把 `Region` 放进 `params`**（会报 `The parameter Region is not recognized`）
+- CLI：`tcb env list -r ap-singapore --json`
+
+绑定非当前地域环境：账号级登录下 `auth(action="set_env", envId="<EnvId>")` 不要求 envId 出现在当前地域候选列表中；环境级 API Key 不能改绑到其他 envId。
+
 #### API Key 模式示例
 
 ```json

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -127,7 +127,7 @@ import ParameterTable from '../../api-reference/components/ApiContainer';
 ## 详细规格
 
 ### `auth`
-CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。
+CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 credential_scope（account=账号级 / single_env=环境级 API Key）与当前 region；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。
 
 #### 参数
 

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -127,7 +127,7 @@ import ParameterTable from '../../api-reference/components/ApiContainer';
 ## 详细规格
 
 ### `auth`
-CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。
+CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。
 
 #### 参数
 
@@ -189,7 +189,7 @@ CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即�
 ---
 
 ### `queryEnv`
-查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
+查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。账号级登录可传 region（ap-shanghai/ap-guangzhou/ap-singapore）查询对应地域，对齐 CLI `tcb env list -r &lt;region&gt;`；环境级 API Key 只能看到绑定的 envId，返回 credential_scope=single_env，不要误判为环境不存在。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
 
 📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。
 
@@ -212,7 +212,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "action",
       type: "string",
       required: true,
-      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
+      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId / region 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
     },
     {
       name: "alias",
@@ -228,6 +228,11 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "envId",
       type: "string",
       description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。`,
+    },
+    {
+      name: "region",
+      type: "string",
+      description: `查询地域。仅 action=list 时有效。账号级凭据会把该值透传到 DescribeEnvs（X-TC-Region），例如 ap-singapore。环境级 API Key 无法用此参数看到其他环境。等价 CLI：tcb env list -r <region> --json。 可填写的值: "ap-shanghai", "ap-guangzhou", "ap-singapore"`,
     },
     {
       name: "limit",
@@ -300,7 +305,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
 ---
 
 ### `envQuery`
-查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
+查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。账号级登录可传 region（ap-shanghai/ap-guangzhou/ap-singapore）查询对应地域，对齐 CLI `tcb env list -r &lt;region&gt;`；环境级 API Key 只能看到绑定的 envId，返回 credential_scope=single_env，不要误判为环境不存在。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。
 
 📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。
 
@@ -323,7 +328,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "action",
       type: "string",
       required: true,
-      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
+      description: `查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId / region 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData） 可填写的值: "list", "info", "domains", "usage", "metrics"`,
     },
     {
       name: "alias",
@@ -339,6 +344,11 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
       name: "envId",
       type: "string",
       description: `环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。`,
+    },
+    {
+      name: "region",
+      type: "string",
+      description: `查询地域。仅 action=list 时有效。账号级凭据会把该值透传到 DescribeEnvs（X-TC-Region），例如 ap-singapore。环境级 API Key 无法用此参数看到其他环境。等价 CLI：tcb env list -r <region> --json。 可填写的值: "ap-shanghai", "ap-guangzhou", "ap-singapore"`,
     },
     {
       name: "limit",
@@ -3326,6 +3336,8 @@ CloudBase Agent 域统一写入口。支持创建、更新和删除远端 Agent�
 
 ⚠️ 云托管（CloudBase Run）统一走 tcbr service（CreateCloudRunEnv / CreateCloudRunServer / DescribeEnvBaseInfo / DescribeCloudRunEnvs，version="2022-02-17"），tcb 旧小租户接口 CreateCloudBaseRunResource 等已被禁用；部署请用 manageCloudRun。查询单个环境基础信息/是否已开通云托管用 DescribeEnvBaseInfo（EnvId 必填），查询环境列表及资源信息用 DescribeCloudRunEnvs（EnvId 可选过滤）。
 
+⚠️ Region 必须作为本工具顶层参数 `region` 传入（对应 X-TC-Region / 地域 endpoint），不要放进 params。params 里的 Region 会被剥离并当作顶层 region 使用。
+
 销毁环境时，常见做法是至少带上 `EnvId` 和 `BypassCheck: true`，如果环境已经处于隔离期再按文档补 `IsForce: true`。
 
 #### 参数
@@ -3352,7 +3364,12 @@ CloudBase Agent 域统一写入口。支持创建、更新和删除远端 Agent�
     {
       name: "params",
       type: "object",
-      description: `Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：\`{ "service": "tcb", "action": "DestroyEnv", "params": { "EnvId": "env-xxx", "BypassCheck": true } }\`，如果环境已经处于隔离期，可再补 \`IsForce: true\`；更新环境别名则可用 \`{ "service": "tcb", "action": "ModifyEnv", "params": { "EnvId": "env-xxx", "Alias": "demo" } }\`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode="openapi")，而不是优先使用 callCloudApi。`,
+      description: `Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：\`{ "service": "tcb", "action": "DestroyEnv", "params": { "EnvId": "env-xxx", "BypassCheck": true } }\`，如果环境已经处于隔离期，可再补 \`IsForce: true\`；更新环境别名则可用 \`{ "service": "tcb", "action": "ModifyEnv", "params": { "EnvId": "env-xxx", "Alias": "demo" } }\`。不要把 Region 放进 params（会报 The parameter Region is not recognized）；跨地域请用顶层 region，例如 \`{ "service": "tcb", "action": "DescribeEnvs", "region": "ap-singapore" }\`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode="openapi")，而不是优先使用 callCloudApi。`,
+    },
+    {
+      name: "region",
+      type: "string",
+      description: `云 API 地域（X-TC-Region）。例如 ap-shanghai、ap-guangzhou、ap-singapore。DescribeEnvs 等接口按地域查询，跨地域必须传此顶层参数，不要写入 params.Region。`,
     }
   ]}
 />

--- a/mcp/src/cloudbase-manager.test.ts
+++ b/mcp/src/cloudbase-manager.test.ts
@@ -485,3 +485,51 @@ describe("cloudbase manager auth gate", () => {
     await expect(getEnvId()).resolves.toBe("env-picked");
   });
 });
+
+describe("listAvailableEnvCandidates region scope", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    delete process.env.CLOUDBASE_ENV_ID;
+    mockPeekLoginState.mockResolvedValue({
+      secretId: "sid",
+      secretKey: "skey",
+      token: "token",
+    });
+    mockCommonServiceCall.mockResolvedValue({
+      EnvList: [
+        { EnvId: "env-sg", Alias: "sg", Region: "ap-singapore", Status: "NORMAL" },
+      ],
+    });
+  });
+
+  it("should pass region override into CloudBase manager", async () => {
+    const { listAvailableEnvCandidates } = await import("./cloudbase-manager.js");
+    const result = await listAvailableEnvCandidates({
+      ignorePinnedEnvId: true,
+      region: "ap-singapore",
+    });
+
+    expect(mockCloudBaseCtor).toHaveBeenCalledWith(
+      expect.objectContaining({
+        region: "ap-singapore",
+      }),
+    );
+    expect(result).toEqual([
+      expect.objectContaining({
+        envId: "env-sg",
+        region: "ap-singapore",
+      }),
+    ]);
+  });
+
+  it("should ignore pinned CLOUDBASE_ENV_ID when requested", async () => {
+    process.env.CLOUDBASE_ENV_ID = "env-pinned";
+    const { listAvailableEnvCandidates } = await import("./cloudbase-manager.js");
+    const result = await listAvailableEnvCandidates({
+      ignorePinnedEnvId: true,
+      region: "ap-singapore",
+    });
+    expect(result.map((item) => item.envId)).toEqual(["env-sg"]);
+  });
+});

--- a/mcp/src/cloudbase-manager.ts
+++ b/mcp/src/cloudbase-manager.ts
@@ -8,7 +8,7 @@ import {
 import { CloudBaseOptions, Logger } from './types.js';
 import { debug, error } from './utils/logger.js';
 import { buildAuthNextStep, throwToolPayloadError } from './utils/tool-result.js';
-import { resolveSiteAndRegion } from './utils/site-map.js';
+import { resolveSiteAndRegion, TCB_QUERY_REGIONS } from './utils/site-map.js';
 
 // Timeout for envId auto-resolution flow.
 // 10 minutes (600 seconds) - matches InteractiveServer timeout
@@ -52,34 +52,50 @@ function createManagerFromLoginState(loginState: any, region?: string): CloudBas
 export async function listAvailableEnvCandidates(options?: {
     cloudBaseOptions?: CloudBaseOptions;
     loginState?: any;
+    region?: string;
+    ignorePinnedEnvId?: boolean;
 }): Promise<EnvCandidate[]> {
-    const { cloudBaseOptions, loginState: providedLoginState } = options ?? {};
+    const {
+        cloudBaseOptions,
+        loginState: providedLoginState,
+        region: regionOverride,
+        ignorePinnedEnvId,
+    } = options ?? {};
 
-    // 优先使用显式传入的 envId
-    if (cloudBaseOptions?.envId) {
-        return [{
-            envId: cloudBaseOptions.envId,
-        }];
+    if (!ignorePinnedEnvId) {
+        // Prefer an explicit envId pin (bound session / API Key).
+        if (cloudBaseOptions?.envId) {
+            return [{
+                envId: cloudBaseOptions.envId,
+                region: cloudBaseOptions.region,
+            }];
+        }
+
+        // When CLOUDBASE_ENV_ID is set and credentials are not explicit, skip DescribeEnvs.
+        const hasExplicitCredentials = !!(cloudBaseOptions?.secretId && cloudBaseOptions?.secretKey);
+        if (process.env.CLOUDBASE_ENV_ID && !hasExplicitCredentials) {
+            return [{
+                envId: process.env.CLOUDBASE_ENV_ID,
+            }];
+        }
     }
 
-    // 当环境变量设置了 CLOUDBASE_ENV_ID 且没有显式 credentials 时，直接返回（避免调 DescribeEnvs）
-    // 有显式 credentials 时需要重新查询，因为可能是不同账号
-    const hasExplicitCredentials = !!(cloudBaseOptions?.secretId && cloudBaseOptions?.secretKey);
-    if (process.env.CLOUDBASE_ENV_ID && !hasExplicitCredentials) {
-        return [{
-            envId: process.env.CLOUDBASE_ENV_ID,
-        }];
-    }
+    const region = resolveSiteAndRegion({
+        ...(cloudBaseOptions ?? {}),
+        ...(regionOverride ? { region: regionOverride } : {}),
+    }).region;
 
     let cloudbase: CloudBase | undefined;
     if (cloudBaseOptions?.secretId && cloudBaseOptions?.secretKey) {
-        cloudbase = createCloudBaseManagerWithOptions(cloudBaseOptions);
+        cloudbase = createCloudBaseManagerWithOptions({
+            ...cloudBaseOptions,
+            region,
+        });
     } else {
         const loginState = providedLoginState ?? await peekLoginState();
         if (!loginState?.secretId || !loginState?.secretKey) {
             return [];
         }
-        const region = resolveSiteAndRegion(cloudBaseOptions ?? {}).region;
         cloudbase = createManagerFromLoginState(loginState, region);
     }
 
@@ -102,6 +118,47 @@ export async function listAvailableEnvCandidates(options?: {
             return [];
         }
     }
+}
+
+/**
+ * Look up an envId across known TCB regions. Used by set_env so a Singapore
+ * env can be bound even when the current session region is ap-shanghai.
+ */
+export async function resolveEnvCandidateByEnvId(options: {
+    envId: string;
+    cloudBaseOptions?: CloudBaseOptions;
+    loginState?: any;
+}): Promise<EnvCandidate | undefined> {
+    const { envId, cloudBaseOptions, loginState } = options;
+    const seenRegions = new Set<string>();
+    const regionsToProbe = [
+        resolveSiteAndRegion({
+            ...(cloudBaseOptions ?? {}),
+        }).region,
+        ...TCB_QUERY_REGIONS,
+    ];
+
+    for (const region of regionsToProbe) {
+        if (seenRegions.has(region)) {
+            continue;
+        }
+        seenRegions.add(region);
+        const candidates = await listAvailableEnvCandidates({
+            cloudBaseOptions,
+            loginState,
+            region,
+            ignorePinnedEnvId: true,
+        });
+        const matched = candidates.find((item) => item.envId === envId);
+        if (matched) {
+            return {
+                ...matched,
+                region: matched.region || region,
+            };
+        }
+    }
+
+    return undefined;
 }
 
 function throwAuthRequiredError() {

--- a/mcp/src/tools/capi.test.ts
+++ b/mcp/src/tools/capi.test.ts
@@ -3,6 +3,7 @@ import {
   assertTcbCloudRunActionAllowed,
   buildCapiErrorMessage,
   removeEmptyStringParams,
+  resolveCloudApiRegionAndParams,
 } from "./capi.js";
 
 describe("buildCapiErrorMessage", () => {
@@ -99,6 +100,43 @@ describe("assertTcbCloudRunActionAllowed", () => {
     expect(() =>
       assertTcbCloudRunActionAllowed("scf", "CreateCloudBaseRunResource"),
     ).not.toThrow();
+  });
+});
+
+describe("resolveCloudApiRegionAndParams", () => {
+  it("prefers top-level region and strips params.Region", () => {
+    expect(
+      resolveCloudApiRegionAndParams({
+        region: "ap-singapore",
+        params: { EnvId: "env-xxx", Region: "ap-shanghai" },
+      }),
+    ).toEqual({
+      region: "ap-singapore",
+      params: { EnvId: "env-xxx" },
+    });
+  });
+
+  it("promotes params.Region when top-level region is omitted", () => {
+    expect(
+      resolveCloudApiRegionAndParams({
+        params: { Region: "ap-singapore" },
+      }),
+    ).toEqual({
+      region: "ap-singapore",
+      params: {},
+    });
+  });
+});
+
+describe("buildCapiErrorMessage region", () => {
+  it("guides callers to top-level region when Region is not recognized", () => {
+    const message = buildCapiErrorMessage(
+      "tcb",
+      "DescribeEnvs",
+      new Error("The parameter Region is not recognized"),
+    );
+    expect(message).toContain("顶层参数 region");
+    expect(message).toContain("X-TC-Region");
   });
 });
 

--- a/mcp/src/tools/capi.ts
+++ b/mcp/src/tools/capi.ts
@@ -55,6 +55,26 @@ export function assertTcbCloudRunActionAllowed(service: string, action: string):
     }
 }
 
+export function resolveCloudApiRegionAndParams(args: {
+    region?: string;
+    params?: Record<string, any>;
+}): { region?: string; params: Record<string, any> } {
+    const raw = { ...(args.params ?? {}) };
+    const nestedRegion =
+        typeof raw.Region === "string" && raw.Region.trim()
+            ? raw.Region.trim()
+            : typeof raw.region === "string" && raw.region.trim()
+                ? raw.region.trim()
+                : undefined;
+    delete raw.Region;
+    delete raw.region;
+    const region =
+        (typeof args.region === "string" && args.region.trim()
+            ? args.region.trim()
+            : undefined) || nestedRegion;
+    return { region, params: raw };
+}
+
 function levenshteinDistance(left: string, right: string) {
     const rows = left.length + 1;
     const cols = right.length + 1;
@@ -204,6 +224,12 @@ export function buildCapiErrorMessage(service: AllowedService, action: string, e
         suggestions.push(buildCapiDocGuidance(service));
     }
 
+    if (/parameter\s+`?Region`?\s+is not recognized/i.test(baseMessage)) {
+        suggestions.push(
+            "Region 不是 Action body 参数。请使用 callCloudApi 顶层参数 region（例如 region=\"ap-singapore\"），对应 X-TC-Region。",
+        );
+    }
+
     if (hasParameterError) {
         suggestions.push("请求参数名与 API 定义不一致，请核对参数字段（区分大小写）并移除未支持字段。");
         if (service === "tcb" && tcbEntry) {
@@ -266,7 +292,6 @@ export function buildCapiErrorMessage(service: AllowedService, action: string, e
 export function registerCapiTools(server: ExtendedMcpServer) {
     const cloudBaseOptions = server.cloudBaseOptions;
     const logger = server.logger;
-    const getManager = () => getCloudBaseManager({ cloudBaseOptions });
 
     server.registerTool?.(
         "callCloudApi",
@@ -282,6 +307,8 @@ export function registerCapiTools(server: ExtendedMcpServer) {
 **数据库**: \`CreateMySQLInstance\`、\`DescribeMySQLInstances\`、\`DestroyMySQLInstance\`
 
 ⚠️ 云托管（CloudBase Run）统一走 tcbr service（CreateCloudRunEnv / CreateCloudRunServer / DescribeEnvBaseInfo / DescribeCloudRunEnvs，version="2022-02-17"），tcb 旧小租户接口 CreateCloudBaseRunResource 等已被禁用；部署请用 manageCloudRun。查询单个环境基础信息/是否已开通云托管用 DescribeEnvBaseInfo（EnvId 必填），查询环境列表及资源信息用 DescribeCloudRunEnvs（EnvId 可选过滤）。
+
+⚠️ Region 必须作为本工具顶层参数 \`region\` 传入（对应 X-TC-Region / 地域 endpoint），不要放进 params。params 里的 Region 会被剥离并当作顶层 region 使用。
 
 销毁环境时，常见做法是至少带上 \`EnvId\` 和 \`BypassCheck: true\`，如果环境已经处于隔离期再按文档补 \`IsForce: true\`。`,
             inputSchema: {
@@ -302,7 +329,13 @@ export function registerCapiTools(server: ExtendedMcpServer) {
                     .record(z.any())
                     .optional()
                     .describe(
-                        "Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；更新环境别名则可用 `{ \"service\": \"tcb\", \"action\": \"ModifyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"Alias\": \"demo\" } }`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。",
+                        "Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；更新环境别名则可用 `{ \"service\": \"tcb\", \"action\": \"ModifyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"Alias\": \"demo\" } }`。不要把 Region 放进 params（会报 The parameter Region is not recognized）；跨地域请用顶层 region，例如 `{ \"service\": \"tcb\", \"action\": \"DescribeEnvs\", \"region\": \"ap-singapore\" }`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。",
+                    ),
+                region: z
+                    .string()
+                    .optional()
+                    .describe(
+                        "云 API 地域（X-TC-Region）。例如 ap-shanghai、ap-guangzhou、ap-singapore。DescribeEnvs 等接口按地域查询，跨地域必须传此顶层参数，不要写入 params.Region。",
                     ),
             },
             annotations: {
@@ -318,11 +351,13 @@ export function registerCapiTools(server: ExtendedMcpServer) {
             action,
             params,
             version,
+            region,
         }: {
             service: AllowedService;
             action: string;
             params?: Record<string, any>;
             version?: string;
+            region?: string;
         }) => {
             if (!ALLOWED_SERVICES.includes(service)) {
                 throw new Error(
@@ -332,7 +367,13 @@ export function registerCapiTools(server: ExtendedMcpServer) {
 
             assertTcbCloudRunActionAllowed(service, action);
 
-            const cloudbase = await getManager();
+            const { region: resolvedRegion, params: bodyParams } =
+                resolveCloudApiRegionAndParams({ region, params });
+            const cloudbase = await getCloudBaseManager({
+                cloudBaseOptions: resolvedRegion
+                    ? { ...cloudBaseOptions, region: resolvedRegion }
+                    : cloudBaseOptions,
+            });
             if (['1', 'true'].includes(process.env.CLOUDBASE_EVALUATE_MODE ?? '')) {
                 if (service === 'lowcode') {
                     throw new Error(`${service}/${action} Cloud API is not exposed or does not exist. Please use another API.`);
@@ -367,7 +408,7 @@ export function registerCapiTools(server: ExtendedMcpServer) {
 
             let result: unknown;
             try {
-                const cleanedParams = params ? removeEmptyStringParams(params) : {};
+                const cleanedParams = removeEmptyStringParams(bodyParams);
                 result = await cloudbase.commonService(service, version).call({
                     Action: action,
                     Param: cleanedParams,

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -31,6 +31,7 @@ const {
   mockEnvManagerSetEnvId,
   mockGetCachedEnvId,
   mockListAvailableEnvCandidates,
+  mockResolveEnvCandidateByEnvId,
   mockGetCloudBaseManager,
   mockResetCloudBaseManagerCache,
   mockResolveAuthOptions,
@@ -90,6 +91,7 @@ const {
   mockEnvManagerSetEnvId: vi.fn(),
   mockGetCachedEnvId: vi.fn(),
   mockListAvailableEnvCandidates: vi.fn(),
+  mockResolveEnvCandidateByEnvId: vi.fn(),
   mockGetCloudBaseManager: vi.fn(),
   mockResetCloudBaseManagerCache: vi.fn(),
   mockCheckAndInitTcbService: vi.fn(),
@@ -149,6 +151,7 @@ vi.mock("../cloudbase-manager.js", () => ({
   getCachedEnvId: mockGetCachedEnvId,
   getCloudBaseManager: mockGetCloudBaseManager,
   listAvailableEnvCandidates: mockListAvailableEnvCandidates,
+  resolveEnvCandidateByEnvId: mockResolveEnvCandidateByEnvId,
   logCloudBaseResult: vi.fn(),
   resetCloudBaseManagerCache: mockResetCloudBaseManagerCache,
 }));
@@ -196,12 +199,15 @@ function createMockServer(ide = "TestIDE", authOptions?: any) {
 describe("env tools - auth", () => {
   let tools: ReturnType<typeof createMockServer>["tools"];
   const originalCloudbaseEnvId = process.env.CLOUDBASE_ENV_ID;
+  const originalTcbRegion = process.env.TCB_REGION;
+  const originalApiKey = process.env.CLOUDBASE_API_KEY;
 
   beforeEach(() => {
     vi.clearAllMocks();
     delete process.env.CLOUDBASE_ENV_ID;
     mockGetCachedEnvId.mockReturnValue(null);
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
     mockGetAuthProgressState.mockResolvedValue({
       status: "IDLE",
       updatedAt: Date.now(),
@@ -244,10 +250,19 @@ describe("env tools - auth", () => {
   afterEach(() => {
     if (originalCloudbaseEnvId === undefined) {
       delete process.env.CLOUDBASE_ENV_ID;
-      return;
+    } else {
+      process.env.CLOUDBASE_ENV_ID = originalCloudbaseEnvId;
     }
-
-    process.env.CLOUDBASE_ENV_ID = originalCloudbaseEnvId;
+    if (originalTcbRegion === undefined) {
+      delete process.env.TCB_REGION;
+    } else {
+      process.env.TCB_REGION = originalTcbRegion;
+    }
+    if (originalApiKey === undefined) {
+      delete process.env.CLOUDBASE_API_KEY;
+    } else {
+      process.env.CLOUDBASE_API_KEY = originalApiKey;
+    }
   });
 
   it("should expose auth tool and remove standalone logout tool", () => {
@@ -275,6 +290,9 @@ describe("env tools - auth", () => {
       tool: "auth",
       action: "start_auth",
     });
+    expect(payload.login_mode).toBe("account");
+    expect(payload.credential_scope).toBe("account");
+    expect(payload.current_region).toBeTruthy();
   });
 
   it("auth(action=get_temp_credentials) should require explicit confirmation", async () => {
@@ -462,6 +480,7 @@ describe("env tools - auth", () => {
       secretKey: "skey",
     });
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
     mockCheckAndCreateFreeEnv.mockImplementation(async (_manager: any, context: any) => ({
       success: true,
       envId: "env-created",
@@ -498,6 +517,7 @@ describe("env tools - auth", () => {
       secretKey: "skey",
     });
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
     mockCheckAndInitTcbService.mockImplementation(async (_manager: any, context: any) => ({
       ...context,
       checkTcbServiceAttempted: true,
@@ -537,6 +557,7 @@ describe("env tools - auth", () => {
       secretKey: "skey",
     });
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
 
     const result = await tools.auth.handler({ action: "status" });
     const payload = JSON.parse(result.content[0].text);
@@ -680,6 +701,7 @@ describe("env tools - auth", () => {
       secretKey: "skey",
     });
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
     mockCheckAndCreateFreeEnv.mockImplementation(async (_manager: any, context: any) => ({
       success: true,
       envId: "env-web-created",
@@ -727,6 +749,66 @@ describe("env tools - auth", () => {
     expect(payload.next_step).toBeUndefined();
     expect(payload.env_candidates).toBeUndefined();
     expect(mockEnvManagerSetEnvId).toHaveBeenCalledWith("env-test");
+  });
+
+  it("auth(action=set_env) should bind envId outside current-region candidates", async () => {
+    mockPeekLoginState.mockResolvedValue({
+      secretId: "sid",
+      secretKey: "skey",
+    });
+    mockListAvailableEnvCandidates.mockResolvedValue([
+      { envId: "env-shanghai", alias: "sh", region: "ap-shanghai" },
+    ]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue({
+      envId: "alfred-test-sg-d7gxpjc7g94e84f6c",
+      alias: "sg",
+      region: "ap-singapore",
+    });
+
+    const { tools: localTools, server } = createMockServer();
+    const result = await localTools.auth.handler({
+      action: "set_env",
+      envId: "alfred-test-sg-d7gxpjc7g94e84f6c",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      code: "ENV_READY",
+      current_env_id: "alfred-test-sg-d7gxpjc7g94e84f6c",
+      current_region: "ap-singapore",
+      login_mode: "account",
+    });
+    expect(mockEnvManagerSetEnvId).toHaveBeenCalledWith("alfred-test-sg-d7gxpjc7g94e84f6c");
+    expect(server.cloudBaseOptions?.region).toBe("ap-singapore");
+    expect(process.env.TCB_REGION).toBe("ap-singapore");
+  });
+
+  it("auth(action=set_env) should reject other envIds in API Key mode", async () => {
+    process.env.CLOUDBASE_API_KEY = "test-api-key";
+    process.env.CLOUDBASE_ENV_ID = "env-pinned";
+    mockPeekLoginState.mockResolvedValue({
+      secretId: "sid",
+      secretKey: "skey",
+    });
+    mockListAvailableEnvCandidates.mockResolvedValue([
+      { envId: "env-pinned" },
+    ]);
+
+    const result = await tools.auth.handler({
+      action: "set_env",
+      envId: "env-other",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(payload).toMatchObject({
+      ok: false,
+      code: "CREDENTIAL_SCOPE_LIMITED",
+      login_mode: "api_key",
+      credential_scope: "single_env",
+    });
+    expect(payload.message).toContain("凭据权限边界");
+    expect(mockEnvManagerSetEnvId).not.toHaveBeenCalled();
+    delete process.env.CLOUDBASE_API_KEY;
   });
 
   it("auth(action=logout) should clear session state", async () => {
@@ -930,6 +1012,7 @@ describe("env tools - envQuery", () => {
     delete process.env.CLOUDBASE_ENV_ID;
     mockGetCachedEnvId.mockReturnValue(null);
     mockListAvailableEnvCandidates.mockResolvedValue([]);
+    mockResolveEnvCandidateByEnvId.mockResolvedValue(undefined);
     mockGetAuthProgressState.mockResolvedValue({
       status: "IDLE",
       updatedAt: Date.now(),
@@ -1017,6 +1100,8 @@ describe("env tools - envQuery", () => {
       fields: ["EnvId", "Alias"],
       currentEnvOnly: false,
     });
+    expect(payload.login_mode).toBe("account");
+    expect(payload.credential_scope).toBe("account");
   });
 
   it("envQuery(list) should support exact alias filtering when requested", async () => {
@@ -1100,6 +1185,56 @@ describe("env tools - envQuery", () => {
       tool: "queryEnv",
       action: "info",
     });
+  });
+
+  it("envQuery(list) should pass region through to CloudBase manager", async () => {
+    const commonServiceCall = vi.fn().mockResolvedValue({
+      EnvList: [
+        {
+          EnvId: "alfred-test-sg-d7gxpjc7g94e84f6c",
+          Alias: "sg",
+          Region: "ap-singapore",
+          Status: "NORMAL",
+        },
+      ],
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      commonService: vi.fn(() => ({
+        call: commonServiceCall,
+      })),
+      env: {
+        listEnvs: vi.fn(),
+      },
+    });
+
+    const { tools } = createMockServer();
+    const result = await tools.queryEnv.handler({
+      action: "list",
+      region: "ap-singapore",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockGetCloudBaseManager).toHaveBeenCalledWith(
+      expect.objectContaining({
+        requireEnvId: false,
+        cloudBaseOptions: expect.objectContaining({
+          region: "ap-singapore",
+        }),
+      }),
+    );
+    expect(payload.EnvList[0].EnvId).toBe("alfred-test-sg-d7gxpjc7g94e84f6c");
+    expect(payload.AppliedFilters.region).toBe("ap-singapore");
+    expect(payload.AppliedFilters.currentEnvOnly).toBe(false);
+    expect(payload.query_region).toBe("ap-singapore");
+  });
+
+  it("queryEnv schema should expose region enum for list", async () => {
+    const { tools } = createMockServer();
+    expect(tools.queryEnv.meta.inputSchema.region.unwrap().options).toEqual([
+      "ap-shanghai",
+      "ap-guangzhou",
+      "ap-singapore",
+    ]);
   });
 
   it("envQuery(list) should use DescribeEnvInfo when CLOUDBASE_ENV_ID is set", async () => {

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -290,7 +290,6 @@ describe("env tools - auth", () => {
       tool: "auth",
       action: "start_auth",
     });
-    expect(payload.login_mode).toBe("account");
     expect(payload.credential_scope).toBe("account");
     expect(payload.current_region).toBeTruthy();
   });
@@ -776,7 +775,6 @@ describe("env tools - auth", () => {
       code: "ENV_READY",
       current_env_id: "alfred-test-sg-d7gxpjc7g94e84f6c",
       current_region: "ap-singapore",
-      login_mode: "account",
     });
     expect(mockEnvManagerSetEnvId).toHaveBeenCalledWith("alfred-test-sg-d7gxpjc7g94e84f6c");
     expect(server.cloudBaseOptions?.region).toBe("ap-singapore");
@@ -803,7 +801,6 @@ describe("env tools - auth", () => {
     expect(payload).toMatchObject({
       ok: false,
       code: "CREDENTIAL_SCOPE_LIMITED",
-      login_mode: "api_key",
       credential_scope: "single_env",
     });
     expect(payload.message).toContain("凭据权限边界");
@@ -1100,7 +1097,6 @@ describe("env tools - envQuery", () => {
       fields: ["EnvId", "Alias"],
       currentEnvOnly: false,
     });
-    expect(payload.login_mode).toBe("account");
     expect(payload.credential_scope).toBe("account");
   });
 

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -673,15 +673,10 @@ async function fetchAccountEnvCandidates(
   }
 }
 
-type LoginMode = "api_key" | "account";
 type CredentialScope = "single_env" | "account";
 
 function isApiKeyCredentialMode(): boolean {
   return Boolean(getCloudBaseApiKeyFromEnv() && process.env.CLOUDBASE_ENV_ID);
-}
-
-function getLoginMode(): LoginMode {
-  return isApiKeyCredentialMode() ? "api_key" : "account";
 }
 
 function getCredentialScope(): CredentialScope {
@@ -689,7 +684,6 @@ function getCredentialScope(): CredentialScope {
 }
 
 function buildCredentialBoundaryPayload(cloudBaseOptions?: { region?: string; envId?: string }) {
-  const loginMode = getLoginMode();
   const credentialScope = getCredentialScope();
   const currentRegion = resolveSiteAndRegion(cloudBaseOptions ?? {}).region;
   const pinnedEnvId = process.env.CLOUDBASE_ENV_ID || cloudBaseOptions?.envId || null;
@@ -699,7 +693,6 @@ function buildCredentialBoundaryPayload(cloudBaseOptions?: { region?: string; en
       : `当前为账号级登录。DescribeEnvs 按地域查询；未传 region 时使用当前地域 ${currentRegion}。其他地域请用 queryEnv(action="list", region="ap-singapore")，或 CLI: tcb env list -r ap-singapore。`;
 
   return {
-    login_mode: loginMode,
     credential_scope: credentialScope,
     current_region: currentRegion,
     scope_note: scopeNote,
@@ -1991,7 +1984,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
     {
       title: "CloudBase 开发阶段登录与环境",
       description:
-        "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
+        "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 credential_scope（account=账号级 / single_env=环境级 API Key）与当前 region；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
       inputSchema: {
         action: z
           .enum(authActionEnum)

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -24,10 +24,12 @@ import {
   listAvailableEnvCandidates,
   logCloudBaseResult,
   resetCloudBaseManagerCache,
+  resolveEnvCandidateByEnvId,
   type EnvCandidate,
 } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import { debug } from "../utils/logger.js";
+import { resolveSiteAndRegion, TCB_QUERY_REGIONS } from "../utils/site-map.js";
 import {
   buildAuthNextStep,
   buildJsonToolResult,
@@ -658,6 +660,65 @@ async function fetchAvailableEnvCandidates(
   }
 }
 
+async function fetchAccountEnvCandidates(
+  cloudBaseOptions: any,
+): Promise<EnvCandidate[]> {
+  try {
+    return await listAvailableEnvCandidates({
+      cloudBaseOptions,
+      ignorePinnedEnvId: true,
+    });
+  } catch {
+    return [];
+  }
+}
+
+type LoginMode = "api_key" | "account";
+type CredentialScope = "single_env" | "account";
+
+function isApiKeyCredentialMode(): boolean {
+  return Boolean(getCloudBaseApiKeyFromEnv() && process.env.CLOUDBASE_ENV_ID);
+}
+
+function getLoginMode(): LoginMode {
+  return isApiKeyCredentialMode() ? "api_key" : "account";
+}
+
+function getCredentialScope(): CredentialScope {
+  return isApiKeyCredentialMode() ? "single_env" : "account";
+}
+
+function buildCredentialBoundaryPayload(cloudBaseOptions?: { region?: string; envId?: string }) {
+  const loginMode = getLoginMode();
+  const credentialScope = getCredentialScope();
+  const currentRegion = resolveSiteAndRegion(cloudBaseOptions ?? {}).region;
+  const pinnedEnvId = process.env.CLOUDBASE_ENV_ID || cloudBaseOptions?.envId || null;
+  const scopeNote =
+    credentialScope === "single_env"
+      ? `当前为环境级 API Key 登录（单环境权限）。只能访问已绑定的 envId${pinnedEnvId ? ` ${pinnedEnvId}` : ""}，看不到账号下其他环境或其他地域。这是凭据权限边界，不是环境不存在。`
+      : `当前为账号级登录。DescribeEnvs 按地域查询；未传 region 时使用当前地域 ${currentRegion}。其他地域请用 queryEnv(action="list", region="ap-singapore")，或 CLI: tcb env list -r ap-singapore。`;
+
+  return {
+    login_mode: loginMode,
+    credential_scope: credentialScope,
+    current_region: currentRegion,
+    scope_note: scopeNote,
+  };
+}
+
+function applyBoundEnvRegion(
+  server: ExtendedMcpServer,
+  region?: string,
+) {
+  if (!region) {
+    return;
+  }
+  process.env.TCB_REGION = region;
+  if (server.cloudBaseOptions) {
+    server.cloudBaseOptions.region = region;
+  }
+}
+
 type AuthAction =
   | "status"
   | "start_auth"
@@ -971,6 +1032,7 @@ function buildEnvQueryListResult(params: {
       alias?: string;
       aliasExact?: boolean;
       envId?: string;
+      region?: string;
       limit?: number;
       offset?: number;
       fields?: EnvFieldName[];
@@ -978,7 +1040,10 @@ function buildEnvQueryListResult(params: {
 }) {
   const envList = Array.isArray(params.result?.EnvList) ? params.result.EnvList : [];
   const shouldRestrictToCurrentEnv =
-    params.hasEnvId && !params.filters.alias && !params.filters.envId;
+    params.hasEnvId &&
+    !params.filters.alias &&
+    !params.filters.envId &&
+    !params.filters.region;
   const baseList = shouldRestrictToCurrentEnv
     ? envList.filter((env: any) => env.EnvId === params.cloudBaseOptions?.envId)
     : envList;
@@ -996,6 +1061,13 @@ function buildEnvQueryListResult(params: {
           "action=list with envId only returns a concise summary. Use action=info to fetch detailed environment information such as full resource metadata and additional environment details.",
       }
     : undefined;
+  const credentialBoundary = buildCredentialBoundaryPayload(params.cloudBaseOptions);
+  const queryRegion =
+    params.filters.region || credentialBoundary.current_region;
+  const currentEnvOnlyNote =
+    shouldRestrictToCurrentEnv && credentialBoundary.credential_scope === "account"
+      ? `已绑定环境，list 默认只返回当前环境。要查看其他地域请传 region（例如 region="ap-singapore"），或使用 CLI: tcb env list -r ap-singapore。`
+      : undefined;
 
   return {
     EnvList: paginated.items.map((env) => selectEnvFields(env, params.filters.fields)),
@@ -1007,9 +1079,13 @@ function buildEnvQueryListResult(params: {
       alias: params.filters.alias ?? null,
       aliasExact: params.filters.aliasExact ?? null,
       envId: params.filters.envId ?? null,
+      region: params.filters.region ?? null,
       fields: params.filters.fields ?? [...DEFAULT_ENV_FIELDS],
       currentEnvOnly: shouldRestrictToCurrentEnv,
     },
+    ...credentialBoundary,
+    query_region: queryRegion,
+    ...(currentEnvOnlyNote ? { scope_note: currentEnvOnlyNote } : {}),
     ...(exactEnvIdSummaryHint
       ? {
           RecommendedNextAction: exactEnvIdSummaryHint,
@@ -1886,15 +1962,19 @@ export function registerEnvTools(server: ExtendedMcpServer) {
       requireEnvId: options?.requireEnvId ?? true,
       mcpServer: server,
     });
-  const getManagerForEnvQuery = (targetEnvId?: string, requireEnvId = true) =>
+  const getManagerForEnvQuery = (
+    targetEnvId?: string,
+    requireEnvId = true,
+    region?: string,
+  ) =>
     getCloudBaseManager({
-      cloudBaseOptions:
-        targetEnvId && targetEnvId !== cloudBaseOptions?.envId
-          ? {
-              ...cloudBaseOptions,
-              envId: targetEnvId,
-            }
-          : cloudBaseOptions,
+      cloudBaseOptions: {
+        ...cloudBaseOptions,
+        ...(targetEnvId && targetEnvId !== cloudBaseOptions?.envId
+          ? { envId: targetEnvId }
+          : {}),
+        ...(region ? { region } : {}),
+      },
       requireEnvId,
       mcpServer: server,
     });
@@ -1911,7 +1991,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
     {
       title: "CloudBase 开发阶段登录与环境",
       description:
-        "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。",
+        "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
       inputSchema: {
         action: z
           .enum(authActionEnum)
@@ -2046,14 +2126,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
           let envPreparation:
             | AuthEnvPreparationResult
             | undefined;
-          const message =
-            authStatus === "READY"
-              ? undefined
-              : authStatus === "PENDING"
-                ? "设备码授权进行中，请完成浏览器授权后再次调用 auth(action=\"status\")"
-                : isCodeBuddyIde(server)
-                  ? "当前未登录。CodeBuddy 暂不支持在 tool 内发起认证，请在外部完成认证后再次调用 auth(action=\"status\")。"
-                  : "当前未登录，请先执行 auth(action=\"start_auth\")";
+          const credentialBoundary = buildCredentialBoundaryPayload(cloudBaseOptions);
 
           if (authStatus === "READY" && loginState) {
             envPreparation = await prepareAuthEnvironment({
@@ -2063,11 +2136,23 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             });
           }
 
+          const statusMessage =
+            authStatus === "READY"
+              ? envPreparation?.message
+                ? `${envPreparation.message} ${credentialBoundary.scope_note}`
+                : credentialBoundary.scope_note
+              : authStatus === "PENDING"
+                ? "设备码授权进行中，请完成浏览器授权后再次调用 auth(action=\"status\")"
+                : isCodeBuddyIde(server)
+                  ? "当前未登录。CodeBuddy 暂不支持在 tool 内发起认证，请在外部完成认证后再次调用 auth(action=\"status\")。"
+                  : "当前未登录，请先执行 auth(action=\"start_auth\")";
+
           return buildJsonToolResult({
             ok: true,
             code: "STATUS",
             auth_status: authStatus,
             ...(isApiKeyMode ? { auth_mode: "api_key" } : {}),
+            ...credentialBoundary,
             auth_config: authConfigSummary,
             ...(envPreparation
               ? buildAuthEnvSetupPayload(envPreparation)
@@ -2080,7 +2165,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               authFlowState.status === "PENDING"
                 ? buildDeviceAuthChallengePayload(authFlowState.authChallenge)
                 : undefined,
-            message,
+            message: statusMessage,
             next_step:
               authStatus === "REQUIRED"
                 ? buildAuthRequiredNextStep(server)
@@ -2406,33 +2491,66 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             });
           }
 
-          const envCandidates = await fetchAvailableEnvCandidates(cloudBaseOptions, server);
+          const credentialBoundary = buildCredentialBoundaryPayload(cloudBaseOptions);
+          const envCandidates = isApiKeyCredentialMode()
+            ? await fetchAvailableEnvCandidates(cloudBaseOptions, server)
+            : await fetchAccountEnvCandidates(cloudBaseOptions);
           if (!envId) {
             return buildJsonToolResult({
               ok: false,
               code: "INVALID_ARGS",
               message: "action=set_env 时必须提供 envId",
+              ...credentialBoundary,
               ...buildEnvCandidatePayload(envCandidates),
               next_step: buildSetEnvNextStep(envCandidates),
             });
           }
 
-          const target = envCandidates.find((item) => item.envId === envId);
-          if (envCandidates.length > 0 && !target) {
+          if (isApiKeyCredentialMode()) {
+            const pinnedEnvId = process.env.CLOUDBASE_ENV_ID;
+            if (pinnedEnvId && envId !== pinnedEnvId) {
+              return buildJsonToolResult({
+                ok: false,
+                code: "CREDENTIAL_SCOPE_LIMITED",
+                message: `当前为环境级 API Key 登录，只能绑定已授权环境 ${pinnedEnvId}，不能切换到 ${envId}。这是凭据权限边界，不是目标环境不存在。`,
+                ...credentialBoundary,
+                current_env_id: pinnedEnvId,
+                ...buildEnvCandidatePayload(envCandidates),
+              });
+            }
+            await envManager.setEnvId(envId);
             return buildJsonToolResult({
-              ok: false,
-              code: "INVALID_ARGS",
-              message: `未找到环境: ${envId}`,
-              ...buildEnvCandidatePayload(envCandidates),
-              next_step: buildSetEnvNextStep(envCandidates),
+              ok: true,
+              code: "ENV_READY",
+              message: `环境设置成功，当前环境: ${envId}`,
+              current_env_id: envId,
+              ...credentialBoundary,
             });
           }
+
+          let target = envCandidates.find((item) => item.envId === envId);
+          if (!target) {
+            target = await resolveEnvCandidateByEnvId({
+              envId,
+              cloudBaseOptions,
+              loginState,
+            });
+          }
+
           await envManager.setEnvId(envId);
+          applyBoundEnvRegion(server, target?.region);
+          const regionHint = target?.region
+            ? `，地域: ${target.region}`
+            : target
+              ? ""
+              : "。未在当前探测地域中确认该 envId，已按唯一 ID 直绑；若后续接口仍指向错误地域，请设置 TCB_REGION 或 queryEnv(action=\"list\", region=...)";
           return buildJsonToolResult({
             ok: true,
             code: "ENV_READY",
-            message: `环境设置成功，当前环境: ${envId}`,
+            message: `环境设置成功，当前环境: ${envId}${regionHint}`,
+            ...credentialBoundary,
             current_env_id: envId,
+            current_region: target?.region || credentialBoundary.current_region,
           });
         }
 
@@ -2556,6 +2674,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
     alias,
     aliasExact,
     envId,
+    region,
     limit,
     offset,
     fields,
@@ -2574,6 +2693,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
       alias?: string;
       aliasExact?: boolean;
       envId?: string;
+      region?: (typeof TCB_QUERY_REGIONS)[number];
       limit?: number;
       offset?: number;
       fields?: EnvFieldName[];
@@ -2594,18 +2714,17 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         switch (action) {
           case "list":
             try {
-              const cloudbaseList = await getCloudBaseManager({
-                cloudBaseOptions,
-                requireEnvId: true,
-                mcpServer: server, // Pass server for IDE detection
-              });
+              const cloudbaseList = await getManagerForEnvQuery(undefined, false, region);
 
-              // 当环境变量设置了 CLOUDBASE_ENV_ID 时（如 API Key 模式），
-              // 避免调用 DescribeEnvs（临时密钥可能不支持该接口），
-              // 改为通过 DescribeEnvInfo 获取单环境信息
-              // 注意：requestFn 模式（如微信 IDE）使用 DescribeEnvs，不走此分支
+              // API Key / env-var pin: skip DescribeEnvs (STS often cannot list).
+              // Account-level sessions that only pinned CLOUDBASE_ENV_ID via set_env
+              // can still pass region/alias/envId to list other environments.
               const envIdFromEnv = !cloudBaseOptions?.requestFn && process.env.CLOUDBASE_ENV_ID;
-              if (envIdFromEnv) {
+              const shouldPinToEnvVar = Boolean(
+                envIdFromEnv &&
+                (isApiKeyCredentialMode() || (!region && !alias && !envId)),
+              );
+              if (shouldPinToEnvVar && envIdFromEnv) {
                 try {
                   const envInfo = await cloudbaseList.env.describeEnvInfo({ EnvId: envIdFromEnv });
                   logCloudBaseResult(server.logger, envInfo);
@@ -2652,11 +2771,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               debug("获取环境列表时出错，尝试降级到 listEnvs():", error instanceof Error ? error : new Error(String(error)));
               // Fallback to original method on error
               try {
-                const cloudbaseList = await getCloudBaseManager({
-                  cloudBaseOptions,
-                  requireEnvId: true,
-                  mcpServer: server, // Pass server for IDE detection
-                });
+                const cloudbaseList = await getManagerForEnvQuery(undefined, false, region);
                 result = await cloudbaseList.env.listEnvs();
                 logCloudBaseResult(server.logger, result);
               } catch (fallbackError) {
@@ -2684,6 +2799,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                 alias,
                 aliasExact,
                 envId,
+                region,
                 limit,
                 offset,
                 fields,
@@ -2896,12 +3012,12 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   const queryEnvToolSchema = {
     title: "CloudBase 环境查询",
     description:
-      "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。账号级登录可传 region（ap-shanghai/ap-guangzhou/ap-singapore）查询对应地域，对齐 CLI `tcb env list -r <region>`；环境级 API Key 只能看到绑定的 envId，返回 credential_scope=single_env，不要误判为环境不存在。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
     inputSchema: {
       action: z
         .enum(["list", "info", "domains", "usage", "metrics"])
         .describe(
-          "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）",
+          "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId / region 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）",
         ),
       alias: z.string().optional().describe("按环境别名筛选。action=list 时可选"),
       aliasExact: z.boolean().optional().describe("按环境别名精确筛选。action=list 时可选；与 alias 配合使用"),
@@ -2910,6 +3026,12 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         .optional()
         .describe(
           "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。",
+        ),
+      region: z
+        .enum(TCB_QUERY_REGIONS)
+        .optional()
+        .describe(
+          "查询地域。仅 action=list 时有效。账号级凭据会把该值透传到 DescribeEnvs（X-TC-Region），例如 ap-singapore。环境级 API Key 无法用此参数看到其他环境。等价 CLI：tcb env list -r <region> --json。",
         ),
       limit: z.number().int().positive().optional().describe("返回数量上限。action=list 时可选"),
       offset: z.number().int().min(0).optional().describe("分页偏移。action=list 时可选"),

--- a/mcp/src/utils/site-map.test.ts
+++ b/mcp/src/utils/site-map.test.ts
@@ -10,6 +10,7 @@ vi.mock("./project-config.js", () => ({
 
 import {
   SITE_REGION_MAP,
+  TCB_QUERY_REGIONS,
   getSite,
   isSiteId,
   normalizeSite,
@@ -21,6 +22,13 @@ describe("site-map mapping table", () => {
   it("should map domestic regions to domestic site", () => {
     expect(getSite("ap-shanghai")).toBe("domestic");
     expect(getSite("ap-guangzhou")).toBe("domestic");
+  });
+
+  it("should keep TCB_QUERY_REGIONS covering SITE_REGION_MAP regions", () => {
+    const mapped = Object.values(SITE_REGION_MAP).flatMap((site) => site.regions);
+    for (const region of mapped) {
+      expect(TCB_QUERY_REGIONS).toContain(region);
+    }
   });
 
   it("should return ambiguous for ap-singapore without explicit site", () => {

--- a/mcp/src/utils/site-map.ts
+++ b/mcp/src/utils/site-map.ts
@@ -43,6 +43,15 @@ export const SITE_REGION_MAP: Record<SiteId, SiteDefinition> = {
 
 export const SITE_IDS = Object.keys(SITE_REGION_MAP) as SiteId[];
 
+/** Regions accepted by envQuery(list) / cross-region DescribeEnvs probes. */
+export const TCB_QUERY_REGIONS = [
+  "ap-shanghai",
+  "ap-guangzhou",
+  "ap-singapore",
+] as const;
+
+export type TcbQueryRegion = (typeof TCB_QUERY_REGIONS)[number];
+
 export function isSiteId(value: unknown): value is SiteId {
   return value === "domestic" || value === "intl";
 }

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -5,7 +5,7 @@
   "tools": [
     {
       "name": "auth",
-      "description": "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。",
+      "description": "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -69,7 +69,7 @@
     },
     {
       "name": "queryEnv",
-      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。账号级登录可传 region（ap-shanghai/ap-guangzhou/ap-singapore）查询对应地域，对齐 CLI `tcb env list -r <region>`；环境级 API Key 只能看到绑定的 envId，返回 credential_scope=single_env，不要误判为环境不存在。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -82,7 +82,7 @@
               "usage",
               "metrics"
             ],
-            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
+            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId / region 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
           },
           "alias": {
             "type": "string",
@@ -95,6 +95,15 @@
           "envId": {
             "type": "string",
             "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。"
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "ap-shanghai",
+              "ap-guangzhou",
+              "ap-singapore"
+            ],
+            "description": "查询地域。仅 action=list 时有效。账号级凭据会把该值透传到 DescribeEnvs（X-TC-Region），例如 ap-singapore。环境级 API Key 无法用此参数看到其他环境。等价 CLI：tcb env list -r <region> --json。"
           },
           "limit": {
             "type": "integer",
@@ -220,7 +229,7 @@
     },
     {
       "name": "envQuery",
-      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
+      "description": "查询 CloudBase 环境相关信息，支持查询环境列表、指定环境详情、安全域名、资源用量与监控指标。（曾用名：envQuery、listEnvs、getEnvInfo、getEnvAuthDomains）当 action=list 时，会按 DescribeEnvs 语义做列表/筛选，标准返回字段为 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，并支持通过 fields 白名单裁剪这些字段；aliasExact=true 时会按别名精确筛选，避免把前缀相近的环境误当作候选；即使传入 envId，action=list 也只返回摘要，不会返回完整资源明细或 expiry。账号级登录可传 region（ap-shanghai/ap-guangzhou/ap-singapore）查询对应地域，对齐 CLI `tcb env list -r <region>`；环境级 API Key 只能看到绑定的 envId，返回 credential_scope=single_env，不要误判为环境不存在。如需查询某个已知 EnvId 对应环境的详细信息（包括资源字段和计费信息），必须使用 action=info 并传入目标环境的 envId 参数。action=info 会在可用时补充 BillingInfo（如 ExpireTime、PayMode、IsAutoRenew 等计费字段）。\n\n📊 action=usage 对齐 tcb env usage/info：透传 Manager SDK describeEnvAccountCircle + describeCreditsUsageDetail，返回计费周期与各模块资源点用量（FLEXDB/SCF/COS 等）。envId 必填；type 可选过滤模块；未传 startDate/endDate 时自动使用当前计费周期。\n\n📈 action=metrics 对齐 TCB DescribeCurveData（manager.monitor.describeCurveData，不是云监控 GetMonitorData）：查询环境/网关 QPS、云函数调用与错误、数据库 CPU/内存/磁盘、云托管 CPU/QPS 等时序。envId 与 metricName 必填；startTime/endTime 格式 YYYY-MM-DD HH:mm:ss，须成对传入，不传则默认最近 24 小时；period 仅 300/3600/86400。GatewayTraceEnvQPS 未传 resourceID 时自动填环境级 all|:|all|:|all|:|all；云托管 Tke* 指标必须传服务名 resourceID。禁止用 callCloudApi 猜测监控 Action。\n\n🔍 action=info 还会派生三个用于后端选型的字段：\n- `EnvInfo.RuntimeMode`：'postgresql' 或 'nosql'，表示新业务建议默认使用的后端（PG 已开通时为 postgresql，否则为 nosql）。\n- `EnvInfo.RuntimeBackends`：`{postgresql, nosql, mysql}` 三个布尔值，描述当前环境实际并存的后端。\n- `EnvInfo.RuntimeModeHints`：每个后端对应的 API/工具/skill 提示。\n\n🌐 action=info 还会在不改写 `StaticStorages[].StaticDomain`（云 API 名义域名）的前提下，投影网关路由 Enable 状态：`StaticStorages[].staticDomainRouteEnabled` 与 `EnvInfo.staticDomainRouteEnabled`（与 queryHosting websiteConfig 同源）。`false` 表示默认静态域名根路由已禁用（访问会返回 GATEWAY_ROUTE_DISABLED），勿把名义域名当成可达 URL。\n\nAI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业务推荐 `app.rdb()` + RLS（`managePgDatabase action=execute` 跑 `CREATE POLICY`）+ pgstore；已存在的 NoSQL 集合 / 旧 storage / `managePermissions(resourceType=\"noSqlDatabase\")` 在 PG 环境下仍然有效。真正不适用的是 MySQL：当 `RuntimeBackends.mysql === false` 时，`manageMysqlDatabase` / `queryMysqlDatabase` / `relational-database-mcp-cloudbase` skill 都不该使用。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -233,7 +242,7 @@
               "usage",
               "metrics"
             ],
-            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
+            "description": "查询类型：list=环境列表/摘要筛选（按 DescribeEnvs 语义筛选，支持通过 envId / region 筛选，返回 EnvId、Alias、Status、EnvType、Region、PackageId、PackageName、IsDefault，不支持 expiry），info=指定环境的详细信息（必须传入 envId，返回资源字段和计费信息），domains=安全域名列表，usage=环境资源用量（必须传入 envId，对齐 tcb env usage/info），metrics=环境监控时序（必须传入 envId 与 metricName，对齐 TCB DescribeCurveData）"
           },
           "alias": {
             "type": "string",
@@ -246,6 +255,15 @@
           "envId": {
             "type": "string",
             "description": "环境 ID。action=list 时可选（仅按 DescribeEnvs 语义做筛选，仍返回摘要）；action=info / action=usage / action=metrics 时必填。"
+          },
+          "region": {
+            "type": "string",
+            "enum": [
+              "ap-shanghai",
+              "ap-guangzhou",
+              "ap-singapore"
+            ],
+            "description": "查询地域。仅 action=list 时有效。账号级凭据会把该值透传到 DescribeEnvs（X-TC-Region），例如 ap-singapore。环境级 API Key 无法用此参数看到其他环境。等价 CLI：tcb env list -r <region> --json。"
           },
           "limit": {
             "type": "integer",
@@ -3553,7 +3571,7 @@
     },
     {
       "name": "callCloudApi",
-      "description": "通用的云 API 调用工具，主要用于 CloudBase / 腾讯云管控面与依赖资源相关 API 调用。调用前请先确认 service、Action 与 Param，避免猜测 Action 名称。如果你的目标是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请不要优先使用 callCloudApi，而应优先查看对应 OpenAPI / Swagger。现有 OpenAPI / Swagger 能力不是通用的管控面 Action 集合；管控面 API 请优先参考 CloudBase API 概览 https://cloud.tencent.com/document/product/876/34809 与云开发依赖资源接口指引 https://cloud.tencent.com/document/product/876/34808。对于 tcb service，常用 Action 分类如下：\n\n**环境管理**: `CreateEnv`、`ModifyEnv`、`DescribeEnvs`、`DestroyEnv`\n**用户管理**: `CreateUser`、`ModifyUser`、`DescribeUserList`、`DeleteUsers`\n**认证配置**: `EditAuthConfig`、`DescribeAuthDomains`\n**云函数**: `DescribeFunctions`、`CreateFunction`、`UpdateFunctionCode`、`DeleteFunction`\n**数据库**: `CreateMySQLInstance`、`DescribeMySQLInstances`、`DestroyMySQLInstance`\n\n⚠️ 云托管（CloudBase Run）统一走 tcbr service（CreateCloudRunEnv / CreateCloudRunServer / DescribeEnvBaseInfo / DescribeCloudRunEnvs，version=\"2022-02-17\"），tcb 旧小租户接口 CreateCloudBaseRunResource 等已被禁用；部署请用 manageCloudRun。查询单个环境基础信息/是否已开通云托管用 DescribeEnvBaseInfo（EnvId 必填），查询环境列表及资源信息用 DescribeCloudRunEnvs（EnvId 可选过滤）。\n\n销毁环境时，常见做法是至少带上 `EnvId` 和 `BypassCheck: true`，如果环境已经处于隔离期再按文档补 `IsForce: true`。",
+      "description": "通用的云 API 调用工具，主要用于 CloudBase / 腾讯云管控面与依赖资源相关 API 调用。调用前请先确认 service、Action 与 Param，避免猜测 Action 名称。如果你的目标是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请不要优先使用 callCloudApi，而应优先查看对应 OpenAPI / Swagger。现有 OpenAPI / Swagger 能力不是通用的管控面 Action 集合；管控面 API 请优先参考 CloudBase API 概览 https://cloud.tencent.com/document/product/876/34809 与云开发依赖资源接口指引 https://cloud.tencent.com/document/product/876/34808。对于 tcb service，常用 Action 分类如下：\n\n**环境管理**: `CreateEnv`、`ModifyEnv`、`DescribeEnvs`、`DestroyEnv`\n**用户管理**: `CreateUser`、`ModifyUser`、`DescribeUserList`、`DeleteUsers`\n**认证配置**: `EditAuthConfig`、`DescribeAuthDomains`\n**云函数**: `DescribeFunctions`、`CreateFunction`、`UpdateFunctionCode`、`DeleteFunction`\n**数据库**: `CreateMySQLInstance`、`DescribeMySQLInstances`、`DestroyMySQLInstance`\n\n⚠️ 云托管（CloudBase Run）统一走 tcbr service（CreateCloudRunEnv / CreateCloudRunServer / DescribeEnvBaseInfo / DescribeCloudRunEnvs，version=\"2022-02-17\"），tcb 旧小租户接口 CreateCloudBaseRunResource 等已被禁用；部署请用 manageCloudRun。查询单个环境基础信息/是否已开通云托管用 DescribeEnvBaseInfo（EnvId 必填），查询环境列表及资源信息用 DescribeCloudRunEnvs（EnvId 可选过滤）。\n\n⚠️ Region 必须作为本工具顶层参数 `region` 传入（对应 X-TC-Region / 地域 endpoint），不要放进 params。params 里的 Region 会被剥离并当作顶层 region 使用。\n\n销毁环境时，常见做法是至少带上 `EnvId` 和 `BypassCheck: true`，如果环境已经处于隔离期再按文档补 `IsForce: true`。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3583,7 +3601,11 @@
           "params": {
             "type": "object",
             "additionalProperties": {},
-            "description": "Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；更新环境别名则可用 `{ \"service\": \"tcb\", \"action\": \"ModifyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"Alias\": \"demo\" } }`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。"
+            "description": "Action 对应的参数对象，键名需与官方 API 定义一致。某些 Action 需要携带 EnvId 等信息；如不确定参数结构，请先查官方文档。tcb 示例：`{ \"service\": \"tcb\", \"action\": \"DestroyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"BypassCheck\": true } }`，如果环境已经处于隔离期，可再补 `IsForce: true`；更新环境别名则可用 `{ \"service\": \"tcb\", \"action\": \"ModifyEnv\", \"params\": { \"EnvId\": \"env-xxx\", \"Alias\": \"demo\" } }`。不要把 Region 放进 params（会报 The parameter Region is not recognized）；跨地域请用顶层 region，例如 `{ \"service\": \"tcb\", \"action\": \"DescribeEnvs\", \"region\": \"ap-singapore\" }`。若你的场景是通过 HTTP 协议直接集成 auth/functions/cloudrun/storage/mysqldb 等 CloudBase 业务 API，请优先使用 OpenAPI / Swagger 或 searchKnowledgeBase(mode=\"openapi\")，而不是优先使用 callCloudApi。"
+          },
+          "region": {
+            "type": "string",
+            "description": "云 API 地域（X-TC-Region）。例如 ap-shanghai、ap-guangzhou、ap-singapore。DescribeEnvs 等接口按地域查询，跨地域必须传此顶层参数，不要写入 params.Region。"
           }
         },
         "required": [

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -5,7 +5,7 @@
   "tools": [
     {
       "name": "auth",
-      "description": "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 login_mode（account=账号级 / api_key=环境级）与 credential_scope；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
+      "description": "CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即可访问云资源；环境(env)是云函数、数据库、静态托管等资源的隔离单元，绑定环境后其他 MCP 工具才能操作该环境。支持：查询状态、发起登录、API Key登录、绑定环境(set_env)、退出登录。auth(status) 会返回 credential_scope（account=账号级 / single_env=环境级 API Key）与当前 region；环境级 API Key 只能看到绑定的 envId，查不到其他地域环境是权限边界而非环境不存在。",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## 背景
用户在 WorkBuddy 通过 CloudBase MCP 查询新加坡（ap-singapore）环境查不到，实际环境存在；CloudBase CLI 3.7.3
Try the tcb ai command to start your AI full-stack development experience
✖ No valid identity information, please use cloudbase login to login

Solution:
  - Run tcb login to log in

Documentation: https://docs.cloudbase.net/cli-v1/quick-start 可查到 → 是 MCP 通道限制。ATO 任务 d6fb1c13。

**关键澄清**：envId + API Key 登录 = 单环境权限，看不到其他环境/地域是预期权限边界。本 PR 重心：① 账号级登录支持跨地域查询 ② 凭据权限边界可见 ③ set_env 可绑定非当前地域 envId。

## 改动（11 文件 / +596 行）
1. **envQuery(list)**：增加 region/site 入参，candidates 按地域解析（SITE_REGION_MAP / TCB_QUERY_REGIONS，账号级凭据）
2. **callCloudApi**：账号级凭据透传 Region
3. **set_env**：放开 candidates 地域校验——envId 唯一，凭据有权即可直绑（不再因不在当前地域候选列表而报 未找到环境）
4. **auth(status)**：暴露登录方式（账号级/api_key）+ 当前 envId/region，凭据边界由 buildCredentialBoundaryPayload 统一生成
5. 文档：doc/connection-modes.mdx、doc/mcp-tools.md、scripts/tools.json 同步更新

## 验证
- env/capi/cloudbase-manager/site-map 单测 **128 passed**
- 明确不做：auth 候选列表按地域分组/筛选（查询职责归 envQuery(list)）