### PR TITLE
fix: correct stale entry points and version pins, sync server.json at publish time

### DIFF
--- a/mcp/manifest.json
+++ b/mcp/manifest.json
@@ -38,11 +38,11 @@
   ],
   "server": {
     "type": "node",
-    "entry_point": "./dist/cli.js",
+    "entry_point": "./dist/cli.cjs",
     "node_version": ">=18.0.0",
     "mcp_config": {
       "command": "node",
-      "args": ["./dist/cli.js"],
+      "args": ["./dist/cli.cjs"],
       "transport": "stdio"
     }
   },

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -51,7 +51,7 @@
     "test:pg:cloud": "npm run build && node ./scripts/verify-pg-cloud-smoke.mjs",
     "test:cli:cloud-mode": "node ./scripts/verify-cli-cloud-mode-smoke.mjs",
     "test:npm:tarball-smoke": "node ./scripts/verify-npm-tarball-smoke.mjs",
-    "test:inspector": "npm run build && npx @modelcontextprotocol/inspector node ./dist/cli.js",
+    "test:inspector": "npm run build && npx @modelcontextprotocol/inspector node ./dist/cli.cjs",
     "prepublishOnly": "npm run build && node scripts/prepare-publish.cjs",
     "postpublish": "node scripts/restore-deps.cjs"
   },

