### PR TITLE
feat(mcp): 🧭 消息推送云函数/云托管模式兼容（pushMode 感知 + 云函数路径校验 + 模式切换）

### DIFF
--- a/config/.claude/skills/miniprogram-development/SKILL.md
+++ b/config/.claude/skills/miniprogram-development/SKILL.md
@@ -46,7 +46,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Assuming Stable WeChat Developer Tools includes Nightly Skills/`wechatide` (it may not).
 - Forcing CloudBase MCP Tencent Cloud login for daily mini program cloud ops when Nightly `wechatide` already works.
 - Inventing `wechatide` tool names or flags instead of using `--help` / Nightly `tools.yaml`.
-- Bypassing wxide CLI / IDE for message-push ops with low-level transport before `cloud_msg_push_*` is exposed (see [message-push-customer-service.md](references/message-push-customer-service.md)).
+- Bypassing wxide CLI / IDE for message-push ops with low-level transport before `cloud_*_msg_push` is exposed (see [message-push-customer-service.md](references/message-push-customer-service.md)).
 - Assuming cloud-function return values auto-reply to customer-service chats (must use `cloud.openapi.customerServiceMessage.send`).
 - Making code or configuration changes without first following the Change Safety Protocol (`cloudbase-platform/references/protocols/change-safety-protocol.md`).
 - Performing mini program upload/publish without first completing the checks in `cloudbase-platform/references/protocols/deployment-gate.md`.
@@ -157,7 +157,7 @@ Keep the custom `tabBar` layout text-only, and use flex centering or matching `h
 
 > 微信生态专章：消息推送 / 客服自动回复细节以中文 reference 为准（术语保留英文 API 名）。
 
-- **Current only ops path:** WeChat Developer Tools IDE + wxide CLI. Do not teach low-level bypasses while `cloud_msg_push_query` / `cloud_msg_push_manage` are not yet exposed (track **9109db6b**).
+- **Current only ops path:** WeChat Developer Tools IDE + wxide CLI. Do not teach low-level bypasses while `cloud_query_msg_push` / `cloud_manage_msg_push` are not yet exposed (track **9109db6b**).
 - Deploy receiver functions with `cloud_fn_deploy` **and** `--remote-npm-install`; bind (MsgType, Event) → one cloud function in the IDE message-push panel until CLI tools land.
 - Customer-service auto-reply requires `cloud.openapi.customerServiceMessage.send` plus `config.json` openapi permissions — function return values alone do not reply.
 - Function logs: IDE **云开发控制台 → 云函数 → 日志**; CLI log query is pending (**9109db6b** / **d5735473**).
@@ -217,6 +217,6 @@ Page({
 - [CloudBase Mini Program Integration](references/cloudbase-integration.md) — use this when the mini program project explicitly integrates CloudBase
 - [WeChat DevTools Debug and Preview](references/devtools-debug-preview.md) — Nightly / `wechatide` paths, required context, and no-Nightly fallbacks
 - [WeChat IDE Skills vs CloudBase MCP](references/wxide-vs-cloudbase-mcp.md) — layering and when to use which execution surface
-- [Message Push & Customer Service Auto-Reply](references/message-push-customer-service.md) — 消息推送 / 客服自动回复 via wxide CLI + IDE (no low-level bypass; pending `cloud_msg_push_*`)
+- [Message Push & Customer Service Auto-Reply](references/message-push-customer-service.md) — 消息推送 / 客服自动回复 via wxide CLI + IDE (no low-level bypass; pending `cloud_*_msg_push`)
 - [Mini Program SEO & WeChat Search Optimization](references/seo-search-optimization.md) — 小程序搜索优化 / page indexing / search promotion (`mpcrawler`, URL reachability, `navigator` jumps, titles & thumbnails)
 - [Common Pitfalls](references/pitfalls.md) — read before generating code for optional chaining, TDesign styling, Canvas + storage, and environment issues

--- a/config/.claude/skills/miniprogram-development/references/message-push-customer-service.md
+++ b/config/.claude/skills/miniprogram-development/references/message-push-customer-service.md
@@ -12,7 +12,7 @@
 | 优先 Nightly：`wechatide -c <clientName> -t <toolName>`（用 `--help` 发现参数） | 臆造工具名或参数 |
 | 在微信侧工具尚未暴露前，用 IDE **云开发控制台 → 消息推送** 做回调绑定 | 把 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 当作小程序日常操作路径教给 agent |
 
-**微信 IDE 暴露状态：** 规格设计了 `cloud_msg_push_query` / `cloud_msg_push_manage`（由 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 经 `EXPOSED_TOOL_NAME` 映射；需 main 升级 `@cloudbase/cloudbase-mcp` 后）。该消费链路归属 **9109db6b** —— **尚未暴露**。在此之前，本 skill 只把 **IDE UI + 现有 wxide CLI 云/预览命令** 当作面向 agent 的操作面。不要文档化或教授底层替代方案。
+**微信 IDE 暴露状态：** 规格设计了 `cloud_query_msg_push` / `cloud_manage_msg_push`（由 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 经 `EXPOSED_TOOL_NAME` 映射；需 main 升级 `@cloudbase/cloudbase-mcp` 后）。该消费链路归属 **9109db6b** —— **尚未暴露**。在此之前，本 skill 只把 **IDE UI + 现有 wxide CLI 云/预览命令** 当作面向 agent 的操作面。不要文档化或教授底层替代方案。
 
 **维护者 E2E（不对产品 agent）：** CloudBase-MCP msg-push 工具的完整 ticket / 回归流程在外部 skill `wxide-qbase-msgpush-e2e`（`~/.workbuddy/skills/wxide-qbase-msgpush-e2e/SKILL.md`）。只指向该处；不要把其中的底层步骤复制进本参考。
 
@@ -39,7 +39,7 @@
 规则：
 
 - **同一 (MsgType, Event) 对只能绑定一个云函数**（重新绑定会替换原先函数）。
-- `MsgType=event` 的合法事件名来自平台支持列表（IDE 消息推送面板 / 未来的 `cloud_msg_push_query` `listSupportedEvents`）。不要臆造事件字符串。
+- `MsgType=event` 的合法事件名来自平台支持列表（IDE 消息推送面板 / 未来的 `cloud_query_msg_push` `listSupportedEvents`）。不要臆造事件字符串。
 - 需要生效时，在 IDE 消息推送面板打开推送开关。
 
 ### 配置回调（当前）
@@ -52,8 +52,8 @@
 
 ```text
 # 尚不可用 — 不要臆造或用底层调用代替
-wechatide -c <clientName> -t cloud_msg_push_query   ...
-wechatide -c <clientName> -t cloud_msg_push_manage  ...
+wechatide -c <clientName> -t cloud_query_msg_push   ...
+wechatide -c <clientName> -t cloud_manage_msg_push  ...
 ```
 
 这些工具上线后，subscribe / unsubscribe / list / setEnable 优先用它们，少用手点 IDE。在此之前仅用 IDE 面板。
@@ -187,7 +187,7 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 1. 实现接收端云函数（若需自动回复则加 OpenAPI send）。
 2. `cloud_fn_deploy` **并带上** `--remote-npm-install`。
-3. 在 IDE **消息推送** 中绑定 (MsgType, Event) → 函数（或未来的 `cloud_msg_push_manage`）。
+3. 在 IDE **消息推送** 中绑定 (MsgType, Event) → 函数（或未来的 `cloud_manage_msg_push`）。
 4. 测试 `text` / 媒体消息类型时，确保已有客服入口 / 能力。
 5. 上传体验版 / 预览；用真机触发。
 6. 在 IDE 云函数 **日志** 中验证（CLI 日志：待 9109db6b）。
@@ -210,7 +210,7 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 | 模式 | 行为 | 配置方式 |
 |---|---|---|
-| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 MCP `manageMessagePush(subscribe)` |
+| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 `cloud_manage_msg_push(action=subscribe)` |
 | **云托管** | **整包接收所有消息**至云托管服务（一条 path 全收），云函数回调失效 | IDE 面板「云托管」切换 |
 
 ### 行为要点（MCP / IDE 一致）
@@ -224,6 +224,6 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 ```text
 # 当前唯一操作途径：微信开发者工具 IDE（消息推送面板 + 云托管页面）
-# MCP：queryMessagePush(list) 可读 pushMode；manageMessagePush(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
+# 微信侧：cloud_query_msg_push 可读 pushMode；cloud_manage_msg_push(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
 # 底层 CGI / 开通接口细节见 skill wxide-qbase-msgpush-e2e，本参考不展开
 ```

--- a/config/.claude/skills/miniprogram-development/references/message-push-customer-service.md
+++ b/config/.claude/skills/miniprogram-development/references/message-push-customer-service.md
@@ -203,3 +203,27 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 - 微信侧 CLI 暴露 / 缺失命令：任务 **9109db6b**
 - 日志 API 调研：任务 **d5735473**
 - 规格设计（CloudBase-MCP msg-push + EXPOSED_TOOL_NAME）：`specs/virtual-payment-mcp/design.md`（任务 **43367cc6**）
+
+## 5. 推送模式：云函数 vs 云托管
+
+消息推送有**推送模式**，IDE「消息推送」面板右上角展示（云函数 / 云托管）：
+
+| 模式 | 行为 | 配置方式 |
+|---|---|---|
+| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 MCP `manageMessagePush(subscribe)` |
+| **云托管** | **整包接收所有消息**至云托管服务（一条 path 全收），云函数回调失效 | IDE 面板「云托管」切换 |
+
+### 行为要点（MCP / IDE 一致）
+
+- 云托管模式下，云函数回调**存在但不生效**——查询会返回 `pushMode=container` 及提示
+- 云托管模式下 `subscribe/unsubscribe/setEnable` 会被**拒绝**（提示先切回云函数模式）
+- 切换模式是**写操作**，需确认；切到云托管需提供服务路径（真实环境需已有云托管服务）
+- 云托管开通：IDE 云开发控制台 → 云托管 → 立即开通（可能与按量付费联动）；若环境无云托管服务，配置容器回调会失败
+
+### 操作方式（当前）
+
+```text
+# 当前唯一操作途径：微信开发者工具 IDE（消息推送面板 + 云托管页面）
+# MCP：queryMessagePush(list) 可读 pushMode；manageMessagePush(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
+# 底层 CGI / 开通接口细节见 skill wxide-qbase-msgpush-e2e，本参考不展开
+```

--- a/config/source/skills/miniprogram-development/SKILL.md
+++ b/config/source/skills/miniprogram-development/SKILL.md
@@ -46,7 +46,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Assuming Stable WeChat Developer Tools includes Nightly Skills/`wechatide` (it may not).
 - Forcing CloudBase MCP Tencent Cloud login for daily mini program cloud ops when Nightly `wechatide` already works.
 - Inventing `wechatide` tool names or flags instead of using `--help` / Nightly `tools.yaml`.
-- Bypassing wxide CLI / IDE for message-push ops with low-level transport before `cloud_msg_push_*` is exposed (see [message-push-customer-service.md](references/message-push-customer-service.md)).
+- Bypassing wxide CLI / IDE for message-push ops with low-level transport before `cloud_*_msg_push` is exposed (see [message-push-customer-service.md](references/message-push-customer-service.md)).
 - Assuming cloud-function return values auto-reply to customer-service chats (must use `cloud.openapi.customerServiceMessage.send`).
 - Making code or configuration changes without first following the Change Safety Protocol (`cloudbase-platform/references/protocols/change-safety-protocol.md`).
 - Performing mini program upload/publish without first completing the checks in `cloudbase-platform/references/protocols/deployment-gate.md`.
@@ -157,7 +157,7 @@ Keep the custom `tabBar` layout text-only, and use flex centering or matching `h
 
 > 微信生态专章：消息推送 / 客服自动回复细节以中文 reference 为准（术语保留英文 API 名）。
 
