### PR TITLE
chore(ci): decouple npm publish from skills lint, unbreak main sync blind spot

### DIFF
--- a/.github/workflows/nightly-build.yaml
+++ b/.github/workflows/nightly-build.yaml
@@ -8,6 +8,11 @@ on:
     branches: [main]
   # 也支持手动触发
   workflow_dispatch:
+  # Safety net: commits pushed by workflows using GITHUB_TOKEN (e.g. skills
+  # sync) do not trigger push events, so breakage they introduce would stay
+  # invisible on main until the next PR. Run the full suite daily regardless.
+  schedule:
+    - cron: '30 21 * * *'
 
 jobs:
   # 构建和发布到pkg.pr.new

--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -59,7 +59,13 @@ jobs:
 
       - name: Run tests
         working-directory: ./mcp
-        run: pnpm exec vitest run
+        # Package tests only (mcp/src). The mcp vitest config also picks up
+        # ../tests/**/*.test.js (repo-wide skills lint etc.) via its include
+        # list; scope this step to src/ so documentation-wording drift in
+        # skills cannot block an npm release (v2.33.2 incident). Repo-wide
+        # tests still gate every PR and main push via the build-and-publish
+        # workflow (Test package + Test hooks).
+        run: pnpm exec vitest run src
 
       - name: Smoke CLI cloud-mode
         working-directory: ./mcp
@@ -170,4 +176,15 @@ jobs:
         run: ./mcp-publisher login github-oidc
 
       - name: Publish server.json
-        run: ./mcp-publisher publish mcp/server.json
+        # The MCP Registry validates the npm package exists; right after a fresh
+        # publish it may not be propagated yet (v2.33.2 incident). Retry window
+        # ≈ 5 min.
+        run: |
+          for i in 1 2 3 4 5; do
+            if ./mcp-publisher publish mcp/server.json; then
+              exit 0
+            fi
+            echo "publish attempt $i failed (npm registry propagation may be pending); retrying in 60s"
+            sleep 60
+          done
+          exit 1

--- a/.github/workflows/sync-cloudbase-plugin-skills.yml
+++ b/.github/workflows/sync-cloudbase-plugin-skills.yml
@@ -31,8 +31,31 @@ jobs:
         with:
           node-version: '20'
 
+      - name: Enable corepack
+        run: corepack enable
+
+      # build-skill-manifest.mjs needs js-yaml from the root lockfile.
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Sync CloudBase plugin skills
         run: node scripts/sync-cloudbase-plugin-skills.mjs
+
+      # Derived artifacts must be regenerated in the same commit that changes
+      # plugin skills. GITHUB_TOKEN pushes do not retrigger other workflows, so
+      # a stale generated/skill-manifest.json or .qoder-plugin/plugin.json would
+      # otherwise stay unnoticed on main until a PR or the npm publish workflow
+      # fails there (v2.33.2 incident). Skip when nothing changed to avoid
+      # timestamp-only commits.
+      - name: Regenerate derived artifacts when skills changed
+        run: |
+          if ! git diff --quiet -- plugin/cloudbase/skills; then
+            echo "Skills changed; regenerating derived artifacts"
+            node scripts/build-skill-manifest.mjs
+            node scripts/build-open-plugin-spec.mjs
+          else
+            echo "No skill changes; skipping regeneration"
+          fi
 
       # GITHUB_TOKEN pushes do not retrigger path-filtered workflows (e.g. Push Plugin Repos).
       # After we land skill changes under plugin/cloudbase/, explicitly dispatch that workflow.
@@ -42,7 +65,10 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add plugin/cloudbase/skills plugin/cloudbase/.sync-metadata.json
+          # Dedicated sync job on a fresh checkout: stage everything the sync +
+          # regeneration steps touched (skills, .sync-metadata.json,
+          # generated/skill-manifest.json, open plugin spec artifacts).
+          git add -A
           if git diff --staged --quiet; then
             echo "No changes, skipping."
             echo "pushed=false" >> "$GITHUB_OUTPUT"
@@ -62,7 +88,9 @@ jobs:
               git fetch origin main
               git reset --hard origin/main
               node scripts/sync-cloudbase-plugin-skills.mjs --force
-              git add plugin/cloudbase/skills plugin/cloudbase/.sync-metadata.json
+              node scripts/build-skill-manifest.mjs
+              node scripts/build-open-plugin-spec.mjs
+              git add -A
               if git diff --staged --quiet; then
                 echo "Remote already has synced skills after reset."
                 pushed=true

