### PR TITLE
refactor(env): converge env domain tool naming into query*/manage* system

### DIFF
--- a/config/source/skills/cloudbase-code-review/references/rules/storage/STORAGE001.md
+++ b/config/source/skills/cloudbase-code-review/references/rules/storage/STORAGE001.md
@@ -22,7 +22,7 @@
 1. 项目是否使用了 CloudBase 云存储？（上传文件、图片等）
 2. 如果是，`localhost:5173`（Vite dev server 默认地址）是否已加入安全域名？
 3. 加入方式：
-   - 通过 MCP 的 `envDomainManagement` 工具？
+   - 通过 MCP 的 `manageEnv(action="addSecurityDomain")` 工具（旧工具名 `envDomainManagement` 已废弃收编）？
    - 通过 CloudBase Console 手动添加？
    - 通过 `CreateAuthDomain` API？
 4. 如果有其他开发端口（如 `5174`、`4173`），是否也加了？
@@ -30,7 +30,7 @@
 
 ## 修复指引
 
-通过 MCP 工具 `envDomainManagement` 添加安全域名，或通过 `CreateAuthDomain` API 添加：
+通过 MCP 工具 `manageEnv(action="addSecurityDomain", domains=[...])` 添加安全域名（旧工具名 `envDomainManagement` 已废弃），或通过 `CreateAuthDomain` API 添加：
 
 ```typescript
 // 通过 CreateAuthDomain API

--- a/config/source/skills/cloudbase-platform/SKILL.md
+++ b/config/source/skills/cloudbase-platform/SKILL.md
@@ -110,7 +110,7 @@ When working with domain-related tasks, use the correct tool based on the requir
 
 | Requirement | Tool | Parameters | Purpose |
 |-------------|------|------------|---------|
-| **Security Domain (安全域名)** | `envDomainManagement` | `action`, `domains` (array of host:port strings) | CORS/request source validation for browser uploads. No certificate involved. |
+| **Security Domain (安全域名)** | `manageEnv(action="addSecurityDomain" \| "removeSecurityDomain")` | `domains` (array of host:port strings) | CORS/request source validation for browser uploads. No certificate involved. (Deprecated alias: `envDomainManagement`.) |
 | **Reuse existing Custom Domain** | `queryGateway(listCustomDomains)` → `manageGateway(createRoute)` | `domain` = existing custom domain; route fields | Expose a service/path on an already-bound custom domain. **No certificateId.** Prefer this when a custom domain already exists. |
 | **Bind new Custom Domain (自定义域名)** | `manageGateway(action="bindCustomDomain")` | `domain` (string), `certificateId` (string) | First-time bind of a new public HTTPS domain. Requires certId from SSL console. |
 | **Delete Custom Domain** | `manageGateway(action="deleteCustomDomain")` | `domain` (string) | Remove custom domain binding (only after routes on that domain are deleted). |
@@ -120,7 +120,7 @@ When working with domain-related tasks, use the correct tool based on the requir
 **Key indicators for choosing the right tool:**
 - Task mentions "自定义域名访问" but env already has a custom domain → `listCustomDomains` then `createRoute(domain=...)` (no certificateId)
 - Task mentions "certificate ID" or "SSL" **and** needs to bind a **new** domain → `manageGateway(action="bindCustomDomain")`
-- Task mentions "浏览器上传" or "CORS" or "安全域名" → Use `envDomainManagement`
+- Task mentions "浏览器上传" or "CORS" or "安全域名" → Use `manageEnv(action="addSecurityDomain" / "removeSecurityDomain")`
 - Task mentions "public access" or "HTTPS" with domain → Prefer reuse via `createRoute` when possible; only `bindCustomDomain` for first-time domain bind
 - Task mentions "关闭/禁用静态托管默认域名" / `*.tcloudbaseapp.com` → `queryGateway(listRoutes)` then `manageGateway(disableRoute)` with that STATIC_STORE domain; never invent `ModifyGatewayRoute`
 

--- a/config/source/skills/cloudbase-platform/references/protocols/deployment-gate.md
+++ b/config/source/skills/cloudbase-platform/references/protocols/deployment-gate.md
@@ -25,7 +25,7 @@ You must read and complete this gate before:
 | SSL certificate obtained + certificateId available | **New** domain bind fails        | Only when first-time `bindCustomDomain`; retrieve certificateId from SSL console |
 
 **Critical distinction**:
-- Security Domain (`envDomainManagement`) ≠ Custom Domain (`manageGateway` Domain/Route)
+- Security Domain (`manageEnv` action=addSecurityDomain/removeSecurityDomain; deprecated alias `envDomainManagement`) ≠ Custom Domain (`manageGateway` Domain/Route)
 - Reusing an existing custom domain = `createRoute` (no cert). Binding a brand-new custom domain = `bindCustomDomain` (needs certificateId).
 
 ### CloudRun (Container Services)

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -1697,8 +1697,8 @@ describe("env tools - envQuery", () => {
         configuredEntries: ["localhost:5173"],
       },
       next_step_template: {
-        tool: "envDomainManagement",
-        action: "create",
+        tool: "manageEnv",
+        action: "addSecurityDomain",
         domains: ["<actual-browser-host>:<actual-browser-port>"],
       },
     });
@@ -1732,8 +1732,8 @@ describe("env tools - envQuery", () => {
       configuredEntries: ["127.0.0.1:4173", "localhost:4173"],
     });
     expect(payload.next_step_template).toMatchObject({
-      tool: "envDomainManagement",
-      action: "create",
+      tool: "manageEnv",
+      action: "addSecurityDomain",
       domains: ["<actual-browser-host>:<actual-browser-port>"],
     });
   });
@@ -2296,6 +2296,89 @@ describe("manageEnv", () => {
     });
     expect(payload.message).toContain("BillTags");
     expect(payload.message).toContain("baas_personal");
+  });
+
+  it("addSecurityDomain should call createEnvDomain and return polling guidance", async () => {
+    const createEnvDomain = vi.fn().mockResolvedValue({
+      RequestId: "req-manageenv-add-domain",
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      env: { createEnvDomain },
+    } as any);
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse(
+      (
+        await tools.manageEnv.handler({
+          action: "addSecurityDomain",
+          domains: ["localhost:5173"],
+        })
+      ).content[0].text,
+    );
+
+    expect(createEnvDomain).toHaveBeenCalledWith(["localhost:5173"]);
+    expect(payload).toMatchObject({
+      ok: true,
+      code: "DOMAIN_UPDATE_PENDING",
+      operation: "create",
+      targetDomains: ["localhost:5173"],
+      propagation: {
+        requiresPolling: true,
+        pollTool: "queryEnv",
+        pollAction: "domains",
+      },
+    });
+  });
+
+  it("removeSecurityDomain should call deleteEnvDomain and return polling guidance", async () => {
+    const deleteEnvDomain = vi.fn().mockResolvedValue({
+      RequestId: "req-manageenv-remove-domain",
+    });
+    mockGetCloudBaseManager.mockResolvedValue({
+      env: { deleteEnvDomain },
+    } as any);
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse(
+      (
+        await tools.manageEnv.handler({
+          action: "removeSecurityDomain",
+          domains: ["localhost:5173"],
+        })
+      ).content[0].text,
+    );
+
+    expect(deleteEnvDomain).toHaveBeenCalledWith(["localhost:5173"]);
+    expect(payload).toMatchObject({
+      ok: true,
+      code: "DOMAIN_DELETE_PENDING",
+      operation: "delete",
+      targetDomains: ["localhost:5173"],
+      propagation: {
+        requiresPolling: true,
+        pollTool: "queryEnv",
+        pollAction: "domains",
+      },
+    });
+  });
+
+  it("addSecurityDomain should require domains parameter", async () => {
+    mockGetCloudBaseManager.mockResolvedValue({
+      env: { createEnvDomain: vi.fn() },
+    } as any);
+
+    const { tools } = createMockServer();
+    const payload = JSON.parse(
+      (
+        await tools.manageEnv.handler({
+          action: "addSecurityDomain",
+        })
+      ).content[0].text,
+    );
+
+    expect(payload).toMatchObject({ ok: false });
+    expect(payload.message).toContain("domains");
+    expect(payload.message).toContain('queryEnv(action="domains")');
   });
 
   it("create should require confirm before execution", async () => {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -2981,11 +2981,11 @@ export function registerEnvTools(server: ExtendedMcpServer) {
                     "此查询不会自动知道你当前浏览器实际使用的自定义域名或本地端口。即使已经存在一些 localhost/127.0.0.1 条目，也不能据此认定浏览器上传已就绪。若浏览器 Web 应用需要直接上传文件到 CloudBase，请先确认并添加当前访问地址对应的 host:port，再依赖 app.uploadFile()。",
                 },
                 next_step_template: {
-                  tool: "envDomainManagement",
-                  action: "create",
+                  tool: "manageEnv",
+                  action: "addSecurityDomain",
                   domains: ["<actual-browser-host>:<actual-browser-port>"],
                   note:
-                    "请把占位符替换为当前浏览器实际访问 origin 对应的 host:port，再执行添加。",
+                    "请把占位符替换为当前浏览器实际访问 origin 对应的 host:port，再执行添加。manageEnv(action=addSecurityDomain) 即原 envDomainManagement(create)。",
                 },
               };
             }
@@ -3228,8 +3228,23 @@ export function registerEnvTools(server: ExtendedMcpServer) {
     },
   };
   server.registerTool?.("queryEnv", queryEnvToolSchema, queryEnvHandler);
-  // 向后兼容：envQuery 作为 queryEnv 的别名注册
-  server.registerTool?.("envQuery", queryEnvToolSchema, queryEnvHandler);
+  // 向后兼容：envQuery 作为 queryEnv 的别名注册。
+  // DEPRECATED：词序与 query*/manage* 规范不一致（灯塔数据显示与 queryEnv 在 2.32.5 并行被调用），
+  // 本版本仅标记废弃，计划下个版本移除此别名注册。
+  server.registerTool?.(
+    "envQuery",
+    {
+      ...queryEnvToolSchema,
+      description:
+        (queryEnvToolSchema.description ?? "") +
+        "\n\n⚠️ DEPRECATED：此工具名已废弃，是 queryEnv 的旧词序别名，入参与 action 完全一致。请直接调用 queryEnv；本别名将在下个版本移除。",
+      annotations: {
+        ...queryEnvToolSchema.annotations,
+        deprecated: true,
+      },
+    },
+    queryEnvHandler,
+  );
 
   // envDomainManagement - 环境域名管理（合并 createEnvDomain + deleteEnvDomain）
   // 微信 IDE 场景不需要域名管理
@@ -3237,9 +3252,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "envDomainManagement",
     {
-      title: "CloudBase 环境域名管理（安全域名 / CORS 白名单）",
+      title: "CloudBase 环境安全域名管理（浏览器 CORS 白名单）【已废弃】",
       description:
-        "管理 CloudBase 环境的安全域名（安全域名 / CORS 白名单），支持添加和删除操作。（原工具名：createEnvDomain/deleteEnvDomain，为兼容旧AI规则可继续使用这些名称）当浏览器 Web 应用需要从本地 Vite / dev server 直接访问 CloudBase 资源时，应先用 queryEnv(action=domains) 检查当前实际浏览器 origin 对应的 host:port 是否已在白名单中，再按该实际值添加。新增或删除后请每约 10 秒轮询 queryEnv(action=domains) 确认状态收敛，勿一次 sleep 满 10 分钟；多数环境数分钟内可收敛。⚠️ 重要：此工具仅用于 CORS/请求来源验证，不涉及 SSL 证书。自定义域名公网 HTTPS：先 queryGateway(listCustomDomains)；已有域名则 manageGateway(createRoute) 显式传 domain（无需证书）；仅首次绑定新域名才用 bindCustomDomain（需 certificateId）。",
+        "⚠️ DEPRECATED：此工具已废弃并收编进 manageEnv，请改用 manageEnv(action=\"addSecurityDomain\") / manageEnv(action=\"removeSecurityDomain\")（入参 domains 完全一致）。本别名将在下个版本移除。\n\n管理【环境安全域名】＝浏览器跨域（CORS）白名单：控制允许哪些网页 origin（host:port）从浏览器直接调用本环境的 CloudBase 资源。只做 CORS 来源验证，不提供访问域名，不涉及 HTTPS 证书。⚠️ 与【网关自定义域名】是两套完全独立的配置，互不相干：如需给自己的域名绑定 HTTPS 访问入口（云托管 / 网关服务），那属于 manageGateway 的职责——先 queryGateway(listCustomDomains)；已有域名则 manageGateway(createRoute) 显式传 domain（无需证书）；仅首次绑定新域名才用 bindCustomDomain（需 certificateId）。不要用本工具做这件事。\n\n操作指引：（原工具名 createEnvDomain/deleteEnvDomain，为兼容旧 AI 规则可继续使用这些名称）当浏览器 Web 应用需要从本地 Vite / dev server 直接访问 CloudBase 资源时，先用 queryEnv(action=domains) 检查当前实际浏览器 origin 对应的 host:port 是否已在白名单中，再按该实际值添加。新增或删除后请每约 10 秒轮询 queryEnv(action=domains) 确认状态收敛，勿一次 sleep 满 10 分钟；多数环境数分钟内可收敛。",
       inputSchema: {
         action: z
           .enum(["create", "delete"])
@@ -3309,14 +3324,20 @@ export function registerEnvTools(server: ExtendedMcpServer) {
   server.registerTool?.(
     "manageEnv",
     {
-      title: "CloudBase 环境管理（创建/变配/续费）",
+      title: "CloudBase 环境管理（创建/变配/续费/安全域名）",
       description:
-        "管理 CloudBase 环境，支持：listPackages=查询可选套餐列表，create=创建新环境（需确认），modifyPlan=变更套餐（升降配，需确认），renew=续费环境（需确认）。\n\n⚠️ 所有涉及费用的操作（create/modifyPlan/renew），执行前必须展示配置摘要并等待用户通过 confirm=\"yes\" 确认。",
+        "管理 CloudBase 环境，支持：listPackages=查询可选套餐列表，create=创建新环境（需确认），modifyPlan=变更套餐（升降配，需确认），renew=续费环境（需确认），addSecurityDomain=添加环境安全域名（浏览器 CORS 白名单，不计费、无需确认），removeSecurityDomain=删除环境安全域名（不计费、无需确认）。\n\n⚠️ 涉及费用的操作（create/modifyPlan/renew），执行前必须展示配置摘要并等待用户通过 confirm=\"yes\" 确认；安全域名操作（addSecurityDomain/removeSecurityDomain）不计费，无需 confirm。\n\nℹ️ 安全域名＝浏览器跨域（CORS）白名单，控制允许哪些网页 origin（host:port）从浏览器直接调用本环境的 CloudBase 资源，不提供访问域名、不涉及 HTTPS 证书。给自己的域名绑定 HTTPS 访问入口（云托管/网关服务）属于 manageGateway（listCustomDomains/bindCustomDomain）的职责，与本工具无关。",
       inputSchema: {
         action: z
-          .enum(["listPackages", "create", "modifyPlan", "renew"])
+          .enum(["listPackages", "create", "modifyPlan", "renew", "addSecurityDomain", "removeSecurityDomain"])
           .describe(
-            "操作类型：listPackages=查询可选套餐，create=创建环境，modifyPlan=变更套餐，renew=续费",
+            "操作类型：listPackages=查询可选套餐，create=创建环境，modifyPlan=变更套餐，renew=续费，addSecurityDomain=添加安全域名（CORS 白名单条目），removeSecurityDomain=删除安全域名",
+          ),
+        domains: z
+          .array(z.string())
+          .optional()
+          .describe(
+            "安全域名数组（格式：host:port，例如 localhost:5173 或 127.0.0.1:4173）。仅 action=addSecurityDomain/removeSecurityDomain 时有效且必填。注意：这是 CORS 白名单条目，不是自定义域名，不需要证书。添加前应先用 queryEnv(action=domains) 检查浏览器实际 origin 是否已在白名单中。",
           ),
         alias: z
           .string()
@@ -3364,6 +3385,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
       duration?: number;
       envId?: string;
       confirm?: string;
+      domains?: string[];
     }) => {
       const action = rawArgs.action ?? "";
       const alias = normalizeOptionalToolString(rawArgs.alias);
@@ -3372,6 +3394,9 @@ export function registerEnvTools(server: ExtendedMcpServer) {
       const duration = rawArgs.duration ?? 1;
       const envId = normalizeOptionalToolString(rawArgs.envId);
       const confirmed = rawArgs.confirm === "yes";
+      const domains = (rawArgs.domains ?? [])
+        .map((d) => (typeof d === "string" ? d.trim() : ""))
+        .filter(Boolean);
 
       try {
         const cloudbase = await getManager({ requireEnvId: false });
@@ -3801,11 +3826,50 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             });
           }
 
+          case "addSecurityDomain":
+          case "removeSecurityDomain": {
+            // 安全域名（浏览器 CORS 白名单）增删。原 envDomainManagement(create/delete) 的能力收编：
+            // 不计费、无需 confirm；微信 IDE 场景不提供域名管理（与原工具的注册 guard 保持一致）。
+            if (server.ide === "wxide") {
+              return buildJsonToolResult({
+                ok: false,
+                code: "TOOL_UNAVAILABLE_IN_WXIDE",
+                message:
+                  "微信开发者工具场景不提供环境安全域名管理。如需配置浏览器 CORS 白名单，请使用其他接入方式（CloudBase MCP / 控制台）。",
+              });
+            }
+            if (!domains.length) {
+              return buildJsonToolResult({
+                ok: false,
+                code: "DOMAINS_REQUIRED",
+                message: `action=${action} 时 domains 为必填参数（host:port 数组，例如 ["localhost:5173"]）。添加前建议先用 queryEnv(action="domains") 检查浏览器实际 origin 是否已在白名单中。`,
+                next_step: {
+                  tool: "queryEnv",
+                  action: "domains",
+                },
+              });
+            }
+            // 安全域名是环境级操作，复用与原 envDomainManagement 相同的管理器获取方式（要求环境上下文）。
+            const domainManager = await getManager();
+            const domainResult =
+              action === "addSecurityDomain"
+                ? await domainManager.env.createEnvDomain(domains)
+                : await domainManager.env.deleteEnvDomain(domains);
+            logCloudBaseResult(server.logger, domainResult);
+            return buildJsonToolResult(
+              buildEnvDomainManagementResult({
+                action: action === "addSecurityDomain" ? "create" : "delete",
+                domains,
+                result: domainResult,
+              }),
+            );
+          }
+
           default:
             return buildJsonToolResult({
               ok: false,
               code: "INVALID_ACTION",
-              message: `不支持的操作: ${action}。支持的操作: listPackages, create, destroy, modifyPlan, renew。`,
+              message: `不支持的操作: ${action}。支持的操作: listPackages, create, modifyPlan, renew, addSecurityDomain, removeSecurityDomain。`,
             });
         }
       } catch (error) {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -3240,7 +3240,6 @@ export function registerEnvTools(server: ExtendedMcpServer) {
         "\n\n⚠️ DEPRECATED：此工具名已废弃，是 queryEnv 的旧词序别名，入参与 action 完全一致。请直接调用 queryEnv；本别名将在下个版本移除。",
       annotations: {
         ...queryEnvToolSchema.annotations,
-        deprecated: true,
       },
     },
     queryEnvHandler,

--- a/mcp/src/tools/gateway.ts
+++ b/mcp/src/tools/gateway.ts
@@ -1469,7 +1469,7 @@ export function registerGatewayTools(server: ExtendedMcpServer) {
         "enablePathTransmission：默认 false 剥触发路径前缀；true 透传完整路径（CBR 多路由、WEB_SCF 自管子路径常需 true；STATIC_STORE 自定义触发路径映射站点根通常 false）。" +
         "⚠️ 自定义域名访问：若环境已有自定义域名（先 queryGateway listCustomDomains），优先 createRoute 并显式传入该 domain，无需 certificateId；" +
         "仅首次绑定全新自定义域名时用 bindCustomDomain（certificateId 可选：未传时按域名自动检索证书，单证书自动选用、多证书返回选择指引）。" +
-        "createRoute / bindCustomDomain 创建前会调用 VerifyHTTPServiceRoute 做归属权等预检（探测→创建）；失败时返回 data.checks 与 DNS TXT 指引，配置后重试。CORS/安全域名用 envDomainManagement。" +
+        "createRoute / bindCustomDomain 创建前会调用 VerifyHTTPServiceRoute 做归属权等预检（探测→创建）；失败时返回 data.checks 与 DNS TXT 指引，配置后重试。CORS/安全域名（浏览器跨域白名单，与本工具的网关自定义域名无关）用 manageEnv(action=addSecurityDomain/removeSecurityDomain)。" +
         "enableService/authSwitch：HTTP 网关总开关与访问鉴权开关；createRoute 后若访问报 HTTPSERVICE_NONACTIVATED，通常是总开关未开启（用 queryGateway getPrivilege 查询、enableService 开启）。",
       inputSchema: {
         action: z


### PR DESCRIPTION
## 背景

来自灯塔流量数据支撑的工具命名审计（2026-09-04）。env 域此前存在 3 个工具 3 种词序的问题：`queryEnv`（读）/ `envQuery`（读，同签名别名）/ `envDomainManagement`（写，词序游离）。本 PR 将 env 域收敛为标准 `query*`（读）/ `manage*`（写 + action enum）双族。

## 灯塔数据依据

| 工具 | 7d 调用 | 30d 调用 | 关键发现 |
|---|---|---|---|
| envQuery | ~76k | ~33万 | 与 queryEnv 签名完全同构（action enum 相同），主力版本均为 2.32.5——当前发布同时注册两种词序，agent 随机选 |
| queryEnv | ~42k | — | 同上 |
| envDomainManagement | 1,917 | 34,084 | 与 manageEnv（7d=2,641）同量级；wxide 本就不注册此工具，无兼容面 |
| NoSQL 四件套 | readNoSqlDatabaseContent 全站第 1（33.5 万/7d） | — | **本 PR 不动**（wxide 占 15%，有兼容风险，另行处理） |

## 改动

### 1. `envDomainManagement` → `manageEnv(action="addSecurityDomain" / "removeSecurityDomain")`

- 新 action 入参 `domains`（host:port[]）与原工具完全一致，云端 API 不变（`env.createEnvDomain` / `env.deleteEnvDomain`）
- 命名不用 `createDomain`：这是往 CORS 白名单里加/删条目，不是"创建域名"；`SecurityDomain` 对齐控制台术语
- 不计费、无需 confirm（description 与涉费 action listPackages/create/modifyPlan/renew 明确区分）
- wxide 兼容：原工具在 wxide 本就不注册，guard 移入 manageEnv 内部 per-action 拒绝（复用 manageFunctions 的门禁模式）
- 原工具保留为 deprecated 别名一个发布周期（title 加【已废弃】，description 首行指向新用法），下版本移除

### 2. `envQuery` 标记废弃（不删除）

- description 追加 DEPRECATED 提示 + annotations `deprecated: true`，指向 `queryEnv`，下版本移除别名注册

### 3. 联动引用更新（避免死引用）

- `queryEnv(action=domains)` 的 `next_step_template`：envDomainManagement(create) → manageEnv(addSecurityDomain)
- `gateway.ts` createRoute/bindCustomDomain 描述中的安全域名指引同步改指新 action
- `config/source/skills`（source-of-truth）：
  - `cloudbase-platform/SKILL.md`：工具表 + 关键词路由
  - `cloudbase-platform/references/protocols/deployment-gate.md`：Security Domain ≠ Custom Domain 对照
  - `cloudbase-code-review/references/rules/storage/STORAGE001.md`：2 处引用

### 4. 描述澄清（顺带落地）

envDomainManagement / 新 action 的 description 明确写清与网关自定义域名（manageGateway bindCustomDomain，需 certificateId）是两套独立配置：安全域名 = 浏览器 CORS 白名单，不涉及证书；HTTPS 访问入口走 manageGateway。

## Test Plan

- [x] `env.test.ts` + `gateway.test.ts`：131 测试通过（含 3 个新增：add/remove 调用与轮询结构、缺 domains 返回结构化 `DOMAINS_REQUIRED` + next_step 指回 queryEnv(domains)）
- [x] config/source 保护测试：`build-skills-repo` / `build-compat-config` / `skill-quality-standards` 11 测试通过
- [ ] 定向评测验证新 action 指引生效
- [ ] 注意：通过 `searchKnowledgeBase(mode=skill)` 路径的 agent 读到的是 npm 包内打包 skill，端到端生效依赖下一个 `@cloudbase/cloudbase-mcp` release（见 specs/attribution.md §6.2.2）

## 后续（不在本 PR）

- 下一个发布周期：移除 envQuery / envDomainManagement 别名注册
- NoSQL 四件套收敛：等 wxide / yyb-gen-app 依赖解除后另行评估
- 门禁表 `cloudIncompatibleTools` 死条目清理（uploadFile）：等 mcp 2.7.0 旧客户端淘汰