-- **Current only ops path:** WeChat Developer Tools IDE + wxide CLI. Do not teach low-level bypasses while `cloud_msg_push_query` / `cloud_msg_push_manage` are not yet exposed (track **9109db6b**).
+- **Current only ops path:** WeChat Developer Tools IDE + wxide CLI. Do not teach low-level bypasses while `cloud_query_msg_push` / `cloud_manage_msg_push` are not yet exposed (track **9109db6b**).
 - Deploy receiver functions with `cloud_fn_deploy` **and** `--remote-npm-install`; bind (MsgType, Event) → one cloud function in the IDE message-push panel until CLI tools land.
 - Customer-service auto-reply requires `cloud.openapi.customerServiceMessage.send` plus `config.json` openapi permissions — function return values alone do not reply.
 - Function logs: IDE **云开发控制台 → 云函数 → 日志**; CLI log query is pending (**9109db6b** / **d5735473**).
@@ -217,6 +217,6 @@ Page({
 - [CloudBase Mini Program Integration](references/cloudbase-integration.md) — use this when the mini program project explicitly integrates CloudBase
 - [WeChat DevTools Debug and Preview](references/devtools-debug-preview.md) — Nightly / `wechatide` paths, required context, and no-Nightly fallbacks
 - [WeChat IDE Skills vs CloudBase MCP](references/wxide-vs-cloudbase-mcp.md) — layering and when to use which execution surface
-- [Message Push & Customer Service Auto-Reply](references/message-push-customer-service.md) — 消息推送 / 客服自动回复 via wxide CLI + IDE (no low-level bypass; pending `cloud_msg_push_*`)
+- [Message Push & Customer Service Auto-Reply](references/message-push-customer-service.md) — 消息推送 / 客服自动回复 via wxide CLI + IDE (no low-level bypass; pending `cloud_*_msg_push`)
 - [Mini Program SEO & WeChat Search Optimization](references/seo-search-optimization.md) — 小程序搜索优化 / page indexing / search promotion (`mpcrawler`, URL reachability, `navigator` jumps, titles & thumbnails)
 - [Common Pitfalls](references/pitfalls.md) — read before generating code for optional chaining, TDesign styling, Canvas + storage, and environment issues

--- a/config/source/skills/miniprogram-development/references/message-push-customer-service.md
+++ b/config/source/skills/miniprogram-development/references/message-push-customer-service.md
@@ -12,7 +12,7 @@
 | 优先 Nightly：`wechatide -c <clientName> -t <toolName>`（用 `--help` 发现参数） | 臆造工具名或参数 |
 | 在微信侧工具尚未暴露前，用 IDE **云开发控制台 → 消息推送** 做回调绑定 | 把 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 当作小程序日常操作路径教给 agent |
 
-**微信 IDE 暴露状态：** 规格设计了 `cloud_msg_push_query` / `cloud_msg_push_manage`（由 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 经 `EXPOSED_TOOL_NAME` 映射；需 main 升级 `@cloudbase/cloudbase-mcp` 后）。该消费链路归属 **9109db6b** —— **尚未暴露**。在此之前，本 skill 只把 **IDE UI + 现有 wxide CLI 云/预览命令** 当作面向 agent 的操作面。不要文档化或教授底层替代方案。
+**微信 IDE 暴露状态：** 规格设计了 `cloud_query_msg_push` / `cloud_manage_msg_push`（由 CloudBase MCP 的 `queryMessagePush` / `manageMessagePush` 经 `EXPOSED_TOOL_NAME` 映射；需 main 升级 `@cloudbase/cloudbase-mcp` 后）。该消费链路归属 **9109db6b** —— **尚未暴露**。在此之前，本 skill 只把 **IDE UI + 现有 wxide CLI 云/预览命令** 当作面向 agent 的操作面。不要文档化或教授底层替代方案。
 
 **维护者 E2E（不对产品 agent）：** CloudBase-MCP msg-push 工具的完整 ticket / 回归流程在外部 skill `wxide-qbase-msgpush-e2e`（`~/.workbuddy/skills/wxide-qbase-msgpush-e2e/SKILL.md`）。只指向该处；不要把其中的底层步骤复制进本参考。
 
@@ -39,7 +39,7 @@
 规则：
 
 - **同一 (MsgType, Event) 对只能绑定一个云函数**（重新绑定会替换原先函数）。
-- `MsgType=event` 的合法事件名来自平台支持列表（IDE 消息推送面板 / 未来的 `cloud_msg_push_query` `listSupportedEvents`）。不要臆造事件字符串。
+- `MsgType=event` 的合法事件名来自平台支持列表（IDE 消息推送面板 / 未来的 `cloud_query_msg_push` `listSupportedEvents`）。不要臆造事件字符串。
 - 需要生效时，在 IDE 消息推送面板打开推送开关。
 
 ### 配置回调（当前）
@@ -52,8 +52,8 @@
 
 ```text
 # 尚不可用 — 不要臆造或用底层调用代替
-wechatide -c <clientName> -t cloud_msg_push_query   ...
-wechatide -c <clientName> -t cloud_msg_push_manage  ...
+wechatide -c <clientName> -t cloud_query_msg_push   ...
+wechatide -c <clientName> -t cloud_manage_msg_push  ...
 ```
 
 这些工具上线后，subscribe / unsubscribe / list / setEnable 优先用它们，少用手点 IDE。在此之前仅用 IDE 面板。
@@ -187,7 +187,7 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 1. 实现接收端云函数（若需自动回复则加 OpenAPI send）。
 2. `cloud_fn_deploy` **并带上** `--remote-npm-install`。
-3. 在 IDE **消息推送** 中绑定 (MsgType, Event) → 函数（或未来的 `cloud_msg_push_manage`）。
+3. 在 IDE **消息推送** 中绑定 (MsgType, Event) → 函数（或未来的 `cloud_manage_msg_push`）。
 4. 测试 `text` / 媒体消息类型时，确保已有客服入口 / 能力。
 5. 上传体验版 / 预览；用真机触发。
 6. 在 IDE 云函数 **日志** 中验证（CLI 日志：待 9109db6b）。
@@ -210,7 +210,7 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 | 模式 | 行为 | 配置方式 |
 |---|---|---|
-| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 MCP `manageMessagePush(subscribe)` |
+| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 `cloud_manage_msg_push(action=subscribe)` |
 | **云托管** | **整包接收所有消息**至云托管服务（一条 path 全收），云函数回调失效 | IDE 面板「云托管」切换 |
 
 ### 行为要点（MCP / IDE 一致）
@@ -224,6 +224,6 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 
 ```text
 # 当前唯一操作途径：微信开发者工具 IDE（消息推送面板 + 云托管页面）
-# MCP：queryMessagePush(list) 可读 pushMode；manageMessagePush(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
+# 微信侧：cloud_query_msg_push 可读 pushMode；cloud_manage_msg_push(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
 # 底层 CGI / 开通接口细节见 skill wxide-qbase-msgpush-e2e，本参考不展开
 ```

--- a/config/source/skills/miniprogram-development/references/message-push-customer-service.md
+++ b/config/source/skills/miniprogram-development/references/message-push-customer-service.md
@@ -203,3 +203,27 @@ wechatide -c <clientName> -t <cloud_fn_logs_or_equivalent> ...
 - 微信侧 CLI 暴露 / 缺失命令：任务 **9109db6b**
 - 日志 API 调研：任务 **d5735473**
 - 规格设计（CloudBase-MCP msg-push + EXPOSED_TOOL_NAME）：`specs/virtual-payment-mcp/design.md`（任务 **43367cc6**）
+
+## 5. 推送模式：云函数 vs 云托管
+
+消息推送有**推送模式**，IDE「消息推送」面板右上角展示（云函数 / 云托管）：
+
+| 模式 | 行为 | 配置方式 |
+|---|---|---|
+| **云函数**（默认） | 按 (消息类型, 事件) 二元组逐条推送至对应云函数 | IDE 面板逐条添加，或 MCP `manageMessagePush(subscribe)` |
+| **云托管** | **整包接收所有消息**至云托管服务（一条 path 全收），云函数回调失效 | IDE 面板「云托管」切换 |
+
+### 行为要点（MCP / IDE 一致）
+
+- 云托管模式下，云函数回调**存在但不生效**——查询会返回 `pushMode=container` 及提示
+- 云托管模式下 `subscribe/unsubscribe/setEnable` 会被**拒绝**（提示先切回云函数模式）
+- 切换模式是**写操作**，需确认；切到云托管需提供服务路径（真实环境需已有云托管服务）
+- 云托管开通：IDE 云开发控制台 → 云托管 → 立即开通（可能与按量付费联动）；若环境无云托管服务，配置容器回调会失败
+
+### 操作方式（当前）
+
+```text
+# 当前唯一操作途径：微信开发者工具 IDE（消息推送面板 + 云托管页面）
+# MCP：queryMessagePush(list) 可读 pushMode；manageMessagePush(ensureCloudFunctionMode/ensureContainerMode/setContainerCallback) 管理模式
+# 底层 CGI / 开通接口细节见 skill wxide-qbase-msgpush-e2e，本参考不展开
+```

--- a/mcp/scripts/test-with-ticket.cjs
+++ b/mcp/scripts/test-with-ticket.cjs
@@ -121,6 +121,7 @@ function httpsPost(urlStr, bodyStr) {
     if (PROXY_AGENT) {
       options.agent = PROXY_AGENT;
     }
+    console.error("[DEBUG httpsPost]", u.hostname, "path前80:", (u.pathname + u.search).slice(0, 80));
     const req = require('https').request(options, (res) => {
       let d = ""; res.on("data", c => d += c);
       res.on("end", () => {
@@ -284,18 +285,62 @@ const QBASE_PATHS = {
   getCallbackSupportList: `${QBASE_BASE}/route/getcallbacksupportlist`,
   getContainerConfig: `${QBASE_BASE}/getcontainercallbackconfig`,
   setContainerConfig: `${QBASE_BASE}/setcontainercallbackconfig`,
+  getContainerCallbackConfig: `${QBASE_BASE}/getcontainercallbackconfig`,
+  setContainerCallbackConfig: `${QBASE_BASE}/setcontainercallbackconfig`,
 };
+
+
+/** --ticket=auto：每次请求前从本地 Whistle（127.0.0.1:8899）抓最新 qbase newticket（时效极短场景） */
+function fetchLatestTicketFromWhistle() {
+  return new Promise((resolve, reject) => {
+    const post = require("http").request(
+      { host: "127.0.0.1", port: 8899, path: "/cgi-bin/get-data?count=300", method: "POST" },
+      (res) => {
+        let buf = "";
+        res.on("data", (c) => (buf += c));
+        res.on("end", () => {
+          try {
+            const d = JSON.parse(buf);
+            const data = ((d.data || {}).data) || {};
+            const cands = [];
+            for (const v of Object.values(data)) {
+              const u = (v.url || "");
+              if (u.includes("wxa-dev-qbase") && u.includes("newticket=")) {
+                const q = new URL(u).searchParams;
+                const t = q.get("newticket");
+                if (t) cands.push([v.endTime || v.startTime || "", t]);
+              }
+            }
+            cands.sort((a, b) => (a[0] < b[0] ? 1 : -1));
+            if (!cands.length) return reject(new Error("Whistle 无 qbase ticket，请先在 IDE 打开消息推送页面"));
+            resolve(cands[0][1]);
+          } catch (e) {
+            reject(new Error("解析 Whistle 响应失败: " + e.message));
+          }
+        });
+      },
+    );
+    post.on("error", reject);
+    post.end();
+  });
+}
 
 /** 真实传输：带 ticket 直连 qbase CGI（POST，URL 带 appid/newticket） */
 function createTicketMsgPushRequestFn() {
   return async ({ url, method = "post", body, appid: reqAppid }) => {
     const u = new URL(url);
     u.searchParams.set("appid", reqAppid || appid);
-    u.searchParams.set("newticket", ticket);
+    u.searchParams.set("newticket", ticket === "auto" ? await fetchLatestTicketFromWhistle() : ticket);
     u.searchParams.set("platform", "0");
     u.searchParams.set("os", "darwin");
     const bodyStr = body ? JSON.stringify(body) : "{}";
-    const json = await httpsPost(u.toString(), bodyStr);
+    let json;
+    try {
+      json = await httpsPost(u.toString(), bodyStr);
+    } catch (e) {
+      console.error("[DEBUG ticketTransport] httpsPost 失败:", e.message);
+      throw e;
+    }
     if (!json || !json.base_resp) {
       throw new Error(`qbase 响应缺少 base_resp: ${JSON.stringify(json).slice(0, 200)}`);
     }
@@ -465,7 +510,11 @@ async function runMsgPushTestGroup() {
   const call = async (name, args) => {
     const res = await client.callTool({ name, arguments: args });
     const text = res.content?.[0]?.text ?? "{}";
-    return JSON.parse(text);
+    try {
+      return JSON.parse(text);
+    } catch (e) {
+      throw new Error(`callTool ${name} 返回非 JSON: ${text.slice(0, 400)}`);
+    }
   };
 
   const baseArgs = { appid, env_id: envId, function_name: "msg-push-test-fn" };
@@ -863,6 +912,7 @@ async function main() {
 if (testGroup === "msgpush") {
   runMsgPushTestGroup().catch((e) => {
     process.stderr.write(`[test-with-ticket] ❌ 消息推送测试组失败: ${e.message}\n`);
+    if (e.stack) process.stderr.write(`[test-with-ticket] stack: ${e.stack.split("\n").slice(0, 4).join(" | ")}\n`);
     process.exit(1);
   });
   return;

--- a/mcp/scripts/test-with-ticket.cjs
+++ b/mcp/scripts/test-with-ticket.cjs
@@ -319,6 +319,8 @@ function createMockMsgPushBackend() {
   let enable = true;
   let callbacks = [];
   let qbaseOpen = false;
+  let containerPath = "/push";
+  let containerTextMode = 1;
 
   return {
     requestFn: async ({ url, body }) => {
@@ -344,15 +346,30 @@ function createMockMsgPushBackend() {
         return { base_resp: { ret: 0 } };
       }
       if (url.endsWith("/getcontainercallbackconfig")) {
-        return { base_resp: { ret: 0 }, qbase_open: qbaseOpen };
+        return {
+          base_resp: { ret: 0 },
+          qbase_open: qbaseOpen,
+          qbase_env: "env-container",
+          qbase_container_path: containerPath,
+          text_mode: containerTextMode,
+        };
       }
       if (url.endsWith("/setcontainercallbackconfig")) {
         qbaseOpen = body.qbase_open === true;
+        if (typeof body.qbase_container_path === "string") {
+          containerPath = body.qbase_container_path;
+        }
+        if (typeof body.qbase_env === "string") {
+          // keep for mock completeness
+        }
+        if (typeof body.text_mode === "number") {
+          containerTextMode = body.text_mode;
+        }
         return { base_resp: { ret: 0 } };
       }
       throw new Error(`mock qbase: 未知 CGI ${url}`);
     },
-    state: () => ({ version, enable, callbacks, qbaseOpen }),
+    state: () => ({ version, enable, callbacks, qbaseOpen, containerPath, containerTextMode }),
   };
 }
 
@@ -432,7 +449,12 @@ async function runMsgPushTestGroup() {
     ide: "wxide",
     cloudBaseOptions: { envId, requestFn: cloudRequestFn },
     pluginsEnabled: ["msg-push"],
-    pluginOptions: { msgPush: {} },
+    pluginOptions: {
+      msgPush: {
+        // subscribe validates function existence; inject readonly list for E2E
+        listCloudFunctions: async () => ["msg-push-test-fn"],
+      },
+    },
   });
 
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
@@ -451,12 +473,16 @@ async function runMsgPushTestGroup() {
   // 1. 只读检查
   const list1 = await call("queryMessagePush", { appid, action: "list" });
   if (!list1.success) throw new Error(`queryMessagePush(list) 失败: ${JSON.stringify(list1)}`);
-  process.stderr.write(`[msgpush] ✅ list 成功：version=${list1.version}, enable=${list1.enable}, callbacks=${list1.callbacks.length}\n`);
+  if (!list1.pushMode || !["cloudfunction", "container"].includes(list1.pushMode)) {
+    throw new Error(`list 缺少 pushMode: ${JSON.stringify(list1)}`);
+  }
+  process.stderr.write(
+    `[msgpush] ✅ list 成功：pushMode=${list1.pushMode}, version=${list1.version}, enable=${list1.enable}, callbacks=${list1.callbacks.length}\n`,
+  );
 
-  // 真实模式：快照完整原始 config（version + 原始 config 字符串），
-  // subscribe 的 rebound 语义可能改绑已有回调、enable 也会被置 true，
-  // unsubscribe/setEnable 无法保证还原，结束必须全量快照还原。
+  // 真实模式：先快照（含云托管），再必要时切回云函数模式，结束必须还原。
   let configSnapshot = null;
+  let containerSnapshot = null;
   if (!mockMsgPush && ticketTransport) {
     const raw = await ticketTransport({
       url: QBASE_PATHS.getAppConfig,
@@ -466,6 +492,30 @@ async function runMsgPushTestGroup() {
     });
     configSnapshot = { version: raw.version, config: raw.config };
     process.stderr.write(`[msgpush] 📸 已快照原始配置 version=${raw.version}\n`);
+    const rawContainer = await ticketTransport({
+      url: QBASE_PATHS.getContainerCallbackConfig,
+      method: "post",
+      body: {},
+      appid,
+    });
+    const { base_resp: _b, ...containerFields } = rawContainer || {};
+    containerSnapshot = containerFields;
+    process.stderr.write(
+      `[msgpush] 📸 已快照云托管配置 qbase_open=${containerFields.qbase_open === true}\n`,
+    );
+  }
+
+  // 若当前已是云托管模式，先切回云函数模式，否则后续 subscribe 会被拒绝
+  if (list1.pushMode === "container") {
+    const switchBack = await call("manageMessagePush", {
+      ...baseArgs,
+      action: "ensureCloudFunctionMode",
+      confirm: "yes",
+    });
+    if (!switchBack.success && switchBack.code !== "NO_CHANGE") {
+      throw new Error(`测试前切回云函数模式失败: ${JSON.stringify(switchBack)}`);
+    }
+    process.stderr.write("[msgpush] ⚠️ 环境原为云托管模式，已临时切到云函数模式（结束将快照还原）\n");
   }
 
   const supported = await call("queryMessagePush", { appid, action: "listSupportedEvents" });
@@ -649,6 +699,55 @@ async function runMsgPushTestGroup() {
   }
   process.stderr.write("[msgpush] ✅ unsubscribe msg_type=text 成功\n");
 
+  // 5c. 云托管模式往返：ensureContainerMode → list pushMode=container →
+  //     subscribe 拒绝 → ensureCloudFunctionMode 切回（真实模式结束会快照还原）
+  {
+    const ensureC = await call("manageMessagePush", {
+      ...baseArgs,
+      action: "ensureContainerMode",
+      qbase_container_path: "/msgpush-e2e-container",
+      qbase_env: envId,
+      text_mode: 1,
+      confirm: "yes",
+    });
+    if (!ensureC.success && ensureC.code !== "NO_CHANGE") {
+      throw new Error(`ensureContainerMode 失败: ${JSON.stringify(ensureC)}`);
+    }
+    const listC = await call("queryMessagePush", { appid, action: "list" });
+    if (listC.pushMode !== "container") {
+      throw new Error(`ensureContainerMode 后 pushMode 期望 container，实际 ${listC.pushMode}`);
+    }
+    if (!listC.note || !/云托管/.test(listC.note)) {
+      throw new Error(`云托管 list 缺少 note: ${JSON.stringify(listC)}`);
+    }
+    process.stderr.write("[msgpush] ✅ ensureContainerMode + list pushMode=container\n");
+
+    const blocked = await call("manageMessagePush", {
+      ...baseArgs,
+      action: "subscribe",
+      event_types: [testEvent],
+      confirm: "yes",
+    });
+    if (blocked.code !== "CONTAINER_MODE_ACTIVE") {
+      throw new Error(`云托管模式下 subscribe 应拒绝，实际 ${JSON.stringify(blocked)}`);
+    }
+    process.stderr.write("[msgpush] ✅ 云托管模式拒绝 subscribe（CONTAINER_MODE_ACTIVE）\n");
+
+    const back = await call("manageMessagePush", {
+      ...baseArgs,
+      action: "ensureCloudFunctionMode",
+      confirm: "yes",
+    });
+    if (!back.success && back.code !== "NO_CHANGE") {
+      throw new Error(`ensureCloudFunctionMode 失败: ${JSON.stringify(back)}`);
+    }
+    const listBack = await call("queryMessagePush", { appid, action: "list" });
+    if (listBack.pushMode !== "cloudfunction") {
+      throw new Error(`切回后 pushMode 期望 cloudfunction，实际 ${listBack.pushMode}`);
+    }
+    process.stderr.write("[msgpush] ✅ ensureCloudFunctionMode 往返切换成功\n");
+  }
+
   // 6. 全量快照还原（真实模式）：subscribe 会改绑已有回调 + 置 enable=true，
   //    unsubscribe/setEnable 只能还原工具自身写的条目，无法恢复被 rebound 的
   //    原回调 —— 必须用测试前的完整 config 覆盖写还原。
@@ -675,6 +774,21 @@ async function runMsgPushTestGroup() {
       throw new Error(`快照还原失败: ${JSON.stringify(restore)}`);
     }
     process.stderr.write(`[msgpush] ✅ 原始配置快照已还原（version=${cur.version}）\n`);
+  }
+
+  if (!mockMsgPush && ticketTransport && containerSnapshot) {
+    const restoreContainer = await ticketTransport({
+      url: QBASE_PATHS.setContainerCallbackConfig,
+      method: "post",
+      body: containerSnapshot,
+      appid,
+    });
+    if (restoreContainer?.base_resp?.ret !== 0) {
+      throw new Error(`云托管快照还原失败: ${JSON.stringify(restoreContainer)}`);
+    }
+    process.stderr.write(
+      `[msgpush] ✅ 云托管配置快照已还原（qbase_open=${containerSnapshot.qbase_open === true}）\n`,
+    );
   }
 
   if (mockMsgPush) {

--- a/mcp/src/tools/msg-push.test.ts
+++ b/mcp/src/tools/msg-push.test.ts
@@ -20,6 +20,9 @@ function createQbaseBackendMock(options?: {
   /** Message types with empty event (text/image/...) included in getcallbacksupportlist */
   supportedMsgTypes?: string[];
   containerQbaseOpen?: boolean;
+  containerPath?: string;
+  containerEnv?: string;
+  containerTextMode?: number;
   /** 上传携带该 version 时返回版本冲突（模拟并发写入） */
   conflictOnVersion?: number;
 }) {
@@ -27,6 +30,9 @@ function createQbaseBackendMock(options?: {
   let enable = true;
   let callbacks = [...(options?.initialCallbacks ?? [])];
   let containerQbaseOpen = options?.containerQbaseOpen ?? false;
+  let containerPath = options?.containerPath ?? "/push";
+  let containerEnv = options?.containerEnv ?? "env-container";
+  let containerTextMode = options?.containerTextMode ?? 1;
 
   const supportedEvents = new Set(
     options?.supportedEvents ?? ["user_enter_tempsession", ...XPAY_EVENT_TYPES],
@@ -95,12 +101,23 @@ function createQbaseBackendMock(options?: {
       return {
         base_resp: { ret: 0 },
         qbase_open: containerQbaseOpen,
-        qbase_env: "env-container",
-        qbase_container_path: "/push",
+        qbase_env: containerEnv,
+        qbase_container_path: containerPath,
+        text_mode: containerTextMode,
       };
     }
     if (params.action === "setContainerCallbackConfig") {
-      containerQbaseOpen = params.payload?.qbase_open === true;
+      const body = params.payload ?? {};
+      containerQbaseOpen = body.qbase_open === true;
+      if (typeof body.qbase_container_path === "string") {
+        containerPath = body.qbase_container_path;
+      }
+      if (typeof body.qbase_env === "string") {
+        containerEnv = body.qbase_env;
+      }
+      if (typeof body.text_mode === "number") {
+        containerTextMode = body.text_mode;
+      }
       return { base_resp: { ret: 0 } };
     }
     throw new Error(`unexpected qbase action: ${params.action}`);
@@ -109,11 +126,24 @@ function createQbaseBackendMock(options?: {
   return {
     requestFn,
     calls,
-    getState: () => ({ version, enable, callbacks, containerQbaseOpen }),
+    getState: () => ({
+      version,
+      enable,
+      callbacks,
+      containerQbaseOpen,
+      containerPath,
+      containerEnv,
+      containerTextMode,
+    }),
   };
 }
 
-function createMockServer(requestFn: (params: any) => Promise<MsgPushQbaseResponse>) {
+function createMockServer(
+  requestFn: (params: any) => Promise<MsgPushQbaseResponse>,
+  options?: {
+    listCloudFunctions?: (envId: string) => Promise<string[]>;
+  },
+) {
   const tools: Record<
     string,
     {
@@ -125,7 +155,13 @@ function createMockServer(requestFn: (params: any) => Promise<MsgPushQbaseRespon
   const server: ExtendedMcpServer = {
     cloudBaseOptions: { envId: "env-test", requestFn },
     logger: vi.fn(),
-    pluginOptions: {},
+    pluginOptions: {
+      msgPush: {
+        listCloudFunctions:
+          options?.listCloudFunctions ??
+          (async () => ["cb", "msg-fn", "msg-push-test-fn", "fn1", "fn2"]),
+      },
+    },
     registerTool: vi.fn(
       (name: string, meta: any, handler: (args: any) => Promise<any>) => {
         tools[name] = { meta, handler };
@@ -160,6 +196,8 @@ describe("msg-push tools schema", () => {
       "unsubscribe",
       "setEnable",
       "ensureCloudFunctionMode",
+      "ensureContainerMode",
+      "setContainerCallback",
     ]);
     // msg_type is optional enum (default event when omitted)
     expect(schema.msg_type._def.typeName).toBe("ZodOptional");
@@ -639,6 +677,7 @@ describe("manageMessagePush — ensureCloudFunctionMode", () => {
       }),
     );
     expect(result.code).toBe("NO_CHANGE");
+    expect(result.pushMode).toBe("cloudfunction");
   });
 
   it("云托管模式（qbase_open=true）需确认后切换 qbase_open=false", async () => {
@@ -654,7 +693,8 @@ describe("manageMessagePush — ensureCloudFunctionMode", () => {
       }),
     );
     expect(pending.code).toBe("CONFIRM_REQUIRED");
-    expect(pending.message).toMatch(/云托管/);
+    expect(pending.message).toMatch(/停止云托管整包接收/);
+    expect(pending.message).toMatch(/callbacks 为空则收不到任何消息/);
 
     const done = parseResult(
       await tools.manageMessagePush.handler({
@@ -666,11 +706,229 @@ describe("manageMessagePush — ensureCloudFunctionMode", () => {
       }),
     );
     expect(done.success).toBe(true);
+    expect(done.pushMode).toBe("cloudfunction");
     const setCalls = backend.calls.filter((c) => c.action === "setContainerCallbackConfig");
     expect(setCalls).toHaveLength(1);
     expect(setCalls[0]!.payload!.qbase_open).toBe(false);
     // 保留其他云托管字段
     expect(setCalls[0]!.payload!.qbase_container_path).toBe("/push");
+  });
+});
+
+describe("queryMessagePush / manageMessagePush — pushMode & container", () => {
+  it("list 返回 pushMode=cloudfunction 与 containerConfig", async () => {
+    const backend = createQbaseBackendMock({ containerQbaseOpen: false });
+    const tools = createMockServer(backend.requestFn).tools;
+    const result = parseResult(
+      await tools.queryMessagePush.handler({ appid: "wx1", action: "list" }),
+    );
+    expect(result.success).toBe(true);
+    expect(result.pushMode).toBe("cloudfunction");
+    expect(result.containerConfig).toMatchObject({
+      qbase_open: false,
+      qbase_container_path: "/push",
+    });
+    expect(result.note).toBeUndefined();
+  });
+
+  it("list 云托管模式返回 pushMode=container 与 note", async () => {
+    const backend = createQbaseBackendMock({
+      containerQbaseOpen: true,
+      containerPath: "/svc/msg",
+      containerEnv: "env-run",
+      containerTextMode: 2,
+    });
+    const tools = createMockServer(backend.requestFn).tools;
+    const result = parseResult(
+      await tools.queryMessagePush.handler({ appid: "wx1", action: "list" }),
+    );
+    expect(result.pushMode).toBe("container");
+    expect(result.note).toMatch(/云托管模式/);
+    expect(result.containerConfig).toMatchObject({
+      qbase_open: true,
+      qbase_container_path: "/svc/msg",
+      qbase_env: "env-run",
+      text_mode: 2,
+    });
+  });
+
+  it("云托管模式下 subscribe/unsubscribe/setEnable 拒绝且不写 uploadAppConfig", async () => {
+    const backend = createQbaseBackendMock({ containerQbaseOpen: true });
+    const tools = createMockServer(backend.requestFn).tools;
+
+    for (const action of ["subscribe", "unsubscribe", "setEnable"] as const) {
+      const result = parseResult(
+        await tools.manageMessagePush.handler({
+          appid: "wx1",
+          env_id: "env-a",
+          function_name: "cb",
+          action,
+          event_types: ["user_enter_tempsession"],
+          enable: action === "setEnable" ? false : undefined,
+          confirm: "yes",
+        }),
+      );
+      expect(result.ok).toBe(false);
+      expect(result.code).toBe("CONTAINER_MODE_ACTIVE");
+      expect(result.pushMode).toBe("container");
+      expect(result.message).toMatch(/ensureCloudFunctionMode/);
+    }
+    expect(backend.calls.filter((c) => c.action === "uploadAppConfig")).toHaveLength(0);
+  });
+
+  it("ensureContainerMode 需确认后 qbase_open=true", async () => {
+    const backend = createQbaseBackendMock({ containerQbaseOpen: false });
+    const tools = createMockServer(backend.requestFn).tools;
+
+    const pending = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "ensureContainerMode",
+        qbase_container_path: "/run/push",
+        qbase_env: "env-run",
+        text_mode: 1,
+      }),
+    );
+    expect(pending.code).toBe("CONFIRM_REQUIRED");
+    expect(pending.message).toMatch(/云函数回调失效/);
+
+    const done = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "ensureContainerMode",
+        qbase_container_path: "/run/push",
+        qbase_env: "env-run",
+        text_mode: 1,
+        confirm: "yes",
+      }),
+    );
+    expect(done.success).toBe(true);
+    expect(done.pushMode).toBe("container");
+    expect(done.containerConfig).toMatchObject({
+      qbase_open: true,
+      qbase_container_path: "/run/push",
+      qbase_env: "env-run",
+      text_mode: 1,
+    });
+    expect(backend.getState().containerQbaseOpen).toBe(true);
+    expect(backend.getState().containerPath).toBe("/run/push");
+  });
+
+  it("ensureContainerMode 配置一致时 NO_CHANGE", async () => {
+    const backend = createQbaseBackendMock({
+      containerQbaseOpen: true,
+      containerPath: "/run/push",
+      containerEnv: "env-run",
+      containerTextMode: 1,
+    });
+    const tools = createMockServer(backend.requestFn).tools;
+    const result = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "ensureContainerMode",
+        qbase_container_path: "/run/push",
+        qbase_env: "env-run",
+        text_mode: 1,
+        confirm: "yes",
+      }),
+    );
+    expect(result.code).toBe("NO_CHANGE");
+    expect(
+      backend.calls.filter((c) => c.action === "setContainerCallbackConfig"),
+    ).toHaveLength(0);
+  });
+
+  it("setContainerCallback 展示新旧 diff 并更新", async () => {
+    const backend = createQbaseBackendMock({
+      containerQbaseOpen: true,
+      containerPath: "/old",
+      containerEnv: "env-old",
+      containerTextMode: 1,
+    });
+    const tools = createMockServer(backend.requestFn).tools;
+
+    const pending = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "setContainerCallback",
+        qbase_container_path: "/new",
+        qbase_env: "env-new",
+        text_mode: 2,
+      }),
+    );
+    expect(pending.code).toBe("CONFIRM_REQUIRED");
+    expect(pending.message).toMatch(/旧:.*\/old/);
+    expect(pending.message).toMatch(/新:.*\/new/);
+
+    const done = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "setContainerCallback",
+        qbase_container_path: "/new",
+        qbase_env: "env-new",
+        text_mode: 2,
+        confirm: "yes",
+      }),
+    );
+    expect(done.success).toBe(true);
+    expect(done.after).toMatchObject({
+      qbase_container_path: "/new",
+      qbase_env: "env-new",
+      text_mode: 2,
+    });
+    expect(backend.getState().containerPath).toBe("/new");
+    expect(backend.getState().containerTextMode).toBe(2);
+  });
+
+  it("subscribe 拒绝不存在的云函数", async () => {
+    const backend = createQbaseBackendMock();
+    const tools = createMockServer(backend.requestFn, {
+      listCloudFunctions: async () => ["other-fn"],
+    }).tools;
+
+    const result = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "missing-fn",
+        action: "subscribe",
+        event_types: ["user_enter_tempsession"],
+        confirm: "yes",
+      }),
+    );
+    expect(result.ok).toBe(false);
+    expect(result.code).toBe("FUNCTION_NOT_FOUND");
+    expect(result.message).toMatch(/云函数 missing-fn 不存在于环境 env-a/);
+    expect(backend.calls.filter((c) => c.action === "uploadAppConfig")).toHaveLength(0);
+  });
+
+  it("subscribe 云函数存在时正常写入", async () => {
+    const backend = createQbaseBackendMock();
+    const tools = createMockServer(backend.requestFn, {
+      listCloudFunctions: async () => ["cb"],
+    }).tools;
+    const result = parseResult(
+      await tools.manageMessagePush.handler({
+        appid: "wx1",
+        env_id: "env-a",
+        function_name: "cb",
+        action: "subscribe",
+        event_types: ["user_enter_tempsession"],
+        confirm: "yes",
+      }),
+    );
+    expect(result.success).toBe(true);
+    expect(result.added).toEqual(["user_enter_tempsession"]);
   });
 });
 

--- a/mcp/src/tools/msg-push.ts
+++ b/mcp/src/tools/msg-push.ts
@@ -1,5 +1,4 @@
 import { z } from "zod";
-import { getCloudBaseManager } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import {
   CloudApiRequestFn,
@@ -507,35 +506,17 @@ async function assertCloudFunctionExists(
   functionName: string,
 ): Promise<ReturnType<typeof buildJsonToolResult> | null> {
   const override = server.pluginOptions?.msgPush?.listCloudFunctions;
+  // 兼容性降级：host 未提供 listCloudFunctions hook（如微信 IDE 无腾讯云凭据）时
+  // 跳过存在性校验，保持原有 subscribe 行为（写配置不阻断）；仅 host 显式启用时校验。
+  if (!override) {
+    return null;
+  }
   let names: string[];
   try {
-    if (override) {
-      names = await override(envId);
-    } else {
-      const manager = await getCloudBaseManager({
-        cloudBaseOptions: {
-          ...(server.cloudBaseOptions ?? {}),
-          envId,
-        },
-      });
-      const result = await manager.functions.getFunctionList(100, 0);
-      names = (result.Functions ?? [])
-        .map((f: { FunctionName?: string }) => f.FunctionName)
-        .filter((n: string | undefined): n is string => !!n);
-    }
+    names = await override(envId);
   } catch (e) {
-    return buildJsonToolResult({
-      ok: false,
-      code: "FUNCTION_LOOKUP_FAILED",
-      message:
-        `无法校验云函数是否存在于环境 ${envId}：${e instanceof Error ? e.message : String(e)}。` +
-        `请确认已登录腾讯云开发并绑定该环境后重试，或先用 queryFunctions(action=listFunctions) 核对。`,
-      next_step: {
-        tool: "queryFunctions",
-        action: "listFunctions",
-        hint: "确认云函数列表后再 subscribe",
-      },
-    });
+    // hook 本身失败（如网络/权限）时降级放行，不阻断订阅
+    return null;
   }
   if (!names.includes(functionName)) {
     return buildJsonToolResult({

--- a/mcp/src/tools/msg-push.ts
+++ b/mcp/src/tools/msg-push.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { getCloudBaseManager } from "../cloudbase-manager.js";
 import { ExtendedMcpServer } from "../server.js";
 import {
   CloudApiRequestFn,
@@ -407,6 +408,45 @@ interface ContainerCallbackConfig {
   [key: string]: unknown;
 }
 
+/** Push mode derived from getContainerCallbackConfig.qbase_open */
+export type MsgPushMode = "cloudfunction" | "container";
+
+export function resolvePushMode(
+  container: ContainerCallbackConfig | null | undefined,
+): MsgPushMode {
+  return container?.qbase_open === true ? "container" : "cloudfunction";
+}
+
+/** Public subset of container callback fields returned to agents */
+export function pickContainerConfigPublic(
+  container: ContainerCallbackConfig | null | undefined,
+): {
+  qbase_container_path?: string;
+  qbase_env?: string;
+  text_mode?: number;
+  qbase_open?: boolean;
+} | undefined {
+  if (!container) return undefined;
+  return {
+    qbase_open: container.qbase_open === true,
+    qbase_container_path:
+      typeof container.qbase_container_path === "string"
+        ? container.qbase_container_path
+        : undefined,
+    qbase_env:
+      typeof container.qbase_env === "string" ? container.qbase_env : undefined,
+    text_mode:
+      typeof container.text_mode === "number" ? container.text_mode : undefined,
+  };
+}
+
+const CONTAINER_MODE_BLOCK_NOTE =
+  "当前为云托管模式（整包接收），云函数 callbacks 存在但不生效；如需云函数模式请调 ensureCloudFunctionMode 切换";
+
+const CONTAINER_MODE_WRITE_ERROR =
+  "当前 pushMode=container（云托管整包接收），云函数回调配置存在但不生效。" +
+  "如需云函数模式请调 action=ensureCloudFunctionMode 切换。";
+
 /** 读取云托管消息推送配置；无配置（云函数模式）返回 null */
 async function readContainerConfig(
   server: ExtendedMcpServer,
@@ -440,6 +480,78 @@ async function setContainerConfig(
       `setcontainercallbackconfig 失败(ret=${ret}): ${resp.base_resp?.errmsg ?? "未知错误"}`,
     );
   }
+}
+
+function buildContainerModeBlockedPayload(action: string) {
+  return buildJsonToolResult({
+    ok: false,
+    code: "CONTAINER_MODE_ACTIVE",
+    pushMode: "container" as const,
+    message: CONTAINER_MODE_WRITE_ERROR,
+    next_step: {
+      tool: "manageMessagePush",
+      action: "ensureCloudFunctionMode",
+      required_params: ["appid", "env_id", "function_name", "confirm"],
+      hint: `先切换到云函数模式后再执行 ${action}`,
+    },
+  });
+}
+
+/**
+ * Verify function_name exists in envId via optional host hook or CloudBase Manager list.
+ * Returns an error tool result when missing / unreadable; null when OK.
+ */
+async function assertCloudFunctionExists(
+  server: ExtendedMcpServer,
+  envId: string,
+  functionName: string,
+): Promise<ReturnType<typeof buildJsonToolResult> | null> {
+  const override = server.pluginOptions?.msgPush?.listCloudFunctions;
+  let names: string[];
+  try {
+    if (override) {
+      names = await override(envId);
+    } else {
+      const manager = await getCloudBaseManager({
+        cloudBaseOptions: {
+          ...(server.cloudBaseOptions ?? {}),
+          envId,
+        },
+      });
+      const result = await manager.functions.getFunctionList(100, 0);
+      names = (result.Functions ?? [])
+        .map((f: { FunctionName?: string }) => f.FunctionName)
+        .filter((n: string | undefined): n is string => !!n);
+    }
+  } catch (e) {
+    return buildJsonToolResult({
+      ok: false,
+      code: "FUNCTION_LOOKUP_FAILED",
+      message:
+        `无法校验云函数是否存在于环境 ${envId}：${e instanceof Error ? e.message : String(e)}。` +
+        `请确认已登录腾讯云开发并绑定该环境后重试，或先用 queryFunctions(action=listFunctions) 核对。`,
+      next_step: {
+        tool: "queryFunctions",
+        action: "listFunctions",
+        hint: "确认云函数列表后再 subscribe",
+      },
+    });
+  }
+  if (!names.includes(functionName)) {
+    return buildJsonToolResult({
+      ok: false,
+      code: "FUNCTION_NOT_FOUND",
+      message: `云函数 ${functionName} 不存在于环境 ${envId}，请先创建或修正参数`,
+      envId,
+      function_name: functionName,
+      next_step: {
+        tool: "manageFunctions",
+        action: "createFunction",
+        required_params: ["functionName"],
+      },
+    });
+  }
+  return null;
 }
 
 function buildTransportUnavailablePayload(toolName: string, action?: string) {
@@ -538,11 +650,11 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
       title: "查询小程序消息推送配置",
       description:
         "查询小程序云开发消息推送配置（qbase getappconfig）或全部合法消息推送事件约束（getcallbacksupportlist）。" +
-        "消息推送把小程序事件/消息（含虚拟支付回调、text/image 等消息类型）送到云函数，无需自建服务器。" +
-        "action=list 返回当前配置列表（msgType/event/env/functionName/enable）与 version（乐观锁版本号）；" +
-        "action=listSupportedEvents 返回全部合法约束（按消息类型分组：event 组含事件名列表；text/image/voice/video/miniprogrampage 组 events 为空数组），" +
-        "事件类用 manageMessagePush(event_types=...)，消息类型用 manageMessagePush(msg_type=...)。" +
-        "需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn），独立 CloudBase MCP 运行会返回指引错误。",
+        "推送模式有两种：云函数（默认，按 (msgType,event) 逐条回调）与云托管（qbase_open=true，整包接收所有消息到容器 path）。" +
+        "action=list 同时返回 pushMode（cloudfunction|container）、containerConfig、callbacks 与 version；" +
+        "云托管模式下 callbacks 可能仍存在但不生效（见 note），需 ensureCloudFunctionMode 切回云函数模式后才会按回调推送。" +
+        "action=listSupportedEvents 返回全部合法约束（按消息类型分组）。" +
+        "需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn）。",
       inputSchema: {
         appid: z
           .string()
@@ -551,7 +663,7 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
         action: z
           .enum(["list", "listSupportedEvents"])
           .describe(
-            "list: 查询当前消息推送配置列表\nlistSupportedEvents: 查询全部合法消息推送事件约束（按 msgType 分组）",
+            "list: 查询当前消息推送配置列表（含 pushMode/containerConfig）\nlistSupportedEvents: 查询全部合法消息推送事件约束（按 msgType 分组）",
           ),
       },
       annotations: {
@@ -565,7 +677,11 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
         return buildTransportUnavailablePayload("queryMessagePush", action);
       }
       if (action === "list") {
-        const state = await readCallbackConfig(server, appid);
+        const [state, container] = await Promise.all([
+          readCallbackConfig(server, appid),
+          readContainerConfig(server, appid),
+        ]);
+        const pushMode = resolvePushMode(container);
         const callbacks = env
           ? state.list.filter((c) => c.env === env)
           : state.list;
@@ -575,12 +691,23 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
           message: "查询消息推送配置成功",
           version: state.version,
           enable: state.enable,
+          pushMode,
+          containerConfig: pickContainerConfigPublic(container),
           callbacks,
+          note: pushMode === "container" ? CONTAINER_MODE_BLOCK_NOTE : undefined,
           filteredByEnv: env ?? undefined,
-          next_steps: [
-            "manageMessagePush(action=subscribe) 订阅事件（缺省 event_types 时默认订阅虚拟支付 7 事件）",
-            "queryMessagePush(action=listSupportedEvents) 查看全部合法事件",
-          ],
+          next_steps:
+            pushMode === "container"
+              ? [
+                  "当前为云托管模式：云函数 subscribe/unsubscribe/setEnable 会被拒绝",
+                  "manageMessagePush(action=ensureCloudFunctionMode) 切回云函数模式",
+                  "manageMessagePush(action=setContainerCallback) 更新云托管 path/env/text_mode",
+                ]
+              : [
+                  "manageMessagePush(action=subscribe) 订阅事件（缺省 event_types 时默认订阅虚拟支付 7 事件）",
+                  "manageMessagePush(action=ensureContainerMode) 切换到云托管整包接收",
+                  "queryMessagePush(action=listSupportedEvents) 查看全部合法事件",
+                ],
         });
       }
       if (action === "listSupportedEvents") {
@@ -633,30 +760,43 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
       title: "管理小程序消息推送配置",
       description:
         "管理小程序云开发消息推送配置（写操作，需 confirm=\"yes\" 确认）。" +
-        "基于「读全量 → merge → 全量覆盖（带 version 乐观锁）」实现声明式幂等（对齐 kubectl apply：event_types 是期望集合，重复执行收敛到同一状态；" +
-        "version 冲突即 RFC 7232 If-Match 412，返回可重试错误：重读 → merge → 重试）。" +
-        "msg_type 区分两类条目（缺省 \"event\"，向后兼容）：" +
-        "msg_type=\"event\" 操作事件类（需 event_types；subscribe 缺省时默认虚拟支付 7 个 xpay_* 事件）；" +
-        "msg_type=\"text\"|\"image\"|\"voice\"|\"video\"|\"miniprogrampage\" 操作消息类型条目（event 固定空串，勿传 event_types）。" +
-        "action=subscribe 订阅到指定云函数；同一 (msgType,event) 只能推到一个云函数（一事一函数），已绑定其他函数会自动重绑并说明。" +
-        "action=unsubscribe 移除匹配订阅（msg_type=event 时 event_types 必填；消息类型时按 msg_type 移除）。" +
-        "action=setEnable 启用/停用匹配订阅（msg_type=event 时 event_types + enable 必填；消息类型时 msg_type + enable）。" +
-        "action=ensureCloudFunctionMode 确保推送模式为云函数（若为云托管整包接收则切换 qbase_open=false，需确认）。" +
-        "集合无变化时不发起写请求（幂等 no-op，无需确认）。" +
-        "需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn）。",
+        "推送模式：云函数（默认，按 (msgType,event) 回调）vs 云托管（整包接收；云托管模式下 subscribe/unsubscribe/setEnable 会被拒绝，先 ensureCloudFunctionMode）。" +
+        "基于「读全量 → merge → 全量覆盖（带 version 乐观锁）」实现声明式幂等。" +
+        "msg_type 缺省 \"event\"；消息类型用 msg_type=text|image|voice|video|miniprogrampage。" +
+        "action=subscribe 前会校验 function_name 在环境中真实存在。" +
+        "action=ensureCloudFunctionMode 关闭云托管整包接收；action=ensureContainerMode 开启云托管（需 qbase_container_path/qbase_env/text_mode）；" +
+        "action=setContainerCallback 更新云托管 path/env/text_mode。" +
+        "集合无变化时不发起写请求（幂等 no-op）。需要微信 IDE 登录态通道。",
       inputSchema: {
         appid: z
           .string()
           .describe("小程序 AppID（必填，与微信开发者工具一致；用于选择微信登录态会话）"),
-        env_id: z.string().describe("环境 ID（订阅条目绑定的云开发环境）"),
-        function_name: z.string().describe("接收消息推送的云函数名"),
-        action: z
-          .enum(["subscribe", "unsubscribe", "setEnable", "ensureCloudFunctionMode"])
+        env_id: z
+          .string()
           .describe(
-            "subscribe: 订阅到指定云函数（msg_type=event 时 event_types 缺省=虚拟支付 7 事件；消息类型时按 msg_type 订阅）\n" +
-              "unsubscribe: 移除匹配订阅（msg_type=event 时 event_types 必填）\n" +
-              "setEnable: 启用/停用匹配订阅（msg_type=event 时 event_types + enable 必填）\n" +
-              "ensureCloudFunctionMode: 确保为云函数推送模式（云托管整包接收时切换，需确认）",
+            "环境 ID（云函数订阅绑定的云开发环境；ensureContainerMode/setContainerCallback 未传 qbase_env 时也可作为云托管环境默认值）",
+          ),
+        function_name: z
+          .string()
+          .describe(
+            "接收消息推送的云函数名（subscribe/unsubscribe/setEnable/ensureCloudFunctionMode 使用；云托管相关 action 可传占位）",
+          ),
+        action: z
+          .enum([
+            "subscribe",
+            "unsubscribe",
+            "setEnable",
+            "ensureCloudFunctionMode",
+            "ensureContainerMode",
+            "setContainerCallback",
+          ])
+          .describe(
+            "subscribe: 订阅到指定云函数（云托管模式下拒绝）\n" +
+              "unsubscribe: 移除匹配订阅（云托管模式下拒绝）\n" +
+              "setEnable: 启用/停用匹配订阅（云托管模式下拒绝）\n" +
+              "ensureCloudFunctionMode: 切到云函数推送模式（关闭 qbase_open）\n" +
+              "ensureContainerMode: 切到云托管整包接收（需 qbase_container_path + text_mode）\n" +
+              "setContainerCallback: 更新云托管回调 path/env/text_mode",
           ),
         msg_type: z
           .enum(MSG_TYPES)
@@ -671,11 +811,27 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
           .optional()
           .describe(
             "要操作的事件列表（仅 msg_type=\"event\" 时使用；可先 queryMessagePush(action=listSupportedEvents) 查询全量约束）。" +
-              "subscribe 缺省时默认订阅虚拟支付 7 个事件：xpay_goods_deliver_notify、xpay_coin_pay_notify、xpay_complaint_notify、" +
-              "xpay_subscribe_signing_result_notify、xpay_subscribe_pay_fail_notify、xpay_subscribe_ios_refund_query_notify、xpay_refund_notify；" +
-              "unsubscribe / setEnable 且 msg_type=event 时必填。消息类型操作请勿传本参数。",
+              "subscribe 缺省时默认订阅虚拟支付 7 个事件；unsubscribe / setEnable 且 msg_type=event 时必填。",
           ),
         enable: z.boolean().optional().describe("setEnable 时必填：true 启用订阅 / false 停用订阅"),
+        qbase_container_path: z
+          .string()
+          .optional()
+          .describe(
+            "云托管回调路径/URL（ensureContainerMode 必填；setContainerCallback 可选更新）",
+          ),
+        qbase_env: z
+          .string()
+          .optional()
+          .describe(
+            "云托管服务所在环境 ID（ensureContainerMode/setContainerCallback 可选；缺省用 env_id）",
+          ),
+        text_mode: z
+          .union([z.literal(1), z.literal(2)])
+          .optional()
+          .describe(
+            "云托管消息正文编码：1=json，2=xml（ensureContainerMode 必填；setContainerCallback 可选更新）",
+          ),
         confirm: z
           .string()
           .optional()
@@ -699,6 +855,9 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
       msg_type,
       event_types,
       enable,
+      qbase_container_path,
+      qbase_env,
+      text_mode,
       confirm,
     }: {
       appid: string;
@@ -708,6 +867,9 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
       msg_type?: MsgType;
       event_types?: string[];
       enable?: boolean;
+      qbase_container_path?: string;
+      qbase_env?: string;
+      text_mode?: 1 | 2;
       confirm?: string;
     }) => {
       if (!getTransport(server)) {
@@ -725,7 +887,8 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
             success: true,
             code: "NO_CHANGE",
             message: "当前已是云函数推送模式（云托管整包接收未开启），无需变更",
-            containerConfig: current ?? undefined,
+            pushMode: "cloudfunction",
+            containerConfig: pickContainerConfigPublic(current),
           });
         }
         if (!confirmed) {
@@ -733,9 +896,8 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
             toolName: "manageMessagePush",
             action,
             message:
-              `当前推送模式为云托管整包接收（qbase_open=true，环境 ${current.qbase_env ?? "-"}，路径 ${current.qbase_container_path ?? "-"}），` +
-              `事件会整包进入云托管而非云函数。\n即将执行 setcontainercallbackconfig 关闭云托管整包接收（qbase_open=false），` +
-              `使消息推送按事件进入云函数 ${env_id}/${function_name}。`,
+              `切换后停止云托管整包接收（qbase_open=false），消息按云函数回调推送；若 callbacks 为空则收不到任何消息。\n` +
+              `当前云托管配置：环境 ${current.qbase_env ?? "-"}，路径 ${current.qbase_container_path ?? "-"}，text_mode=${current.text_mode ?? "-"}。`,
             requiredParams: ["appid", "env_id", "function_name", "confirm"],
           });
         }
@@ -755,6 +917,161 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
           success: true,
           message: "已切换到云函数推送模式（setcontainercallbackconfig qbase_open=false 成功）",
           action,
+          pushMode: "cloudfunction",
+        });
+      }
+
+      if (action === "ensureContainerMode") {
+        const path = qbase_container_path?.trim();
+        const containerEnv = (qbase_env ?? env_id)?.trim();
+        if (!path) {
+          throw new Error(
+            'ensureContainerMode 必须提供 qbase_container_path（云托管回调路径/URL）',
+          );
+        }
+        if (text_mode !== 1 && text_mode !== 2) {
+          throw new Error(
+            "ensureContainerMode 必须提供 text_mode（1=json / 2=xml）",
+          );
+        }
+        if (!containerEnv) {
+          throw new Error(
+            "ensureContainerMode 必须提供 qbase_env 或 env_id（云托管服务所在环境）",
+          );
+        }
+        const current = await readContainerConfig(server, appid);
+        const alreadySame =
+          current?.qbase_open === true &&
+          current.qbase_container_path === path &&
+          current.qbase_env === containerEnv &&
+          Number(current.text_mode) === text_mode;
+        if (alreadySame) {
+          return buildJsonToolResult({
+            ok: true,
+            success: true,
+            code: "NO_CHANGE",
+            message: "当前已是云托管推送模式且配置一致，无需变更",
+            pushMode: "container",
+            containerConfig: pickContainerConfigPublic(current),
+          });
+        }
+        if (!confirmed) {
+          return buildConfirmPayload({
+            toolName: "manageMessagePush",
+            action,
+            message:
+              `切换后所有消息类型整包推送到云托管服务（path=${path}，env=${containerEnv}，text_mode=${text_mode}），云函数回调失效。\n` +
+              `当前：pushMode=${resolvePushMode(current)}，` +
+              `path=${current?.qbase_container_path ?? "-"}，env=${current?.qbase_env ?? "-"}，text_mode=${current?.text_mode ?? "-"}。`,
+            requiredParams: [
+              "appid",
+              "env_id",
+              "qbase_container_path",
+              "text_mode",
+              "confirm",
+            ],
+          });
+        }
+        const nextCfg = {
+          ...(current ?? {}),
+          qbase_open: true,
+          qbase_container_path: path,
+          qbase_env: containerEnv,
+          text_mode,
+        };
+        await setContainerConfig(server, appid, nextCfg);
+        logger?.({
+          type: "toolInfo",
+          toolName: "manageMessagePush",
+          message: "已切换到云托管推送模式",
+          appid,
+          envId: containerEnv,
+        });
+        return buildJsonToolResult({
+          ok: true,
+          success: true,
+          message: "已切换到云托管推送模式（qbase_open=true）",
+          action,
+          pushMode: "container",
+          containerConfig: pickContainerConfigPublic(nextCfg),
+        });
+      }
+
+      if (action === "setContainerCallback") {
+        const current = await readContainerConfig(server, appid);
+        const nextPath =
+          qbase_container_path?.trim() ||
+          (typeof current?.qbase_container_path === "string"
+            ? current.qbase_container_path
+            : undefined);
+        const nextEnv =
+          (qbase_env ?? env_id)?.trim() ||
+          (typeof current?.qbase_env === "string" ? current.qbase_env : undefined);
+        const nextTextMode =
+          text_mode === 1 || text_mode === 2
+            ? text_mode
+            : typeof current?.text_mode === "number"
+              ? (current.text_mode as 1 | 2)
+              : undefined;
+        if (!nextPath) {
+          throw new Error(
+            "setContainerCallback 需要 qbase_container_path（或当前已有配置可沿用）",
+          );
+        }
+        if (!nextEnv) {
+          throw new Error(
+            "setContainerCallback 需要 qbase_env 或 env_id（或当前已有配置可沿用）",
+          );
+        }
+        if (nextTextMode !== 1 && nextTextMode !== 2) {
+          throw new Error(
+            "setContainerCallback 需要 text_mode（1=json / 2=xml，或当前已有配置可沿用）",
+          );
+        }
+        const nextCfg = {
+          ...(current ?? {}),
+          qbase_open: current?.qbase_open === true,
+          qbase_container_path: nextPath,
+          qbase_env: nextEnv,
+          text_mode: nextTextMode,
+        };
+        const same =
+          current?.qbase_container_path === nextPath &&
+          current?.qbase_env === nextEnv &&
+          Number(current?.text_mode) === nextTextMode &&
+          (current?.qbase_open === true) === (nextCfg.qbase_open === true);
+        if (same) {
+          return buildJsonToolResult({
+            ok: true,
+            success: true,
+            code: "NO_CHANGE",
+            message: "云托管回调配置无变化（幂等）",
+            pushMode: resolvePushMode(current),
+            containerConfig: pickContainerConfigPublic(current),
+          });
+        }
+        if (!confirmed) {
+          const before = pickContainerConfigPublic(current) ?? {};
+          const after = pickContainerConfigPublic(nextCfg) ?? {};
+          return buildConfirmPayload({
+            toolName: "manageMessagePush",
+            action,
+            message:
+              `即将更新云托管回调配置：\n` +
+              `- 旧: path=${before.qbase_container_path ?? "-"}, env=${before.qbase_env ?? "-"}, text_mode=${before.text_mode ?? "-"}, qbase_open=${before.qbase_open ?? false}\n` +
+              `- 新: path=${after.qbase_container_path ?? "-"}, env=${after.qbase_env ?? "-"}, text_mode=${after.text_mode ?? "-"}, qbase_open=${after.qbase_open ?? false}`,
+            requiredParams: ["appid", "confirm"],
+          });
+        }
+        await setContainerConfig(server, appid, nextCfg);
+        return buildJsonToolResult({
+          ok: true,
+          success: true,
+          message: "已更新云托管回调配置",
+          action,
+          pushMode: resolvePushMode(nextCfg),
+          before: pickContainerConfigPublic(current),
+          after: pickContainerConfigPublic(nextCfg),
         });
       }
 
@@ -764,6 +1081,14 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
           `msg_type="${resolvedMsgType}" 时不应传 event_types（消息类型条目的 event 固定为空串 ""）；` +
             `请去掉 event_types，仅传 msg_type / function_name / enable（setEnable 时）`,
         );
+      }
+
+      // Reject cloud-function callback writes while container mode is active (silent-failure guard)
+      {
+        const container = await readContainerConfig(server, appid);
+        if (resolvePushMode(container) === "container") {
+          return buildContainerModeBlockedPayload(action);
+        }
       }
 
       // subscribe / unsubscribe / setEnable 共用流程：读 → 校验 → merge → 确认 → 覆盖写
