### PR TITLE
fix(tests): retry temp dir cleanup in cloudbase-sites-plugin tests

### DIFF
--- a/tests/cloudbase-sites-plugin.test.js
+++ b/tests/cloudbase-sites-plugin.test.js
@@ -17,7 +17,10 @@ const tempDirs = [];
 
 afterEach(() => {
   for (const dir of tempDirs.splice(0)) {
-    fs.rmSync(dir, { recursive: true, force: true });
+    // Session hooks spawn nohup'd background processes (preview / install)
+    // that keep writing into the temp dir after spawnSync returns; retry to
+    // survive the ENOTEMPTY race on slow CI runners.
+    fs.rmSync(dir, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
   }
 });
 


### PR DESCRIPTION
## 问题

main 上 pkg.pr.new workflow（run 32963578075）失败：`tests/cloudbase-sites-plugin.test.js > SessionStart hook guidance > injects absolute CLI fallback when cwd is a Vite project` 的 afterEach 报

```
Error: ENOTEMPTY: directory not empty, rmdir '/tmp/cloudbase-sites-test-zsYAok'
```

## 根因

SessionStart hook（`on-session-start.sh`）对 Vite 项目会启动 nohup 后台进程（`cloudbase-sites preview`）。`spawnSync` 只等 bash 主进程退出即返回，但后台子进程仍在往测试临时目录写状态/日志，afterEach 的 `fs.rmSync(recursive)` 与其竞态，慢速 CI runner 上窗口变大即触发 ENOTEMPTY。属于 flaky test，与最近合入的任何功能改动无关。

## 修复

给 afterEach 的 `rmSync` 加 `maxRetries: 10, retryDelay: 200`（Node `fs.rm` 对 ENOTEMPTY/EBUSY 原生重试），最小改动只动这一个文件。其他测试文件不运行 session hook、不起后台进程，无同类竞态。

## 验证

本地 `npx vitest run ../tests/cloudbase-sites-plugin.test.js`：20/20 passed。