### PR TITLE
fix(mcp): queryEnv(list) pin to bound env for hosted OAuth token (环境级 STS)

### DIFF
--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -686,17 +686,28 @@ function isApiKeyCredentialMode(): boolean {
   return Boolean(getCloudBaseApiKeyFromEnv() && process.env.CLOUDBASE_ENV_ID);
 }
 
-function getCredentialScope(): CredentialScope {
+function getCredentialScope(cloudBaseOptions?: {
+  region?: string;
+  envId?: string;
+  token?: string;
+}): CredentialScope {
+  // 托管 OAuth（tcb-bff 签发的环境级 federated token）与单环境 API Key 同属环境级凭证：
+  // 账号级 DescribeEnvs(不带 EnvId) 会被后端拒绝（invalid token），只能访问绑定环境。
+  if (cloudBaseOptions?.envId && cloudBaseOptions?.token) return "single_env";
   return isApiKeyCredentialMode() ? "single_env" : "account";
 }
 
-function buildCredentialBoundaryPayload(cloudBaseOptions?: { region?: string; envId?: string }) {
-  const credentialScope = getCredentialScope();
+function buildCredentialBoundaryPayload(cloudBaseOptions?: {
+  region?: string;
+  envId?: string;
+  token?: string;
+}) {
+  const credentialScope = getCredentialScope(cloudBaseOptions);
   const currentRegion = resolveSiteAndRegion(cloudBaseOptions ?? {}).region;
   const pinnedEnvId = process.env.CLOUDBASE_ENV_ID || cloudBaseOptions?.envId || null;
   const scopeNote =
     credentialScope === "single_env"
-      ? `当前为环境级 API Key 登录（单环境权限）。只能访问已绑定的 envId${pinnedEnvId ? ` ${pinnedEnvId}` : ""}，看不到账号下其他环境或其他地域。这是凭据权限边界，不是环境不存在。`
+      ? `当前为环境级凭证登录（单环境权限，API Key 或托管授权 token）。只能访问已绑定的 envId${pinnedEnvId ? ` ${pinnedEnvId}` : ""}，看不到账号下其他环境或其他地域。这是凭据权限边界，不是环境不存在。queryEnv(action="list") 会自动降级为仅返回绑定环境的信息。`
       : `当前为账号级登录。DescribeEnvs 按地域查询；未传 region 时使用当前地域 ${currentRegion}。其他地域请用 queryEnv(action="list", region="ap-singapore")，或 CLI: tcb env list -r ap-singapore。`;
 
   return {
@@ -2805,6 +2816,13 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                 } catch (envInfoError) {
                   debug("DescribeEnvInfo 失败，返回基础环境信息:", envInfoError instanceof Error ? envInfoError : new Error(String(envInfoError)));
                   result = { EnvList: [{ EnvId: envIdFromEnv }] };
+                }
+                // 给调用方 AI 说明降级原因，避免误判为"账号只有一个环境"
+                if (tokenScopedEnvId) {
+                  result = {
+                    ...result,
+                    scope_note: `当前凭证为环境级（托管授权 token 绑定 ${envIdFromEnv}），账号级环境列表接口无权限，已降级为仅返回绑定环境的信息。如需查看账号下全部环境，请用有账号级权限的凭证登录。`,
+                  };
                 }
               } else {
                 // Use commonService to call DescribeEnvs with filter parameters

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -687,20 +687,19 @@ function isApiKeyCredentialMode(): boolean {
 }
 
 function getCredentialScope(cloudBaseOptions?: {
-  region?: string;
-  envId?: string;
-  token?: string;
+  credentialScope?: string;
 }): CredentialScope {
-  // 托管 OAuth（tcb-bff 签发的环境级 federated token）与单环境 API Key 同属环境级凭证：
-  // 账号级 DescribeEnvs(不带 EnvId) 会被后端拒绝（invalid token），只能访问绑定环境。
-  if (cloudBaseOptions?.envId && cloudBaseOptions?.token) return "single_env";
+  // 只认宿主的显式声明 credentialScope: 'env'（如 tcb-bff hosted OAuth 签发的
+  // 环境级 federated STS）。账号级 DescribeEnvs（不带 EnvId）会被后端拒绝（invalid token）。
+  // 注意：不能用 token 字段的有无推断范围——sessionToken 本身不携带权限范围语义。
+  if (cloudBaseOptions?.credentialScope === "env") return "single_env";
   return isApiKeyCredentialMode() ? "single_env" : "account";
 }
 
 function buildCredentialBoundaryPayload(cloudBaseOptions?: {
   region?: string;
   envId?: string;
-  token?: string;
+  credentialScope?: string;
 }) {
   const credentialScope = getCredentialScope(cloudBaseOptions);
   const currentRegion = resolveSiteAndRegion(cloudBaseOptions ?? {}).region;
@@ -2779,23 +2778,21 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               // API Key / env-var pin: skip DescribeEnvs (STS often cannot list).
               // Account-level sessions that only pinned CLOUDBASE_ENV_ID via set_env
               // can still pass region/alias/envId to list other environments.
-              // Hosted OAuth (env-scoped federated STS: cloudBaseOptions.token + envId)
-              // hits the same backend rejection ("invalid token") on account-level
-              // DescribeEnvs, so pin to the token-bound envId as well.
-              const tokenScopedEnvId =
+              // Hosted OAuth: 宿主（tcb-bff）显式声明 credentialScope: 'env'，签发的
+              // 环境级 federated STS 调账号级 DescribeEnvs 会被拒（"invalid token"），
+              // 同样 pin 到绑定 envId 降级为 describeEnvInfo。
+              const isEnvScopedCredential =
+                cloudBaseOptions?.credentialScope === "env" &&
                 typeof cloudBaseOptions?.envId === "string" &&
-                cloudBaseOptions.envId.length > 0 &&
-                typeof cloudBaseOptions?.token === "string" &&
-                cloudBaseOptions.token.length > 0
-                  ? cloudBaseOptions.envId
-                  : undefined;
+                cloudBaseOptions.envId.length > 0;
               const envIdFromEnv =
                 !cloudBaseOptions?.requestFn &&
-                (process.env.CLOUDBASE_ENV_ID || tokenScopedEnvId);
+                (process.env.CLOUDBASE_ENV_ID ||
+                  (isEnvScopedCredential ? cloudBaseOptions.envId : undefined));
               const shouldPinToEnvVar = Boolean(
                 envIdFromEnv &&
                 (isApiKeyCredentialMode() ||
-                  tokenScopedEnvId ||
+                  isEnvScopedCredential ||
                   (!region && !alias && !envId)),
               );
               if (shouldPinToEnvVar && envIdFromEnv) {
@@ -2818,10 +2815,10 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                   result = { EnvList: [{ EnvId: envIdFromEnv }] };
                 }
                 // 给调用方 AI 说明降级原因，避免误判为"账号只有一个环境"
-                if (tokenScopedEnvId) {
+                if (isEnvScopedCredential) {
                   result = {
                     ...result,
-                    scope_note: `当前凭证为环境级（托管授权 token 绑定 ${envIdFromEnv}），账号级环境列表接口无权限，已降级为仅返回绑定环境的信息。如需查看账号下全部环境，请用有账号级权限的凭证登录。`,
+                    scope_note: `当前凭证为环境级（托管授权凭证绑定 ${envIdFromEnv}），账号级环境列表接口无权限，已降级为仅返回绑定环境的信息。如需查看账号下全部环境，请用有账号级权限的凭证登录。`,
                   };
                 }
               } else {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -2768,10 +2768,24 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               // API Key / env-var pin: skip DescribeEnvs (STS often cannot list).
               // Account-level sessions that only pinned CLOUDBASE_ENV_ID via set_env
               // can still pass region/alias/envId to list other environments.
-              const envIdFromEnv = !cloudBaseOptions?.requestFn && process.env.CLOUDBASE_ENV_ID;
+              // Hosted OAuth (env-scoped federated STS: cloudBaseOptions.token + envId)
+              // hits the same backend rejection ("invalid token") on account-level
+              // DescribeEnvs, so pin to the token-bound envId as well.
+              const tokenScopedEnvId =
+                typeof cloudBaseOptions?.envId === "string" &&
+                cloudBaseOptions.envId.length > 0 &&
+                typeof cloudBaseOptions?.token === "string" &&
+                cloudBaseOptions.token.length > 0
+                  ? cloudBaseOptions.envId
+                  : undefined;
+              const envIdFromEnv =
+                !cloudBaseOptions?.requestFn &&
+                (process.env.CLOUDBASE_ENV_ID || tokenScopedEnvId);
               const shouldPinToEnvVar = Boolean(
                 envIdFromEnv &&
-                (isApiKeyCredentialMode() || (!region && !alias && !envId)),
+                (isApiKeyCredentialMode() ||
+                  tokenScopedEnvId ||
+                  (!region && !alias && !envId)),
               );
               if (shouldPinToEnvVar && envIdFromEnv) {
                 try {

--- a/mcp/src/types.ts
+++ b/mcp/src/types.ts
@@ -86,6 +86,14 @@ export type CloudBaseOptions = CloudBaseConfigBase & {
   requestFn?: CloudApiRequestFn
   /** 站点：domestic（国内站）/ intl（国际站）。可选；缺省按 TCB_SITE / region 映射表 / 项目配置解析 */
   site?: string
+  /**
+   * 凭证权限范围的显式声明（可选，由宿主传入）。
+   * - 'env'：环境级凭证（如 tcb-bff hosted OAuth 签发的 federated STS，policy 收敛到单个 env）。
+   *   MCP 据此启用 queryEnv(action="list") 的 pin 降级，并在凭证边界标注中上报 single_env。
+   * - 缺省/'account'：账号级凭证，按地域全量 DescribeEnvs。
+   * 注意：不要用 token 字段的有无来推断权限范围——sessionToken 本身不携带范围语义。
+   */
+  credentialScope?: 'env' | 'account'
 }
 
 /**


### PR DESCRIPTION
## 问题

托管 OAuth（tcb-bff 签发的环境级 federated token）登录后，`queryEnv(action="list")` 调用账号级 `DescribeEnvs`（不带 EnvId）会被后端拒绝，报 `invalid token`；而单环境查询（`envinfo` / `action="info"`，走 DescribeEnvInfo 带 EnvId）正常。

## 根因

- 托管 OAuth 下发给 MCP 的凭证是**环境级** STS（secretId/secretKey/sessionToken 三元组，policy 收敛到 `qcs::tcb::uin/{ownerUin}:env/{envId}`）
- 账号级 `DescribeEnvs`（不带 EnvId）超出该凭证的资源边界，被后端拒绝
- 这与已有的 API Key 限制一致（代码中已有注释 `STS often cannot list`），但已有的 pin 兜底只覆盖 API Key / `CLOUDBASE_ENV_ID` 环境变量模式，未覆盖托管 OAuth 模式

## 设计：显式 credentialScope 声明（不用 token+envId 启发式）

sessionToken 本身只表示"临时凭证"，**不携带权限范围语义**——环境级还是账号级取决于签发方 attach 的 policy。用 `token + envId` 组合推断范围是启发式，存在误判面（将来账号级临时密钥也可能带 token+envId）。

因此采用**显式标志**：

1. **`CloudBaseOptions` 新增可选字段 `credentialScope?: 'env' | 'account'`**（mcp/src/types.ts），由宿主声明凭证范围
2. **宿主（tcb-bff，MR !237 分支 commit 403b091）**：OAuth 路径（secretToken 存在）传 `credentialScope: 'env'`；API Key 路径不声明（由 MCP 侧 `isApiKeyCredentialMode` 自行判定）
3. **MCP 只认标志**：
   - `getCredentialScope`：`credentialScope === 'env'` → `single_env`（此前该场景被误报为 `account`）
   - `queryEnv(action="list")` pin 降级：`isEnvScopedCredential` 时 pin 到绑定 envId，降级为 `describeEnvInfo`
   - **向调用方 AI 说明**：降级发生时返回体附带 `scope_note`，明确"仅返回绑定环境是凭据权限边界，不是账号只有一个环境"

## 验证

- `tsc --noEmit` 通过
- 预发实测：环境级 token 下 `envinfo`（DescribeEnvInfo）正常返回；`action=list` 修复前 403 invalid token，pin 降级后返回绑定环境
- BFF 侧注意：不能在 BFF 用 `process.env.CLOUDBASE_ENV_ID` 兜底（pod 级全局变量，多用户互相污染），pin 必须在 MCP 侧基于 `cloudBaseOptions` 判断

## 生效路径

- 本 PR 合入发版后，BFF 升级 `@cloudbase/cloudbase-mcp`（当前 2.20.1）；BFF 的 `credentialScope: 'env'` 声明已在 MR !237 分支同步就绪
