### PR TITLE
fix(auth): apply intl site rewrite to auth tool device flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file. Follow the 
 
 ## Unreleased
 
+### Bug Fixes
+
+* **auth**: international-site (`TCB_SITE=intl`) device-flow login now rewrites the OAuth endpoint and verification page to the intl hosts (`tcb-api.tencentcloud.com` / `tcb.tencentcloud.com`). The auth tool's `start_auth` device branch called `loginByWebAuth` directly and bypassed the intl rewrite in `ensureLogin`, so intl accounts kept getting domestic-site device codes that can never be authorized (the device-code registries are isolated per site). Both paths now share one `buildDeviceLoginOptions` helper.
+* **auth**: allow `oauthCustom: false` together with an explicit `oauthEndpoint` — required for standard `{code,result}`-wrapped endpoints such as the intl OAuth backend; previously the tool rejected this combination outright.
+
 ## [2.33.0](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/compare/v2.32.5...v2.33.0) (2026-09-04)
 
 ### Features

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -161,7 +161,7 @@ CloudBase（腾讯云开发）开发阶段登录与环境绑定。登录后即�
     {
       name: "oauthCustom",
       type: "boolean",
-      description: `高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true，且不能设为 false`,
+      description: `高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true。标准 {code,result} 包装格式的端点（如国际站 tcb-api.tencentcloud.com）应显式传 false`,
     },
     {
       name: "envId",

--- a/mcp/src/auth.test.ts
+++ b/mcp/src/auth.test.ts
@@ -193,17 +193,77 @@ describe("auth config resolution", () => {
     ).toContain("oauthCustom=true");
   });
 
