### PR TITLE
docs(api-reference): remove internal sync banner from generated page

### DIFF
--- a/doc/api-reference.md
+++ b/doc/api-reference.md
@@ -1,7 +1,5 @@
 # CloudBase 云 API（CloudAPI）清单
 
-> 本页面由定时任务每日自动从腾讯云官方文档同步生成（脚本：`scripts/generate-api-reference.mjs`），请勿手工编辑。
->
 > - 数据源：[API 概览](https://cloud.tencent.com/document/api/876/34809) · [依赖产品接口指引](https://cloud.tencent.com/document/api/876/34808)
 > - 所有接口均为腾讯云 API 3.0 管控面接口，支持各语言官方 SDK 调用；也可通过 CloudBase MCP 的 `callCloudApi` 工具或 [API Explorer](https://console.cloud.tencent.com/api/explorer) 直接调用
 > - 最近同步：2026-09-07

--- a/scripts/generate-api-reference.mjs
+++ b/scripts/generate-api-reference.mjs
@@ -1,7 +1,8 @@
 /**
  * 生成 CloudBase 云 API（CloudAPI）清单页（doc/api-reference.md）
  *
- * 每日由 .github/workflows/sync-api-reference.yml 在 main 上自动运行：
+ * ⚠️ 生成产物，请勿手工编辑：修改本脚本后重新生成即可。
+ * 本页面每日由 .github/workflows/sync-api-reference.yml 在 main 上自动运行：
  * 1. 拉取腾讯云官方文档两页：API 概览(876/34809) + 依赖产品接口指引(876/34808)
  * 2. 提取正文，turndown(+gfm) 转 Markdown
  * 3. 组合写入 doc/api-reference.md，随 cloudbase-docs 同步链路发布到 docs.cloudbase.net
@@ -123,8 +124,6 @@ async function main() {
   const today = new Date().toISOString().slice(0, 10);
   const output = `# CloudBase 云 API（CloudAPI）清单
 
-> 本页面由定时任务每日自动从腾讯云官方文档同步生成（脚本：\`scripts/generate-api-reference.mjs\`），请勿手工编辑。
->
 > - 数据源：[API 概览](https://cloud.tencent.com/document/api/876/34809) · [依赖产品接口指引](https://cloud.tencent.com/document/api/876/34808)
 > - 所有接口均为腾讯云 API 3.0 管控面接口，支持各语言官方 SDK 调用；也可通过 CloudBase MCP 的 \`callCloudApi\` 工具或 [API Explorer](https://console.cloud.tencent.com/api/explorer) 直接调用
 > - 最近同步：${today}


### PR DESCRIPTION
## 改动

移除 `doc/api-reference.md` 页头对用户可见的内部维护提示（"本页面由定时任务每日自动同步生成（脚本：`scripts/generate-api-reference.mjs`），请勿手工编辑"）：

- `scripts/generate-api-reference.mjs`：生成模板中删去该行；维护者提示移入脚本头部注释
- `doc/api-reference.md`：生成产物同步更新

保留对用户有意义的 blockquote：数据源链接、callCloudApi / API Explorer 调用说明、最近同步日期。

## 原因

该提示随同步链路发布到 docs.cloudbase.net，内部脚本路径与维护指令不应暴露给文档读者。未采用 HTML 注释方案，因为 Docusaurus 走 MDX，不支持 `<!-- -->` 注释。
