### PR TITLE
chore(experts): bump plugin version to 1.0.1

### DIFF
--- a/plugins/experts/cloudbase-webdev-expert/.codebuddy-plugin/plugin.json
+++ b/plugins/experts/cloudbase-webdev-expert/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudbase-webdev-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CloudBase Web application expert: builds and deploys full-stack web apps — frontend hosting, PostgreSQL, RLS row-level security, cloud functions, and AI/LLM integration — for non-developers building internal tools and teams shipping SaaS MVPs.",
   "author": {
     "name": "booker",

--- a/plugins/experts/miniprogram-clouddev-expert/.codebuddy-plugin/plugin.json
+++ b/plugins/experts/miniprogram-clouddev-expert/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "miniprogram-clouddev-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "WeChat mini program cloud development expert: builds mini programs on WeChat Cloud Development (CloudBase) using cloud-dev skills as knowledge and WeChat DevTools CLI/MCP as tools, covering cloud functions, cloud database, message push callbacks, and virtual payment integration.",
   "author": {
     "name": "booker",


### PR DESCRIPTION
## Summary

两个 WorkBuddy 专家包（miniprogram-clouddev-expert / cloudbase-webdev-expert）上传时被拒：`包内版本号 "1.0.0" 必须大于当前最新版本 "1.0.0"`。将两包 `plugin.json` 的 version 从 1.0.0 递增到 1.0.1，内容无其他变更。

## Changes

- `plugins/experts/miniprogram-clouddev-expert/.codebuddy-plugin/plugin.json`: version 1.0.0 → 1.0.1
- `plugins/experts/cloudbase-webdev-expert/.codebuddy-plugin/plugin.json`: version 1.0.0 → 1.0.1
