### PR TITLE
refactor(kimi): assemble sibling skills into cloudbase/references

### DIFF
--- a/scripts/pack-kimi-plugin.mjs
+++ b/scripts/pack-kimi-plugin.mjs
@@ -2,12 +2,22 @@
 /**
  * Pack plugin/cloudbase as a Kimi Code / Kimi Work plugin zip.
  *
- * Whitelist-only: archive contains ONLY what the Kimi plugin needs —
- *   - kimi.plugin.json  (Open Plugin Spec style manifest)
- *   - skills/           (CloudBase knowledge base: routing skill + sibling skills)
- *   - assets/           (icons referenced by skills, e.g. ui-design)
- * Everything else (agents/, hooks/, commands/, .claude-plugin/,
- * gemini-extension.json, etc.) is IDE-specific and excluded.
+ * Self-contained structure — the archive top level contains ONLY what the
+ * Kimi manifest declares:
+ *   - kimi.plugin.json   (Open Plugin Spec style manifest)
+ *   - skills/cloudbase/  (routing skill, self-contained)
+ *
+ * Sibling skills (cloud-functions, auth-*, etc.) are NOT shipped as separate
+ * top-level skills; they are assembled into
+ * skills/cloudbase/references/<skill-id>/ — matching the routing skill's
+ * activation contract ("Prefer local relative paths:
+ * references/<skill-id>/SKILL.md or sibling skill directories") and the same
+ * structure already used by the CodeBuddy plugin. Because they are assembled
+ * at pack time from plugin/cloudbase/skills/, the references are always in
+ * sync with the current source (no stale mirror to maintain).
+ *
+ * IDE-specific content (agents/, hooks/, commands/, .claude-plugin/,
+ * gemini-extension.json, assets/ ...) is excluded.
  *
  * Output name is version-free: dist/cloudbase-kimi.zip (release tag carries
  * the version, so a stable asset name keeps zip-url stable across releases).
@@ -22,16 +32,16 @@
 
 import { execFileSync } from "child_process";
 import fs from "fs";
+import os from "os";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, "..");
 const PLUGIN_DIR = path.join(ROOT, "plugin", "cloudbase");
+const SKILLS_DIR = path.join(PLUGIN_DIR, "skills");
+const ROUTING_SKILL = "cloudbase";
 const MANIFEST_PATH = path.join(PLUGIN_DIR, "kimi.plugin.json");
-
-// Whitelist of archive entries (relative to PLUGIN_DIR) — only Kimi needs.
-const INCLUDE = ["kimi.plugin.json", "skills", "assets"];
 const DEFAULT_OUT_NAME = "cloudbase-kimi.zip";
 
 function parseArgs(argv = process.argv.slice(2)) {
@@ -49,11 +59,38 @@ function parseArgs(argv = process.argv.slice(2)) {
 }
 
 function assertReady() {
-  for (const entry of INCLUDE) {
-    if (!fs.existsSync(path.join(PLUGIN_DIR, entry))) {
-      throw new Error(`Missing required path for Kimi pack: ${entry}`);
-    }
+  if (!fs.existsSync(MANIFEST_PATH)) {
+    throw new Error(`Missing required path for Kimi pack: ${MANIFEST_PATH}`);
   }
+  const routingDir = path.join(SKILLS_DIR, ROUTING_SKILL);
+  if (!fs.existsSync(routingDir)) {
+    throw new Error(`Missing routing skill: ${routingDir}`);
+  }
+}
+
+function copyDir(src, dest) {
+  fs.cpSync(src, dest, {
+    recursive: true,
+    filter: (p) => !p.endsWith(".DS_Store"),
+  });
+}
+
+function assembleStaging(stagingDir) {
+  fs.mkdirSync(stagingDir, { recursive: true });
+  copyDir(MANIFEST_PATH, path.join(stagingDir, "kimi.plugin.json"));
+  copyDir(path.join(SKILLS_DIR, ROUTING_SKILL), path.join(stagingDir, "skills", ROUTING_SKILL));
+
+  // Assemble sibling skills into routing skill's references/<skill-id>/
+  const refsDir = path.join(stagingDir, "skills", ROUTING_SKILL, "references");
+  let siblingCount = 0;
+  for (const skillId of fs.readdirSync(SKILLS_DIR)) {
+    if (skillId === ROUTING_SKILL || skillId.startsWith(".")) continue;
+    const src = path.join(SKILLS_DIR, skillId);
+    if (!fs.statSync(src).isDirectory()) continue;
+    copyDir(src, path.join(refsDir, skillId));
+    siblingCount += 1;
+  }
+  return siblingCount;
 }
 
 function main() {
@@ -61,7 +98,8 @@ function main() {
   if (args.help) {
     console.log(`Pack CloudBase plugin for Kimi Code / Kimi Work.
 
-Only ${INCLUDE.join(", ")} are included; IDE-specific dirs are excluded.
+Self-contained: only kimi.plugin.json + skills/cloudbase/ at top level;
+sibling skills are assembled into skills/cloudbase/references/<skill-id>/.
 
 Usage:
   node scripts/pack-kimi-plugin.mjs
@@ -72,23 +110,31 @@ Usage:
 
   assertReady();
 
-  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
   const outPath = args.out || path.join(ROOT, "dist", DEFAULT_OUT_NAME);
+  const stagingDir = fs.mkdtempSync(path.join(os.tmpdir(), "kimi-pack-"));
 
-  fs.mkdirSync(path.dirname(outPath), { recursive: true });
-  if (fs.existsSync(outPath)) fs.rmSync(outPath);
+  let siblingCount = 0;
+  try {
+    siblingCount = assembleStaging(stagingDir);
 
-  // zip from inside plugin dir so archive root is the plugin contents
-  execFileSync("zip", ["-r", outPath, ...INCLUDE, "-x", "*.DS_Store"], {
-    cwd: PLUGIN_DIR,
-    stdio: "inherit",
-  });
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    if (fs.existsSync(outPath)) fs.rmSync(outPath);
+
+    execFileSync("zip", ["-r", outPath, ".", "-x", "*.DS_Store"], {
+      cwd: stagingDir,
+      stdio: "inherit",
+    });
+  } finally {
+    fs.rmSync(stagingDir, { recursive: true, force: true });
+  }
 
   const size = fs.statSync(outPath).size;
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
   console.log("");
   console.log(`Packed: ${outPath}`);
   console.log(`Size:   ${(size / 1024 / 1024).toFixed(2)} MiB`);
   console.log(`Name:   ${manifest.name}@${manifest.version}`);
+  console.log(`Skills: routing=${ROUTING_SKILL} + ${siblingCount} siblings in references/`);
   console.log("");
   console.log("Next:");
   console.log("  1. Upload this zip to the GitHub release assets");


### PR DESCRIPTION
## 补充提交（PR #943 合并后遗漏）
PR #943（白名单版，已合并进 v2.30.0）合并后才推的 references 组装版，未进 main。

## 改动（f1c063f1b）
- 打包时把 28 个 sibling skill 动态组装进 `skills/cloudbase/references/<skill-id>/`，zip 顶层只剩 manifest 声明的 `kimi.plugin.json` + `skills/cloudbase/`
- 去掉 assets/（iconUrl 是远端 URL，ui-design 引用是示例代码）
- 结构对齐 routing skill 的 references 加载约定 + codebuddy-plugin 布局，与源始终同步

## 验证
- 本地打包：顶层仅 2 项，187 文件 / 468K，无 IDE 杂项