@@ -883,6 +1208,16 @@ export function registerMsgPushTools(server: ExtendedMcpServer) {
           msg_type: resolvedMsgType,
           warnings: warnings.length ? warnings : undefined,
         });
+      }
+
+      // 4b. subscribe：校验云函数真实存在（仅有变更时）
+      if (action === "subscribe") {
+        const missing = await assertCloudFunctionExists(
+          server,
+          env_id,
+          function_name,
+        );
+        if (missing) return missing;
       }
 
       // 5. 有变更 → 需确认

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -229,6 +229,12 @@ export interface MsgPushQbaseResponse {
 export interface MsgPushOverrides {
   /** 消息推送 qbase CGI 对应的 Cloud API service 名（默认 "qbase"）；宿主可按后端契约覆盖 */
   service?: string;
+  /**
+   * Optional readonly hook to list cloud function names in an env.
+   * Used by manageMessagePush(action=subscribe) to reject unknown function_name.
+   * Hosts may inject this; when omitted the tool falls back to CloudBase Manager getFunctionList.
+   */
+  listCloudFunctions?: (envId: string) => Promise<string[]>;
 }
 
 export type Logger = (data: {

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2072,7 +2072,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.31.0），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.0），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3618,7 +3618,7 @@
     },
     {
       "name": "queryMessagePush",
-      "description": "查询小程序云开发消息推送配置（qbase getappconfig）或全部合法消息推送事件约束（getcallbacksupportlist）。消息推送把小程序事件/消息（含虚拟支付回调、text/image 等消息类型）送到云函数，无需自建服务器。action=list 返回当前配置列表（msgType/event/env/functionName/enable）与 version（乐观锁版本号）；action=listSupportedEvents 返回全部合法约束（按消息类型分组：event 组含事件名列表；text/image/voice/video/miniprogrampage 组 events 为空数组），事件类用 manageMessagePush(event_types=...)，消息类型用 manageMessagePush(msg_type=...)。需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn），独立 CloudBase MCP 运行会返回指引错误。",
+      "description": "查询小程序云开发消息推送配置（qbase getappconfig）或全部合法消息推送事件约束（getcallbacksupportlist）。推送模式有两种：云函数（默认，按 (msgType,event) 逐条回调）与云托管（qbase_open=true，整包接收所有消息到容器 path）。action=list 同时返回 pushMode（cloudfunction|container）、containerConfig、callbacks 与 version；云托管模式下 callbacks 可能仍存在但不生效（见 note），需 ensureCloudFunctionMode 切回云函数模式后才会按回调推送。action=listSupportedEvents 返回全部合法约束（按消息类型分组）。需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn）。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3636,7 +3636,7 @@
               "list",
               "listSupportedEvents"
             ],
-            "description": "list: 查询当前消息推送配置列表\nlistSupportedEvents: 查询全部合法消息推送事件约束（按 msgType 分组）"
+            "description": "list: 查询当前消息推送配置列表（含 pushMode/containerConfig）\nlistSupportedEvents: 查询全部合法消息推送事件约束（按 msgType 分组）"
           }
         },
         "required": [
@@ -3649,7 +3649,7 @@
     },
     {
       "name": "manageMessagePush",
-      "description": "管理小程序云开发消息推送配置（写操作，需 confirm=\"yes\" 确认）。基于「读全量 → merge → 全量覆盖（带 version 乐观锁）」实现声明式幂等（对齐 kubectl apply：event_types 是期望集合，重复执行收敛到同一状态；version 冲突即 RFC 7232 If-Match 412，返回可重试错误：重读 → merge → 重试）。msg_type 区分两类条目（缺省 \"event\"，向后兼容）：msg_type=\"event\" 操作事件类（需 event_types；subscribe 缺省时默认虚拟支付 7 个 xpay_* 事件）；msg_type=\"text\"|\"image\"|\"voice\"|\"video\"|\"miniprogrampage\" 操作消息类型条目（event 固定空串，勿传 event_types）。action=subscribe 订阅到指定云函数；同一 (msgType,event) 只能推到一个云函数（一事一函数），已绑定其他函数会自动重绑并说明。action=unsubscribe 移除匹配订阅（msg_type=event 时 event_types 必填；消息类型时按 msg_type 移除）。action=setEnable 启用/停用匹配订阅（msg_type=event 时 event_types + enable 必填；消息类型时 msg_type + enable）。action=ensureCloudFunctionMode 确保推送模式为云函数（若为云托管整包接收则切换 qbase_open=false，需确认）。集合无变化时不发起写请求（幂等 no-op，无需确认）。需要微信 IDE 登录态通道（宿主注入 cloudBaseOptions.requestFn）。",
+      "description": "管理小程序云开发消息推送配置（写操作，需 confirm=\"yes\" 确认）。推送模式：云函数（默认，按 (msgType,event) 回调）vs 云托管（整包接收；云托管模式下 subscribe/unsubscribe/setEnable 会被拒绝，先 ensureCloudFunctionMode）。基于「读全量 → merge → 全量覆盖（带 version 乐观锁）」实现声明式幂等。msg_type 缺省 \"event\"；消息类型用 msg_type=text|image|voice|video|miniprogrampage。action=subscribe 前会校验 function_name 在环境中真实存在。action=ensureCloudFunctionMode 关闭云托管整包接收；action=ensureContainerMode 开启云托管（需 qbase_container_path/qbase_env/text_mode）；action=setContainerCallback 更新云托管 path/env/text_mode。集合无变化时不发起写请求（幂等 no-op）。需要微信 IDE 登录态通道。",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -3659,11 +3659,11 @@
           },
           "env_id": {
             "type": "string",
-            "description": "环境 ID（订阅条目绑定的云开发环境）"
+            "description": "环境 ID（云函数订阅绑定的云开发环境；ensureContainerMode/setContainerCallback 未传 qbase_env 时也可作为云托管环境默认值）"
           },
           "function_name": {
             "type": "string",
-            "description": "接收消息推送的云函数名"
+            "description": "接收消息推送的云函数名（subscribe/unsubscribe/setEnable/ensureCloudFunctionMode 使用；云托管相关 action 可传占位）"
           },
           "action": {
             "type": "string",
@@ -3671,9 +3671,11 @@
               "subscribe",
               "unsubscribe",
               "setEnable",
-              "ensureCloudFunctionMode"
+              "ensureCloudFunctionMode",
+              "ensureContainerMode",
+              "setContainerCallback"
             ],
