### PR TITLE
fix(functions): mask env variable values by default in getFunctionDetail/listFunctionTriggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. Follow the 
 
 ## Unreleased
 
+### Security
+
+* **functions**: mask cloud-function environment variable values by default in `queryFunctions` (`getFunctionDetail` / `listFunctionTriggers`). The full raw SCF detail — including `Environment.Variables` plaintext — used to be returned to the model context on every read. Values are now replaced with `***` plus a `ValueLength` field (sufficient for config inspection and change verification); pass `revealEnvValues=true` to opt in to plaintext. Results written to the MCP server log are always masked, with no plaintext opt-out. Plaintext remains available via the console or `tcb fn detail` (fixes #971).
+
 ## [2.32.2](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/compare/v2.32.1...v2.32.2) (2026-08-25)
 
 ### Bug Fixes

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1190,6 +1190,11 @@ CloudBase 云函数统一只读入口。通过更自解释的 action 查询 Clou
       description: `代码保护密钥，用于解密函数代码`,
     },
     {
+      name: "revealEnvValues",
+      type: "boolean",
+      description: `getFunctionDetail / listFunctionTriggers 时是否返回环境变量明文值。默认 false：Value 脱敏为 ***，仅保留 Key 与 ValueLength，足以确认配置了哪些变量及变更是否生效；true 时返回明文，敏感变量会进入模型上下文，谨慎使用。如需查看明文，建议优先使用控制台或 CLI`,
+    },
+    {
       name: "startTime",
       type: "string",
       description: `日志查询开始时间，格式必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 00:00:00）。与 endTime 间隔不能超过一天。不传时默认查询最近一天`,
@@ -1960,7 +1965,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.2），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.4），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数

--- a/mcp/src/tools/functions.test.ts
+++ b/mcp/src/tools/functions.test.ts
@@ -561,4 +561,85 @@ describe("functions tool helpers", () => {
     expect(mockUpdateFunctionConfig).toHaveBeenCalledTimes(1);
     expect(mockGetFunctionDetail.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
+
+  describe("env variable masking (getFunctionDetail / listFunctionTriggers)", () => {
+    const detailWithSecret = {
+      Status: "Active",
+      Timeout: 20,
+      Environment: {
+        Variables: [
+          { Key: "DB_PASSWORD", Value: "super-secret-value" },
+          { Key: "NODE_ENV", Value: "production" },
+        ],
+      },
+      VpcConfig: {},
+    };
+
+    it("masks env variable values by default and keeps Key + ValueLength", async () => {
+      mockGetFunctionDetail.mockResolvedValue(detailWithSecret);
+
+      const result = await tools.queryFunctions.handler({
+        action: "getFunctionDetail",
+        functionName: "hello",
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      const variables = payload.data.functionDetail.Environment.Variables;
+      expect(variables[0]).toMatchObject({
+        Key: "DB_PASSWORD",
+        Value: "***",
+        ValueLength: "super-secret-value".length,
+      });
+      expect(variables[1]).toMatchObject({
+        Key: "NODE_ENV",
+        Value: "***",
+        ValueLength: "production".length,
+      });
+      // raw 与 functionDetail 同步脱敏，明文不出现在任何返回字段
+      expect(JSON.stringify(payload)).not.toContain("super-secret-value");
+      // 日志侧也拿到脱敏后的结果
+      const logged = mockLogCloudBaseResult.mock.calls.at(-1)?.[1];
+      expect(logged.Environment.Variables[0].Value).toBe("***");
+    });
+
+    it("returns plaintext env values only when revealEnvValues=true, but still masks logs", async () => {
+      mockGetFunctionDetail.mockResolvedValue(detailWithSecret);
+
+      const result = await tools.queryFunctions.handler({
+        action: "getFunctionDetail",
+        functionName: "hello",
+        revealEnvValues: true,
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(payload.data.functionDetail.Environment.Variables[0]).toMatchObject({
+        Key: "DB_PASSWORD",
+        Value: "super-secret-value",
+      });
+      const logged = mockLogCloudBaseResult.mock.calls.at(-1)?.[1];
+      expect(logged.Environment.Variables[0].Value).toBe("***");
+    });
+
+    it("masks env variable values in listFunctionTriggers raw payload", async () => {
+      mockGetFunctionDetail.mockResolvedValue(detailWithSecret);
+
+      const result = await tools.queryFunctions.handler({
+        action: "listFunctionTriggers",
+        functionName: "hello",
+      });
+
+      const payload = JSON.parse(result.content[0].text);
+      expect(JSON.stringify(payload)).not.toContain("super-secret-value");
+      expect(payload.data.raw.Environment.Variables[0]).toMatchObject({
+        Key: "DB_PASSWORD",
+        Value: "***",
+      });
+    });
+
+    it("documents the default-masking behavior in the queryFunctions schema", () => {
+      const schema = tools.queryFunctions.meta.inputSchema;
+      expect(schema.revealEnvValues).toBeDefined();
+      expect(schema.revealEnvValues._def.description).toContain("默认 false");
+    });
+  });
 });

--- a/mcp/src/tools/functions.ts
+++ b/mcp/src/tools/functions.ts
@@ -194,6 +194,7 @@ type QueryFunctionsInput = {
   limit?: number;
   offset?: number;
   codeSecret?: string;
+  revealEnvValues?: boolean;
   startTime?: string;
   endTime?: string;
   requestId?: string;
@@ -244,8 +245,37 @@ type ManageFunctionsInput = {
   imageConfig?: FunctionImageConfigInput;
 };
 
-const VPC_SCHEMA = z.object({
-  vpcId: z
+/** 环境变量脱敏后的占位值（不保留任何明文片段）。 */
+export const MASKED_ENV_VALUE = "***";
+
+/**
+ * 对 getFunctionDetail 返回的 Environment.Variables 做脱敏：
+ * 保留 Key 与原始值长度（ValueLength），Value 置为占位符。
+ * 用于默认工具返回与日志落盘，避免明文进入模型上下文 / 持久化日志。
+ */
+export function maskFunctionDetailEnvValues<
+  T extends { Environment?: { Variables?: IEnvVariable[] } | null },
+>(detail: T): T {
+  const variables = detail?.Environment?.Variables;
+  if (!Array.isArray(variables) || variables.length === 0) {
+    return detail;
+  }
+  return {
+    ...detail,
+    Environment: {
+      ...detail.Environment,
+      Variables: variables.map((item) => ({
+        ...item,
+        Value: MASKED_ENV_VALUE,
+        ...(typeof item.Value === "string"
+          ? { ValueLength: item.Value.length }
+          : {}),
+      })),
+    },
+  } as T;
+}
+
+const VPC_SCHEMA = z.object({  vpcId: z
     .string()
     .describe(
       "VPC ID from the real database/network console (e.g. vpc-xxxxxxxx). Required for non-native TCP DB access. Do NOT invent or use placeholders.",
@@ -803,16 +833,21 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         input.functionName,
         input.codeSecret,
       );
-      logCloudBaseResult(server.logger, result);
+      // 日志侧一律脱敏（持久化，不提供明文口子）；工具返回侧按 revealEnvValues 决定
+      logCloudBaseResult(server.logger, maskFunctionDetailEnvValues(result));
+      const functionDetail =
+        input.revealEnvValues === true
+          ? result
+          : maskFunctionDetailEnvValues(result);
       return buildEnvelope(
         {
           action: input.action,
           functionName: input.functionName,
-          functionDetail: result,
+          functionDetail,
           layers: normalizeFunctionLayers(result.Layers),
           triggers: result.Triggers || [],
           requestId: result.RequestId,
-          raw: result,
+          raw: functionDetail,
         },
         `已获取函数 ${input.functionName} 的详情`,
         [
@@ -1072,14 +1107,18 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         input.functionName,
         input.codeSecret,
       );
-      logCloudBaseResult(server.logger, result);
+      logCloudBaseResult(server.logger, maskFunctionDetailEnvValues(result));
+      const detail =
+        input.revealEnvValues === true
+          ? result
+          : maskFunctionDetailEnvValues(result);
       return buildEnvelope(
         {
           action: input.action,
           functionName: input.functionName,
-          triggers: result.Triggers || [],
-          requestId: result.RequestId,
-          raw: result,
+          triggers: detail.Triggers || [],
+          requestId: detail.RequestId,
+          raw: detail,
         },
         `已获取函数 ${input.functionName} 的触发器列表`,
         [
@@ -2051,6 +2090,12 @@ export function registerFunctionTools(server: ExtendedMcpServer) {
         limit: z.number().optional().describe("分页数量（limit）。列表类 action 可选，默认值由后端决定"),
         offset: z.number().optional().describe("分页偏移（offset）。列表类 action 可选，默认 0"),
         codeSecret: z.string().optional().describe("代码保护密钥，用于解密函数代码"),
+        revealEnvValues: z
+          .boolean()
+          .optional()
+          .describe(
+            "getFunctionDetail / listFunctionTriggers 时是否返回环境变量明文值。默认 false：Value 脱敏为 ***，仅保留 Key 与 ValueLength，足以确认配置了哪些变量及变更是否生效；true 时返回明文，敏感变量会进入模型上下文，谨慎使用。如需查看明文，建议优先使用控制台或 CLI",
+          ),
         startTime: z
           .string()
           .optional()

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -1270,6 +1270,10 @@
             "type": "string",
             "description": "代码保护密钥，用于解密函数代码"
           },
+          "revealEnvValues": {
+            "type": "boolean",
+            "description": "getFunctionDetail / listFunctionTriggers 时是否返回环境变量明文值。默认 false：Value 脱敏为 ***，仅保留 Key 与 ValueLength，足以确认配置了哪些变量及变更是否生效；true 时返回明文，敏感变量会进入模型上下文，谨慎使用。如需查看明文，建议优先使用控制台或 CLI"
+          },
           "startTime": {
             "type": "string",
             "description": "日志查询开始时间，格式必须为 YYYY-MM-DD HH:mm:ss（如 2024-01-01 00:00:00）。与 endTime 间隔不能超过一天。不传时默认查询最近一天"
@@ -2072,7 +2076,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.2），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.4），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
## 问题

`queryFunctions` 的 `getFunctionDetail` 与 `listFunctionTriggers` 两个 action 直接把 Manager SDK 的全量返回（含 `raw: result`）透传给调用方，其中 `Environment.Variables` 是函数环境变量的**明文值**。在 MCP 场景下，工具返回值会进入模型上下文，被 IDE 日志、模型服务等多方接触——secret 一旦进入上下文即脱离"仅运行时配置"的信任边界，且轮换无法根治（下一次调用又暴露）。对应 OWASP MCP Top 10 的 MCP01:2025（contextual secret leakage）。

前提说明：调用方需已持有该环境的合法授权凭据，因此这不是权限提升类漏洞，而是工具返回面与 agent 上下文之间缺敏感字段边界的问题。

## 修复方案

**默认脱敏 + 显式口子**（不做敏感分级智能判断——分类必然有漏网）：

- `getFunctionDetail` / `listFunctionTriggers` 默认将 `Environment.Variables` 的 `Value` 脱敏为 `***`，保留 `Key` 与 `ValueLength`——足以支撑"配了哪些变量""变更是否生效"等常见 agent 操作
- 新增 `revealEnvValues` 入参（默认 `false`），显式传 `true` 时返回明文，覆盖确有读回需求的场景；工具 description 中标注了风险
- **日志侧不留口子**：写入 MCP server 日志前一律脱敏（日志是持久化的，没有"临时要看"的需求）
- 同步重新生成 `scripts/tools.json` / `doc/mcp-tools.md`，补 CHANGELOG

`updateFunctionConfig` 内部的环境变量合并逻辑走 SDK 内部读取、不经过 tool result，不受影响；明文仍可通过控制台或 `tcb fn detail`（人的终端）查看。

## 测试

- 新增 4 个单测：默认脱敏（含 raw 与日志侧）、`revealEnvValues=true` 明文口子（日志仍脱敏）、`listFunctionTriggers` raw 脱敏、schema 文档校验
- `functions.test.ts` 29 用例全部通过；`npm run build` 通过

Fixes #971
