### PR TITLE
docs(dsh-plugin): README 精简重写，移除未发布的右侧面板内容

### DIFF
--- a/dsh-plugin/README.md
+++ b/dsh-plugin/README.md
@@ -4,23 +4,19 @@
 >
 > 你在 DSH 里 vibecoding 时，最烦的事是什么？模型很聪明，但写完代码没地方跑——数据库要开控制台建、文件要自己传、部署要切去另一个网站。**一离开对话，心流就断了。**
 >
-> `@cloudbase/dsh-plugin` 把 CloudBase 的整个后端搬进 DSH：
+> `@cloudbase/dsh-plugin` 把 CloudBase 后端搬进 DSH：
 >
-> - **对话里建全栈应用**：说需求 → AI 拉模板、建 PG 表、写前端 → 右侧面板实时看数据
-> - **右侧资源面板**：数据库（表树 / 数据表格 / SQL 编辑器）、存储、认证、配置、用量分析，5 个 tab 即点即得
-> - **一键部署拿域名**：产物预览、部署上线、链接直接发出去
+> - **对话里建全栈应用**：说需求 → AI 拉模板、建 PG 表、写前端、部署拿域名
+> - **查询结果变卡片**：数据库 / MySQL / NoSQL 查询直接渲染成表格——分页、排序、导出 CSV；部署后有 iframe 预览和打开按钮
+> - **38 个 MCP 工具**：建表、查询、托管、认证、环境配置，全在对话里调用
 >
-> 你的模型（DeepSeek / Claude / 随便换）、你的后端（自己的 CloudBase 环境）、你的数据（本地会话 + 自己数据库）。**Lovable 的体验，开放式的底座。**
+> 你的模型（DeepSeek / Claude / 随便换）、你的后端（自己的 CloudBase 环境）、你的数据（本地会话 + 自己数据库）。
 
-English follows the Chinese sections.
+CloudBase backend for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). Compatible with **DSH `>=0.1.0-rc.6 <0.2.0`** · Node `>=18` · MCP tools follow `@cloudbase/cloudbase-mcp@latest`.
 
-CloudBase backend for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). Compatible with **DSH `>=0.1.0-rc.6 <0.2.0`**. MCP tools follow `@cloudbase/cloudbase-mcp@latest`.
+## 安装
 
-一句话卖点 / one-liner: **DSH 的 CloudBase 后端插件——对话建全栈应用、右侧数据库/存储/认证面板、一键部署拿域名.**
-
-## 安装（≤ 2 步）
-
-**Web UI（含右侧面板与工具卡片）：**
+**Web UI（含工具卡片）：**
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/dsh-plugin/scripts/install.sh | bash
@@ -30,7 +26,7 @@ curl -fsSL https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolk
 
 ```bash
 dsh plugin --profile web add @cloudbase/dsh-plugin
-# pnpm ≥9 默认禁止依赖的 install 脚本（protobufjs 会失败）
+# pnpm ≥9 默认禁止依赖 install 脚本（protobufjs 会失败）
 echo "enable-scripts=true" >> ~/.dsh/profiles/web/.npmrc
 (cd ~/.dsh/profiles/web && pnpm install)
 # UI 插件需要重建 DSH web 前端
@@ -38,32 +34,20 @@ pnpm --dir "$(dirname "$(dirname "$(command -v dsh)")")" run build:web || true
 dsh --profile web
 ```
 
-**Headless（只要 MCP 桥，不要前端构建）：**
+**Headless（只要 MCP 工具，不要前端构建）：**
 
 ```bash
 dsh plugin --profile headless add @cloudbase/dsh-plugin
 dsh --profile headless "列出所有 mcp__cloudbase__ 工具"
 ```
 
-Headless 用户**不必**执行 `build:web`。
-
-本地开发（仓库路径）：
-
-```bash
-cd dsh-plugin && npm install && npm run build
-dsh plugin --profile web add .
-dsh --profile web --dump-config   # 应出现 # == @cloudbase/dsh-plugin 与 mcp-cloudbase
-```
-
 ## 登录（device-code，无需 API Key）
 
-插件**不传任何 CloudBase env、不传 API Key**。登录走 cloudbase-mcp 自身的 device-code 流程。本机已有 `tcb login` 登录态时直接复用。
-
-无登录态时，对模型说：
+插件不传任何 CloudBase env、不传 API Key，登录走 cloudbase-mcp 自身的 device-code 流程（本机已有 `tcb login` 登录态时直接复用）。无登录态时，对模型说：
 
 > 调用 `mcp__cloudbase__auth`，`action=start_auth`，`authMode=device`，把 verification URL 给我。
 
-浏览器授权一次后登录态持久化。登录后通过 `mcp__cloudbase__auth`（`action=set_env`）选择环境，后续工具自动使用该环境，插件无需也不能指定环境 ID。
+浏览器授权一次后登录态持久化。再用 `mcp__cloudbase__auth`（`action=set_env`）选择环境，后续工具自动使用该环境。
 
 ## 功能
 
