### PR TITLE
fix(cloudrun): mask service env params by default in queryCloudRun detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. Follow the 
 
 ## Unreleased
 
+### Security
+
+- **cloudrun**: `queryCloudRun(action="detail")` 默认脱敏服务环境变量（`ServerConfig.EnvParams` 的值置为 `***`，保留 key），新增 `revealEnvParams` 入参（默认 `false`）显式获取明文，避免带密码的连接串等敏感值进入模型上下文
+
 ## [2.32.2](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/compare/v2.32.1...v2.32.2) (2026-08-25)
 
 ### Bug Fixes

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -1960,7 +1960,7 @@ CloudBase 云函数统一写入口。支持创建函数、更新代码、更新�
 - aider: Aider AI编辑器
 
 特别说明：
-- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.2），便于后续维护和版本追踪
+- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.4），便于后续维护和版本追踪
 - 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）
 
 #### 参数
@@ -2173,6 +2173,11 @@ API名：ai_model API介绍：AI 大模型接入 API - 统一 AI 模型 HTTP API
       name: "runId",
       type: "string",
       description: `运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志`,
+    },
+    {
+      name: "revealEnvParams",
+      type: "boolean",
+      description: `是否返回服务环境变量（ServerConfig.EnvParams）明文值（仅 action=detail 时生效）。默认 false，值脱敏为 "***"（保留 key，足够排查配置了哪些变量、变更是否生效）；true 时返回明文，敏感变量（如带密码的 DATABASE_URL）可能暴露给模型上下文，谨慎使用`,
     }
   ]}
 />

