### PR TITLE
fix(doc): 修正 quick-start/create-env 相对链接层级

### DIFF
--- a/doc/getting-started.mdx
+++ b/doc/getting-started.mdx
@@ -30,7 +30,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/antigravity.mdx
+++ b/doc/ide-setup/antigravity.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/augment-code.mdx
+++ b/doc/ide-setup/augment-code.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/baidu-comate.mdx
+++ b/doc/ide-setup/baidu-comate.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/claude-code.mdx
+++ b/doc/ide-setup/claude-code.mdx
@@ -30,7 +30,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/cline.mdx
+++ b/doc/ide-setup/cline.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/cloudbase-cli.mdx
+++ b/doc/ide-setup/cloudbase-cli.mdx
@@ -35,7 +35,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/codebuddy-code.mdx
+++ b/doc/ide-setup/codebuddy-code.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/codebuddy.mdx
+++ b/doc/ide-setup/codebuddy.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/codex.mdx
+++ b/doc/ide-setup/codex.mdx
@@ -29,7 +29,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/cursor.mdx
+++ b/doc/ide-setup/cursor.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/gemini-cli.mdx
+++ b/doc/ide-setup/gemini-cli.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/github-copilot.mdx
+++ b/doc/ide-setup/github-copilot.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/iflow-cli.mdx
+++ b/doc/ide-setup/iflow-cli.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/kimi-code.mdx
+++ b/doc/ide-setup/kimi-code.mdx
@@ -39,7 +39,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/kiro.mdx
+++ b/doc/ide-setup/kiro.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/openai-codex-cli.mdx
+++ b/doc/ide-setup/openai-codex-cli.mdx
@@ -29,7 +29,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/openclaw.mdx
+++ b/doc/ide-setup/openclaw.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/opencode.mdx
+++ b/doc/ide-setup/opencode.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/qoder.mdx
+++ b/doc/ide-setup/qoder.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/qwen-code.mdx
+++ b/doc/ide-setup/qwen-code.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/roocode.mdx
+++ b/doc/ide-setup/roocode.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/tongyi-lingma.mdx
+++ b/doc/ide-setup/tongyi-lingma.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/trae.mdx
+++ b/doc/ide-setup/trae.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/wechat-devtools.mdx
+++ b/doc/ide-setup/wechat-devtools.mdx
@@ -33,7 +33,7 @@ AI 预览 / 调试能力在 **Nightly** 中提供，稳定版往往没有。Nigh
 <details>
 <summary><strong>已准备好云开发环境</strong></summary>
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/windsurf.mdx
+++ b/doc/ide-setup/windsurf.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/workbuddy.mdx
+++ b/doc/ide-setup/workbuddy.mdx
@@ -28,7 +28,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 

--- a/doc/ide-setup/zcode.mdx
+++ b/doc/ide-setup/zcode.mdx
@@ -32,7 +32,7 @@ node --version
 
 如果未安装，请从 [Node.js 官网](https://nodejs.org/en/download) 下载安装。
 
-**云开发环境：** 请参考文档 [开通云开发环境](../../quick-start/create-env)。新用户可以免费开通体验。
+**云开发环境：** 请参考文档 [开通云开发环境](../../../quick-start/create-env)。新用户可以免费开通体验。
 
 </details>
 


### PR DESCRIPTION
## 改动

修正 `doc/` 下指向 `quick-start/create-env` 的相对链接层级（28 个文件，每处 1 行）：

- `doc/getting-started.mdx`：`../quick-start/create-env` → `../../quick-start/create-env`
- `doc/ide-setup/*.mdx`（27 个）：`../../quick-start/create-env` → `../../../quick-start/create-env`

## 原因

docs.cloudbase.net 上这些页面的 URL 前缀是 `/ai/cloudbase-ai-toolkit/`，原链接少一级，会解析到不存在的 `/ai/quick-start/create-env`，导致下游文档仓 `check:i18n-docs` 相对链接检查报 56 项失败。

## 验证

- 修改后 `doc/` 内已无 `](../quick-start/create-env)` 与 `](../../quick-start/create-env)` 两种错误层级（grep 0 命中）
- 下游 cloudbase-docs MR 同步修正后 `yarn check:i18n-docs` 通过
