### PR TITLE
fix(skills): add missing sibling-skills section to unblock v2.33.2 npm publish

### DIFF
--- a/config/source/skills/cloud-api-operations/SKILL.md
+++ b/config/source/skills/cloud-api-operations/SKILL.md
@@ -8,6 +8,12 @@ version: 2.33.2
 
 Operate Tencent Cloud resources that CloudBase depends on but that no dedicated MCP tool covers (monitoring & alarms, CLB, CAM roles, cross-product infra). Two goals: **find the right API without guessing**, and **reuse proven workflows instead of re-exploring**.
 
+## Sibling skills (local only)
+
+Sibling CloudBase skills ship beside this skill. Use local relative paths such as `../cloudbase-platform/SKILL.md`.
+
+If a referenced sibling skill file is missing from this environment, ask the user to install the full CloudBase plugin (or the missing skill). Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
+
 ## When to use
 
 - The user asks to manage/operate Tencent Cloud resources beyond CloudBase's dedicated MCP tools (e.g. configure alarm policies, inspect CLB, attach CAM policies).

--- a/config/source/skills/cloudbase-declarative-deploy/SKILL.md
+++ b/config/source/skills/cloudbase-declarative-deploy/SKILL.md
@@ -23,7 +23,7 @@ Sibling CloudBase skills ship beside this skill. Use local relative paths such a
 Cloud-hosted MCP mode does not guarantee access to a local workspace filesystem or
 stable relative paths. If a referenced sibling file is not available in cloud mode,
 use this skill's embedded guidance as source of truth and ask the user for any
-missing constraints — do not HTTP-fetch remote skill markdown.
+missing constraints (or to install the missing skill). Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
 
 **Cross-cutting protocols** (required before applying any deploy):
 - Change Safety Protocol: `../cloudbase-platform/references/protocols/change-safety-protocol.md`

--- a/plugin/cloudbase/.qoder-plugin/plugin.json
+++ b/plugin/cloudbase/.qoder-plugin/plugin.json
@@ -39,6 +39,7 @@
     "./skills/cloudbase-agent/",
     "./skills/cloudbase-cli/",
     "./skills/cloudbase-code-review/",
+    "./skills/cloudbase-declarative-deploy/",
     "./skills/cloudbase-document-database-in-wechat-miniprogram/",
     "./skills/cloudbase-document-database-web-sdk/",
     "./skills/cloudbase-platform/",