--- a/mcp/src/tools/cloudrun-detail-envparams.test.ts
+++ b/mcp/src/tools/cloudrun-detail-envparams.test.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it, vi } from "vitest";
+
+const { mockGetCloudBaseManager, mockGetEnvId } = vi.hoisted(() => ({
+  mockGetCloudBaseManager: vi.fn(),
+  mockGetEnvId: vi.fn(),
+}));
+
+vi.mock("../cloudbase-manager.js", () => ({
+  getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
+}));
+
+async function createCloudRunTools() {
+  const tools: Record<string, { meta: any; handler: (args: any) => Promise<any> }> = {};
+  const server: any = {
+    cloudBaseOptions: {},
+    ide: "CodeBuddy",
+    server: {
+      sendLoggingMessage: vi.fn(),
+    },
+    registerTool: vi.fn((name: string, meta: any, handler: (args: any) => Promise<any>) => {
+      tools[name] = { meta, handler };
+    }),
+  };
+  const { registerCloudRunTools } = await import("./cloudrun.js");
+  registerCloudRunTools(server);
+  return { tools, server };
+}
+
+function parseToolResult(res: any) {
+  return JSON.parse(res.content[0].text);
+}
+
+function makeManager(detailResponse: any) {
+  return {
+    commonService: vi.fn().mockReturnValue({ call: vi.fn() }),
+    cloudrun: {
+      detail: vi.fn().mockResolvedValue(detailResponse),
+      getDeployRecords: vi.fn().mockResolvedValue({
+        DeployRecords: [
+          {
+            DeployId: "d1",
+            DeployTime: "2026-09-01 10:00:00",
+            Status: "normal",
+            RunId: "run-1",
+            BuildId: 100,
+            FlowRatio: 100,
+            ImageUrl: "",
+            ScaleStatus: "normal",
+            HasTraffic: true,
+            TrafficType: "FULL",
+            IsReleasing: false,
+          },
+        ],
+      }),
+    },
+  };
+}
+
+function makeDetailResponse(envParams: string) {
+  return {
+    BaseInfo: { ServerName: "my-svc", Status: "normal" },
+    ServerConfig: {
+      EnvParams: envParams,
+      Cpu: 0.5,
+      Mem: 1,
+      MinNum: 0,
+      MaxNum: 2,
+    },
+    OnlineVersionInfos: [
+      { VersionName: "my-svc-001", ImageUrl: "img", FlowRatio: "100" },
+    ],
+    RequestId: "req-1",
+  };
+}
+
+describe("queryCloudRun detail EnvParams masking", () => {
+  it("masks EnvParams values by default while preserving keys", async () => {
+    const manager = makeManager(
+      makeDetailResponse(
+        JSON.stringify({
+          DATABASE_URL: "postgres://user:pass@10.0.0.1:5432/db",
+          NODE_ENV: "production",
+        }),
+      ),
+    );
+    mockGetCloudBaseManager.mockResolvedValue(manager);
+
+    const { tools } = await createCloudRunTools();
+    const res = await tools.queryCloudRun.handler({
+      action: "detail",
+      detailServerName: "my-svc",
+    });
+    const payload = parseToolResult(res);
+
+    expect(payload.success).toBe(true);
+    const envParams = JSON.parse(payload.data.service.ServerConfig.EnvParams);
+    expect(envParams).toEqual({
+      DATABASE_URL: "***",
+      NODE_ENV: "***",
+    });
+    expect(payload.data.service.ServerConfig.Cpu).toBe(0.5);
+  });
+
+  it("returns plaintext EnvParams when revealEnvParams=true", async () => {
+    const plaintext = JSON.stringify({
+      DATABASE_URL: "postgres://user:pass@10.0.0.1:5432/db",
+    });
+    const manager = makeManager(makeDetailResponse(plaintext));
+    mockGetCloudBaseManager.mockResolvedValue(manager);
+
+    const { tools } = await createCloudRunTools();
+    const res = await tools.queryCloudRun.handler({
+      action: "detail",
+      detailServerName: "my-svc",
+      revealEnvParams: true,
+    });
+    const payload = parseToolResult(res);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.service.ServerConfig.EnvParams).toBe(plaintext);
+  });
+
+  it("masks the whole EnvParams string when it is not valid JSON", async () => {
+    const manager = makeManager(makeDetailResponse("not-a-json-value"));
+    mockGetCloudBaseManager.mockResolvedValue(manager);
+
+    const { tools } = await createCloudRunTools();
+    const res = await tools.queryCloudRun.handler({
+      action: "detail",
+      detailServerName: "my-svc",
+    });
+    const payload = parseToolResult(res);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.service.ServerConfig.EnvParams).toBe("***");
+  });
+
+  it("keeps the detail response intact when EnvParams is absent or empty", async () => {
+    const manager = makeManager(makeDetailResponse(""));
+    mockGetCloudBaseManager.mockResolvedValue(manager);
+
+    const { tools } = await createCloudRunTools();
+    const res = await tools.queryCloudRun.handler({
+      action: "detail",
+      detailServerName: "my-svc",
+    });
+    const payload = parseToolResult(res);
+
+    expect(payload.success).toBe(true);
+    expect(payload.data.service.ServerConfig.EnvParams).toBe("");
+  });
+
+  it("exposes revealEnvParams as a boolean input with default false", async () => {
+    const { tools } = await createCloudRunTools();
+    const reveal = tools.queryCloudRun.meta.inputSchema.revealEnvParams;
+    expect(reveal).toBeDefined();
+    expect(reveal._def.typeName).toBe("ZodDefault");
+    expect(reveal._def.innerType._def.typeName).toBe("ZodOptional");
+    expect(reveal.parse(undefined)).toBe(false);
+    expect(reveal.parse(true)).toBe(true);
+  });
+});

--- a/mcp/src/tools/cloudrun.ts
+++ b/mcp/src/tools/cloudrun.ts
@@ -29,6 +29,48 @@ export type CloudRunAccessType = typeof CLOUDRUN_ACCESS_TYPES[number];
 export const CLOUDRUN_PACKAGE_TYPES = ['Trial', 'Standard', 'Professional', 'Enterprise'] as const;
 export type CloudRunPackageType = typeof CLOUDRUN_PACKAGE_TYPES[number];
 