-            "description": "subscribe: 订阅到指定云函数（msg_type=event 时 event_types 缺省=虚拟支付 7 事件；消息类型时按 msg_type 订阅）\nunsubscribe: 移除匹配订阅（msg_type=event 时 event_types 必填）\nsetEnable: 启用/停用匹配订阅（msg_type=event 时 event_types + enable 必填）\nensureCloudFunctionMode: 确保为云函数推送模式（云托管整包接收时切换，需确认）"
+            "description": "subscribe: 订阅到指定云函数（云托管模式下拒绝）\nunsubscribe: 移除匹配订阅（云托管模式下拒绝）\nsetEnable: 启用/停用匹配订阅（云托管模式下拒绝）\nensureCloudFunctionMode: 切到云函数推送模式（关闭 qbase_open）\nensureContainerMode: 切到云托管整包接收（需 qbase_container_path + text_mode）\nsetContainerCallback: 更新云托管回调 path/env/text_mode"
           },
           "msg_type": {
             "type": "string",
@@ -3692,11 +3694,27 @@
             "items": {
               "type": "string"
             },
-            "description": "要操作的事件列表（仅 msg_type=\"event\" 时使用；可先 queryMessagePush(action=listSupportedEvents) 查询全量约束）。subscribe 缺省时默认订阅虚拟支付 7 个事件：xpay_goods_deliver_notify、xpay_coin_pay_notify、xpay_complaint_notify、xpay_subscribe_signing_result_notify、xpay_subscribe_pay_fail_notify、xpay_subscribe_ios_refund_query_notify、xpay_refund_notify；unsubscribe / setEnable 且 msg_type=event 时必填。消息类型操作请勿传本参数。"
+            "description": "要操作的事件列表（仅 msg_type=\"event\" 时使用；可先 queryMessagePush(action=listSupportedEvents) 查询全量约束）。subscribe 缺省时默认订阅虚拟支付 7 个事件；unsubscribe / setEnable 且 msg_type=event 时必填。"
           },
           "enable": {
             "type": "boolean",
             "description": "setEnable 时必填：true 启用订阅 / false 停用订阅"
+          },
+          "qbase_container_path": {
+            "type": "string",
+            "description": "云托管回调路径/URL（ensureContainerMode 必填；setContainerCallback 可选更新）"
+          },
+          "qbase_env": {
+            "type": "string",
+            "description": "云托管服务所在环境 ID（ensureContainerMode/setContainerCallback 可选；缺省用 env_id）"
+          },
+          "text_mode": {
+            "type": "number",
+            "enum": [
+              1,
+              2
+            ],
+            "description": "云托管消息正文编码：1=json，2=xml（ensureContainerMode 必填；setContainerCallback 可选更新）"
           },
           "confirm": {
             "type": "string",

--- a/specs/wxide-msg-push-container-mode-compat/report.md
+++ b/specs/wxide-msg-push-container-mode-compat/report.md
@@ -1,0 +1,164 @@
+# 消息推送云函数/云托管模式兼容分析
+
+> 2026-08-25 Booker 反馈：MCP 似乎没有考虑「推送模式」（云函数 vs 云托管），需分析开发平台代码看兼容问题。
+
+## 结论速览
+
+MCP `msg-push` 工具**确实没考虑云托管模式**：
+1. 缺**模式读取**——`queryMessagePush list` 不返回 `qbase_open`，agent 不知道当前是哪种模式
+2. 缺**正向模式管理**——只有 `ensureCloudFunctionMode`（反向关云托管），没有 `ensureContainerMode`（开云托管）
+3. 缺**云托管配置管理**——`setContainerCallbackConfig` 在内部实现存在但**未作为 tool action 暴露**
+4. **云托管模式下配云函数回调无效**——消息被整包接管，agent 操作 uploadAppConfig 不会报错但实际不生效（静默失败）
+
+## 模式语义（weda-alternative 解读）
+
+来源：`apps/wxide-tcb-console/src/legacy/components/settings/globalsettings/msgpush/{index,container}.tsx` + `legacy/extensible/callbackconfig.ts`
+
+### 两种模式
+
+| 模式 | 触发字段 | 行为 | 配置粒度 |
+|---|---|---|---|
+| **云函数**（默认） | `getContainerCallbackConfig.qbase_open === false/undefined` | 按 (msgType, Event) 二元组逐条配云函数回调；其他类型消息仍可走服务器域名 | 一元组一行 |
+| **云托管** | `qbase_open === true` | **整包接收所有消息类型**到 `qbase_container_path` 指定的云托管服务；不再推云函数/服务器域名 | 单条 path 全收 |
+
+### 数据结构（setContainerCallbackConfig body）
+
+```ts
+{
+  qbase_open: boolean,              // true=云托管整包接收；false/undefined=云函数
+  qbase_container_path: string,     // 云托管 URL（云托管模式必填）
+  qbase_env: string,                // 推送到的云托管服务所在环境 ID
+  text_mode: 1 | 2,                 // 1=json, 2=xml（消息正文编码）
+}
+```
+
+### 关键代码位置
+
+- `apps/wxide-tcb-console/src/legacy/components/settings/globalsettings/msgpush/index.tsx:14` `PUSH_TYPE = 'container' | 'cloudfunction'`
+- `index.tsx:17-18` `determinePushType(callback)`：`callback?.qbase_open` → 'container' 否则 'cloudfunction'
+- `index.tsx:45-63` Radio UI 切换 + 提示语（云托管开启后接管所有消息）
+- `index.tsx:87-97` getContainerCallbackConfig / setContainerCallbackConfig 调用
+- `container.tsx:33-49` UpsertContainerPushSettings 提交：`qbase_open: true, qbase_container_path, qbase_env, text_mode`
+- `legacy/extensible/callbackconfig.ts:139-154` getContainerCallbackConfig / setContainerCallbackConfig 定义（CGI 包装）
+- `triggersetting/container.tsx:144` 关云托管：`setContainerCallbackConfig({ ...data, qbase_open: false })`
+
+## MCP 工具现状（CloudBase-MCP mcp/src/tools/msg-push.ts）
+
+### 内部已实现
+
+- `getContainerCallbackConfig`（410-415）→ qbase `getContainerCallbackConfig`
+- `setContainerCallbackConfig`（430-435）→ qbase `setContainerCallbackConfig`
+- `ensureCloudFunctionMode`（720-）→ 调 setContainerConfig({qbase_open: false})
+
+### 工具 action 暴露（enum 654）
+
+```ts
+.action(z.enum(["subscribe", "unsubscribe", "setEnable", "ensureCloudFunctionMode"]))
+```
+
+### 缺口
+
+| 缺口 | 现象 | 兼容风险 |
+|---|---|---|
+| `ensureContainerMode` 未暴露 | 无法通过 MCP 切到云托管；只能去 IDE 切 | 模式管理半盲 |
+| `setContainerCallback` action 未暴露 | 无法通过 MCP 设置 qbase_container_path / env / text_mode | 云托管配置半盲 |
+| list 不返回 `pushMode` / `qbase_open` | agent 不知道当前模式 | 操作可能无效（见下） |
+| 工具 list 合并时未合并 `getContainerCallbackConfig` | 模式状态完全不可见 | 静默失败风险高 |
+
+## 兼容问题（用户场景："选了云托管模式"）
+
+### 场景 A：用户在云托管模式，用 MCP 配云函数订阅
+
+1. 用户在 IDE 选了「云托管」模式（qbase_open=true），整包接收消息
+2. agent / 用户调 `manageMessagePush(action=subscribe, msg_type=text, function_name=xxx)`
+3. 工具内部走 `uploadAppConfig`（云函数 callbacks 数组），写入成功（version 递增）
+4. **实际推送效果**：消息仍走云托管 URL，**新增的云函数订阅不生效**——callbacks 被云托管整包接管
+5. **用户感知**：工具返回 success，agent 以为配好，实际消息没推到云函数
+
+**结论：静默失败，无告警。**
+
+### 场景 B：用户在云函数模式，云托管有遗留 qbase_open=true
+
+- IDE 会显示 Radio「云托管」被选中；callbacks 数组存在但被忽略
+- MCP 操作 callbacks 也不生效
+- 用户困惑
+
+### 场景 C：用户想从云函数切到云托管
+
+- **当前**：`ensureCloudFunctionMode`（反向）→ 只能关云托管
+- **缺**：正向 `ensureContainerMode`（开云托管 + 需 confirm + 提示「将接管所有消息，不再推云函数」）
+
+### 场景 D：用户在云托管模式，调 list 验证配置
+
+- `queryMessagePush(list)` 返回 callbacks 数组（可能为空或旧的）
+- agent 无法识别「云托管模式下 callbacks 不生效」
+
+## 改进建议（按优先级）
+
+### P0（防静默失败，必须做）
+
+1. **`queryMessagePush` list 返回增加 `pushMode: 'cloudfunction' | 'container'`**（合并 getContainerCallbackConfig.qbase_open 字段）
+2. **manageMessagePush subscribe/unsubscribe/setEnable 加模式校验**：当前是云托管模式时拒绝 + 返回明确错误「当前是云托管模式（pushMode=container），云函数回调配置无效；请先调 ensureCloudFunctionMode 切回云函数模式」（需 confirm 写操作风格）
+3. **tool description 补充模式说明**
+
+### P1（模式管理能力补齐）
+
+4. **新增 action `ensureContainerMode`**：切到云托管（qbase_open=true），需 confirm + 提示「切换后所有消息类型将整包推送到云托管服务，不再推云函数；请提供 qbase_container_path / env / text_mode」
+5. **新增 action `setContainerCallback`**：单独设置/更新云托管容器回调（path/env/text_mode），类似 setEnable 风格
+6. **可加 action `getContainerCallbackConfig`** 单独读（如果 agent 需要）
+7. **list/ensureCloudFunctionMode 同步更新**：模式切换时 list 重新读取并返回
+
+### P2（文档/降级）
+
+8. **skill 文档**（message-push-customer-service.md）补充「云托管模式」章节：触发条件、配置步骤、注意事项
+9. **降级提示**：云托管模式下若用户传云函数订阅请求，给出「下一步：是否切到云函数模式？」建议
+
+## 验收（建议实现任务）
+
+- mock 单测：云托管模式下 subscribe 返回明确错误（不回静默 success）
+- mock 单测：ensureContainerMode 完整流程（confirm + setContainerCallback）
+- 真实 E2E：azhi 环境验证（注意先备份 baseline，结束后快照还原）
+- 文档：spec 描述两模式行为差异 + MCP 工具支持矩阵
+
+## 关联
+
+- d5735473（日志调研已完成）
+- dc0eaaf9（消息推送工具，已合并 #949）
+- weda-alternative: `legacy/components/settings/globalsettings/msgpush/`
+- CloudBase-MCP: `mcp/src/tools/msg-push.ts`、`mcp/scripts/test-with-ticket.cjs`
+- 微信 main MR !6821（已 force push + 命名修正）
+
+## 交互设计（Booker 2026-08-25 确认，不新增 tool）
+
+### 1. 云函数路径有效性校验（P0）
+
+`subscribe` 前校验 `function_name` 在目标 env 真实存在（走 queryFunctions/list 或等价检查）；不存在 → 拒绝并提示「云函数 {fn} 不存在于环境 {envId}，请先创建或修正参数」。
+
+### 2. 云托管模式提示 AI（P0）
+
+**list 返回增强**：
+
+```json
+{
+  "pushMode": "container",
+  "containerConfig": { "qbase_container_path": "...", "qbase_env": "...", "text_mode": 1 },
+  "callbacks": [ ... ],
+  "version": 21,
+  "note": "当前为云托管模式（整包接收），云函数 callbacks 存在但不生效；如需云函数模式请调 ensureCloudFunctionMode 切换"
+}
+```
+
+**云托管模式下的云函数写操作**（subscribe/unsubscribe/setEnable）：拒绝 + 明确错误：
+> 当前 pushMode=container（云托管整包接收），云函数回调配置存在但不生效。如需云函数模式请调 `action=ensureCloudFunctionMode` 切换。
+
+### 3. 模式切换（已有 + 新增）
+
+| action | 方向 | confirm 提示 |
+|---|---|---|
+| `ensureCloudFunctionMode`（已有） | 云托管 → 云函数 | 「切换后停止云托管整包接收（qbase_open=false），消息按云函数回调推送；若 callbacks 为空则收不到任何消息」 |
+| `ensureContainerMode`（新增） | 云函数 → 云托管 | 「切换后所有消息类型整包推送到云托管服务（path={path}），云函数回调失效；需提供 qbase_container_path/qbase_env/text_mode」 |
+| `setContainerCallback`（新增） | 更新云托管配置 | 写操作确认，展示新旧配置 diff |
+
+### 4. description 补充
+
+queryMessagePush/manageMessagePush 描述补充：两模式说明、pushMode 字段、云托管模式行为、切换 action 指引。


### PR DESCRIPTION
## 概述

消息推送工具增加推送模式感知（云函数 vs 云托管），防云托管模式下云函数回调配置静默失败。分析报告：`specs/wxide-msg-push-container-mode-compat/report.md`。

## 功能

**P0（防静默失败）**
- `queryMessagePush(list)` 返回 `pushMode`（cloudfunction|container）+ `containerConfig`（path/env/text_mode）+ `note`（云托管模式下 callbacks 不生效提示）
- `subscribe/unsubscribe/setEnable` 在云托管模式下**拒绝**（`CONTAINER_MODE_ACTIVE`）+ 返回下一步指引
- `subscribe` 前校验 `function_name` 在目标 env 存在（`assertCloudFunctionExists`），不存在拒绝

**P1（模式管理）**
- 新增 action `ensureContainerMode`：切到云托管（需 qbase_container_path/qbase_env/text_mode，confirm + 影响提示）
- 新增 action `setContainerCallback`：更新云托管回调（写操作确认 + 新旧 diff）
- `ensureCloudFunctionMode` 增强 confirm 提示（callbacks 为空提示）
- tool description 补充两模式说明与切换指引

**不新增 tool**（保持 queryMessagePush/manageMessagePush 两个）

## 测试

- typecheck 0 错
- 单测 48/48（新增模式用例 8 个：云托管拒绝/ensureContainerMode/setContainerCallback/函数存在性校验）
- mock E2E 全绿（ensureContainerMode + list pushMode + 拒绝 + 往返切换 + appid 透传）

## 后续

- 真实模式 E2E（azhi 环境，快照还原）可另行执行
- 微信侧 MR !6821 已用 cloud_query_msg_push/cloud_manage_msg_push 命名