### PR TITLE
feat(experts): add connector & skill prerequisite checks to cloudbase-webdev-expert

### DIFF
--- a/plugins/experts/cloudbase-webdev-expert/.codebuddy-plugin/plugin.json
+++ b/plugins/experts/cloudbase-webdev-expert/.codebuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "cloudbase-webdev-expert",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "CloudBase Web application expert: builds and deploys full-stack web apps — frontend hosting, PostgreSQL, RLS row-level security, cloud functions, and AI/LLM integration — for non-developers building internal tools and teams shipping SaaS MVPs.",
   "author": {
     "name": "booker",

--- a/plugins/experts/cloudbase-webdev-expert/README.md
+++ b/plugins/experts/cloudbase-webdev-expert/README.md
@@ -15,10 +15,13 @@ CloudBase Web 全栈单专家。定位：**前端页面 + PostgreSQL + RLS 行�
 | 核心 | 平台总览 / Web 开发部署 / PG / 前端直连 PG / MCP 建表 | `cloudbase-platform`、`cloudbase-sites-runtime`、`postgresql-development-cloudbase`、`relational-database-web-cloudbase`、`relational-database-mcp-cloudbase` |
 | 补充 | 云函数 / 鉴权 / 存储 / 大模型 / 建模 / UI | `cloud-functions`、`auth-web-cloudbase`、`cloud-storage-web`、`ai-model-web`、`data-model-creation`、`ui-design` |
 | 包内 | 企业落地模式、需求描述模板、安全红线、场景适配判断 | `references/enterprise-web-toolkit-playbook.md` |
+| 逃生通道 | 包内未列的其他 CloudBase 能力（文档数据库、CloudRun、网关等） | 先查 `cloudbase-platform` 路由到对应官方 skill，未安装按 skillhub.md 提示安装；无 skill 时查 docs.cloudbase.net |
 
 ## 使用
 
 WorkBuddy 专家中心选择本专家，直接描述需求（如"帮我做一个客户跟进管理工具，按角色区分权限"）。
+
+**使用前提**：会话需已连接「腾讯云 CloudBase」connector（建表、部署等 MCP 工具的来源）；未连接时专家只出方案，会引导先连接。引用的官方 skills 未安装时，专家会按 skillhub.md 方式提示安装。
 
 ## 维护
 

--- a/plugins/experts/cloudbase-webdev-expert/agents/cloudbase-webdev-expert.md
+++ b/plugins/experts/cloudbase-webdev-expert/agents/cloudbase-webdev-expert.md
@@ -23,6 +23,13 @@ categoryId: "02-Engineering"
 
 领域知识一律引用运行时可用的 CloudBase 官方 skills，不在本包内复制，避免双份漂移。官方 skill 未覆盖的踩坑经验才写进包内 references。
 
+## 工具与连接前提
+
+| 前提 | 检查方式 | 缺失时动作 |
+|------|----------|------------|
+| CloudBase connector 已连接 | 尝试一个只读 MCP 工具（如查询环境列表）；失败即视为未连接 | 引导用户在连接器管理页连接「腾讯云 CloudBase」，未连接前只出方案，不执行建表 / 写库 / 部署类操作 |
+| 引用的官方 skills 可用 | 调用前确认对应 skill 存在 | 按 https://skillhub.cn/install/skillhub.md 的方式提示用户安装对应 skill，再继续；不凭记忆复述 skill 内容 |
+
 ## Skill 调用分层
 
 1. **核心（按场景调用）**
@@ -39,6 +46,7 @@ categoryId: "02-Engineering"
    - 复杂业务建模 → `data-model-creation`
    - UI 视觉规范 → `ui-design`
 3. **企业落地模式**（统一采购凭证、对内对外域名隔离、非开发者需求描述模板、安全红线）→ 包内 `references/enterprise-web-toolkit-playbook.md`
+4. **逃生通道（本包未列的其他 CloudBase 能力）**：文档数据库 Web 端、CloudRun 容器部署、网关等能力不在上面分层里——先查 `cloudbase-platform` 总览路由到对应的 CloudBase 官方 skill，skill 未安装时按 https://skillhub.cn/install/skillhub.md 的方式提示用户安装再继续；没有对应 skill 时查官方文档（https://docs.cloudbase.net/ ）验证后动手，不凭记忆编造 API
 
 ## 工作流程
 


### PR DESCRIPTION
## What

`cloudbase-webdev-expert`（云开发业务系统专家）此前只描述能力、不校验运行前提。用户如果没连 CloudBase connector 或缺少运行时 skill，专家会直接开工然后失败。本 PR 把"前置检查 + 兜底路径"写进专家 SOP：

1. **Agent MD 新增「工具与连接前提」**（对齐 miniprogram-clouddev-expert 的「工具链前提」做法）：
   - CloudBase connector 未连接（试一个只读 MCP 工具即知）→ 只出方案，不执行建表 / 写库 / 部署，引导用户先连接
   - 引用的官方 skill 缺失 → 按 skillhub.md 方式提示安装，不凭记忆复述
2. **Agent MD Skill 调用分层新增第 4 条「逃生通道」**：包内未列的其他 CloudBase 能力（文档数据库 Web SDK、CloudRun、网关等）→ 经 `cloudbase-platform` 总览路由到对应官方 skill → 缺 skill 按 skillhub.md 安装 → 无 skill 查 docs.cloudbase.net 验证后动手。避免逐一枚举 skill 造成双份清单漂移。
3. **README** 补使用前提说明。
4. plugin.json version 1.0.1 → 1.0.2（`experts:sync` validate passed）。

## Why not manifest 层强制

调研过 expert-manager 的 validate_expert.py / register_expert.py：专家包格式没有 connector / MCP 依赖声明字段（`skills: []` 仅支持打包 skill 目录）。所以"要求连接 connector"只能做在 Agent MD 的 SOP 层；"打包 skill"技术上可行但违反"引用为主、不复制防漂移"原则（这些 skills 是 WorkBuddy 内置），故不采用。

## Verification

- `npm run experts:sync cloudbase-webdev-expert`：validate_expert.py + register_expert.py 通过
- plugin.json 改动仅 version 一行（保留原格式）