+/** 环境变量脱敏后的占位值（不保留任何明文片段）。 */
+export const MASKED_CLOUDRUN_ENV_VALUE = "***";
+
+/**
+ * 对云托管 detail 返回的 ServerConfig.EnvParams（JSON 字符串）做脱敏：
+ * 解析后把所有 value 置为占位符、保留 key，再序列化回 JSON 字符串。
+ * 解析失败（非 JSON）时整串替换为占位符，避免任何明文片段外泄。
+ * 用于默认工具返回，避免明文进入模型上下文。
+ */
+export function maskCloudRunDetailEnvParams<
+  T extends { ServerConfig?: { EnvParams?: string } | null },
+>(detail: T): T {
+  const envParams = detail?.ServerConfig?.EnvParams;
+  if (typeof envParams !== "string" || envParams === "") {
+    return detail;
+  }
+
+  let masked: string;
+  try {
+    const parsed = JSON.parse(envParams);
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      masked = JSON.stringify(
+        Object.fromEntries(
+          Object.entries(parsed).map(([key]) => [key, MASKED_CLOUDRUN_ENV_VALUE]),
+        ),
+      );
+    } else {
+      masked = MASKED_CLOUDRUN_ENV_VALUE;
+    }
+  } catch {
+    masked = MASKED_CLOUDRUN_ENV_VALUE;
+  }
+
+  return {
+    ...detail,
+    ServerConfig: {
+      ...detail.ServerConfig,
+      EnvParams: masked,
+    },
+  } as T;
+}
+
 // Input schema for queryCloudRun tool
 const queryCloudRunInputSchema = {
   action: z.enum(['list', 'detail', 'templates', 'getDeployLog', 'getProcessLog', 'getDeployRecords', 'envStatus']).describe('查询操作类型：list=获取云托管服务列表（支持分页和筛选），detail=查询指定服务的详细信息（包含服务配置和最新部署状态），templates=获取可用的项目模板列表（用于初始化新项目），getDeployLog=获取构建日志（仅云端源码构建有意义，走 CODING/DescribeCloudRunBuildLog；已有镜像部署无构建过程；未登录 CODING 的账号会报错），getProcessLog=获取运行日志（部署阶段步骤+容器启动/运行日志，走 tcbr/DescribeCloudRunProcessLog；镜像部署与源码构建均可用，不依赖 CODING；RunId 来自 detail/getDeployRecords 的 latestDeploy.RunId），getDeployRecords=获取指定服务的部署记录列表（按部署时间倒序，含 BuildId/RunId/FlowRatio/Status 等字段，用于查看历史发布与回滚上下文），envStatus=查询当前环境云托管是否已开通及开通状态（Status=creating开通中/normal已开通），用于initEnv之后轮询进度或deploy之前确认环境是否就绪'),
@@ -44,6 +86,7 @@ const queryCloudRunInputSchema = {
   detailServerName: z.string().optional().describe('要查询详细信息、部署记录、构建日志或运行日志的服务名称。当action为detail、getDeployLog、getProcessLog或getDeployRecords时建议提供，必须是已存在的服务名称。可通过list操作获取可用的服务名称列表'),
   buildId: z.number().optional().describe('构建ID，仅在action=getDeployLog时使用（构建日志，仅云端源码构建）。不传时默认返回最近一次部署的构建日志'),
   runId: z.string().optional().describe('运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志'),
+  revealEnvParams: z.boolean().optional().default(false).describe('是否返回服务环境变量（ServerConfig.EnvParams）明文值（仅 action=detail 时生效）。默认 false，值脱敏为 "***"（保留 key，足够排查配置了哪些变量、变更是否生效）；true 时返回明文，敏感变量（如带密码的 DATABASE_URL）可能暴露给模型上下文，谨慎使用'),
 };
 
 // Input schema for manageCloudRun tool
@@ -150,6 +193,7 @@ type queryCloudRunInput = {
   buildId?: number;
   runId?: string;
   envId?: string;
+  revealEnvParams?: boolean;
 };
 
 type ManageCloudRunInput = {
@@ -1219,7 +1263,8 @@ export function registerCloudRunTools(server: ExtendedMcpServer) {
                   text: JSON.stringify({
                     success: true,
                     data: {
-                      service: result,
+                      // 默认脱敏 ServerConfig.EnvParams 的值（保留 key）；revealEnvParams=true 时返回明文
+                      service: input.revealEnvParams === true ? result : maskCloudRunDetailEnvParams(result),
                       latestDeploy,
                       // 若最新部署记录带镜像信息（镜像部署），透出便于展示
                       ...(extractCloudRunImageInfo(result, latestDeploy)

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -2072,7 +2072,7 @@
     },
     {
       "name": "downloadTemplate",
-      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.2），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
+      "description": "自动下载并部署CloudBase项目模板。\n**Note**: Call this tool when the user requests to create a new project using a CloudBase template.\n\n支持的模板:\n- react: React + CloudBase 全栈应用模板\n- vue: Vue + CloudBase 全栈应用模板\n- miniprogram: 微信小程序 + 云开发模板  \n- uniapp: UniApp + CloudBase 跨端应用模板\n- rules: 只包含AI编辑器配置文件（包含Cursor、WindSurf、CodeBuddy等所有主流编辑器配置），适合在已有项目中补充AI编辑器配置\n\n支持的IDE类型:\n- all: 下载所有IDE配置\n- cursor: Cursor AI编辑器\n- 其他IDE类型见下方列表\n\n注意：如果未传入 ide 参数且无法从环境变量检测到 IDE，将提示错误并要求传入 ide 参数\n- windsurf: WindSurf AI编辑器\n- codebuddy: CodeBuddy AI编辑器\n- claude-code: Claude Code AI编辑器\n- cline: Cline AI编辑器\n- gemini-cli: Gemini CLI\n- opencode: OpenCode AI编辑器\n- qwen-code: 通义灵码\n- baidu-comate: 百度Comate\n- openai-codex-cli: OpenAI Codex CLI\n- augment-code: Augment Code\n- github-copilot: GitHub Copilot\n- roocode: RooCode AI编辑器\n- tongyi-lingma: 通义灵码\n- trae: Trae AI编辑器\n- qoder: Qoder AI编辑器\n- antigravity: Google Antigravity AI编辑器\n- vscode: Visual Studio Code\n- kiro: Kiro AI编辑器\n- aider: Aider AI编辑器\n\n特别说明：\n- rules 模板会自动包含当前 mcp 版本号信息（版本号：2.32.4），便于后续维护和版本追踪\n- 下载 rules 模板时，如果项目中已存在 README.md 文件，系统会自动保护该文件不被覆盖（除非设置 overwrite=true）",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -2328,6 +2328,11 @@
           "runId": {
             "type": "string",
             "description": "运行ID（RunId），仅在action=getProcessLog时使用。不传时默认取该服务最近一次部署记录的 RunId（与 detail/getDeployRecords 的 latestDeploy.RunId 同源）。镜像部署与源码构建均可查询运行日志"
+          },
+          "revealEnvParams": {
+            "type": "boolean",
+            "default": false,
+            "description": "是否返回服务环境变量（ServerConfig.EnvParams）明文值（仅 action=detail 时生效）。默认 false，值脱敏为 \"***\"（保留 key，足够排查配置了哪些变量、变更是否生效）；true 时返回明文，敏感变量（如带密码的 DATABASE_URL）可能暴露给模型上下文，谨慎使用"
           }
         },
         "required": [


### PR DESCRIPTION
## 问题

`queryCloudRun(action="detail")` 把 `cloudrunService.detail()` 的全量返回放进 `data.service`，其中 `ServerConfig.EnvParams` 是服务环境变量的 **JSON 明文串**——云托管场景的典型内容是带密码的连接串（如 `DATABASE_URL`）。在 MCP 场景下，工具返回值会进入模型上下文，被 IDE 日志、模型服务等多方接触，敏感值一旦进入上下文即脱离"仅运行时配置"的信任边界，且轮换无法根治（下一次调用又暴露）。

前提说明：调用方需已持有该环境的合法授权凭据，因此这不是权限提升类漏洞，而是工具返回面与 agent 上下文之间缺敏感字段边界的问题。

已核实其余读取面不带 EnvParams（`getDeployRecords` / `list` / `OnlineVersionInfos` 均无），`deploy` / `updateConfig` 返回路径此前已按 key-only 收敛（`summarizeConfigSnapshot`），本 PR 将 `detail` 路径对齐同一惯例。

## 修复方案

**默认脱敏 + 显式口子**（与 #974 云函数侧修复同模式）：

- `detail` 默认将 `ServerConfig.EnvParams` 的值脱敏为 `***`、保留 key——足以支撑"配了哪些变量""变更是否生效"等常见 agent 操作
- 新增 `revealEnvParams` 入参（默认 `false`），显式传 `true` 时返回明文，覆盖确有读回需求的场景；工具 description 中标注了风险
- 环境变量串非 JSON 时整串替换为 `***`，不保留任何明文片段
- 同步重新生成 `scripts/tools.json` / `doc/mcp-tools.md`，补 CHANGELOG

## 测试

- 新增 5 个单测：默认脱敏（key 保留）、`revealEnvParams=true` 明文口子、非 JSON 整串脱敏、空值原样返回、schema 校验
- `cloudrun-detail-envparams.test.ts` 5 用例全部通过；`npm run build` 通过