--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -103,7 +103,10 @@ async function resolvePackageMeta(requested) {
   log("resolve", metaUrl);
 
   let lastError;
-  for (let attempt = 1; attempt <= 8; attempt++) {
+  // npm registry propagation after a fresh publish can take minutes; a short
+  // retry window causes false post-publish-smoke failures (v2.33.2 incident).
+  // 12 attempts with exponential backoff (capped 30s) ≈ 4.5 min total.
+  for (let attempt = 1; attempt <= 12; attempt++) {
     try {
       const meta = await fetchJson(metaUrl);
       assert(meta?.version, `Registry response missing version for ${requested}`);
@@ -117,8 +120,8 @@ async function resolvePackageMeta(requested) {
       };
     } catch (error) {
       lastError = error;
-      const delayMs = Math.min(15000, 1000 * attempt);
-      log("resolve-retry", `attempt ${attempt}/8 failed (${error.message}); wait ${delayMs}ms`);
+      const delayMs = Math.min(30000, 2000 * 2 ** (attempt - 1));
+      log("resolve-retry", `attempt ${attempt}/12 failed (${error.message}); wait ${delayMs}ms`);
       await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
   }

--- a/plugin/cloudbase/generated/skill-manifest.json
+++ b/plugin/cloudbase/generated/skill-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 2,
-  "generatedAt": "2026-09-09T04:53:10.805Z",
+  "generatedAt": "2026-09-09T06:48:12.044Z",
   "skills": {
     "ai-model-nodejs": {
       "name": "ai-model-nodejs",

--- a/tests/hooks/build-skill-manifest.test.mjs
+++ b/tests/hooks/build-skill-manifest.test.mjs
@@ -28,7 +28,12 @@ const ROOT_DIR = join(__dirname, "..", "..");
 const MANIFEST_PATH = join(ROOT_DIR, "plugin", "cloudbase", "generated", "skill-manifest.json");
 const SKILLS_DIR = join(ROOT_DIR, "plugin", "cloudbase", "skills");
 const TEMPLATE_PATH = join(ROOT_DIR, "plugin", "cloudbase", "skill-metadata.template.json");
-const EXPECTED_MANIFEST_SKILL_COUNT = 28;
+// Derived from the non-deprecated plugin skill dirs instead of a hardcoded
+// number: adding a skill no longer requires bumping a constant, and the count
+// assertions below still verify the generated manifest is fresh (covers every
+// non-deprecated dir). The old hardcoded constant (27, then 28) silently went
+// stale when the skills sync landed a new skill (v2.33.2 incident).
+const EXPECTED_MANIFEST_SKILL_COUNT = listNonDeprecatedSkillDirs().length;
 
 const tempDirs = [];
 afterEach(() => {
@@ -83,7 +88,7 @@ describe("skill-manifest.json", () => {
     expect(manifest.version).toBe(2);
   });
 
-  it("has 28 non-deprecated skills including minimal-web-baas-demo", () => {
+  it("manifest covers every non-deprecated plugin skill (fresh manifest)", () => {
     const manifest = JSON.parse(readFileSync(MANIFEST_PATH, "utf-8"));
     expect(Object.keys(manifest.skills).length).toBe(EXPECTED_MANIFEST_SKILL_COUNT);
     expect(manifest.skills["minimal-web-baas-demo"]).toBeDefined();
@@ -159,7 +164,7 @@ describe("skill-metadata.json", () => {
   it("covers every non-deprecated plugin skill with non-empty promptSignals", () => {
     const metadataSkills = loadSkillMetadata(SKILL_METADATA_PATH);
     const dirs = listNonDeprecatedSkillDirs();
-    expect(dirs.length).toBe(EXPECTED_MANIFEST_SKILL_COUNT);
+    expect(dirs.length).toBeGreaterThan(0);
     for (const dirName of dirs) {
       const entry = metadataSkills[dirName];
       expect(entry, `${dirName} must exist in skill-metadata.json`).toBeDefined();

--- a/tests/single-skill-fallback-links.test.js
+++ b/tests/single-skill-fallback-links.test.js
@@ -32,6 +32,14 @@ const LOCAL_SIBLING_SECTION_TITLE = '## Sibling skills (local only)';
 const FORBIDDEN_FETCH_PHRASE =
   'Do **not** HTTP-fetch remote skill or protocol markdown into the agent context';
 
+// Positive assertions are matched against whitespace-flattened text so that
+// equivalent wording with different line wrapping still passes. Negative
+// assertions (forbidden URLs/phrases) stay on the raw text on purpose: a
+// forbidden URL split across lines would not function as a link anyway.
+function flatten(text) {
+  return text.replace(/\s+/g, ' ');
+}
+
 afterEach(() => {
   fs.rmSync(SKILLS_REPO_OUTPUT_DIR, { recursive: true, force: true });
   while (tempDirs.length > 0) {
@@ -54,8 +62,8 @@ describe('local-only sibling skill links (no remote skill fetch)', () => {
         'utf8',
       );
 
-      expect(raw).toContain(LOCAL_SIBLING_SECTION_TITLE);
-      expect(raw).toContain(FORBIDDEN_FETCH_PHRASE);
+      expect(flatten(raw)).toContain(LOCAL_SIBLING_SECTION_TITLE);
+      expect(flatten(raw)).toContain(FORBIDDEN_FETCH_PHRASE);
       expect(raw).not.toContain(RAW_SKILLS_ROOT_URL);
       expect(raw).not.toContain('standalone fallback:');
       expect(raw).not.toContain('## Standalone Install Note');
@@ -122,8 +130,8 @@ describe('local-only sibling skill links (no remote skill fetch)', () => {
       'utf8',
     );
 
-    expect(outputSkill).toContain(LOCAL_SIBLING_SECTION_TITLE);
-    expect(outputSkill).toContain(FORBIDDEN_FETCH_PHRASE);
+    expect(flatten(outputSkill)).toContain(LOCAL_SIBLING_SECTION_TITLE);
+    expect(flatten(outputSkill)).toContain(FORBIDDEN_FETCH_PHRASE);
     expect(outputSkill).not.toContain(RAW_SKILLS_ROOT_URL);
     expect(outputSkill).toContain('../auth-tool-cloudbase/SKILL.md');
   });
@@ -142,7 +150,7 @@ describe('local-only sibling skill links (no remote skill fetch)', () => {
       'utf8',
     );
 
-    expect(outputSkill).toContain(LOCAL_SIBLING_SECTION_TITLE);
+    expect(flatten(outputSkill)).toContain(LOCAL_SIBLING_SECTION_TITLE);
     expect(outputSkill).not.toContain(RAW_SKILLS_ROOT_URL);
     expect(outputSkill).toContain('../auth-tool-cloudbase/SKILL.md');
   });
@@ -160,7 +168,7 @@ describe('local-only sibling skill links (no remote skill fetch)', () => {
       'utf8',
     );
 
-    expect(compatSkill).toContain(LOCAL_SIBLING_SECTION_TITLE);
+    expect(flatten(compatSkill)).toContain(LOCAL_SIBLING_SECTION_TITLE);
     expect(compatSkill).not.toContain(RAW_SKILLS_ROOT_URL);
     expect(compatSkill).toContain('../auth-tool-cloudbase/SKILL.md');
   });


### PR DESCRIPTION
Follow-up to the v2.33.2 npm publish incident (fix in #1011). 落实事故复盘的 4 条改进（原 #1013 内容，转内部跟进后由本 PR 落地），其中一条根因在排查中进一步定位：

## 1. publish 测试范围与 skills lint 解耦

`mcp/vitest.config.ts` 的 include 同时覆盖 `../tests/**/*.test.js`（根目录 skills lint）和 `src/**/*.test.ts`，而 npm-publish 的 Run tests 跑的是全量 → skill 文档措辞问题阻断 npm 发布。改为 `pnpm exec vitest run src` 只跑 mcp 包测试；全仓测试仍由 build-and-publish（Test package + Test hooks）在每个 PR 和 main push 上把关。

## 2. fallback-links 正向断言改归一化匹配

标题与禁抓取短语断言改为对空白归一化（flatten）后的文本 `toContain`，换行位置不再导致 fail；负向断言（禁远程 raw URL 等）保留逐字匹配——被换行切断的 URL 本来也不是可用链接。

## 3. manifest 测试计数动态推导

`EXPECTED_MANIFEST_SKILL_COUNT` 从硬编码 27/28 改为 `listNonDeprecatedSkillDirs().length` 派生，新增 skill 无需改常量；计数断言仍校验「manifest 覆盖全部非 deprecated 目录」（即 manifest 是新鲜的）。

## 4. 修复 sync 引入的 main 盲区（根因修正）

排查发现 main push 上 nightly-build 实际有跑（此前「main 假绿」判断不准）——真正的盲区是：**GITHUB_TOKEN 推送的 commit 不触发其他 workflow**，sync-cloudbase-plugin-skills 引入的 `skill-manifest.json` / `.qoder-plugin/plugin.json` 过期因此只在 PR/publish 上爆出来。修复：

- sync workflow 在 skills 变化时（`git diff --quiet` 判断，避免纯时间戳 commit）同 commit 内重新生成 `skill-manifest.json` 与 open plugin spec 产物并一并提交；新 skill 缺 metadata 时 buildManifest fail-closed，sync 直接报红
- nightly-build 增加每日 cron 兜底，覆盖 GITHUB_TOKEN push 不触发 workflow 的盲区

## 5. post-publish 传播窗口拉长

- tarball smoke 的 registry resolve 重试从 8×~1-8s（≈40s）改为 12×指数退避 cap 30s（≈4.5min）
- publish-mcp-registry 的 `mcp-publisher publish` 增加最多 5 次 × 60s 重试（MCP Registry 校验 npm 包存在，同受传播延迟影响，v2.33.2 时同样误报）

## 验证

- 本地 `vitest run ../tests/single-skill-fallback-links.test.js`：7/7 通过
- 本地 `vitest run tests/hooks/`：122/122 通过（8 文件）
- 两个生成脚本在干净 main 上空跑确认幂等（仅 generatedAt 时间戳差异，已据此设计条件 regen）