@@ -71,62 +55,46 @@ dsh --profile web --dump-config   # 应出现 # == @cloudbase/dsh-plugin 与 mcp
 |---|---|
 | MCP 桥 | 注册 `mcp__cloudbase__*`（与 `@cloudbase/cloudbase-mcp` 工具集一致，当前 38 个） |
 | DataTableCard | `queryPgDatabase` / `queryMysqlDatabase` / `readNoSqlDatabaseContent` 结果表格：分页、排序、复制 JSON、导出 CSV |
-| DeployPreviewCard | `manageHosting` upload 后 iframe 预览真实域名 + 打开按钮。**无回滚按钮**（托管无版本回滚 API） |
-| 交付物行 | `conversation.chat.turnTail` 展示产物路径 + 域名 |
-| 右侧 details 面板 | 数据库 / 存储 / 认证 / 配置 / 分析。登录后自动 `openDetails()` |
-| 数据通道 | 面板走 Host `cloudbaseData` 服务（typert RPC），**不消耗模型 token** |
-| Sites | 携带 `sites` skill：downloadTemplate(react) → Vite → 建表 → manageHosting → 域名 |
+| DeployPreviewCard | `manageHosting` upload 后 iframe 预览真实域名 + 打开按钮 |
+| 交付物行 | 会话尾部展示产物路径 + 域名 |
+| Sites skill | downloadTemplate(react) → Vite → 建表 → manageHosting → 域名 |
 
 写操作（SQL / 上传 / 删行）一律注入会话，由模型按 DSH approval 执行，插件 UI 不绕过权限模型。
 
-## 已知坑（必读）
+## 注意事项
 
-1. **`!!js` 求值为 `undefined` 会让 dsh 启动崩溃。** `env` 里每个值必须是字符串。本插件 **不声明任何 env**（登录走 MCP device-code），天然避开此坑。若用户在自己 patch 里加 env，每个值必须是字符串。
-2. **pnpm v9+ 默认禁止依赖 install 脚本。** `@cloudbase/cloudbase-mcp` 间接依赖 protobufjs，必须 `enable-scripts=true` 后再 `pnpm install`。一键脚本已包含此步。
-3. **UI 插件要重建 web 前端。** 装完后若看不到表格卡片 / 右侧面板，从 DSH 安装目录执行 `pnpm run build:web`，再重启 `dsh --profile web`。Headless 不需要。
-4. **凭据 scrubbing。** DSH stdio 桥会丢掉名字匹配 `KEY|PASSWORD|SECRET|TOKEN` 的环境变量。本插件不声明任何 env，登录/环境全部走 cloudbase-mcp 的 auth（device-code + set_env）。`HOME` 会继承，因此本机 tcb 登录态可用。
-5. **首次 npx 拉包可能 10–90s。** headless 首轮工具列表可能还是空的；重试即可。Web 长驻进程无此问题。本地验收：`cd dsh-plugin && npm run build && npm run e2e:live`。
-6. **不要塞无效 API Key。** cloudbase-mcp 检测到 Key 会走 Key 模式，device-code 会被挡住。
+1. **pnpm v9+ 默认禁止依赖 install 脚本**：必须 `enable-scripts=true` 后再 `pnpm install`（一键脚本已包含此步）。
+2. **Web UI 插件要重建 DSH web 前端**：装完看不到卡片时，从 DSH 安装目录执行 `pnpm run build:web` 再重启；Headless 不需要。
+3. **首次 npx 拉包可能 10–90s**：headless 首轮工具列表可能为空，重试即可。
+4. **不要给插件配置 `CLOUDBASE_API_KEY`**：无效 Key 会挡住 device-code 登录。登录与环境选择全部走 `mcp__cloudbase__auth`。
 
 ## 隐私
 
-凭据只走本机 tcb 登录态或 `~/.dsh/.credentials.yaml`（权限 600）。插件不上传密钥。面板读操作只查询你自己的 CloudBase 环境。
-
-## 兼容性
-
-- DSH `>=0.1.0-rc.6 <0.2.0`（以 `@deepseek-ai/dsh@0.1.0-rc.6` 验证）
-- Node `>=18`
-- `@cloudbase/cloudbase-mcp@latest`
+凭据只存本机（tcb 登录态或 `~/.dsh/.credentials.yaml`，权限 600），插件不上传密钥，读操作只访问你自己的 CloudBase 环境。
 
 ## 开发
 
 ```bash
 cd dsh-plugin
 npm install
-npm test
-npm run build
-npm run e2e:live   # spawns cloudbase-mcp; needs network + local tcb login for EnvList
+npm test          # vitest 单测
+npm run build     # dist/index.js（Host）+ dist/client.js（Web ModuleLoader factory）
+npm run e2e:live  # 需要网络 + 本机 tcb 登录态
 ```
 
-产物：`dist/index.js`（Host）+ `dist/client.js`（Web ModuleLoader factory）。除 peer（cordis / react）外运行时 0 依赖。
+除 peer（cordis / react）外运行时 0 依赖。
+
+## License
+
+MIT
 
 ---
 
 # English
 
