### PR TITLE
fix(apps): harden cloud-mode deployApp localPath gate

### DIFF
--- a/mcp/src/tools/apps.test.ts
+++ b/mcp/src/tools/apps.test.ts
@@ -13,6 +13,10 @@ const {
   mockCreateApp,
   mockDescribeBuildLog,
   mockDescribeCosInfo,
+  mockDeleteApp,
+  mockDeleteAppVersion,
+  mockIsCloudMode,
+  mockGetEnvId,
 } = vi.hoisted(() => ({
   mockGetCloudBaseManager: vi.fn(),
   mockLogCloudBaseResult: vi.fn(),
@@ -24,15 +28,20 @@ const {
   mockCreateApp: vi.fn(),
   mockDescribeBuildLog: vi.fn(),
   mockDescribeCosInfo: vi.fn(),
+  mockDeleteApp: vi.fn(),
+  mockDeleteAppVersion: vi.fn(),
+  mockIsCloudMode: vi.fn(() => false),
+  mockGetEnvId: vi.fn(async () => "env-test"),
 }));
 
 vi.mock("../cloudbase-manager.js", () => ({
   getCloudBaseManager: mockGetCloudBaseManager,
+  getEnvId: mockGetEnvId,
   logCloudBaseResult: mockLogCloudBaseResult,
 }));
 
 vi.mock("../utils/cloud-mode.js", () => ({
-  isCloudMode: () => false,
+  isCloudMode: mockIsCloudMode,
 }));
 
 function createMockServer() {
@@ -56,6 +65,8 @@ describe("app tools", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsCloudMode.mockReturnValue(false);
+    mockGetEnvId.mockResolvedValue("env-test");
     mockDescribeAppList.mockResolvedValue({
       Total: 1,
       ServiceList: [{ ServiceName: "demo-app" }],
@@ -88,6 +99,12 @@ describe("app tools", () => {
       VersionName: "v1",
       RequestId: "req-app-create",
     });
+    mockDeleteApp.mockResolvedValue({
+      RequestId: "req-app-delete",
+    });
+    mockDeleteAppVersion.mockResolvedValue({
+      RequestId: "req-app-delete-version",
+    });
     mockDescribeBuildLog.mockResolvedValue({
       Response: {
         Total: 2,
@@ -113,6 +130,8 @@ describe("app tools", () => {
         uploadCode: mockUploadCode,
         createApp: mockCreateApp,
         describeCosInfo: mockDescribeCosInfo,
+        deleteApp: mockDeleteApp,
+        deleteAppVersion: mockDeleteAppVersion,
       },
       commonService: () => ({
         call: mockDescribeBuildLog,
@@ -235,6 +254,72 @@ describe("app tools", () => {
         serviceName: "demo-app",
       },
     });
+  });
+
+  it("cloud mode deployApp rejects localPath", async () => {
+    mockIsCloudMode.mockReturnValue(true);
+
+    const result = await tools.manageApps.handler({
+      action: "deployApp",
+      serviceName: "demo-app",
+      filePath: "/etc",
+      buildPath: "dist",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockUploadCode).not.toHaveBeenCalled();
+    expect(mockCreateApp).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      success: false,
+      code: "CLOUD_MODE_UNSUPPORTED_ACTION",
+      data: {
+        code: "CLOUD_MODE_UNSUPPORTED_ACTION",
+        action: "deployApp",
+        reason: "localPath",
+      },
+    });
+    expect(payload.message).toContain("localPath");
+  });
+
+  it("cloud mode deleteApp still works", async () => {
+    mockIsCloudMode.mockReturnValue(true);
+
+    const result = await tools.manageApps.handler({
+      action: "deleteApp",
+      serviceName: "demo-app",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockDeleteApp).toHaveBeenCalledWith({
+      deployType: "static-hosting",
+      serviceName: "demo-app",
+    });
+    expect(mockUploadCode).not.toHaveBeenCalled();
+    expect(payload).toMatchObject({
+      success: true,
+      data: {
+        action: "deleteApp",
+        serviceName: "demo-app",
+      },
+    });
+  });
+
+  it("cloud mode deployApp with cosTimestamp still works", async () => {
+    mockIsCloudMode.mockReturnValue(true);
+
+    const result = await tools.manageApps.handler({
+      action: "deployApp",
+      serviceName: "demo-app",
+      cosTimestamp: "1741234567",
+      framework: "static",
+      installCmd: "",
+      buildCmd: "",
+    });
+    const payload = JSON.parse(result.content[0].text);
+
+    expect(mockUploadCode).not.toHaveBeenCalled();
+    expect(mockCreateApp).toHaveBeenCalled();
+    expect(payload.success).toBe(true);
   });
 
   it("manageApps(action=getUploadUrl) should return pre-signed URL", async () => {

--- a/mcp/src/tools/apps.ts
+++ b/mcp/src/tools/apps.ts
@@ -16,6 +16,7 @@ type ToolEnvelope = {
   success: boolean;
   data: Record<string, unknown>;
   message: string;
+  code?: string;
 };
 
 function buildEnvelope(data: Record<string, unknown>, message: string): ToolEnvelope {
@@ -26,11 +27,41 @@ function buildEnvelope(data: Record<string, unknown>, message: string): ToolEnve
   };
 }
 
-function buildErrorEnvelope(error: unknown): ToolEnvelope {
+function buildErrorEnvelope(error: unknown, code?: string): ToolEnvelope {
   return {
     success: false,
-    data: {},
+    data: code ? { code } : {},
     message: error instanceof Error ? error.message : String(error),
+    ...(code ? { code } : {}),
+  };
+}
+
+const CLOUD_MODE_UNSUPPORTED_ACTION = "CLOUD_MODE_UNSUPPORTED_ACTION";
+
+function buildCloudModeUnsupportedDeployEnvelope(serviceName: string, reason: "localPath" | "missingCosTimestamp"): ToolEnvelope {
+  const message =
+    reason === "localPath"
+      ? "CLOUD_MODE_UNSUPPORTED_ACTION: cloud mode does not support deployApp with localPath/filePath " +
+        "(server has no trusted local filesystem). Use getUploadUrl → HTTP PUT zip → deployApp(cosTimestamp), " +
+        "or run manageApps in local stdio mode / CLI."
+      : "CLOUD_MODE_UNSUPPORTED_ACTION: cloud mode deployApp requires cosTimestamp. " +
+        "Call getUploadUrl first, upload the zip to the pre-signed URL, then pass cosTimestamp.";
+
+  return {
+    success: false,
+    code: CLOUD_MODE_UNSUPPORTED_ACTION,
+    data: {
+      code: CLOUD_MODE_UNSUPPORTED_ACTION,
+      action: "deployApp",
+      serviceName,
+      reason,
+      nextStep: {
+        tool: "manageApps",
+        args: { action: "getUploadUrl", serviceName },
+        hint: "getUploadUrl → PUT zip to uploadUrl → deployApp(cosTimestamp)",
+      },
+    },
+    message,
   };
 }
 
@@ -453,23 +484,24 @@ export function registerAppTools(server: ExtendedMcpServer) {
         }
 
         if (action === "deployApp") {
-          // cloud mode 下必须有 cosTimestamp；本地模式必须有 filePath
+          // Per-action cloud gate: never read caller-controlled local paths in cloud mode.
+          // Upload channel: getUploadUrl → agent HTTP PUT zip → deployApp(cosTimestamp).
           if (isCloudMode()) {
+            if (filePath) {
+              return jsonContent(buildCloudModeUnsupportedDeployEnvelope(serviceName, "localPath"));
+            }
             if (!cosTimestamp) {
-              throw new Error(
-                "cloud mode 下 deployApp 需要 cosTimestamp 参数。请先调用 getUploadUrl 获取预签名上传 URL。" +
-                "上传代码后再用 cosTimestamp 调用 deployApp。",
-              );
+              return jsonContent(buildCloudModeUnsupportedDeployEnvelope(serviceName, "missingCosTimestamp"));
             }
           } else if (!filePath && !cosTimestamp) {
             throw new Error("action=deployApp 时必须提供 filePath（本地模式）或 cosTimestamp（cloud mode）。");
           }
 
-          // 上传代码到 COS（仅本地模式需要，cloud mode 用 cosTimestamp 跳过）
+          // Local stdio only: pack directory and upload. Cloud mode must never reach uploadCode.
           let cosTs = cosTimestamp;
-          if (filePath && !cosTs) {
-            // 默认排除大目录（2026-08-14 实证：ato 项目 target/ 54GB 被整个打进 zip）
-            // 用户显式传 ignore 时合并，避免覆盖默认值
+          if (!isCloudMode() && filePath && !cosTs) {
+            // Default excludes large build dirs (empirically target/ can be tens of GB).
+            // Merge caller ignore with defaults so explicit ignore does not drop safety excludes.
             const mergedIgnore = Array.from(new Set([
               ...defaultPackIgnore,
               ...(ignore ?? []),

--- a/mcp/src/utils/cloud-mode.ts
+++ b/mcp/src/utils/cloud-mode.ts
@@ -84,6 +84,10 @@ export function shouldRegisterTool(toolName: string): boolean {
     'manageCloudRun',
     // Download tools - local file downloads
     'manageStorage',
+
+    // manageApps is intentionally NOT listed: deployApp with localPath/filePath is
+    // blocked per-action in apps.ts (CLOUD_MODE_UNSUPPORTED_ACTION) so cloud mode
+    // can still use getUploadUrl + cosTimestamp, deleteApp, and deleteAppVersion.
   ];
 
   return !cloudIncompatibleTools.includes(toolName);


### PR DESCRIPTION
## Summary

- Harden `manageApps(action=deployApp)` cloud-mode gate: reject `filePath`/`localPath` with structured `CLOUD_MODE_UNSUPPORTED_ACTION` and never call `uploadCode` (closes arbitrary directory pack/exfil via cloud MCP).
- Keep upload-channel deploy (`getUploadUrl` → PUT zip → `deployApp(cosTimestamp)`) and cloud-safe `deleteApp` / `deleteAppVersion`; do **not** add `manageApps` to `cloudIncompatibleTools` (documented in comment).
- Add tests: `cloud mode deployApp rejects localPath`, `cloud mode deleteApp still works`, plus cosTimestamp regression in cloud mode.

## Context

Cloud MCP (`--cloud-mode`) previously allowed `manageApps` deploy with caller-controlled local paths. Server-side `uploadCode` packs any readable directory to COS and returns a public hosting URL. Local stdio deploy via `filePath` is unchanged intentional capability.

## Test plan

- [x] `cd mcp && npm run build`
- [x] `cd mcp && npx vitest run src/tools/apps.test.ts`
- [x] grep checks for `isCloudMode`, `CLOUD_MODE_UNSUPPORTED_ACTION`, test name
- [ ] CI green on this PR

