### PR TITLE
feat(env-binding): use cloudbaserc.json as field-level binding fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. Follow the 
 
 ## Unreleased
 
+### Features
+
+* **env-binding**: `cloudbaserc.json` 现在作为环境绑定的字段级回退源（envId / region / site），位于 `.cloudbase/project.json` 之后、账号登录态之前。已有 CLI 项目无需再维护第二份绑定配置：envId 支持字面量与 `{{env.KEY}}` 模板（模板从项目根 `.env` / `.env.local` 解析，与 CLI 同源；`{{private.X}}` 与解析失败的模板安全跳过、回落下一级）。MCP 仍不写 `cloudbaserc.json`，机器管理的绑定持久化继续走 `.cloudbase/project.json`。注意这是对存量 CLI 用户的行为变化：以前 `cloudbaserc.json` 的 envId 不影响 MCP 环境绑定，现在会自动生效。
+
 ## [2.32.5](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/compare/v2.32.4...v2.32.5) (2026-09-01)
 
 ### Features

--- a/doc/connection-modes.mdx
+++ b/doc/connection-modes.mdx
@@ -132,6 +132,7 @@ CloudBase 有**国内站**（`domestic`，cloud.tencent.com）与**国际站**�
 显式 cloudBaseOptions.site/region
   > 环境变量 TCB_SITE / TCB_REGION
   > 项目级配置 .cloudbase/project.json
+  > cloudbaserc.json（按字段回退，site 为 MCP 扩展字段）
   > 全局默认：domestic + ap-shanghai
 ```
 
@@ -195,9 +196,16 @@ CloudBase 有**国内站**（`domestic`，cloud.tencent.com）与**国际站**�
   > 环境变量 CLOUDBASE_ENV_ID
   > 当前进程内已绑定的环境（auth(action="set_env") 结果）
   > 项目级配置 .cloudbase/project.json 的 envId
+  > cloudbaserc.json 的 envId（按字段回退）
   > 账号登录态里的环境
   > 返回 ENV_REQUIRED，引导调用 auth(action="set_env")
 ```
+
+`cloudbaserc.json` 回退源说明（面向已有 CLI 项目，无需重复维护绑定配置）：
+
+- **按字段回退**：project.json 与 cloudbaserc.json 各字段独立互补（如 project.json 只写 site、cloudbaserc.json 只写 envId 时两边同时生效），同一字段以 project.json 优先
+- **envId / region 支持字面量与 `{{env.KEY}}` 模板**：模板从项目根 `.env` / `.env.local` 解析（与 CLI 同源）；`{{private.X}}` 及解析失败的模板会被跳过，继续走下一级，不会报错
+- **MCP 不写 cloudbaserc.json**：它是 CLI 维护的人工部署配置（CLI 部署后还会自动回写）；机器管理的绑定持久化走 `.cloudbase/project.json`
 
 因为该文件在仓库内且随仓库提交，所以新起的 MCP 进程、以及同一仓库的每个 Git worktree 都会自动命中同一环境，无需为每个 worktree 重新 `set_env`；不同仓库各读自己的文件，绑定不会互相串。
 

--- a/mcp/src/cloudbase-manager.test.ts
+++ b/mcp/src/cloudbase-manager.test.ts
@@ -20,14 +20,16 @@ const mockEnsureLogin = vi.fn();
 const mockCommonServiceCall = vi.fn();
 const mockListEnvs = vi.fn();
 