-> **From one sentence to a working full-stack app — inside DeepSeek Harness.**
->
-> You're vibecoding in DSH. The model is smart, but when the code is written there's nowhere to run it — databases need a console, files need uploading, deploys need another website. **The flow breaks the moment you leave the chat.**
->
-> `@cloudbase/dsh-plugin` brings the whole CloudBase backend into DSH:
->
-> - **Full-stack apps from chat**: describe → AI scaffolds templates, creates PG tables, writes the frontend → watch data live in the side panel
-> - **Resource panel on the right**: Database (table tree / data browser / SQL editor), Storage, Auth, Config, Usage analytics — 5 tabs, click and it's there
-> - **One-click deploy with a domain**: preview the build, go live, share the link
->
-> Your model (DeepSeek / Claude / any), your backend (your own CloudBase env), your data (local sessions + your database). **The Lovable experience, on an open base.**
+CloudBase backend for [DeepSeek Harness](https://github.com/deepseek-ai/deepseek-harness). Brings the whole backend into DSH: full-stack apps from chat (scaffold → PG tables → frontend → deploy with a domain), query results rendered as table cards (paginate / sort / export CSV), deploy preview with iframe, and 38 MCP tools (`mcp__cloudbase__*`).
 
-## Install (≤ 2 steps)
+## Install
 
 **Web UI:**
 
@@ -134,30 +102,26 @@ npm run e2e:live   # spawns cloudbase-mcp; needs network + local tcb login for E
 curl -fsSL https://raw.githubusercontent.com/TencentCloudBase/CloudBase-AI-Toolkit/main/dsh-plugin/scripts/install.sh | bash
 ```
 
-**Headless (bridge only, no frontend rebuild):**
+**Headless (MCP bridge only, no frontend rebuild):**
 
 ```bash
 dsh plugin --profile headless add @cloudbase/dsh-plugin
 ```
 
-Compatibility: DSH `>=0.1.0-rc.6 <0.2.0`. Node `>=18`.
-
 ## Login
 
-The plugin **forwards no CloudBase env and no API key** — login goes through cloudbase-mcp's own device-code flow. Reuse local `tcb login` state. If unsigned, ask the model to call `mcp__cloudbase__auth` with `action=start_auth` and `authMode=device`, then pick an environment with `action=set_env` (tools use that env automatically).
+No env and no API key are forwarded — login goes through cloudbase-mcp's device-code flow (reuses local `tcb login` state). If unsigned, ask the model to call `mcp__cloudbase__auth` with `action=start_auth`, `authMode=device`, then pick an environment with `action=set_env`.
 
-## Known pitfalls
+## Notes
 
-1. `!!js` evaluating to `undefined` crashes dsh. Every `env` value must be a string. This plugin declares **no env at all** (device-code login), avoiding the trap entirely.
-2. pnpm v9+ blocks dependency install scripts. Set `enable-scripts=true` then `pnpm install` (the one-shot script does this).
-3. UI plugins need `pnpm run build:web` on the DSH install. Headless does not.
-4. Credential scrubbing: variables matching `KEY|PASSWORD|SECRET|TOKEN` are stripped. We declare no env — login and env selection go through cloudbase-mcp's auth tool (device-code + set_env). `HOME` is inherited so local `tcb login` state works.
-5. First `npx` fetch can take 10–90s; retry the headless turn if tools are missing. Local gate: `npm run e2e:live`.
-6. Never inject an invalid API Key — it blocks device-code.
+1. pnpm v9+ blocks dependency install scripts — set `enable-scripts=true` first (the one-shot script handles this).
+2. Web UI plugins require rebuilding the DSH frontend: `pnpm run build:web` in the DSH install dir. Headless does not.
+3. First `npx` fetch can take 10–90s; retry the headless turn if tools are missing.
+4. Never configure `CLOUDBASE_API_KEY` — an invalid key blocks device-code login.
 
 ## Privacy
 
-Credentials stay in local tcb login state or `~/.dsh/.credentials.yaml` (mode 600). The plugin does not upload secrets.
+Credentials stay local (tcb login state or `~/.dsh/.credentials.yaml`, mode 600). The plugin does not upload secrets.
 
 ## License
 


### PR DESCRIPTION
## 背景

`@cloudbase/dsh-plugin@0.1.0` 已发布 npm，但 README 还停留在含右侧 details 面板的版本：功能描述与实际交付不符，且混有维护者视角的内部细节。

## 改动

- **移除右侧面板全部描述**（header 卖点、one-liner、功能表 2 行、注意事项）——该功能已在 #996 下线
- 功能表聚焦 0.1.0 实际交付：MCP 桥（38 工具）/ DataTableCard / DeployPreviewCard / 交付物行 / Sites skill
- 注意事项 6 → 4 条：`!!js` env 细节与凭据 scrubbing 内部机制移出（维护者信息，留在 HANDOFF），`e2e:live` 归入开发段
- English 段从全量重复改为紧凑摘要（165 行 → 精简后单文件 -36 行净减）

## 验证

- 纯文档改动，无代码影响
- 与 `dsh-plugin/AGENTS.md` / `CODEBUDDY.md` 已更新的边界描述一致（details 面板 0.1.0 已下线）
