### PR TITLE
docs: 清理残留的「让 AI 安装 Skills」对话引导，统一 skill.md 自引导

### DIFF
--- a/doc/ide-setup/openclaw.mdx
+++ b/doc/ide-setup/openclaw.mdx
@@ -41,7 +41,7 @@ node --version
 **Q: OpenClaw 需要单独创建 `.mcp.json` 吗？**  
 A: 不需要。OpenClaw 章节默认走 CloudBase Skills 工作流，不要求你手动维护项目级 MCP 配置文件。
 
-**Q: 是否需要先安装 CloudBase Skills？**  
+**Q: 是否需要手动配置 Skills 或规则？**  
 A: 不需要手动安装。你可以直接在 OpenClaw 对话中让 AI 安装；如果暂时不需要额外规则，也可以直接开始开发。
 
 更多问题请查看：[完整 FAQ](../faq)

--- a/doc/index.mdx
+++ b/doc/index.mdx
@@ -42,7 +42,7 @@ AI 负责代码生成和问题修复，CloudBase 提供运行环境。两者结�
 npx skills add tencentcloudbase/cloudbase-skills
 ```
 
-也可以直接对 AI 说“安装 CloudBase Skills”。
+也可以让 AI 阅读 [Setup Skill](https://docs.cloudbase.net/skill.md) 自引导完成配置。
 
 详见 [如何使用 Skill](./prompts/how-to-use)。
 

--- a/doc/prompts/how-to-use.mdx
+++ b/doc/prompts/how-to-use.mdx
@@ -24,7 +24,7 @@ CloudBase AI Skills 是一套「技能包」，把云开发的专业知识注入
 npx skills add tencentcloudbase/cloudbase-skills
 ```
 
-按提示选择 AI 工具即可。也可对 AI 说「安装 CloudBase Skills」。
+按提示选择 AI 工具即可。也可以让 AI 阅读 [Setup Skill](https://docs.cloudbase.net/skill.md) 自引导完成配置。
 
 只装单个 Skill：
 


### PR DESCRIPTION
## 背景

PR #1002 清理了 IDE 配置页「步骤 2」的旧安装提示词，但全仓扫描发现还有 3 处同款「让 AI 安装 CloudBase Skills」的对话引导文案残留。本 PR 将其统一对齐到 skill.md 自引导流程（与 index.mdx / how-to-use.mdx 开头已有的 skill.md 接入步骤一致）。

## 改动（3 文件各 1 行）

- `doc/index.mdx:45`：「也可以直接对 AI 说"安装 CloudBase Skills"。」→「也可以让 AI 阅读 Setup Skill（docs.cloudbase.net/skill.md）自引导完成配置。」
- `doc/prompts/how-to-use.mdx:27`：「也可对 AI 说「安装 CloudBase Skills」。」→ 同上
- `doc/ide-setup/openclaw.mdx:44`：FAQ 标题「是否需要先安装 CloudBase Skills？」→「是否需要手动配置 Skills 或规则？」（答案行由 #1002 更新，本 PR 不动该行，避免冲突）

## 刻意未动

- 显式 CLI 安装命令（`npx skills add`）：README 表格、prompts 页「安装与查看」区块（`scripts/generate-prompts.mjs` 的 `FULL_INSTALL_COMMAND`）、tutorials、index.mdx 第 2 步代码块——显式安装路径仍有效
- AI-facing skill 内容（`config/codebuddy-plugin/skills/cloudbase/SKILL.md` 等 agent 兜底逻辑）

## 依赖

建议在 #1002 合并后再合本 PR（openclaw.mdx 同文件不同行，可自动合并）。