-const { mockReadProjectConfig, mockReadProjectEnvId } = vi.hoisted(() => ({
+const { mockReadProjectConfig, mockReadProjectEnvId, mockReadCloudbaseRcBinding } = vi.hoisted(() => ({
   mockReadProjectConfig: vi.fn(),
   mockReadProjectEnvId: vi.fn(),
+  mockReadCloudbaseRcBinding: vi.fn(),
 }));
 
 vi.mock("./utils/project-config.js", () => ({
   readProjectConfig: mockReadProjectConfig,
   readProjectEnvId: mockReadProjectEnvId,
+  readCloudbaseRcBinding: mockReadCloudbaseRcBinding,
 }));
 
 vi.mock("./auth.js", () => ({
@@ -55,6 +57,7 @@ describe("cloudbase manager auth gate", () => {
     delete process.env.CLOUDBASE_ENV_ID;
     mockReadProjectConfig.mockReturnValue(undefined);
     mockReadProjectEnvId.mockReturnValue(undefined);
+    mockReadCloudbaseRcBinding.mockReturnValue(undefined);
     mockAuthGetProgressState.mockResolvedValue({
       status: "IDLE",
       updatedAt: Date.now(),
@@ -548,6 +551,7 @@ describe("listAvailableEnvCandidates region scope", () => {
     delete process.env.CLOUDBASE_ENV_ID;
     mockReadProjectConfig.mockReturnValue(undefined);
     mockReadProjectEnvId.mockReturnValue(undefined);
+    mockReadCloudbaseRcBinding.mockReturnValue(undefined);
     mockPeekLoginState.mockResolvedValue({
       secretId: "sid",
       secretKey: "skey",
@@ -602,6 +606,7 @@ describe("project-pinned envId (.cloudbase/project.json)", () => {
     delete process.env.TCB_SITE;
     mockReadProjectConfig.mockReturnValue(undefined);
     mockReadProjectEnvId.mockReturnValue(undefined);
+    mockReadCloudbaseRcBinding.mockReturnValue(undefined);
     mockAuthGetProgressState.mockResolvedValue({
       status: "IDLE",
       updatedAt: Date.now(),
@@ -622,6 +627,7 @@ describe("project-pinned envId (.cloudbase/project.json)", () => {
 
   afterEach(() => {
     mockReadProjectEnvId.mockReturnValue(undefined);
+    mockReadCloudbaseRcBinding.mockReturnValue(undefined);
     delete process.env.CLOUDBASE_ENV_ID;
   });
 

--- a/mcp/src/cloudbase-manager.ts
+++ b/mcp/src/cloudbase-manager.ts
@@ -340,11 +340,12 @@ class EnvironmentManager {
                 return this.cachedEnvId;
             }
 
-            // 2. 项目级配置固定的环境（`.cloudbase/project.json` 的 envId）
+            // 2. 项目级配置固定的环境（.cloudbase/project.json 的 envId，
+            //    回退 cloudbaserc.json 的字面量/{{env.*}} envId）
             // 优先于账号级登录态：登录态是全局的，可能指向另一个仓库绑定的环境。
             const projectEnvId = readProjectEnvId();
             if (projectEnvId) {
-                debug('使用项目配置(.cloudbase/project.json)的环境ID:', { envId: projectEnvId });
+                debug('使用项目配置(project.json/cloudbaserc.json)的环境ID:', { envId: projectEnvId });
                 this._setCachedEnvId(projectEnvId);
                 return projectEnvId;
             }
@@ -644,7 +645,7 @@ export async function getCloudBaseManager(options: GetManagerOptions = {}): Prom
                     finalEnvId = cachedEnvId;
                 } else if (projectEnvId) {
                     // 项目级绑定优先于全局登录态 envId：后者可能来自另一个仓库
-                    debug('使用项目配置(.cloudbase/project.json)的环境ID:', { projectEnvId });
+                    debug('使用项目配置(project.json/cloudbaserc.json)的环境ID:', { projectEnvId });
                     await envManager.setEnvId(projectEnvId);
                     finalEnvId = projectEnvId;
                 } else if (loginEnvId) {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -927,7 +927,7 @@ async function prepareAuthEnvironment(params: {
   const currentEnvId =
     getCachedEnvId() ||
     process.env.CLOUDBASE_ENV_ID ||
-    // 项目级绑定（`.cloudbase/project.json` 的 envId）优先于账号级登录态：
+    // 项目级绑定（.cloudbase/project.json 的 envId，回退 cloudbaserc.json）优先于账号级登录态：
     // 登录态是全局的，可能指向别的仓库绑定的环境。
     readProjectEnvId() ||
     (typeof loginState?.envId === "string" && loginState.envId.length > 0

--- a/mcp/src/utils/project-config.test.ts
+++ b/mcp/src/utils/project-config.test.ts
@@ -2,11 +2,17 @@ import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { readProjectConfig, readProjectEnvId } from "./project-config.js";
+import { readCloudbaseRcBinding, readProjectConfig, readProjectEnvId } from "./project-config.js";
 
 function writeProjectConfig(dir: string, config: Record<string, unknown>) {
   mkdirSync(join(dir, ".cloudbase"), { recursive: true });
   writeFileSync(join(dir, ".cloudbase", "project.json"), JSON.stringify(config), "utf-8");
+  return dir;
+}
+
+function writeCloudbaseRc(dir: string, config: Record<string, unknown>) {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "cloudbaserc.json"), JSON.stringify(config), "utf-8");
   return dir;
 }
 
@@ -98,5 +104,117 @@ describe("readProjectEnvId", () => {
   it("should trim surrounding whitespace", () => {
     const dir = writeProjectConfig(join(tempDir, "padded"), { envId: " env-project-a\n" });
     expect(readProjectEnvId(dir)).toBe("env-project-a");
+  });
+});
+
+describe("readCloudbaseRcBinding", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "cloudbase-rc-binding-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should return undefined when cloudbaserc.json does not exist", () => {
+    expect(readCloudbaseRcBinding(tempDir)).toBeUndefined();
+  });
+
+  it("should read literal envId and region", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "literal"), {
+      envId: "env-rc-literal",
+      region: "ap-shanghai",
+    });
+
+    expect(readCloudbaseRcBinding(dir)).toEqual({
+      envId: "env-rc-literal",
+      region: "ap-shanghai",
+    });
+  });
+
+  it("should resolve {{env.X}} template from project .env", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "template"), { envId: "{{env.TCB_TEST_ENV_ID}}" });
+    writeFileSync(join(dir, ".env"), "TCB_TEST_ENV_ID=env-from-dotenv\n", "utf-8");
+
+    expect(readCloudbaseRcBinding(dir)?.envId).toBe("env-from-dotenv");
+  });
+
+  it("should prefer .env.local over .env for template resolution", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "local-overrides"), {
+      envId: "{{env.TCB_TEST_ENV_ID}}",
+    });
+    writeFileSync(join(dir, ".env"), "TCB_TEST_ENV_ID=env-base\n", "utf-8");
+    writeFileSync(join(dir, ".env.local"), "TCB_TEST_ENV_ID=env-local\n", "utf-8");
+
+    expect(readCloudbaseRcBinding(dir)?.envId).toBe("env-local");
+  });
+
+  it("should skip {{private.X}} and unknown template syntax", () => {
+    expect(
+      readCloudbaseRcBinding(writeCloudbaseRc(join(tempDir, "private"), { envId: "{{private.ENV_ID}}" })),
+    ).toBeUndefined();
+    expect(
+      readCloudbaseRcBinding(writeCloudbaseRc(join(tempDir, "unknown"), { envId: "{{deploy.envId}}" })),
+    ).toBeUndefined();
+  });
+
+  it("should return undefined when the referenced .env key is missing", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "missing-key"), { envId: "{{env.NOT_PRESENT}}" });
+
+    expect(readCloudbaseRcBinding(dir)?.envId).toBeUndefined();
+  });
+
+  it("should return undefined on malformed JSON without throwing", () => {
+    const dir = join(tempDir, "broken");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, "cloudbaserc.json"), "{invalid", "utf-8");
+
+    expect(readCloudbaseRcBinding(dir)).toBeUndefined();
+  });
+
+  it("should return raw site value for the MCP extension field", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "site"), { site: "intl" });
+
+    expect(readCloudbaseRcBinding(dir)?.site).toBe("intl");
+  });
+});
+
+describe("readProjectEnvId fallback to cloudbaserc.json", () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), "cloudbase-env-fallback-"));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it("should fall back to cloudbaserc.json envId when project.json is absent", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "rc-only"), { envId: "env-rc-only" });
+
+    expect(readProjectEnvId(dir)).toBe("env-rc-only");
+  });
+
+  it("should let project.json envId win over cloudbaserc.json", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "both"), { envId: "env-rc" });
+    writeProjectConfig(dir, { envId: "env-project" });
+
+    expect(readProjectEnvId(dir)).toBe("env-project");
+  });
+
+  it("should fall back to cloudbaserc.json when project.json envId is blank", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "blank-project"), { envId: "env-rc" });
+    writeProjectConfig(dir, { envId: "   " });
+
+    expect(readProjectEnvId(dir)).toBe("env-rc");
+  });
+
+  it("should keep behavior unchanged when neither file defines envId", () => {
+    const dir = writeCloudbaseRc(join(tempDir, "region-only"), { region: "ap-shanghai" });
+
+    expect(readProjectEnvId(dir)).toBeUndefined();
   });
 });

