### PR TITLE
fix(deps): migrate lockfile to maintained alias

### DIFF
--- a/mcp/package-lock.json
+++ b/mcp/package-lock.json
@@ -20,7 +20,7 @@
         "cors": "^2.8.5",
         "express": "5.1.0",
         "fd-slicer": "^1.1.0",
-        "lockfile": "^1.0.4",
+        "lockfile": "npm:@stackline/lockfile@1.0.5",
         "open": "^10.1.2",
         "punycode": "^2.3.1",
         "unzipper": "^0.12.3",
@@ -7867,12 +7867,16 @@
       }
     },
     "node_modules/lockfile": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "name": "@stackline/lockfile",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@stackline/lockfile/-/lockfile-1.0.5.tgz",
+      "integrity": "sha512-joabBF+8zd6JwdHweGfmi9S9T/JU6Mjf40ocYo84FJWB9oKfvINwx0feHG3t/lY1FVmaMLRGLZ3b+mhyFbhPng==",
       "license": "ISC",
       "dependencies": {
-        "signal-exit": "^3.0.2"
+        "signal-exit": "3.0.7"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/lodash": {
@@ -17092,11 +17096,11 @@
       }
     },
     "lockfile": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz",
-      "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
+      "version": "npm:@stackline/lockfile@1.0.5",
+      "resolved": "https://registry.npmjs.org/@stackline/lockfile/-/lockfile-1.0.5.tgz",
+      "integrity": "sha512-joabBF+8zd6JwdHweGfmi9S9T/JU6Mjf40ocYo84FJWB9oKfvINwx0feHG3t/lY1FVmaMLRGLZ3b+mhyFbhPng==",
       "requires": {
-        "signal-exit": "^3.0.2"
+        "signal-exit": "3.0.7"
       }
     },
     "lodash": {

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -80,7 +80,7 @@
     "cors": "^2.8.5",
     "express": "5.1.0",
     "fd-slicer": "^1.1.0",
-    "lockfile": "^1.0.4",
+    "lockfile": "npm:@stackline/lockfile@1.0.5",
     "open": "^10.1.2",
     "punycode": "^2.3.1",
     "unzipper": "^0.12.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^1.1.0
         version: 1.1.0
       lockfile:
-        specifier: ^1.0.4
-        version: 1.0.4
+        specifier: npm:@stackline/lockfile@1.0.5
+        version: '@stackline/lockfile@1.0.5'
       open:
         specifier: ^10.1.2
         version: 10.2.0
@@ -1299,6 +1299,10 @@ packages:
 
   '@so-ric/colorspace@1.1.6':
     resolution: {integrity: sha512-/KiKkpHNOBgkFJwu9sh48LkHSMYGyuTcSFK/qMBdnOAlrRJzRSXAOFB5qwzaVQuDl8wAvHVMkaASQDReTahxuw==}
+
+  '@stackline/lockfile@1.0.5':
+    resolution: {integrity: sha512-joabBF+8zd6JwdHweGfmi9S9T/JU6Mjf40ocYo84FJWB9oKfvINwx0feHG3t/lY1FVmaMLRGLZ3b+mhyFbhPng==}
+    engines: {node: '>=14.17'}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3235,9 +3239,6 @@ packages:
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
     engines: {node: '>=8'}
-
-  lockfile@1.0.4:
-    resolution: {integrity: sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==}
 
   lodash.defaults@4.2.0:
     resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
@@ -5689,6 +5690,10 @@ snapshots:
       color: 5.0.3
       text-hex: 1.0.0
 
+  '@stackline/lockfile@1.0.5':
+    dependencies:
+      signal-exit: 3.0.7
+
   '@standard-schema/spec@1.1.0': {}
 
   '@testing-library/dom@10.4.0':
@@ -7912,10 +7917,6 @@ snapshots:
   locate-path@5.0.0:
     dependencies:
       p-locate: 4.1.0
-
-  lockfile@1.0.4:
-    dependencies:
-      signal-exit: 3.0.7
 
   lodash.defaults@4.2.0: {}
 


### PR DESCRIPTION
## Summary

- preserve the existing `lockfile` dependency key while resolving it to `@stackline/lockfile@1.0.5`
- refresh the MCP npm lock and root pnpm lock for the published artifact
- keep the MCP cache-lock imports and call sites unchanged

`mcp/src/tools/rag.ts` already handles asynchronous unlock errors and logs a warning when a cache lock cannot be released. `lockfile@1.0.4` discards asynchronous unlink errors, so that failure path cannot observe a retained-lock error. The maintained 1.0.5 package preserves `ENOENT` as an already-unlocked success while forwarding other unlink errors.

I maintain `@stackline/lockfile`. Installing it under the historical `lockfile` key keeps this change limited to dependency metadata and lockfiles.

## Verification

- `npm ci --ignore-scripts --no-audit --no-fund` at the root and in `mcp` (Node 20 and Node 24)
- `corepack pnpm@10.8.0 install --frozen-lockfile --ignore-scripts`
- `npm run build` in `mcp` (webpack, declarations, and API Extractor; Node 20 and Node 24)
- `npx vitest run src/tools/rag.test.ts` in `mcp` (7 passed; Node 20 and Node 24)
- package identity/API smoke: `require("lockfile")` resolves to `@stackline/lockfile@1.0.5` with the existing public API

The root `package-lock.json` remains byte-for-byte unchanged because it has no MCP workspace importer. A bounded full-suite run showed no failures before the existing CloudBase Sites supervisor kept Vitest alive after tarball packaging; it was stopped after 150 seconds without a final summary.
