### PR TITLE
fix(skills): satisfy local-only sibling-links invariants blocking v2.33.2 publish

### DIFF
--- a/config/.claude/skills/cloud-api-operations/SKILL.md
+++ b/config/.claude/skills/cloud-api-operations/SKILL.md
@@ -4,6 +4,12 @@ description: Operate Tencent Cloud control-plane resources (monitoring/alarms, C
 version: 2.33.2
 ---
 
+## Sibling skills (local only)
+
+Sibling CloudBase skills ship beside this skill. Use local relative paths such as `../auth-tool-cloudbase/SKILL.md`.
+
+If a referenced sibling skill file is missing from this environment, ask the user to install the full CloudBase plugin (or the missing skill). Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
+
 # Cloud API Operations
 
 Operate Tencent Cloud resources that CloudBase depends on but that no dedicated MCP tool covers (monitoring & alarms, CLB, CAM roles, cross-product infra). Two goals: **find the right API without guessing**, and **reuse proven workflows instead of re-exploring**.

--- a/config/.claude/skills/cloudbase-declarative-deploy/SKILL.md
+++ b/config/.claude/skills/cloudbase-declarative-deploy/SKILL.md
@@ -23,7 +23,7 @@ Sibling CloudBase skills ship beside this skill. Use local relative paths such a
 Cloud-hosted MCP mode does not guarantee access to a local workspace filesystem or
 stable relative paths. If a referenced sibling file is not available in cloud mode,
 use this skill's embedded guidance as source of truth and ask the user for any
-missing constraints — do not HTTP-fetch remote skill markdown.
+missing constraints. Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
 
 **Cross-cutting protocols** (required before applying any deploy):
 - Change Safety Protocol: `../cloudbase-platform/references/protocols/change-safety-protocol.md`

--- a/config/source/skills/cloud-api-operations/SKILL.md
+++ b/config/source/skills/cloud-api-operations/SKILL.md
@@ -4,6 +4,12 @@ description: Operate Tencent Cloud control-plane resources (monitoring/alarms, C
 version: 2.33.2
 ---
 
+## Sibling skills (local only)
+
+Sibling CloudBase skills ship beside this skill. Use local relative paths such as `../auth-tool-cloudbase/SKILL.md`.
+
+If a referenced sibling skill file is missing from this environment, ask the user to install the full CloudBase plugin (or the missing skill). Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
+
 # Cloud API Operations
 
 Operate Tencent Cloud resources that CloudBase depends on but that no dedicated MCP tool covers (monitoring & alarms, CLB, CAM roles, cross-product infra). Two goals: **find the right API without guessing**, and **reuse proven workflows instead of re-exploring**.

--- a/config/source/skills/cloudbase-declarative-deploy/SKILL.md
+++ b/config/source/skills/cloudbase-declarative-deploy/SKILL.md
@@ -23,7 +23,7 @@ Sibling CloudBase skills ship beside this skill. Use local relative paths such a
 Cloud-hosted MCP mode does not guarantee access to a local workspace filesystem or
 stable relative paths. If a referenced sibling file is not available in cloud mode,
 use this skill's embedded guidance as source of truth and ask the user for any
-missing constraints — do not HTTP-fetch remote skill markdown.
+missing constraints. Do **not** HTTP-fetch remote skill or protocol markdown into the agent context.
 
 **Cross-cutting protocols** (required before applying any deploy):
 - Change Safety Protocol: `../cloudbase-platform/references/protocols/change-safety-protocol.md`


### PR DESCRIPTION
## Why

v2.33.2 publish run ([34227729938](https://github.com/TencentCloudBase/CloudBase-AI-Toolkit/actions/runs/34227729938)) failed at the **Run tests** stage (twice, including a rerun), so `@cloudbase/cloudbase-mcp@2.33.2` never reached npm (registry latest is still 2.33.1).

Two source skills violate the invariants enforced by `tests/single-skill-fallback-links.test.js`:

- **cloud-api-operations** (new in 2.33.2 range): missing the `## Sibling skills (local only)` section and the `Do **not** HTTP-fetch remote skill or protocol markdown into the agent context` disclaimer entirely
- **cloudbase-declarative-deploy**: has the section but with paraphrased wording (`do not HTTP-fetch remote skill markdown`) that fails the exact-phrase assertion

## What

- Add the canonical sibling section to `config/source/skills/cloud-api-operations/SKILL.md` (placed right after frontmatter, matching other skills)
- Replace the paraphrased clause in `cloudbase-declarative-deploy` with the canonical sentence
- Re-run `scripts/sync-claude-skills-mirror.mjs` so `config/.claude/skills` mirrors the source
- Verified locally: replicated the full assertion set (title / forbidden phrase / no raw URL / no standalone fallback / no absolute guideline path) across all 30 source skill dirs — all pass

Note: the same run also hit the known intermittent ClawHub `upload-ticket mismatch` (openclaw/clawhub#3394 / #3397) inside the tests step; after merging this, re-run the publish via workflow_dispatch (or re-tag).