--- a/mcp/scripts/prepare-publish.cjs
+++ b/mcp/scripts/prepare-publish.cjs
@@ -55,6 +55,53 @@ try {
   // Read package.json
   const packageJson = readPackageJson();
 
+  // Sync server.json versions from package.json (single source of truth).
+  // Must run BEFORE the no-dependencies early exit below: the published npm
+  // tarball ships server.json (see package.json "files"), and CI only syncs
+  // versions in its own workspace for the MCP Registry submission — it never
+  // writes back to the repo. Without this sync, the tarball carries whatever
+  // stale version was last committed (e.g. 2.33.0 tarball shipping in 2.33.2).
+  const serverJsonPath = path.join(__dirname, '../server.json');
+  if (fs.existsSync(serverJsonPath)) {
+    const serverJson = JSON.parse(fs.readFileSync(serverJsonPath, 'utf8'));
+    let serverJsonChanged = false;
+    if (serverJson.version !== packageJson.version) {
+      serverJson.version = packageJson.version;
+      serverJsonChanged = true;
+    }
+    const npmPkg = (serverJson.packages || []).find((p) => p.registryType === 'npm');
+    if (npmPkg && npmPkg.version !== packageJson.version) {
+      npmPkg.version = packageJson.version;
+      serverJsonChanged = true;
+    }
+    if (serverJsonChanged) {
+      const content = JSON.stringify(serverJson, null, 2) + '\n';
+      JSON.parse(content); // guard against generating invalid JSON
+      fs.writeFileSync(serverJsonPath, content, 'utf8');
+      console.log(`✓ server.json version synced to ${packageJson.version}`);
+    } else {
+      console.log(`✓ server.json version already matches ${packageJson.version}`);
+    }
+  }
+
+  // Integrity check: DXT manifest.json must only reference files that exist
+  // in dist/ (e.g. catches stale "./dist/cli.js" after a rename to cli.cjs).
+  const dxtManifestPath = path.join(__dirname, '../manifest.json');
+  if (fs.existsSync(dxtManifestPath)) {
+    const dxt = JSON.parse(fs.readFileSync(dxtManifestPath, 'utf8'));
+    const refs = [dxt.server && dxt.server.entry_point]
+      .concat((dxt.server && dxt.server.mcp_config && dxt.server.mcp_config.args) || [])
+      .filter((ref) => typeof ref === 'string' && ref.startsWith('./'));
+    for (const ref of refs) {
+      if (!fs.existsSync(path.join(__dirname, '..', ref))) {
+        throw new Error(`DXT manifest.json references missing file: ${ref}`);
+      }
+    }
+    if (refs.length > 0) {
+      console.log(`✓ DXT manifest.json entry points verified (${refs.length} refs)`);
+    }
+  }
+
   // Check if dependencies exist
   if (!packageJson.dependencies || Object.keys(packageJson.dependencies).length === 0) {
     console.log('⚠️  No dependencies to clear, skipping backup');

--- a/mcp/scripts/verify-npm-tarball-smoke.mjs
+++ b/mcp/scripts/verify-npm-tarball-smoke.mjs
@@ -358,6 +358,25 @@ async function main() {
     assert(pkgJson.version === meta.version, `package.json version ${pkgJson.version} != ${meta.version}`);
     log("package.json", `version=${pkgJson.version}`);
 
+    // server.json ships inside the tarball (see package.json "files"); its
+    // version must match the published version, otherwise the MCP Registry
+    // and other consumers reading the tarball see a stale version.
+    const serverJsonPath = path.join(pkgRoot, "server.json");
+    assert(existsSync(serverJsonPath), `Published tarball missing server.json at ${serverJsonPath}`);
+    const serverJson = JSON.parse(readFileSync(serverJsonPath, "utf8"));
+    assert(
+      serverJson.version === meta.version,
+      `server.json version ${serverJson.version} != published version ${meta.version}`,
+    );
+    const npmServerPkg = (serverJson.packages || []).find((p) => p.registryType === "npm");
+    if (npmServerPkg) {
+      assert(
+        npmServerPkg.version === meta.version,
+        `server.json npm package version ${npmServerPkg.version} != published version ${meta.version}`,
+      );
+    }
+    log("server.json", `version=${serverJson.version}`);
+
     assertOpaStrings(pkgRoot);
     const { toolNames } = await assertToolRegistration(pkgRoot);
     await assertCliCloudMode(pkgRoot);

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.TencentCloudBase/cloudbase-mcp",
   "title": "CloudBase",
   "description": "CloudBase MCP: DB, functions, storage, hosting via @cloudbase/cloudbase-mcp",
-  "version": "2.33.0",
+  "version": "2.33.2",
   "websiteUrl": "https://github.com/TencentCloudBase/CloudBase-AI-Toolkit",
   "repository": {
     "url": "https://github.com/TencentCloudBase/CloudBase-AI-Toolkit",
@@ -25,7 +25,7 @@
       "registryType": "npm",
       "registryBaseUrl": "https://registry.npmjs.org",
       "identifier": "@cloudbase/cloudbase-mcp",
-      "version": "2.33.0",
+      "version": "2.33.2",
       "runtimeHint": "npx",
       "transport": {
         "type": "stdio"

--- a/mcp/webpack/README.md
+++ b/mcp/webpack/README.md
@@ -55,8 +55,7 @@ Node.js 内置模块列表，这些模块保持外部化：
 - CJS 版本：`dist/index.cjs`
 
 #### cli.config.cjs
-CLI 配置，生成 ESM 和 CJS 两种格式：
-- ESM 版本：`dist/cli.js` (带 shebang)
+CLI 配置，仅生成 CJS 格式：
 - CJS 版本：`dist/cli.cjs` (带 shebang)
 
 ### 主配置文件 (index.cjs)
@@ -67,7 +66,6 @@ CLI 配置，生成 ESM 和 CJS 两种格式：
 构建完成后会生成以下文件：
 - `dist/index.js` - ESM 格式的库文件
 - `dist/index.cjs` - CJS 格式的库文件
-- `dist/cli.js` - ESM 格式的 CLI 文件
 - `dist/cli.cjs` - CJS 格式的 CLI 文件
 - `dist/index.d.ts` - TypeScript 类型定义
 - `dist/cli.d.ts` - CLI TypeScript 类型定义
@@ -97,10 +95,6 @@ const { CloudBaseMCP } = require('@cloudbase/cloudbase-mcp');
 
 ### 作为 CLI 使用
 ```bash
-# 使用 ESM 版本
-node dist/cli.js
-
-# 使用 CJS 版本
 node dist/cli.cjs
 ```
 

--- a/mcp/webpack/cli.config.cjs
+++ b/mcp/webpack/cli.config.cjs
@@ -7,7 +7,7 @@ const createMinimalExternals = require('./minimal-externals.cjs');
 
 /**
  * CLI 配置
- * 生成 ESM 和 CJS 两种格式的 CLI 文件
+ * 生成 CJS 格式的 CLI 文件（ESM 版已移除，bin 入口固定为 cli.cjs）
  */
 function createCLIConfigs() {
   const baseConfig = createBaseConfig();

--- a/plugin/cloudbase/kimi.plugin.json
+++ b/plugin/cloudbase/kimi.plugin.json
@@ -36,7 +36,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@cloudbase/cloudbase-mcp@2.33.0"
+        "@cloudbase/cloudbase-mcp@latest"
       ],
       "env": {
         "INTEGRATION_IDE": "Kimi"

--- a/scripts/pack-kimi-plugin.mjs
+++ b/scripts/pack-kimi-plugin.mjs
@@ -66,6 +66,17 @@ function assertReady() {
   if (!fs.existsSync(routingDir)) {
     throw new Error(`Missing routing skill: ${routingDir}`);
   }
+  // Guard: the CloudBase MCP reference must follow @latest. A pinned version
+  // silently strands plugin users on a stale tool set (every pinned manifest
+  // in the wild required an out-of-band PR to unpin — don't create the next one).
+  const manifest = JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8"));
+  const mcpArgsJson = JSON.stringify(manifest.mcpServers || {});
+  if (/@cloudbase\/cloudbase-mcp@\d/.test(mcpArgsJson)) {
+    throw new Error(
+      "kimi.plugin.json pins a version of @cloudbase/cloudbase-mcp; " +
+        "use '@latest' so plugin users always get the current tool set",
+    );
+  }
 }
 
 function copyDir(src, dest) {


### PR DESCRIPTION
## 背景

排查 npm 线上数据时发现多处「手工同步导致的滞后 / 死引用」：发布 2.33.2 时 npm tarball 内的 `server.json` 仍是 2.33.0（CI 的 Sync server.json version 步骤只改 CI 工作区副本、从不回写仓库）；DXT `manifest.json` 的 `entry_point` / `args` 指向早已改名的 `dist/cli.js`；`kimi.plugin.json` 把 MCP 包 pin 在 `@2.33.0`（仓库惯例是 `@latest`）。

本 PR 修复全部存量死引用，并把版本同步从「人肉记得改」改为「发布时自动注入 + 校验」，从机制上消除这类漂移。

## 改动

### 存量修正（6 处）

| 文件 | 内容 |
|---|---|
| `mcp/manifest.json` | DXT `entry_point` / `args`：`dist/cli.js` → `dist/cli.cjs`（真死链，Claude Desktop 按此启动会找不到文件） |
| `mcp/package.json` | `test:inspector` 同样指向 `dist/cli.js`，修正 |
| `mcp/server.json` | 顶层 `version` + `packages[0].version`：2.33.0 → 2.33.2，对齐 `package.json` |
| `mcp/webpack/README.md` | 删除 4 处「ESM 版 CLI」过时描述（`cli.config.cjs` 的 `return [cjsConfig]` 早已只产 CJS，文档没跟上代码） |
| `mcp/webpack/cli.config.cjs` | 头注释同步更正 |
| `plugin/cloudbase/kimi.plugin.json` | `@cloudbase/cloudbase-mcp@2.33.0` → `@latest`（全仓库 29 处官方配置均用 `@latest`，仅此一处 pin） |

### 机制加固（3 个脚本）

| 文件 | 内容 |
|---|---|
| `mcp/scripts/prepare-publish.cjs` | ① 发布前从 `package.json` 自动同步 `server.json` 两处版本（置于「无依赖提前退出」分支**之前**）；② 校验 DXT `manifest.json` 引用的 dist 文件真实存在，死链直接发布失败 |
| `mcp/scripts/verify-npm-tarball-smoke.mjs` | 发布后断言 tarball 内 `server.json` 版本 === 包版本 |
| `scripts/pack-kimi-plugin.mjs` | 守卫：kimi manifest 若 pin 数字版本（`cloudbase-mcp@数字`）直接打包失败；`@latest` / `@^2` / `@*` 等范围写法放行 |

## 验证

- 将 `server.json` 改为 `0.0.0-test` 后运行 `prepare-publish.cjs` → 自动同步回 2.33.2；DXT 引用校验通过；`restore-deps` 后依赖完整恢复
- smoke 断言正反例均符合预期（当前状态 PASS，模拟 2.33.0 被正确拦截）
- kimi 守卫实测：pin 检出 / `@latest` 放行；`node --check` 全部脚本语法通过
- 全仓库 `dist/cli.js` 死引用清零（仅 prepare-publish 注释中的示意保留）
- 独立 agent review：PASS，无功能性 bug

## Notes

- `verify-npm-tarball-smoke` 的新断言对「已发布的旧版本 tarball」会失败（包内 server.json 为旧版），属正确检测而非误报
- kimi 插件经 `push-plugin-repos.yaml` 自动同步 `cloudbase-plugin` 仓库，本仓库为唯一源头
- 守卫口径：数字开头的版本 spec（含 `@2`、`@2.x` 这类主版本范围）一律拦截，按仓库「一律 `@latest`」惯例宁严勿松