-  it("should reject oauthEndpoint when oauthCustom is explicitly false", async () => {
+  it("should allow oauthEndpoint when oauthCustom is explicitly false (standard wrapped endpoint)", async () => {
     const { getAuthConfigValidationError } = await import("./auth.js");
 
     expect(
       getAuthConfigValidationError({
         authMode: "device",
-        oauthEndpoint: "https://custom.example.com/oauth",
+        oauthEndpoint: "https://tcb-api.tencentcloud.com/qcloud-tcb/v1/oauth",
         oauthCustom: false,
         usesToolboxDefaults: false,
       }),
-    ).toContain("oauthEndpoint");
+    ).toBeNull();
+  });
+
+  it("buildDeviceLoginOptions should apply intl endpoint override and auth URL rewrite", async () => {
+    const { buildDeviceLoginOptions } = await import("./auth.js");
+
+    const loginOptions = buildDeviceLoginOptions(
+      {
+        authMode: "device",
+        oauthCustom: false,
+        usesToolboxDefaults: true,
+      },
+      { site: "intl" },
+    );
+
+    expect(loginOptions.flow).toBe("device");
+    expect((loginOptions.getOAuthEndpoint as (h: string) => string)("ignored")).toBe(
+      "https://tcb-api.tencentcloud.com/qcloud-tcb/v1/oauth",
+    );
+    const rewritten = (loginOptions.getAuthUrl as (u: string) => string)(
+      "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+    );
+    expect(rewritten).toBe(
+      "https://tcb.tencentcloud.com/dev#/cli-auth?from=cli&flow=device",
+    );
+    expect(loginOptions.custom).toBeUndefined();
+  });
+
+  it("buildDeviceLoginOptions should prefer explicit oauthEndpoint over intl override", async () => {
+    const { buildDeviceLoginOptions } = await import("./auth.js");
+
+    const loginOptions = buildDeviceLoginOptions(
+      {
+        authMode: "device",
+        oauthEndpoint: "https://custom.example.com/oauth",
+        oauthCustom: true,
+        usesToolboxDefaults: false,
+      },
+      { site: "intl" },
+    );
+
+    expect((loginOptions.getOAuthEndpoint as (h: string) => string)("ignored")).toBe(
+      "https://custom.example.com/oauth",
+    );
+    expect(loginOptions.custom).toBe(true);
+  });
+
+  it("buildDeviceLoginOptions should not rewrite anything for domestic site", async () => {
+    const { buildDeviceLoginOptions } = await import("./auth.js");
+
+    const loginOptions = buildDeviceLoginOptions(
+      {
+        authMode: "device",
+        oauthCustom: false,
+        usesToolboxDefaults: true,
+      },
+      { site: "domestic" },
+    );
+
+    expect(loginOptions.getOAuthEndpoint).toBeUndefined();
+    expect(loginOptions.getAuthUrl).toBeUndefined();
   });
 
   it("should reject device-only overrides when authMode is web", async () => {
@@ -335,6 +395,25 @@ describe("CloudBase API Key env resolution", () => {
       "env-intl",
       expect.objectContaining({ cwd: expect.any(String), region: "ap-singapore" }),
     );
+  });
+
+  it("peekLoginState should pass through TENCENTCLOUD_SECRETID/SECRETKEY directly under TCB_SITE=intl", async () => {
+    // 国际站腾讯云密钥直登：密钥凭据与站点无关，原样透传，不触发 API Key 换取或 device flow
+    process.env.TENCENTCLOUD_SECRETID = "intl-secret-id";
+    process.env.TENCENTCLOUD_SECRETKEY = "intl-secret-key";
+    process.env.CLOUDBASE_ENV_ID = "soroli-i2gzw04ic6518ac3a";
+    process.env.TCB_SITE = "intl";
+
+    const { peekLoginState } = await import("./auth.js");
+    const loginState = await peekLoginState();
+
+    expect(mockAuthLoginByApiKey).not.toHaveBeenCalled();
+    expect(mockAuthLoginByWebAuth).not.toHaveBeenCalled();
+    expect(loginState).toMatchObject({
+      secretId: "intl-secret-id",
+      secretKey: "intl-secret-key",
+      envId: "soroli-i2gzw04ic6518ac3a",
+    });
   });
 
   it("peekLoginState should not pass region for domestic default gateway", async () => {

--- a/mcp/src/auth.ts
+++ b/mcp/src/auth.ts
@@ -323,9 +323,10 @@ export function getAuthConfigValidationError(options: ResolvedAuthOptions): stri
     return "oauthCustom=true 时必须同时提供 oauthEndpoint。";
   }
 
-  if (options.oauthEndpoint && !options.oauthCustom) {
-    return "配置自定义 oauthEndpoint 时必须启用 oauthCustom=true。";
-  }
+  // oauthEndpoint + 显式 oauthCustom=false 放行：resolveAuthOptions 对"只配 endpoint
+  // 未配 custom"已默认 custom=true，走到这里的 endpoint+false 只可能是用户显式指定——
+  // 即标准 {code,result} 包装格式的自定义端点（如国际站 tcb-api.tencentcloud.com），
+  // 拦截会导致标准格式端点在工具层永远不可用。
 
   return null;
 }
@@ -338,6 +339,51 @@ export function buildAuthConfigSummary(options: ResolvedAuthOptions) {
     oauth_custom: options.oauthCustom,
     uses_toolbox_defaults: options.usesToolboxDefaults,
   };
+}
+
+/**
+ * 构造 device flow 的 loginByWebAuth 基础参数（onDeviceCode 由调用方按需注入）。
+ *
+ * 所有 device 登录路径（ensureLogin 与 auth 工具 start_auth 的 device 分支）必须
+ * 共享本函数：TCB_SITE=intl 时的 getOAuthEndpoint 覆写与 getAuthUrl 授权页改写
+ * 只在 ensureLogin 生效，会导致工具层直连路径仍打国内站端点/授权页，国际站账号
+ * 无法完成授权（device-code 注册表国内外隔离，国内授权页对国际站账号无效）。
+ */
+export function buildDeviceLoginOptions(
+  resolvedAuthOptions: ResolvedAuthOptions,
+  siteHints: { region?: string; site?: string } = {},
+): Record<string, unknown> {
+  const resolvedSite = resolveSite(
+    siteHints.region,
+    siteHints.site ?? process.env.TCB_SITE,
+  );
+  const loginOptions: Record<string, unknown> = { flow: "device" };
+
+  if (resolvedAuthOptions.clientId) {
+    loginOptions.client_id = resolvedAuthOptions.clientId;
+  }
+  if (resolvedAuthOptions.oauthEndpoint) {
+    loginOptions.getOAuthEndpoint = () => resolvedAuthOptions.oauthEndpoint!;
+  } else if (resolvedSite === "intl") {
+    // 国际站 OAuth 后端独立部署（2026-09-01 实测 device/code+token 可用，注册表与国内站隔离）；
+    // 不覆写时 toolbox 默认打国内站端点，国际站账号无法完成授权
+    loginOptions.getOAuthEndpoint = () => SITE_REGION_MAP.intl.oauthEndpoint!;
+  }
+  if (resolvedSite === "intl") {
+    // device 模式的 verification_uri 标准模式下由客户端拼接，指向国内站授权页；
+    // 与 web 模式同款 host 改写，把授权页切到国际站
+    loginOptions.getAuthUrl = (url: string) =>
+      url
+        .replace(
+          `${SITE_REGION_MAP.domestic.authHost}/dev`,
+          `${SITE_REGION_MAP.intl.authHost}/dev`,
+        )
+        .replace(SITE_REGION_MAP.domestic.authHost, SITE_REGION_MAP.intl.authHost);
+  }
+  if (resolvedAuthOptions.oauthCustom) {
+    loginOptions.custom = true;
+  }
+  return loginOptions;
 }
 
 export function setPendingAuthProgressState(
@@ -640,30 +686,14 @@ export async function ensureLogin(options?: EnsureLoginOptions) {
             return `${finalUrl}${separator}allowNoEnv=true`;
           };
     } else {
-      if (resolvedAuthOptions.clientId) {
-        loginOptions.client_id = resolvedAuthOptions.clientId;
-      }
-      if (resolvedAuthOptions.oauthEndpoint) {
-        loginOptions.getOAuthEndpoint = () => resolvedAuthOptions.oauthEndpoint!;
-      } else if (resolvedSite === "intl") {
-        // 国际站 OAuth 后端独立部署（2026-09-01 实测 device/code+token 可用，注册表与国内站隔离）；
-        // 不覆写时 toolbox 默认打国内站端点，国际站账号无法完成授权
-        loginOptions.getOAuthEndpoint = () => SITE_REGION_MAP.intl.oauthEndpoint!;
-      }
-      if (resolvedSite === "intl") {
-        // device 模式的 verification_uri 标准模式下由客户端拼接，指向国内站授权页；
-        // 与 web 模式同款 host 改写，把授权页切到国际站
-        loginOptions.getAuthUrl = (url: string) =>
-          url
-            .replace(
-              `${SITE_REGION_MAP.domestic.authHost}/dev`,
-              `${SITE_REGION_MAP.intl.authHost}/dev`,
-            )
-            .replace(SITE_REGION_MAP.domestic.authHost, SITE_REGION_MAP.intl.authHost);
-      }
-      if (resolvedAuthOptions.oauthCustom) {
-        loginOptions.custom = true;
-      }
+      // device 模式：与 auth 工具 start_auth device 分支共享 intl 端点覆写与授权页改写
+      Object.assign(
+        loginOptions,
+        buildDeviceLoginOptions(resolvedAuthOptions, {
+          region: options?.region,
+          site: options?.site,
+        }),
+      );
       if (options?.onDeviceCode) {
         loginOptions.onDeviceCode = (info: DeviceFlowAuthInfo) => {
           setPendingAuthProgressState(info, mode);

--- a/mcp/src/tools/env.test.ts
+++ b/mcp/src/tools/env.test.ts
@@ -81,9 +81,6 @@ const {
     if (options.oauthCustom && !options.oauthEndpoint) {
       return "oauthCustom=true 时必须同时提供 oauthEndpoint。";
     }
-    if (options.oauthEndpoint && !options.oauthCustom) {
-      return "配置自定义 oauthEndpoint 时必须启用 oauthCustom=true。";
-    }
     return null;
   }),
   mockSupervisorLoginByWebAuth: vi.fn(),
@@ -133,24 +130,28 @@ vi.mock("@cloudbase/toolbox", () => ({
   },
 }));
 
-vi.mock("../auth.js", () => ({
-  buildAuthConfigSummary: mockBuildAuthConfigSummary,
-  buildDeviceAuthChallengePayload: mockBuildDeviceAuthChallengePayload,
-  buildVerificationUriComplete: mockBuildVerificationUriComplete,
-  ensureLogin: mockEnsureLogin,
-  ensureSlottedCredential: mockEnsureSlottedCredential,
-  listUsableCredentialSites: mockListUsableCredentialSites,
-  getAuthConfigValidationError: mockGetAuthConfigValidationError,
-  getCloudBaseApiKeyFromEnv: () =>
-    process.env.CLOUDBASE_API_KEY || process.env.CLOUDBASE_APIKEY || undefined,
-  peekLoginState: mockPeekLoginState,
-  getAuthProgressState: mockGetAuthProgressState,
-  logout: mockLogout,
-  rejectAuthProgressState: vi.fn(),
-  resolveAuthOptions: mockResolveAuthOptions,
-  resolveAuthProgressState: vi.fn(),
-  setPendingAuthProgressState: vi.fn(),
-}));
+vi.mock("../auth.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../auth.js")>();
+  return {
+    ...actual,
+    buildAuthConfigSummary: mockBuildAuthConfigSummary,
+    buildDeviceAuthChallengePayload: mockBuildDeviceAuthChallengePayload,
+    buildVerificationUriComplete: mockBuildVerificationUriComplete,
+    ensureLogin: mockEnsureLogin,
+    ensureSlottedCredential: mockEnsureSlottedCredential,
+    listUsableCredentialSites: mockListUsableCredentialSites,
+    getAuthConfigValidationError: mockGetAuthConfigValidationError,
+    getCloudBaseApiKeyFromEnv: () =>
+      process.env.CLOUDBASE_API_KEY || process.env.CLOUDBASE_APIKEY || undefined,
+    peekLoginState: mockPeekLoginState,
+    getAuthProgressState: mockGetAuthProgressState,
+    logout: mockLogout,
+    rejectAuthProgressState: vi.fn(),
+    resolveAuthOptions: mockResolveAuthOptions,
+    resolveAuthProgressState: vi.fn(),
+    setPendingAuthProgressState: vi.fn(),
+  };
+});
 
 vi.mock("../cloudbase-manager.js", () => ({
   envManager: {
@@ -691,16 +692,73 @@ describe("env tools - auth", () => {
     expect(payload.message).toContain("oauthCustom=true");
   });
 
-  it("auth(action=start_auth) should reject oauthEndpoint when oauthCustom is explicitly false", async () => {
+  it("auth(action=start_auth) should allow standard-format endpoint with explicit oauthCustom=false", async () => {
+    mockPeekLoginState.mockResolvedValue(null);
+    mockSupervisorLoginByWebAuth.mockImplementation(
+      async ({ onDeviceCode }: { onDeviceCode: (info: any) => void }) => {
+        onDeviceCode({
+          user_code: "WDJB-MJHT",
+          verification_uri: "https://example.com/device",
+          device_code: "device-code",
+          expires_in: 600,
+        });
+        return new Promise(() => {});
+      },
+    );
+
     const result = await tools.auth.handler({
       action: "start_auth",
-      oauthEndpoint: "https://custom.example.com/oauth",
+      oauthEndpoint: "https://tcb-api.tencentcloud.com/qcloud-tcb/v1/oauth",
       oauthCustom: false,
     });
     const payload = JSON.parse(result.content[0].text);
 
-    expect(payload).toHaveProperty("code", "INVALID_ARGS");
-    expect(payload.message).toContain("oauthEndpoint");
+    expect(payload).toHaveProperty("code", "AUTH_PENDING");
+    const callArgs = mockSupervisorLoginByWebAuth.mock.calls.at(-1)![0];
+    expect(callArgs.getOAuthEndpoint("ignored")).toBe(
+      "https://tcb-api.tencentcloud.com/qcloud-tcb/v1/oauth",
+    );
+    expect(callArgs.custom).toBeUndefined();
+  });
+
+  it("auth(action=start_auth) should rewrite device endpoint and auth URL for intl site", async () => {
+    mockPeekLoginState.mockResolvedValue(null);
+    mockSupervisorLoginByWebAuth.mockImplementation(
+      async ({ onDeviceCode }: { onDeviceCode: (info: any) => void }) => {
+        onDeviceCode({
+          user_code: "WDJB-MJHT",
+          verification_uri:
+            "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+          device_code: "device-code",
+          expires_in: 600,
+        });
+        return new Promise(() => {});
+      },
+    );
+
+    process.env.TCB_SITE = "intl";
+    try {
+      const result = await tools.auth.handler({
+        action: "start_auth",
+        authMode: "device",
+      });
+      const payload = JSON.parse(result.content[0].text);
+
+      expect(payload).toHaveProperty("code", "AUTH_PENDING");
+      const callArgs = mockSupervisorLoginByWebAuth.mock.calls.at(-1)![0];
+      expect(callArgs.getOAuthEndpoint("ignored")).toBe(
+        "https://tcb-api.tencentcloud.com/qcloud-tcb/v1/oauth",
+      );
+      expect(
+        callArgs.getAuthUrl(
+          "https://tcb.cloud.tencent.com/dev#/cli-auth?from=cli&flow=device",
+        ),
+      ).toBe(
+        "https://tcb.tencentcloud.com/dev#/cli-auth?from=cli&flow=device",
+      );
+    } finally {
+      delete process.env.TCB_SITE;
+    }
   });
 
   it("auth(action=start_auth, authMode=web) should continue environment preparation after login", async () => {

--- a/mcp/src/tools/env.ts
+++ b/mcp/src/tools/env.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import {
   buildAuthConfigSummary,
   buildDeviceAuthChallengePayload,
+  buildDeviceLoginOptions,
   buildVerificationUriComplete,
   ensureLogin,
   ensureSlottedCredential,
@@ -2085,7 +2086,7 @@ export function registerEnvTools(server: ExtendedMcpServer) {
               oauthCustom: z
                 .boolean()
                 .optional()
-                .describe("高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true，且不能设为 false"),
+                .describe("高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true。标准 {code,result} 包装格式的端点（如国际站 tcb-api.tencentcloud.com）应显式传 false"),
             }
           : {}),
         envId: z
@@ -2371,19 +2372,15 @@ export function registerEnvTools(server: ExtendedMcpServer) {
             };
 
             try {
-              // 启动 Device Flow，全流程由 toolbox 负责轮询和写入 credential，这里不等待完成
+              // 启动 Device Flow，全流程由 toolbox 负责轮询和写入 credential，这里不等待完成。
+              // 登录参数（含 TCB_SITE=intl 端点覆写与授权页改写）与 ensureLogin 共享同一 helper，
+              // 避免此直连路径绕过国际站改写导致国际站账号拿到的仍是国内站链接
               auth
                 .loginByWebAuth({
-                  flow: "device",
-                  ...(resolvedAuthOptions.clientId
-                    ? { client_id: resolvedAuthOptions.clientId }
-                    : {}),
-                  ...(resolvedAuthOptions.oauthEndpoint
-                    ? { getOAuthEndpoint: () => resolvedAuthOptions.oauthEndpoint! }
-                    : {}),
-                  ...(resolvedAuthOptions.oauthCustom
-                    ? { custom: true }
-                    : {}),
+                  ...buildDeviceLoginOptions(resolvedAuthOptions, {
+                    region,
+                    site: server.cloudBaseOptions?.site,
+                  }),
                   onDeviceCode: deviceOnCode,
                 })
                 .then(async () => {

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -39,7 +39,7 @@
           },
           "oauthCustom": {
             "type": "boolean",
-            "description": "高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true，且不能设为 false"
+            "description": "高级可选：自定义 endpoint 返回格式开关。未配置 endpoint 时默认 false；配置 endpoint 后默认 true。标准 {code,result} 包装格式的端点（如国际站 tcb-api.tencentcloud.com）应显式传 false"
           },
           "envId": {
             "type": "string",


### PR DESCRIPTION
## 问题

国际站（`TCB_SITE=intl`）会话里，auth 工具 `start_auth`（device flow）返回的仍是**国内站**设备码链接（`tcb.cloud.tencent.com/dev`）和国内站 OAuth 端点，国际站账号无法完成授权。

### 根因

#972 的国际站改写（`getOAuthEndpoint` 覆写 + `getAuthUrl` 授权页切到 `tcb.tencentcloud.com`）只加在 `ensureLogin()` 里（`mcp/src/auth.ts`），而 auth 工具的 `start_auth` device 分支（`mcp/src/tools/env.ts`）**直连 `auth.loginByWebAuth({flow:"device",...})`**，不带端点/授权页改写，`TCB_SITE` 在这条路径上被完全忽略。

连带问题：`getAuthConfigValidationError` 拦截「配置 endpoint 时必须 `oauthCustom=true`」。由于 `resolveAuthOptions` 对「只配 endpoint」已默认 `custom=true`，这条拦截唯一命中的就是显式 `false`——即标准 `{code,result}` 包装格式的国际站端点（`tcb-api.tencentcloud.com`），在工具层永远传不进去。

实测佐证：device-code 注册表国内外站隔离（国内端点签发的 code 在国际站端点轮询返回 `expired_token`，反之亦然），所以拿到国内站链接的国际站用户点了也无法完成授权。

### 修复

| 文件 | 改动 |
|---|---|
| `mcp/src/auth.ts` | ① 新增导出 `buildDeviceLoginOptions()` 共享 helper（intl endpoint 覆写 + 授权页 host 改写），`ensureLogin` 复用；② 删除「endpoint + 显式 `oauthCustom=false`」拦截分支 |
| `mcp/src/tools/env.ts` | `start_auth` device 分支改用共享 helper，`TCB_SITE=intl` 从此生效；schema description 同步 |
| 产物 | `scripts/tools.json`、`doc/mcp-tools.md` 同步（仅 oauthCustom 描述一行）；`CHANGELOG.md` Unreleased 补条目 |

注：`capi.ts` 无同款 `loginByWebAuth` 调用（全仓仅 auth.ts 与 env.ts 两处），无需额外覆盖。

### 兼容性

- **腾讯云密钥直登**（`TENCENTCLOUD_SECRETID/SECRETKEY`）与 **CloudBase API Key 换取**（`CLOUDBASE_API_KEY`）路径不受影响：密钥直登是站点无关的直通设计，API Key 换取网关已按站点选型（`resolveApiKeyExchangeRegion`）。本次新增回归测试锁定了「intl + 密钥直登不触发 OAuth/device 逻辑」的行为。
- `oauthCustom` 校验放开后，原有「只配 endpoint 默认 custom=true」的行为不变，仅放行显式 `false`。

### 验收标准

- [x] `TCB_SITE=intl` 下 `auth(start_auth, device)` 返回的 `verification_uri` 为 `tcb.tencentcloud.com/dev`，OAuth 端点为 `tcb-api.tencentcloud.com`
- [x] `TCB_SITE` 未设置（国内站）时行为不变（仍为 `tcb.cloud.tencent.com` / `tcb-api.cloud.tencent.com`）
- [x] 显式 `oauthCustom=false` + endpoint 组合被接受，标准包装格式端点可用
- [x] `TENCENTCLOUD_SECRETID/SECRETKEY` 直登路径不受影响

### 测试

- `auth.test.ts`：新增 `buildDeviceLoginOptions` 单测（intl 改写、domestic 不改写、显式 endpoint 优先）+ `oauthCustom=false` 放行 + intl 密钥直通回归测试
- `env.test.ts`：auth mock 改为 `importOriginal` hybrid（保留真实 helper），新增 intl `start_auth` 端到端改写测试
- 本地 `auth.test.ts`（38）+ `env.test.ts`（87）共 125 个用例全部通过
