### PR TITLE
refactor(dsh-plugin): 下线右侧 details 面板（0.1.0 精简）

### DIFF
--- a/dsh-plugin/AGENTS.md
+++ b/dsh-plugin/AGENTS.md
@@ -11,7 +11,7 @@ This directory is the npm package that plugs CloudBase into DeepSeek Harness.
 ## Source of truth
 
 - Host entry: `src/server/index.ts` (`apply`, `cloudbaseData` typert object)
-- Client entry: `src/client/index.ts` (slots: toolview / turnTail / details)
+- Client entry: `src/client/index.ts` (slots: toolview / turnTail；右侧 details 面板 0.1.0 已下线，组件源码保留待 v0.2 以 kit 形态回归，勿在 apply 里重新注册)
 - MCP patch: `cordis.patch.yml` — **never** pass `CLOUDBASE_API_KEY`
 - Product names: `src/server/term-map.ts` (no FLEXDB / SCF / TDSQL in UI)
 

--- a/dsh-plugin/HANDOFF.md
+++ b/dsh-plugin/HANDOFF.md
@@ -3,6 +3,13 @@
 > 接手 agent 请先读本文。需要 dsh-plugin 的历史上下文时看本地 `.workbuddy/memory/`（该目录不入库，缺失时跑 `npm run internal:restore` 恢复，见仓库根 `AGENTS.md` 的 `<internal_dirs>` 段）。
 > PR 状态：https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/pull/933（feat/dsh-plugin，OPEN MERGEABLE）
 
+## 〇、2026-09-04 裁剪：右侧 details 面板 0.1.0 下线
+
+- **决策**：0.1.0 重发 npm 前全砍右侧 details 面板（后端 5 tab + 预览 webview + 顶部胶囊 + 启动强开 + shadow 原生 details）。原因：开箱体验依赖宿主 layout patch（不随包分发），用户装到的是 300-520px 窄条且启动抢屏；核心价值（toolview 卡片/交付物行）全在聊天流、零面板耦合
+- **改动**：`src/client/index.ts` 移除 Panel 注册/withData/启动 openDetails、`inject` 去掉 layout；`styles.ts` 清掉 16 个面板专用死选择器；`DetailsPanel/` 组件源码保留（不注册不打包），v0.2 以 kit 形态回归时再接线
+- **验证**：vitest 110/110、tsc clean、esbuild 通过；bundle 中 `cloudbase-details`/`openDetails` 为 0，`cloudbase-deliverable`/`cloudbase-env-bound` 保留
+- **登录引导**：随面板下线后走 DSH 对话内（模型调 cloudbase auth 工具）；未登录 UI 入口是 v0.2 kit 的必修项
+
 ## 一、项目位置 & 核心信息
 
 - **仓库根**：`~/Projects/CloudBase-MCP/`（name=`cloudbase-ai-toolkit` v1.7.3，包管理 pnpm）

--- a/dsh-plugin/src/client/index.ts
+++ b/dsh-plugin/src/client/index.ts
@@ -11,29 +11,16 @@ import { ToolViewRouter } from "./components/ToolViewRouter.js";
 import { makeWriteOpToolCard } from "./components/WriteOpToolCard.js";
 import { DeliverableRow } from "./components/DeliverableRow.js";
 import { DeployPreviewCard } from "./components/DeployPreviewCard.js";
-import { DetailsPanel } from "./components/DetailsPanel/index.js";
 import { EnvBoundRow } from "./components/EnvBoundRow.js";
-import { openDetails, registerKeyedSlot, registerNamedSlot, type SlotHost } from "./lib/slots.js";
+import { registerKeyedSlot, registerNamedSlot, type SlotHost } from "./lib/slots.js";
 import { getDataService } from "./lib/typert.js";
 import { ensureStyles } from "./styles.js";
 
 export const name = "cloudbase-dsh-plugin-client";
 // connection 提供 /api RPC 通道（CloudBase 数据直调 host Remote，不依赖 ctx.remote 的
 // 编译期固定能力集）。不能 inject "remote.cloudbaseData"（第三方贡献不可注入）。