--- a/plugin/cloudbase/generated/skill-manifest.json
+++ b/plugin/cloudbase/generated/skill-manifest.json
@@ -1,11 +1,11 @@
 {
   "version": 2,
-  "generatedAt": "2026-09-08T12:04:02.304Z",
+  "generatedAt": "2026-09-09T04:53:10.805Z",
   "skills": {
     "ai-model-nodejs": {
       "name": "ai-model-nodejs",
       "description": "Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express/Koa/NestJS, serverless APIs, scheduled jobs, LLM proxies, agent orchestration. The only SDK supporting image generation (ai.createImageModel + generateImage). Text via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*; model ids (e.g. deepseek-v4-flash, glm-5, kimi-k2.6) go in the `model` field of generateText/streamText. MUST run two-step preflight before code — see body. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat).",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -92,7 +92,7 @@
     "ai-model-web": {
       "name": "ai-model-web",
       "description": "Use this skill when a browser/Web app (React, Vue, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI, 页面, 前端, 网页) needs AI models via @cloudbase/js-sdk. Default routing for Web/frontend AI — call directly from the browser, do NOT propose a Node.js proxy. Covers generateText and streamText; models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*, model id in the `model` field. MUST run two-step preflight before code — see body. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only).",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -168,7 +168,7 @@
     "ai-model-wechat": {
       "name": "ai-model-wechat",
       "description": "Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, wx.cloud apps). Covers generateText and streamText with callbacks (onText, onEvent, onFinish); streamText needs a data wrapper, generateText returns the raw response. Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*; model id goes in the data wrapper `model` field. MUST run two-step preflight before code — see body. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs).",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -232,7 +232,7 @@
     "auth-nodejs-cloudbase": {
       "name": "auth-nodejs-cloudbase",
       "description": "CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -307,7 +307,7 @@
     "auth-tool-cloudbase": {
       "name": "auth-tool-cloudbase",
       "description": "CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 8
       },
@@ -374,7 +374,7 @@
     "auth-web-cloudbase": {
       "name": "auth-web-cloudbase",
       "description": "CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -443,7 +443,7 @@
     "auth-wechat-miniprogram": {
       "name": "auth-wechat-miniprogram",
       "description": "CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -509,7 +509,7 @@
     "cloud-api-operations": {
       "name": "cloud-api-operations",
       "description": "Operate Tencent Cloud control-plane resources (monitoring/alarms, CLB, CAM roles, COS, MySQL, SCF, etc.) via cloud APIs when no dedicated MCP tool exists. Covers API discovery via the api-reference index, calling via MCP callCloudApi or official SDKs, credential/permission models with CAM authorization escalation, and battle-tested workflow recipes. Use when the task requires Tencent Cloud control-plane operations beyond CloudBase's own tooling.",
-      "version": "1.1.0",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -590,7 +590,7 @@
     "cloud-functions": {
       "name": "cloud-functions",
       "description": "CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 8
       },
@@ -657,7 +657,7 @@
     "cloud-storage-web": {
       "name": "cloud-storage-web",
       "description": "Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -716,7 +716,7 @@
     "cloudbase": {
       "name": "cloudbase",
       "description": "Use this skill when you develop, design, build, deploy, debug, migrate, or troubleshoot CloudBase (腾讯云开发, 云开发, TCB, 微信云开发) projects — Web, 微信小程序, 小程序, uni-app, mobile (iOS, Android, Flutter, React Native). Covers UI (页面, 界面, 表单, dashboard, prototype, 原型); auth (登录, 注册, OAuth, publishable key); databases (NoSQL 文档数据库, MySQL 关系型数据库, PostgreSQL/CloudBase PG, app.rdb(), queryPgDatabase/managePgDatabase, CRUD, security rules); 云函数/cloud functions (serverless, scf_bootstrap); CloudRun (云托管, Dockerfile); 云存储; built-in AI (内置大模型, AI 对话, streaming, 流式输出, 图片生成, generateText, streamText, createModel, generateImage, TokenHub, Hunyuan, DeepSeek, GLM, Kimi, Token Credits 资源包, 小程序成长计划); third-party/custom model onboarding (第三方大模型接入, 大模型调用, LLM API); AI agent (智能体, AG-UI, LangGraph); ops troubleshooting (巡检, 诊断, 日志); spec workflow (需求文档, 技术方案, requirements, tasks.md). Do NOT use for non-CloudBase projects, pure frontend without CloudBase, or self-hosted backends without CloudBase.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -773,7 +773,7 @@
     "cloudbase-agent": {
       "name": "cloudbase-agent",
       "description": "Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -838,7 +838,7 @@
     "cloudbase-cli": {
       "name": "cloudbase-cli",
       "description": "CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. Use when deploying cloud functions, CloudRun, storage, NoSQL/MySQL, static hosting, permissions, CORS/domains via tcb; for CI/CD and batch ops; when the user prefers CLI; or as the first-session fallback when CloudBase MCP tools are not loaded yet (after install/config, before IDE restart). Covers tcb login (device code for Tencent Cloud accounts; --cloudbase-api-key -e for environment API Key without an account; --apiKeyId/--apiKey for CI) and domain commands (fn/hosting/cloudrun/…) as MCP auth/manage parity — do not default to tcb deploy.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -896,7 +896,7 @@
     "cloudbase-code-review": {
       "name": "cloudbase-code-review",
       "description": "Code review and validation for CloudBase projects. After writing code for Web / miniprogram / CloudRun / cloud-function projects, call this skill to check for known pitfalls — auth guard misuse, missing database tables, RLS misconfiguration, storage domain setup, and SDK API misuse. Supports automated lint scripts (regex-based) + LLM semantic review.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -947,10 +947,87 @@
       "pathRegexSources": [],
       "bashPatterns": []
     },
+    "cloudbase-declarative-deploy": {
+      "name": "cloudbase-declarative-deploy",
+      "description": "CloudBase declarative deployment from a cloudbaserc config (声明式部署, 配置式部署, cloudbaserc 部署) through the deployApply / deployPlan MCP tools. Use when deploying database, functions, app, hosting, or gateway resources described in cloudbaserc.json/yaml as a single desired-state config, when a user wants a dry-run plan before applying, or when handling multi-environment deploys via mode / envOverrides. Covers plan-then-apply flow (deployPlan dry-run → deployApply confirm=true), envId resolution priority, only/skip filtering, concurrency, and continueOnError. Prefer deployPlan before deployApply; do not confuse with per-resource tcb CLI deploy or single-function deploy.",
+      "version": "2.33.2",
+      "metadata": {
+        "priority": 6
+      },
+      "promptSignals": {
+        "phrases": [
+          "声明式部署",
+          "配置式部署",
+          "cloudbaserc 部署",
+          "deployplan",
+          "declarative deploy",
+          "deploy from cloudbaserc",
+          "部署整个项目",
+          "dry-run 部署计划",
+          "预演部署"
+        ],
+        "allOf": [
+          [
+            "cloudbaserc",
+            "部署"
+          ],
+          [
+            "声明式",
+            "部署"
+          ],
+          [
+            "declarative",
+            "deploy"
+          ]
+        ],
+        "anyOf": [
+          "deployPlan",
+          "deployApply",
+          "deploy",
+          "envOverrides",
+          "desired state"
+        ],
+        "minScore": 6,
+        "noneOf": [
+          "tcb deploy",
+          "单个函数"
+        ]
+      },
+      "retrieval": {
+        "aliases": [
+          "声明式部署",
+          "配置式部署",
+          "cloudbaserc deploy",
+          "declarative deploy"
+        ],
+        "intents": [
+          "从 cloudbaserc 部署整个项目",
+          "预演部署计划",
+          "多环境部署",
+          "声明式部署资源"
+        ],
+        "entities": [
+          "cloudbaserc",
+          "deployPlan",
+          "deployApply",
+          "deploy",
+          "envOverrides",
+          "DeployOrchestrator"
+        ],
+        "examples": [
+          "用 cloudbaserc 声明式部署整个项目",
+          "先预演一下部署计划再执行",
+          "按 production mode 部署到生产环境",
+          "deploy the whole project from cloudbaserc"
+        ]
+      },
+      "pathRegexSources": [],
+      "bashPatterns": []
+    },
     "cloudbase-document-database-in-wechat-miniprogram": {
       "name": "cloudbase-document-database-in-wechat-miniprogram",
       "description": "Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -1005,7 +1082,7 @@
     "cloudbase-document-database-web-sdk": {
       "name": "cloudbase-document-database-web-sdk",
       "description": "Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 7
       },
@@ -1071,7 +1148,7 @@
     "cloudbase-platform": {
       "name": "cloudbase-platform",
       "description": "CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 8
       },
@@ -1124,7 +1201,7 @@
     "cloudbase-wechat-integration": {
       "name": "cloudbase-wechat-integration",
       "description": "CloudBase WeChat integration guide for Mini Program WeChat Pay, Mini Program virtual payment (虚拟支付, wx.requestVirtualPayment), Official Account JSAPI Pay, Native QR-code Pay, Official Account OAuth, openid handling, payment callbacks, and CloudBase Integration Center generated functions. This skill should be used when users ask to add, debug, or extend WeChat payment, virtual payment, or official-account flows on CloudBase.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -1194,7 +1271,7 @@
     "cloudrun-development": {
       "name": "cloudrun-development",
       "description": "CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, AI agent development, or migrating existing/GitHub apps that need VPC access to MySQL/PostgreSQL/Redis. Also use when diagnosing CloudRun container deploy failures (deploy_failed, readiness/probe failed, image won't start, docker.io pull loops). For stateless HTTP services, prefer HTTP cloud functions.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 7
       },
@@ -1275,7 +1352,7 @@
     "http-api-cloudbase": {
       "name": "http-api-cloudbase",
       "description": "CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 5
       },
@@ -1325,7 +1402,7 @@
     "minimal-web-baas-demo": {
       "name": "minimal-web-baas-demo",
       "description": "Fast path for a minimal CloudBase Web + database demo (最小前后端 / 最小可用 fullstack / Lovable-like BaaS). Defaults to @cloudbase/js-sdk client CRUD (NoSQL app.database / PG app.rdb), MCP-only schema, preview-first, and forbids cloud functions unless secrets, cron/background jobs, or logic that security rules/RLS cannot express. Use for 搭一套 demo、留言板、Todo、Notes、Kanban, or when users say 带云函数+云数据库 but only need CRUD. NOT for production multi-service backends, CloudRun, WeChat Mini Programs, or tasks that truly need server secrets.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 7
       },
@@ -1396,7 +1473,7 @@
     "miniprogram-development": {
       "name": "miniprogram-development",
       "description": "WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects (小程序开发、调试、预览、发布). Covers project structure and config (`project.config.json`, `appid`, `miniprogramRoot`, `tabBar`, routing/navigation, icon assets), WeChat Developer Tools Nightly workflows (`wechatide` CLI, WeChat IDE Skills/MCP), `miniprogram-ci` preview/upload, console/network debugging, message push (消息推送) and customer-service auto-reply (客服消息), mini program SEO / search indexing (小程序搜索优化、页面收录、搜索推广、mpcrawler), and CloudBase integration (`wx.cloud`, 腾讯云开发, 云开发) when explicitly used. Use when users create, develop, modify, debug, preview, deploy, publish, or promote WeChat Mini Programs. NOT for Web frontend (use web-development), pure backend services (use cloudrun-development / cloud-functions), or UI-design-only tasks (use ui-design).",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 8
       },
@@ -1498,7 +1575,7 @@
     "ops-inspector": {
       "name": "ops-inspector",
       "description": "AIOps-style CloudBase inspection skill (v3). Use when users need health checks, log diagnosis, alarm interpretation (CPU alert normal?, peak QPS), metrics via queryEnv(action=metrics), or fault playbooks for 429 / function 404 / ACCESS_TOKEN_INVALID / zero invocations. Triggers on 巡检, 诊断, 告警, 峰值 QPS, 限频, 调用量为 0, troubleshooting.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -1583,7 +1660,7 @@
     "postgresql-development-cloudbase": {
       "name": "postgresql-development-cloudbase",
       "description": "Use when building, debugging, or evaluating CloudBase PostgreSQL / CloudBase PG / PG mode apps, including Postgres schema setup, queryPgDatabase/managePgDatabase, JS SDK v3 app.rdb() CRUD/RPC, PG HTTP API fallback, RLS-style permissions, username-password auth, and Web CMS/admin CRUD flows backed by CloudBase PG.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 7
       },
@@ -1662,7 +1739,7 @@
     "spec-workflow": {
       "name": "spec-workflow",
       "description": "Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 6
       },
@@ -1722,7 +1799,7 @@
     "ui-design": {
       "name": "ui-design",
       "description": "Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 9
       },
@@ -1782,7 +1859,7 @@
     "web-development": {
       "name": "web-development",
       "description": "Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.",
-      "version": "2.33.1",
+      "version": "2.33.2",
       "metadata": {
         "priority": 8
       },

--- a/tests/hooks/build-skill-manifest.test.mjs
+++ b/tests/hooks/build-skill-manifest.test.mjs
@@ -28,7 +28,7 @@ const ROOT_DIR = join(__dirname, "..", "..");
 const MANIFEST_PATH = join(ROOT_DIR, "plugin", "cloudbase", "generated", "skill-manifest.json");
 const SKILLS_DIR = join(ROOT_DIR, "plugin", "cloudbase", "skills");
 const TEMPLATE_PATH = join(ROOT_DIR, "plugin", "cloudbase", "skill-metadata.template.json");
-const EXPECTED_MANIFEST_SKILL_COUNT = 27;
+const EXPECTED_MANIFEST_SKILL_COUNT = 28;
 
 const tempDirs = [];
 afterEach(() => {
@@ -83,7 +83,7 @@ describe("skill-manifest.json", () => {
     expect(manifest.version).toBe(2);
   });
 
-  it("has 27 non-deprecated skills including minimal-web-baas-demo", () => {
+  it("has 28 non-deprecated skills including minimal-web-baas-demo", () => {
     const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf-8"));
     expect(Object.keys(manifest.skills).length).toBe(EXPECTED_MANIFEST_SKILL_COUNT);
     expect(manifest.skills["minimal-web-baas-demo"]).toBeDefined();


### PR DESCRIPTION
## 问题

v2.33.2 的 GitHub Release 已发，但 `Publish to npm`（run 34227729938）在 Run tests 步骤失败，npm 未发布（latest 仍为 2.33.1）。

失败测试：`tests/single-skill-fallback-links.test.js:57`，要求每个 source skill 的 SKILL.md 包含精确的 `## Sibling skills (local only)` 节与禁抓取短语。

## 根因与修复

1. **cloud-api-operations**（00b06f61 新增，随 v2.33.2 发布）：SKILL.md 缺少该节 → 按现有 skill 标准措辞补齐
2. **cloudbase-declarative-deploy**：措辞为语义等价的 "do not HTTP-fetch remote skill markdown"，不满足断言的连续子串精确匹配 → 对齐为标准短语（CI 只报第一个失败目录，若只修 ① 下一次发布仍会栽在这里）

## 验证

- 本地模拟该测试全部断言（title/phrase/禁远程 raw URL/禁 standalone fallback 等），31 个 source skills 全部通过
- 另建议（后续 issue）：正向断言改归一化匹配或构建时注入样板；publish 工作流的测试范围与 skills lint 解耦，避免文档措辞问题阻断 npm 发布