--- a/mcp/src/utils/project-config.ts
+++ b/mcp/src/utils/project-config.ts
@@ -1,6 +1,104 @@
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
+import { loadEnvVariables } from "@cloudbase/toolbox";
 import type { ProjectConfig } from "./site-map.js";
+
+const CLOUDBASE_RC_FILENAME = "cloudbaserc.json";
+
+/**
+ * `cloudbaserc.json` 中对绑定有效的字段。
+ *
+ * MCP 对该文件**只读不写**：它是 CLI 维护的人工部署配置（CLI 部署成功后会自动回写），
+ * 绑定语义的持久化由 `.cloudbase/project.json`（机器管理）承担。
+ */
+export interface CloudBaseRcBinding {
+  envId?: string;
+  region?: string;
+  /** MCP 扩展字段（官方 schema 尚未收录，additionalProperties: true），原样返回由调用方 normalize */
+  site?: string;
+}
+
+/**
+ * 解析 cloudbaserc.json 字段值用于绑定（fail-safe：解析不出一律返回 undefined 回落下一级）：
+ * - 字面量 → trim 后直接返回
+ * - `{{env.KEY}}` → 从项目根 `.env` / `.env.local` 解析（复用 @cloudbase/toolbox 的
+ *   loadEnvVariables，与 CLI 解析 `{{env.X}}` 同源）；key 缺失/值为空 → undefined
+ * - `{{private.X}}` / 其他模板语法 → undefined（私密配置与未知语法不进绑定链）
+ *
+ * 注意：loadEnvVariables 的 mode 取自 CLI 语境的 yargs.argv.mode，MCP 进程内为 undefined，
+ * 即只读 `.env` 与 `.env.local`——MCP 没有"部署模式"概念，该语义是安全的。
+ */
+function resolveBindingValue(raw: string, projectRoot: string): string | undefined {
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) {
+    return undefined;
+  }
+  const template = /^\{\{([^{}]+)\}\}$/.exec(trimmed);
+  if (!template) {
+    return trimmed;
+  }
+  const templatePath = template[1].trim();
+  if (templatePath.startsWith("private.") || !templatePath.startsWith("env.")) {
+    return undefined;
+  }
+  const key = templatePath.slice("env.".length).trim();
+  if (!key) {
+    return undefined;
+  }
+  try {
+    const envVars = loadEnvVariables(projectRoot) as Record<string, unknown>;
+    let value: unknown = envVars;
+    for (const part of key.split(".")) {
+      if (!value || typeof value !== "object") {
+        value = undefined;
+        break;
+      }
+      value = (value as Record<string, unknown>)[part];
+    }
+    if (typeof value !== "string") {
+      return undefined;
+    }
+    const normalized = value.trim();
+    return normalized.length > 0 ? normalized : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * 读取 `cloudbaserc.json` 中绑定相关的字段（envId / region / site）。
+ *
+ * CLI 项目往往已有该文件（官方契约含 envId + region）；按**字段级**回退与
+ * `.cloudbase/project.json` 互补，而不是整文件二选一。只处理 `cloudbaserc.json`
+ * （JSON）；`cloudbaserc.js` / `.ts` 需要执行代码，出于安全考虑不读取。
+ * 读失败/文件不存在/无有效字段返回 undefined，不阻塞调用方。
+ */
+export function readCloudbaseRcBinding(cwd?: string): CloudBaseRcBinding | undefined {
+  try {
+    const projectRoot = cwd ?? process.env.WORKSPACE_FOLDER_PATHS ?? process.cwd();
+    const configPath = join(projectRoot, CLOUDBASE_RC_FILENAME);
+    if (!existsSync(configPath)) {
+      return undefined;
+    }
+    const parsed = JSON.parse(readFileSync(configPath, "utf-8"));
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    const binding: CloudBaseRcBinding = {};
+    if (typeof parsed.envId === "string") {
+      binding.envId = resolveBindingValue(parsed.envId, projectRoot);
+    }
+    if (typeof parsed.region === "string") {
+      binding.region = resolveBindingValue(parsed.region, projectRoot);
+    }
+    if (typeof parsed.site === "string" && parsed.site.trim().length > 0) {
+      binding.site = parsed.site.trim();
+    }
+    return binding.envId || binding.region || binding.site ? binding : undefined;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * 读取项目级配置 `.cloudbase/project.json`。
@@ -28,18 +126,23 @@ export function readProjectConfig(cwd?: string): ProjectConfig | undefined {
 }
 
 /**
- * 读取项目级配置里的默认环境（`.cloudbase/project.json` 的 `envId`）。
+ * 读取项目级绑定的环境 ID。
  *
- * 该字段让环境绑定跟随仓库工作区，而不是跟随单个 MCP 进程：
- * 新起的 stdio 进程、以及同一仓库的每个 Git worktree（`.cloudbase/project.json`
- * 已提交，各 worktree 都有该文件）都能直接命中同一环境，无需重复 `auth(set_env)`；
- * 不同仓库各读自己的文件，绑定不会互相串。
+ * 来源与优先级：
+ * 1. `.cloudbase/project.json` 的 `envId`（MCP 机器管理的绑定文件）
+ * 2. `cloudbaserc.json` 的 `envId`（CLI 项目已有配置，字面量或 `{{env.X}}` 模板）
+ *
+ * 该绑定让环境跟随仓库工作区，而不是跟随单个 MCP 进程：
+ * 新起的 stdio 进程、以及同一仓库的每个 Git worktree 都能直接命中同一环境，
+ * 无需重复 `auth(set_env)`；不同仓库各读自己的文件，绑定不会互相串。
  */
 export function readProjectEnvId(cwd?: string): string | undefined {
   const envId = readProjectConfig(cwd)?.envId;
-  if (typeof envId !== "string") {
-    return undefined;
+  if (typeof envId === "string") {
+    const trimmed = envId.trim();
+    if (trimmed.length > 0) {
+      return trimmed;
+    }
   }
-  const trimmed = envId.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
+  return readCloudbaseRcBinding(cwd)?.envId;
 }

--- a/mcp/src/utils/site-map.test.ts
+++ b/mcp/src/utils/site-map.test.ts
@@ -1,11 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockReadProjectConfig } = vi.hoisted(() => ({
+const { mockReadProjectConfig, mockReadCloudbaseRcBinding } = vi.hoisted(() => ({
   mockReadProjectConfig: vi.fn(),
+  mockReadCloudbaseRcBinding: vi.fn(),
 }));
 
 vi.mock("./project-config.js", () => ({
   readProjectConfig: mockReadProjectConfig,
+  readCloudbaseRcBinding: mockReadCloudbaseRcBinding,
 }));
 
 import {
@@ -145,6 +147,45 @@ describe("resolveSiteAndRegion priority chain", () => {
       region: "ap-shanghai",
     });
   });
+
+  it("should fall back to cloudbaserc.json when project config is absent", () => {
+    mockReadCloudbaseRcBinding.mockReturnValue({
+      site: "intl",
+      region: "ap-singapore",
+    });
+    expect(resolveSiteAndRegion()).toEqual({
+      site: "intl",
+      region: "ap-singapore",
+    });
+  });
+
+  it("should fall back to cloudbaserc.json per field when project config is partial", () => {
+    // project.json 只写 site，cloudbaserc.json 只写 region：字段级互补，不是整文件二选一
+    mockReadProjectConfig.mockReturnValue({ site: "domestic" });
+    mockReadCloudbaseRcBinding.mockReturnValue({ region: "ap-singapore" });
+    expect(resolveSiteAndRegion()).toEqual({
+      site: "domestic",
+      region: "ap-singapore",
+    });
+  });
+
+  it("should let project config override cloudbaserc.json", () => {
+    mockReadProjectConfig.mockReturnValue({ site: "domestic", region: "ap-shanghai" });
+    mockReadCloudbaseRcBinding.mockReturnValue({ site: "intl", region: "ap-singapore" });
+    expect(resolveSiteAndRegion()).toEqual({
+      site: "domestic",
+      region: "ap-shanghai",
+    });
+  });
+
+  it("should let env override cloudbaserc.json", () => {
+    mockReadCloudbaseRcBinding.mockReturnValue({ site: "intl" });
+    process.env.TCB_SITE = "domestic";
+    expect(resolveSiteAndRegion()).toEqual({
+      site: "domestic",
+      region: "ap-shanghai",
+    });
+  });
 });
 
 describe("resolveApiKeyExchangeRegion", () => {
@@ -153,6 +194,7 @@ describe("resolveApiKeyExchangeRegion", () => {
     delete process.env.TCB_SITE;
     delete process.env.TCB_REGION;
     mockReadProjectConfig.mockReturnValue(undefined);
+    mockReadCloudbaseRcBinding.mockReturnValue(undefined);
   });
 
   it("should return intl region only for explicit intl site", () => {

--- a/mcp/src/utils/site-map.ts
+++ b/mcp/src/utils/site-map.ts
@@ -1,4 +1,4 @@
-import { readProjectConfig } from "./project-config.js";
+import { readCloudbaseRcBinding, readProjectConfig } from "./project-config.js";
 
 export type SiteId = "domestic" | "intl";
 
@@ -136,21 +136,24 @@ export interface ProjectConfig {
 /**
  * 统一 site/region 解析入口（收敛各调用点分散的 region fallback）。
  *
- * 优先级：显式参数 > 环境变量（TCB_SITE/TCB_REGION）> 项目配置（.cloudbase/project.json）> 全局默认
- * （site=domestic, region=ap-shanghai）。
+ * 优先级：显式参数 > 环境变量（TCB_SITE/TCB_REGION）> 项目配置（.cloudbase/project.json）
+ * > cloudbaserc.json（CLI 项目已有配置，按字段回退）> 全局默认（site=domestic, region=ap-shanghai）。
  *
  * 当仅指定 region 且该 region 在多个 site 的地域列表中都存在（如 ap-singapore）时，
  * 返回 site=intl 并标记 ambiguous=true（兼容既有国际站行为），调用方可用 ambiguous 提示用户显式指定 site。
  */
 export function resolveSiteAndRegion(opts: { site?: string; region?: string } = {}): SiteResolution {
   const projectConfig = readProjectConfig();
+  const rcBinding = readCloudbaseRcBinding();
 
   const explicitSite =
     normalizeSite(opts.site) ??
     normalizeSite(process.env.TCB_SITE) ??
-    normalizeSite(projectConfig?.site);
+    normalizeSite(projectConfig?.site) ??
+    normalizeSite(rcBinding?.site);
 
-  const explicitRegion = opts.region ?? process.env.TCB_REGION ?? projectConfig?.region;
+  const explicitRegion =
+    opts.region ?? process.env.TCB_REGION ?? projectConfig?.region ?? rcBinding?.region;
 
   let site = explicitSite;
   let ambiguous = false;


### PR DESCRIPTION
## Summary

Follow-up to #982 / #983: `cloudbaserc.json` now serves as a **field-level fallback source** for environment binding, so projects that already use the CloudBase CLI don't need to maintain a second binding config.

## Resolution chain (after this PR)

```
envId:   explicit > CLOUDBASE_ENV_ID > in-process set_env > .cloudbase/project.json > cloudbaserc.json > login state > ENV_REQUIRED
site:    explicit > TCB_SITE > project.json > cloudbaserc.json > region inference > domestic
region:  explicit > TCB_REGION > project.json > cloudbaserc.json > site default
```

## Design points

- **Field-level fallback, not whole-file switch**: `project.json` and `cloudbaserc.json` complement each other per field (e.g. project.json only pins `site`, cloudbaserc.json only has `envId` — both take effect). Same field prefers `project.json`.
- **Template variables are supported**: `envId` / `region` accept literals and `{{env.KEY}}` templates. Templates are resolved from the project-root `.env` / `.env.local` via `@cloudbase/toolbox`'s `loadEnvVariables` — the same resolution source the CLI uses for `{{env.X}}`, so CLI users' existing `.env` workflows keep working. (`{{private.X}}` and unresolvable templates are safely skipped and fall through to the next level — never an error.)
- **MCP never writes `cloudbaserc.json`**: it is CLI-owned human deploy config (the CLI auto-writes it back after deploys). Machine-managed binding persistence stays in `.cloudbase/project.json` (the Vercel `vercel.json` / `.vercel/project.json` split).
- **`site` is a forward-compatible MCP extension field** on cloudbaserc.json (official schema has no `site` yet, `additionalProperties: true`), consumed via `normalizeSite`.
- Only `cloudbaserc.json` (JSON) is read; `cloudbaserc.js` / `.ts` are intentionally not executed.

## Behavior change note

For existing CLI users: previously `cloudbaserc.json`'s `envId` had no effect on MCP binding; now it binds automatically (below project.json, above login state). Called out in the CHANGELOG.

## Tests

- `project-config.test.ts`: literal / `{{env.X}}` from `.env` / `.env.local` precedence / `{{private.X}}` skipped / unknown templates skipped / missing key falls through / malformed JSON / project.json-vs-cloudbaserc precedence (10 new cases)
- `site-map.test.ts`: field-level fallback, project.json > cloudbaserc, env > cloudbaserc (4 new cases)
- `cloudbase-manager.test.ts` 22/22, `tools/env.test.ts` 83/83, `tsc --noEmit` clean

Refs #982