-export const inject = ["slots", "layout", "connection"];
-
-function withData(
-  ctx: SlotHost,
-  Component: React.ComponentType<{ cloudbaseData?: ReturnType<typeof getDataService>; openDetails?: () => void }>,
-) {
-  return function Bound(props: Record<string, unknown>) {
-    return React.createElement(Component, {
-      ...props,
-      cloudbaseData: getDataService(ctx),
-      openDetails: () => ctx.layout?.openDetails?.(),
-    });
-  };
-}
+// 0.1.0 精简：右侧 details 面板已下线（v0.2 以 kit 形态回归），只保留聊天流 slot。
+export const inject = ["slots", "connection"];
 
 export function apply(ctx: SlotHost): void {
   ensureStyles();
@@ -90,28 +77,7 @@ export function apply(ctx: SlotHost): void {
       return hasSetEnv ? nodes : null;
     },
   });
-
-  const Panel = withData(ctx, DetailsPanel);
-  for (const slotName of ["details", "conversation.details", "layout.details"]) {
-    // 用更低 priority shadow 原生 details 面板：登录后右侧栏即 CloudBase 面板。
-    registerNamedSlot(ctx, slotName, "cloudbase-details", Panel, { priority: -10 });
-  }
-
-  // Always open details so unsigned users see the login card (Device code / API Key).
-  // Gating on signedIn left no entry point when authStatus fails or returns unsigned.
-  void getDataService(ctx)
-    ?.authStatus()
-    .then(() => {
-      openDetails(ctx);
-    })
-    .catch((error: unknown) => {
-      console.warn(
-        "[cloudbase] authStatus probe failed; still opening details for login:",
-        error instanceof Error ? error.message : String(error),
-      );
-      openDetails(ctx);
-    });
 }
 
-export { DataTableCard, DeployPreviewCard, DeliverableRow, DetailsPanel };
+export { DataTableCard, DeployPreviewCard, DeliverableRow };
 export { EnvBadge } from "./kit/components/EnvBadge.js";

--- a/dsh-plugin/src/client/styles.ts
+++ b/dsh-plugin/src/client/styles.ts
@@ -15,7 +15,7 @@ export const PANEL_CSS = `
   min-width: 0;
 }
 .cb-root svg { width: 14px; height: 14px; flex-shrink: 0; }
-.cb-toolcard, .cb-deliverable, .cb-details {
+.cb-toolcard, .cb-deliverable {
   border: 1px solid var(--cb-border);
   border-radius: var(--cb-r);
   background: var(--cb-panel);
@@ -23,7 +23,7 @@ export const PANEL_CSS = `
   overflow: hidden;
   min-width: 0;
 }
