### PR TITLE
chore(dsh-plugin): bump version to 0.1.1

### DIFF
--- a/dsh-plugin/package.json
+++ b/dsh-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudbase/dsh-plugin",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "CloudBase backend for DeepSeek Harness — full-stack apps from chat, DB/Storage/Auth panel, one-click deploy",
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
版本号 bump 至 0.1.1，随 tag `dsh-plugin-v0.1.1` 发布，将 #998 的精简 README 带上 npm（0.1.0 README 为旧版）。

无代码改动，仅 `dsh-plugin/package.json` version 0.1.0 → 0.1.1。
