### PR TITLE
fix: correct misleading output from queryHosting, PG sqlPreview and queryEnv errors

### DIFF
--- a/mcp/src/tools/databasePG.test.ts
+++ b/mcp/src/tools/databasePG.test.ts
@@ -142,6 +142,68 @@ describe("PG database tools", () => {
     });
   });
 
+  it("queryPgDatabase(sql) echoes the user's original SQL in sqlPreview when execution fails", async () => {
+    const { server, tools } = createMockServer();
+    const userSql = "SELECT id FROM public.users WHERE id = 1";
+    const executedSql: string[] = [];
+    const fakeClient = createFakeClient(async (sql: string) => {
+      if (sql === "SELECT 1") {
+        return { rows: [{ "?column?": 1 }], rowCount: 1 };
+      }
+      executedSql.push(sql);
+      throw new Error('ERROR: column "id" does not exist (SQLSTATE 42703)');
+    });
+
+    registerPGDatabaseTools(server, {
+      createClient: vi.fn(() => fakeClient),
+    });
+
+    const payload = buildToolPayload(
+      await tools.queryPgDatabase.handler({
+        action: "sql",
+        sql: userSql,
+      }),
+    );
+
+    expect(payload).toMatchObject({
+      success: false,
+      errorCode: "PG_SQL_EXEC_FAILED",
+    });
+    // 服务端执行的确实是带 limit 包装的只读 SQL
+    expect(
+      executedSql.some((sql) => sql.includes("cloudbase_mcp_readonly_limit")),
+    ).toBe(true);
+    // 但回显给调用方的必须是用户原始 SQL，而不是内部包装 SQL
+    expect(payload.data.sqlPreview).toBe(userSql);
+    expect(payload.data.sqlPreview).not.toContain("cloudbase_mcp_readonly_limit");
+  });
+
+  it("queryPgDatabase(sql) truncates sqlPreview to 500 chars on failure", async () => {
+    const { server, tools } = createMockServer();
+    const userSql = `SELECT ${"x".repeat(800)}`;
+    const fakeClient = createFakeClient(async (sql: string) => {
+      if (sql === "SELECT 1") {
+        return { rows: [{ "?column?": 1 }], rowCount: 1 };
+      }
+      throw new Error("ERROR: unexpected failure (SQLSTATE 42601)");
+    });
+
+    registerPGDatabaseTools(server, {
+      createClient: vi.fn(() => fakeClient),
+    });
+
+    const payload = buildToolPayload(
+      await tools.queryPgDatabase.handler({
+        action: "sql",
+        sql: userSql,
+      }),
+    );
+
+    expect(payload.errorCode).toBe("PG_SQL_EXEC_FAILED");
+    expect(payload.data.sqlPreview).toHaveLength(500);
+    expect(userSql.startsWith(payload.data.sqlPreview)).toBe(true);
+  });
+
   it("queryPgDatabase(objects) returns schema-qualified summaries without init", async () => {
     const { server, tools } = createMockServer();
     const fakeClient = createFakeClient(async (sql: string) => {

--- a/mcp/src/tools/databasePG.ts
+++ b/mcp/src/tools/databasePG.ts
@@ -2090,7 +2090,7 @@ async function handleReadOnlySql(
       message: `PostgreSQL read-only SQL execution failed: ${reason}`,
       data: {
         role: context.role,
-        sqlPreview: limitedSql.trim().slice(0, 500),
+        sqlPreview: args.sql.trim().slice(0, 500),
       },
     });
   }

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1942,6 +1942,59 @@ describe("env tools - envQuery", () => {
     expect(missingMetric.content[0].text).toContain("metricName 为必填参数");
   });
 
+  it("queryEnv should guide on parameters (not auth) when the API reports an invalid parameter", async () => {
+    mockGetCloudBaseManager.mockResolvedValue({
+      monitor: {
+        describeCurveData: vi.fn().mockRejectedValue(
+          new Error(
+            "[DescribeCurveData] InvalidParameterValue: invalid parameter value period=86400 is not supported for the given time range",
+          ),
+        ),
+      },
+    });
+
+    const { tools } = createMockServer();
+    const text = (
+      await tools.queryEnv.handler({
+        action: "metrics",
+        envId: "env-test",
+        metricName: "GatewayTraceEnvQPS",
+        startTime: "2026-08-27 00:00:00",
+        endTime: "2026-08-28 00:00:00",
+        period: 86400,
+      })
+    ).content[0].text;
+
+    expect(text).toContain("参数错误");
+    expect(text).toContain("queryEnv(action=\"metrics\")");
+    // 参数类错误不该把 Agent 误导到鉴权方向
+    expect(text).not.toContain("认证");
+    expect(text).not.toContain("登录");
+    expect(text).not.toContain("auth");
+  });
+
+  it("queryEnv should keep auth guidance for real authentication errors", async () => {
+    mockGetCloudBaseManager.mockResolvedValue({
+      monitor: {
+        describeCurveData: vi
+          .fn()
+          .mockRejectedValue(new Error("[DescribeCurveData] AuthFailure: token expired")),
+      },
+    });
+
+    const { tools } = createMockServer();
+    const text = (
+      await tools.queryEnv.handler({
+        action: "metrics",
+        envId: "env-test",
+        metricName: "GatewayTraceEnvQPS",
+      })
+    ).content[0].text;
+
+    expect(text).toContain("认证错误");
+    expect(text).toContain("auth(action=\"status\")");
+  });
+
   it("envQuery(metrics) should call monitor.describeCurveData and summarize the curve", async () => {
     const describeCurveData = vi.fn().mockResolvedValue({
       StartTime: "2026-08-16 16:00:00",

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -1538,10 +1538,11 @@ function buildEnvQueryErrorMessage(error: unknown, action: string): string {
   const suggestions: string[] = [];
 
   if (hasInvalidParameterError) {
-    suggestions.push("参数错误：可能是认证信息无效或已过期，请尝试以下步骤：");
-    suggestions.push("1. 先调用 auth(action=\"status\") 检查当前登录状态");
-    suggestions.push("2. 如果未登录，调用 auth(action=\"start_auth\", authMode=\"device\") 完成登录");
-    suggestions.push("3. 登录完成后再次调用 queryEnv(action=\"list\")");
+    suggestions.push("参数错误：请求未通过服务端的参数校验，请检查本次调用的入参：");
+    suggestions.push("1. 各参数取值是否在允许范围内（枚举值、时间粒度、数量上限等）");
+    suggestions.push("2. 各参数格式是否正确，需要成对传入的参数是否齐全");
+    suggestions.push("3. 必填参数是否都已提供，参数名与类型是否正确");
+    suggestions.push(`4. 修正参数后重新调用 queryEnv(action=\"${action}\")`);
   }
 
   if (hasAuthError) {

--- a/mcp/src/tools/hosting.test.ts
+++ b/mcp/src/tools/hosting.test.ts
@@ -624,6 +624,80 @@ describe('hosting tools', () => {
     expect(payload.message).not.toContain('QPS 限制');
   });
 
+  it('queryHosting(action=findFiles) should map COS-style Contents into the files array', async () => {
+    const tools = createMockServer();
+    mockFindFiles.mockResolvedValueOnce({
+      Contents: [
+        { Key: 'site/index.html', Size: 10, LastModified: '2026-08-28T00:00:00.000Z' },
+        { Key: 'site/app.js', Size: 20, LastModified: '2026-08-28T00:00:01.000Z' },
+      ],
+      IsTruncated: true,
+      NextMarker: 'site/app.js',
+    });
+
+    const payload = JSON.parse((await tools.queryHosting.handler({
+      action: 'findFiles',
+      prefix: 'site/',
+    })).content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.files).toHaveLength(2);
+    expect(payload.data.files[0]).toMatchObject({ key: 'site/index.html', size: 10 });
+    expect(payload.data.files[1].key).toBe('site/app.js');
+    expect(payload.message).toContain('共 2 个');
+    // 分页信息透传：findFiles 的 marker 是 COS 游标，保持原样不做 offset 解析
+    expect(payload.data.isTruncated).toBe(true);
+    expect(payload.data.nextMarker).toBe('site/app.js');
+    expect(payload.message).toContain('nextMarker');
+    // 原始返回保持兼容
+    expect(payload.data.result).toMatchObject({ IsTruncated: true });
+  });
+
+  it('queryHosting(action=findFiles) should support the lowercase contents variant', async () => {
+    const tools = createMockServer();
+    mockFindFiles.mockResolvedValueOnce({
+      contents: [{ Key: 'site/index.html', Size: 10, LastModified: '2026-08-28T00:00:00.000Z' }],
+    });
+
+    const payload = JSON.parse((await tools.queryHosting.handler({
+      action: 'findFiles',
+      prefix: 'site/',
+    })).content[0].text);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.files).toHaveLength(1);
+    expect(payload.data.files[0].key).toBe('site/index.html');
+  });
+
+  it('queryHosting(action=listFiles) should keep numeric-offset marker pagination', async () => {
+    const tools = createMockServer();
+    mockListFiles.mockResolvedValue([
+      { Key: 'a.txt' },
+      { Key: 'b.txt' },
+      { Key: 'c.txt' },
+    ]);
+
+    const firstPage = JSON.parse((await tools.queryHosting.handler({
+      action: 'listFiles',
+      maxKeys: 2,
+    })).content[0].text);
+
+    expect(firstPage.data.files.map((file: { key: string }) => file.key)).toEqual(['a.txt', 'b.txt']);
+    expect(firstPage.data.totalCount).toBe(3);
+    // listFiles 的 marker 是自实现的数字 offset 字符串，不能被 COS 游标逻辑覆盖
+    expect(firstPage.data.nextMarker).toBe('2');
+
+    const secondPage = JSON.parse((await tools.queryHosting.handler({
+      action: 'listFiles',
+      maxKeys: 2,
+      marker: '2',
+    })).content[0].text);
+
+    expect(secondPage.data.files.map((file: { key: string }) => file.key)).toEqual(['c.txt']);
+    expect(secondPage.data.nextMarker).toBeUndefined();
+    expect(secondPage.data.isTruncated).toBe(false);
+  });
+
   it('manageHosting(action=setWebsiteDocument) should forward document settings and routing rules', async () => {
     const tools = createMockServer();
     const payload = JSON.parse((await tools.manageHosting.handler({

--- a/mcp/src/tools/hosting.ts
+++ b/mcp/src/tools/hosting.ts
@@ -563,11 +563,36 @@ function buildFailureResult(action: string, error: unknown) {
   });
 }
 
-function normalizeFileFields(files: unknown): Array<Record<string, unknown>> {
-  if (!Array.isArray(files)) return [];
+function extractFileList(files: unknown): unknown[] {
+  // hosting.listFiles 直接返回文件数组
+  if (Array.isArray(files)) return files;
 
-  return files.map(file => {
-    if (typeof file !== 'object' || file === null) return file;
+  // hosting.findFiles 返回 COS 风格对象，文件列表在 Contents 里
+  if (typeof files === 'object' && files !== null) {
+    const record = files as Record<string, unknown>;
+    if (Array.isArray(record.Contents)) return record.Contents;
+    if (Array.isArray(record.contents)) return record.contents;
+  }
+
+  return [];
+}
+
+function extractFilePagination(result: unknown): { isTruncated?: boolean; nextMarker?: string } {
+  if (typeof result !== 'object' || result === null) return {};
+
+  const record = result as Record<string, unknown>;
+  const isTruncated = record.IsTruncated ?? record.isTruncated;
+  const nextMarker = record.NextMarker ?? record.nextMarker;
+
+  return {
+    isTruncated: typeof isTruncated === 'boolean' ? isTruncated : undefined,
+    nextMarker: typeof nextMarker === 'string' && nextMarker.length > 0 ? nextMarker : undefined,
+  };
+}
+
+function normalizeFileFields(files: unknown): Array<Record<string, unknown>> {
+  return extractFileList(files).map((file): Record<string, unknown> => {
+    if (typeof file !== 'object' || file === null) return file as Record<string, unknown>;
 
     const record = file as Record<string, unknown>;
     return {
@@ -677,6 +702,8 @@ export function registerHostingTools(server: ExtendedMcpServer) {
             });
             logCloudBaseResult(server.logger, result);
             const normalizedFiles = normalizeFileFields(result);
+            // findFiles 的 marker 是 COS 游标字符串，与 listFiles 的数字 offset 语义不同，此处只透传不做解析
+            const { isTruncated, nextMarker } = extractFilePagination(result);
             return buildJsonToolResult({
               success: true,
               data: {
@@ -685,9 +712,11 @@ export function registerHostingTools(server: ExtendedMcpServer) {
                 marker: input.marker,
                 maxKeys: input.maxKeys,
                 files: normalizedFiles,
+                nextMarker,
+                isTruncated,
                 result,
               },
-              message: `已按前缀 \`${input.prefix}\` 查询静态托管文件，共 ${Array.isArray(normalizedFiles) ? normalizedFiles.length : 0} 个。`,
+              message: `已按前缀 \`${input.prefix}\` 查询静态托管文件，共 ${normalizedFiles.length} 个。${nextMarker ? ' 还有更多文件，可使用 nextMarker 继续查询。' : ''}`,
             });
           }
 


### PR DESCRIPTION
## Summary

Fixes three defects found during a quality pass over the CloudBase MCP Server. All three produce **misleading output rather than a visible error**, so an Agent acting on them reaches a wrong conclusion without any signal that something broke.

---

### 1. (P0) `queryHosting(action="findFiles")` silently reported 0 files

**Repro**

```
queryHosting(action="findFiles", prefix="site/")
```

The COS response underneath contained real data (5 files observed), but the tool answered `共 0 个` and `data.files` was `[]`.

**Root cause** — `mcp/src/tools/hosting.ts:566`

`normalizeFileFields()` opened with `if (!Array.isArray(files)) return [];`. Two callers feed it different shapes:

- `listFiles` returns an **array** — normalized correctly
- `findFiles` returns a **COS-style object** `{ Contents: [...], IsTruncated, NextMarker, ... }` — not an array, so it short-circuited to `[]`

The call site at `hosting.ts:679` then rendered the empty array into the message, while the real rows sat untouched in `data.result.Contents`.

**Fix**

- Added `extractFileList()`, which unwraps `Contents` (and the lowercase `contents` variant) before the existing per-field normalization; plain arrays still pass straight through.
- Added `extractFilePagination()` and surfaced `nextMarker` / `isTruncated` in the `findFiles` payload, plus the "还有更多文件" hint, matching the `listFiles` shape.
- **Marker semantics are deliberately kept apart**: `listFiles` uses a self-implemented numeric-offset marker (`String(start + maxKeys)`), while `findFiles` uses a COS cursor string. The new pagination helper only echoes the COS cursor and does no offset parsing, so `listFiles` paging is untouched (covered by a dedicated regression test).
- `data.result` is still returned verbatim.

---

### 2. (P2) PG read-only SQL failures echoed the internal wrapper SQL

**Repro**

```
queryPgDatabase(action="sql", sql="SELECT id FROM public.users WHERE id = 1")
```

On failure, `data.sqlPreview` came back as `SELECT * FROM (...) AS cloudbase_mcp_readonly_limit LIMIT n` — the MCP's own wrapper, not the caller's statement.

**Root cause** — `mcp/src/tools/databasePG.ts:2093`

The catch block used `limitedSql`, the output of `buildLimitedReadOnlySql(args.sql, limit)`. The success path at `databasePG.ts:2350` already used `args.sql.trim()`, so the two paths disagreed.

**Fix** — line 2093 now uses `args.sql.trim().slice(0, 500)`, consistent with the success path. The other `sqlPreview` sites (2225 / 2301 / 2322 / 2350) were audited and already passed the original SQL, so no change was needed there. `limitedSql` is still what gets sent to the server; only the echo changed.

---

### 3. (P2) `queryEnv` appended auth troubleshooting to parameter errors

**Repro**

```
queryEnv(action="metrics", envId=..., metricName="GatewayTraceEnvQPS", period=86400)  # over a 1-day range
```

A purely out-of-range `period` produced a message that started with 参数错误 and then instructed the caller to check login state and run `auth(action="start_auth")`. The Agent under test genuinely started doubting its credentials.

**Root cause** — `mcp/src/tools/env.ts:1540-1545`

The `hasInvalidParameterError` branch was self-contradictory: a parameter diagnosis followed by an authentication remedy.

**Fix** — the branch now gives parameter-only guidance (value ranges, formats, required/complete params) and points at re-calling `queryEnv` with the actual action. The `hasAuthError` branch at `env.ts:1547` is unchanged, since that is the correct place for real credential problems.

Note the trigger regex is `/400|invalid parameter|invalid argument|parameter value/i`, which can also match non-parameter 400s, so the copy stays generic rather than naming a specific parameter.

---

## Tests

Seven new tests across the three existing test files. Five are regression tests; two are guards that lock in behavior which must *not* change.

| Test | File |
|---|---|
| `findFiles` maps COS-style `Contents` into `files` | `mcp/src/tools/hosting.test.ts` |
| `findFiles` supports the lowercase `contents` variant | `mcp/src/tools/hosting.test.ts` |
| `listFiles` keeps numeric-offset marker pagination *(guard)* | `mcp/src/tools/hosting.test.ts` |
| failure `sqlPreview` equals the user's original SQL | `mcp/src/tools/databasePG.test.ts` |
| failure `sqlPreview` truncates at 500 chars | `mcp/src/tools/databasePG.test.ts` |
| parameter errors carry no auth guidance | `mcp/src/tools/env.test.ts` |
| real auth errors still carry auth guidance *(guard)* | `mcp/src/tools/env.test.ts` |

Each regression test was verified to **fail against the unpatched source** and pass after the fix.

## Verification

Build: webpack bundles compile with 0 errors (`build:webpack` / `build:types` / `build:permissions`); API Extractor completes successfully.

Tests: `cd mcp && npx vitest run`

```
Test Files  86 passed | 6 skipped (92)
     Tests  1094 passed | 62 skipped (1156)
```

## Scope

Only `hosting.ts`, `databasePG.ts`, `env.ts` and their test files. No schema or description changes, so `scripts/tools.json` and `doc/mcp-tools.md` are intentionally untouched and not regenerated. No version bump.

> Note on local tooling: `npm test` could not complete verbatim in this environment because its `prebuild` step runs `rm -rf dist`, which the safe-delete hook intercepts. The build sub-steps were run individually (all green) and the full suite was then executed directly via vitest.