-.cb-tc-head, .cb-tfoot, .cb-db-toolbar, .cb-auth-head {
+.cb-tc-head, .cb-tfoot {
   display: flex; align-items: center; gap: 8px;
   padding: 8px 12px; border-bottom: 1px solid var(--cb-border);
   font-size: 11px; color: var(--cb-text-3); background: var(--cb-bg);
@@ -36,7 +36,6 @@ export const PANEL_CSS = `
 .cb-table th { text-align: left; font-weight: 500; color: var(--cb-text-2); font-size: 11px; padding: 8px 12px; border-bottom: 1px solid var(--cb-border); background: var(--cb-bg); white-space: nowrap; cursor: pointer; }
 .cb-table td { padding: 7px 12px; border-bottom: 1px solid var(--cb-border); font-family: var(--cb-mono); font-size: 12px; white-space: nowrap; }
 .cb-table tbody tr:hover td { background: var(--cb-hover); }
-.cb-table tbody tr.cb-row-edit { cursor: pointer; }
 .cb-row-id { color: var(--cb-text-3); }
 .cb-tfoot { border-top: 1px solid var(--cb-border); border-bottom: none; color: var(--cb-text-3); font-size: 11.5px; }
 .cb-act, .cb-mini, .cb-btn, .cb-copy {
@@ -62,36 +61,11 @@ export const PANEL_CSS = `
 .cb-ok { display: inline-flex; align-items: center; gap: 5px; font-size: 11px; color: var(--cb-ok); font-weight: 500; }
 .cb-deliverable { display: flex; align-items: center; gap: 8px; padding: 9px 12px; font-size: 12px; color: var(--cb-text-2); }
 .cb-deliverable .f { font-family: var(--cb-mono); font-size: 11px; color: var(--cb-text); }
-.cb-details { display: flex; flex-direction: column; height: 100%; min-height: 360px; border-radius: 0; border: none; box-shadow: none; }
-.cb-topbar { display: flex; align-items: center; gap: 6px; padding: 5px 8px; border-bottom: 1px solid var(--cb-border); background: var(--cb-bg); position: relative; }
-.cb-logo { display: flex; align-items: center; color: var(--cb-blue); flex-shrink: 0; }
-.cb-logo svg { width: 19px; height: 19px; }
-.cb-gh { display: flex; align-items: center; color: var(--cb-text-3); text-decoration: none; flex-shrink: 0; }
-.cb-gh:hover { color: var(--cb-text); }
-.cb-gh svg { width: 16px; height: 16px; }
-.cb-capsule { display: flex; gap: 2px; flex-shrink: 0; position: absolute; left: 50%; transform: translateX(-50%); }
-.cb-capsule-btn {
-  display: inline-flex; align-items: center; justify-content: center; gap: 4px;
-  padding: 3px 9px; font-size: 11px; color: var(--cb-text-2); background: transparent;
-  border: 1px solid var(--cb-border); border-radius: 12px; cursor: pointer; white-space: nowrap;
-}
-.cb-capsule-btn:hover { background: var(--cb-hover); }
-.cb-capsule-btn.active { background: var(--cb-text); color: #fff; border-color: var(--cb-text); font-weight: 600; }
-.cb-dtabs { display: flex; border-bottom: 1px solid var(--cb-border); padding: 0 8px; }
-.cb-dtab {
-  flex: 1; min-width: 0; padding: 10px 4px; font-size: 12px; color: var(--cb-text-3);
-  cursor: pointer; border: none; border-bottom: 2px solid transparent; background: transparent;
-  display: flex; align-items: center; justify-content: center; gap: 5px; white-space: nowrap;
-}
-.cb-dtab.active { color: var(--cb-text); border-bottom-color: var(--cb-text); font-weight: 500; }
-.cb-dpanel { flex: 1; overflow: hidden; display: flex; flex-direction: column; min-height: 0; }
-.cb-db { display: flex; flex: 1; min-height: 0; }
-.cb-tree { width: 160px; min-width: 130px; border-right: 1px solid var(--cb-border); overflow-y: auto; padding: 8px 0; }
+.cb-select { width: auto; max-width: 200px; font: inherit; font-size: 11.5px; color: var(--cb-text-1); background: var(--cb-panel); border: 1px solid var(--cb-border); border-radius: 6px; padding: 3px 6px; min-width: 0; }
 .cb-tree-sec { padding: 8px 12px 4px; font-size: 10px; color: var(--cb-text-3); text-transform: uppercase; letter-spacing: .07em; display: flex; align-items: center; gap: 5px; }
 .cb-tree-item { padding: 5px 12px; font-size: 12.5px; color: var(--cb-text-2); cursor: pointer; display: flex; align-items: center; gap: 7px; border: none; background: transparent; width: 100%; text-align: left; }
 .cb-tree-item.active { background: var(--cb-accent); color: var(--cb-text); font-weight: 500; }
 .cb-cnt { margin-left: auto; font-size: 10.5px; color: var(--cb-text-3); font-family: var(--cb-mono); }
-.cb-env-list { padding: 12px; display: flex; flex-direction: column; gap: 7px; overflow-y: auto; }
 .cb-env-row { display: flex; align-items: center; justify-content: space-between; gap: 10px; padding: 9px 11px; border: 1px solid var(--cb-border); border-radius: 6px; }
 .cb-env-row .k { font-family: var(--cb-mono); color: var(--cb-text-2); white-space: nowrap; }
 .cb-env-row .v { color: var(--cb-text-3); display: flex; align-items: center; gap: 6px; min-width: 0; }
@@ -102,7 +76,6 @@ export const PANEL_CSS = `
 .cb-auth-state { margin: 12px; border: 1px solid var(--cb-border); border-radius: 8px; overflow: hidden; }
 .cb-auth-row { display: flex; justify-content: space-between; padding: 8px 12px; font-size: 12px; color: var(--cb-text-2); border-bottom: 1px solid var(--cb-border); }
 .cb-auth-row:last-child { border-bottom: none; }
-.cb-chart-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; padding: 4px 12px; }
 .cb-chart-card { border: 1px solid var(--cb-border); border-radius: 8px; padding: 10px 12px; }
 .cb-chart-head { display: flex; align-items: center; gap: 6px; font-size: 11.5px; color: var(--cb-text-2); }
 .cb-spark { width: 100%; height: 34px; margin-top: 6px; }
@@ -120,7 +93,6 @@ export const PANEL_CSS = `
 .cb-dialog-a { padding: 13px 18px; border-top: 1px solid var(--cb-border); display: flex; justify-content: flex-end; gap: 9px; }
 .cb-sql { flex: 1; min-height: 120px; }
 .cb-sql-bar { display: flex; align-items: center; gap: 10px; padding: 9px 12px; border-top: 1px solid var(--cb-border); }
-.cb-hint { font-size: 11px; color: var(--cb-text-3); flex: 1; }
 .cb-toast { font-size: 11px; color: var(--cb-ok); }
 .cb-env-select { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; }
 .cb-env-badge {


### PR DESCRIPTION
## 背景

PR #933 合入后 `@cloudbase/dsh-plugin@0.1.0` 尚未发布 npm。右侧 details 面板（后端 5 tab + 预览 webview）的开箱体验依赖宿主 `dsh-client-ui-layout` 本机 patch（不随包分发），普通用户装到的是 300-520px 窄条且客户端启动时无条件强开面板、shadow 原生 details——第一印象差，且面板与宿主 layout 耦合深。

## 改动

- **0.1.0 全砍右侧 details 面板**：移除 `DetailsPanel` 注册（3 个 details slot shadow）与启动 `openDetails` 强开逻辑，`inject` 收敛为 `slots + connection`
- **保留聊天流全部能力**：toolview 卡片（DataTableCard / DeployPreviewCard / WriteOp / ToolViewRouter）、turnTail 交付物行、EnvBoundRow、38 个 MCP 工具透传——均零面板耦合
- **styles.ts 清理**：自动比对保留组件 class 使用后删除 16 个面板专用死选择器，聊天卡片样式不动
- `DetailsPanel/` 组件源码保留（不注册不进 bundle），v0.2 以 Platform Kit 形态回归
- 登录引导改走 DSH 对话内（模型调 cloudbase auth 工具）；未登录 UI 入口列入 v0.2 kit 待办
- HANDOFF.md / AGENTS.md 同步更新边界说明

## 验证

- `npm test`：vitest 110/110
- `npx tsc --noEmit`：clean
- `npm run build`：esbuild 通过；bundle 中 `cloudbase-details` / `openDetails` 计数 0，`cloudbase-deliverable` / `cloudbase-env-bound` 保留
