### PR TITLE
docs: 步骤 2 改为阅读 skill.md 自引导，去掉 npx skills add 提示词

### DIFF
--- a/doc/components/IDESelector.tsx
+++ b/doc/components/IDESelector.tsx
@@ -616,7 +616,7 @@ const translations: Record<string, Record<string, string>> = {
     showMore: '显示配置选项',
     showLess: '收起',
     verifyDescription: '在 AI 对话中依次输入以下内容:',
-    installSkillsPrompt: '安装 CloudBase Skills：命令 npx skills add tencentcloudbase/cloudbase-skills -y',
+    installSkillsPrompt: '阅读 https://docs.cloudbase.net/skill.md，帮我介绍可以做什么',
     useSkillsPrefix: '使用 CloudBase Skills：',
     cliCommand: 'CLI 命令',
     alternativeConfig: '替代配置',
@@ -647,7 +647,7 @@ const translations: Record<string, Record<string, string>> = {
     showMore: 'Show configuration options',
     showLess: 'Show less',
     verifyDescription: 'Enter the following in your AI chat in order:',
-    installSkillsPrompt: 'Install CloudBase Skills: run npx skills add tencentcloudbase/cloudbase-skills -y',
+    installSkillsPrompt: 'Read https://docs.cloudbase.net/skill.md and tell me what it can do',
     useSkillsPrefix: 'Use CloudBase Skills:',
     cliCommand: 'CLI command',
     alternativeConfig: 'Alternative configuration',
@@ -825,7 +825,7 @@ export default function IDESelector({
   const [randomPrompt, setRandomPrompt] = useState<string>(() => getRandomPrompt());
   const [copiedSecondPrompt, setCopiedSecondPrompt] = useState(false);
   const secondPrompt = customPrompt || randomPrompt;
-  const installPrompt = t.installSkillsPrompt || '安装 CloudBase Skills：命令 npx skills add tencentcloudbase/cloudbase-skills -y';
+  const installPrompt = t.installSkillsPrompt || '阅读 https://docs.cloudbase.net/skill.md，帮我介绍可以做什么';
   const secondPromptWithSkills = `${t.useSkillsPrefix || '使用 CloudBase Skills：'} ${secondPrompt}`.trim();
 
   const handleRefreshPrompt = () => {
@@ -1085,11 +1085,11 @@ export default function IDESelector({
 
             {ide.id === 'openclaw' && (
               <div className={styles.templateHint}>
-                <strong>{isEnglish ? 'Chat-based setup:' : '通过对话安装：'}</strong>
+                <strong>{isEnglish ? 'Guided setup:' : '自引导配置：'}</strong>
                 {isEnglish ? (
-                  <span> In OpenClaw, you can install CloudBase Skills through chat. If you do not need extra CloudBase rules yet, you can also start the conversation directly.</span>
+                  <span> In OpenClaw, you can let the AI read https://docs.cloudbase.net/skill.md and follow the guided setup. If you do not need extra CloudBase rules yet, you can also start the conversation directly.</span>
                 ) : (
-                  <span> 在 OpenClaw 中可通过对话安装 CloudBase Skills；如果暂时不需要额外的 CloudBase 规则和工作流，也可以直接开始对话。</span>
+                  <span> 在 OpenClaw 中可让 AI 阅读 https://docs.cloudbase.net/skill.md 自引导完成配置；如果暂时不需要额外的 CloudBase 规则和工作流，也可以直接开始对话。</span>
                 )}
               </div>
             )}

--- a/doc/ide-setup/openclaw.mdx
+++ b/doc/ide-setup/openclaw.mdx
@@ -3,12 +3,12 @@ import RelatedResources from '../components/RelatedResources';
 
 # OpenClaw 配置指南
 
-在 OpenClaw 中不需要手动维护项目级 MCP 配置文件；如果需要补充 CloudBase 规则和工作流，可以直接通过对话安装 CloudBase Skills。
+在 OpenClaw 中不需要手动维护项目级 MCP 配置文件；如果需要补充 CloudBase 规则和工作流，可以让 AI 阅读官方 Setup Skill 自引导完成。
 
-你可以直接在对话中让 AI 执行：
+你可以直接在对话中输入：
 
 ```text
-安装 CloudBase Skills：命令 npx skills add tencentcloudbase/cloudbase-skills -y
+阅读 https://docs.cloudbase.net/skill.md，帮我介绍可以做什么
 ```
 
 如果暂时不需要额外的 CloudBase 规则和工作流，也可以直接输入你的业务需求开始开发。
@@ -42,7 +42,7 @@ node --version
 A: 不需要。OpenClaw 章节默认走 CloudBase Skills 工作流，不要求你手动维护项目级 MCP 配置文件。
 
 **Q: 是否需要先安装 CloudBase Skills？**  
-A: 不需要手动安装。你可以直接在 OpenClaw 对话中让 AI 安装；如果暂时不需要额外规则，也可以直接开始开发。
+A: 不需要手动安装。你可以让 AI 阅读 [Setup Skill](https://docs.cloudbase.net/skill.md) 自引导完成配置；如果暂时不需要额外规则，也可以直接开始开发。
 
 更多问题请查看：[完整 FAQ](../faq)
 


### PR DESCRIPTION
## 背景

docs.cloudbase.net 各 IDE 配置页的「步骤 2：和 AI 对话」中，第一条 prompt 仍是「安装 CloudBase Skills：命令 npx skills add tencentcloudbase/cloudbase-skills -y」。该步骤已不再需要——AI 直接阅读官方 Setup Skill（https://docs.cloudbase.net/skill.md，已验证可访问）即可自引导完成配置。

## 改动

- `doc/components/IDESelector.tsx`：
  - `installSkillsPrompt`（zh/en）改为「阅读 https://docs.cloudbase.net/skill.md，帮我介绍可以做什么」（组件内 fallback 同步）
  - OpenClaw 专属提示：「通过对话安装」→「自引导配置」，指向 skill.md
- `doc/ide-setup/openclaw.mdx`：正文示例 prompt 与 FAQ 同步改为 skill.md 引导方式

## 验证

- https://docs.cloudbase.net/skill.md 返回 200，内容为面向 AI agent 的 Setup Skill
- 改动仅文案，无逻辑变更；diff 共 2 文件 10 行

## 未动（如需一并对齐请告知）

- `doc/index.mdx` / `doc/prompts/how-to-use.mdx` 中 `npx skills add` 作为 CLI 安装命令的说明（那是显式安装路径，与对话引导是两回事）
