### PR TITLE
docs(skills): PG env routing, owner-table template, public-read bucket RLS, migration retry semantics

### DIFF
--- a/config/.claude/skills/ai-model-nodejs/SKILL.md
+++ b/config/.claude/skills/ai-model-nodejs/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-nodejs
 description: "Use this skill for Node.js backend AI via @cloudbase/node-sdk (>=3.16.0) — cloud functions, CloudRun, Express/Koa/NestJS, serverless APIs, scheduled jobs, LLM proxies, agent orchestration. The only SDK supporting image generation (ai.createImageModel + generateImage). Text via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*; model ids (e.g. deepseek-v4-flash, glm-5, kimi-k2.6) go in the `model` field of generateText/streamText. MUST run two-step preflight before code — see body. NOT for browser/Web (use ai-model-web) or Mini Program (use ai-model-wechat)."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-web/SKILL.md
+++ b/config/.claude/skills/ai-model-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-web
 description: "Use this skill when a browser/Web app (React, Vue, Next, Nuxt, static sites, SPAs, dashboards, AI chat UI, 页面, 前端, 网页) needs AI models via @cloudbase/js-sdk. Default routing for Web/frontend AI — call directly from the browser, do NOT propose a Node.js proxy. Covers generateText and streamText; models via ai.createModel with groups cloudbase, hunyuan-exp, or custom-*, model id in the `model` field. MUST run two-step preflight before code — see body. NOT for Node.js backend (use ai-model-nodejs), Mini Program (use ai-model-wechat), or image generation (Node SDK only)."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ai-model-wechat/SKILL.md
+++ b/config/.claude/skills/ai-model-wechat/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ai-model-wechat
 description: "Use this skill for WeChat Mini Program AI via wx.cloud.extend.AI (小程序, wx.cloud apps). Covers generateText and streamText with callbacks (onText, onEvent, onFinish); streamText needs a data wrapper, generateText returns the raw response. Models via wx.cloud.extend.AI.createModel with groups hunyuan-exp (小程序成长计划), cloudbase (main managed), or custom-*; model id goes in the data wrapper `model` field. MUST run two-step preflight before code — see body. NOT for browser/Web (use ai-model-web), Node.js backend (use ai-model-nodejs), or image generation (use ai-model-nodejs)."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-nodejs-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-nodejs-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-nodejs-cloudbase
 description: CloudBase Node SDK auth guide for server-side identity, user lookup, and custom login tickets. This skill should be used when Node.js code must read caller identity, inspect end users, or bridge an existing user system into CloudBase; not when configuring providers or building client login UI.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-tool-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-tool-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-tool-cloudbase
 description: CloudBase auth provider configuration and login-readiness guide. This skill should be used when users need to inspect, enable, disable, or configure auth providers, publishable-key prerequisites, login methods, SMS/email sender setup, or other provider-side readiness before implementing a client or backend auth flow.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -194,6 +194,22 @@ auth.onAuthStateChange((event, session) => {
 const { error } = await auth.signOut()
 ```
 
+**Mandatory auth gate before user-scoped data.** Before reading/writing user-owned PG rows or Storage objects, check the session and show login when absent — never "fix" data errors by silently calling `signInAnonymously`:
+
+```js
+const { data } = await auth.getSession()
+if (!data?.session) { navigate('/login'); return }
+```
+
+**Completion Bar** — before calling the auth task done, the generated source must have ALL of:
+
+- [ ] `signInWithPassword` (when password login is part of the UI)
+- [ ] a verification-code path: `signUp` + `data.verifyOtp` and/or `signInWithOtp`
+- [ ] auth gate before user-scoped DB/Storage calls (rule above)
+- [ ] `onAuthStateChange` wired at bootstrap (route guard reacts to `SIGNED_OUT`)
+- [ ] errors surfaced from `error.message`, no invented error text
+- [ ] NO `signInAnonymously` as a fallback for permission errors, no mock/localStorage sessions
+
 ---
 
 ## Extended guide

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -129,6 +129,8 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
 
+**Default auth UI contract:** when the user asks for 登录/注册/账号体系/user system without restricting the method, the login page must make ALL of these reachable (tabs or separate forms): password sign-in, OTP sign-in, verified sign-up (code + password), and forgot-password (whenever password sign-in exists). Never ship OTP-only or password-only UI unless explicitly asked. Never reveal whether an identifier is already registered in user-facing copy — route existing users to login with neutral wording.
+
 **Password sign-in** (username-style or email identifiers both go here):
 
 ```js
@@ -143,13 +145,32 @@ if (error) { /* show error.message */ } else { /* data.user */ }
 const { error } = await auth.signInAnonymously()
 ```
 
-**Register (email/phone OTP flow)** — `signUp` sends the verification code, `data.verifyOtp` completes it:
+**Registration — verification code is MANDATORY.** There is no password-only signup: `signUp` itself sends a code, and `data.verifyOtp` must complete it. Smart flow: existing identifier → plain login; new identifier → register + auto-login. Phone/SMS is 上海地域 only — prefer email:
 
 ```js
 const { data, error } = await auth.signUp({ email, password }) // or { phone, password }
 if (error) throw error
-const { data: login, error: verifyErr } = await data.verifyOtp({ token: code }) // code from email/SMS
+// user types the code from their inbox...
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code })
+// login.user / login.session — signed in on both paths
 ```
+
+**OTP sign-in (no password)** — same shape as `signUp`, auto-creates the user by default (`shouldCreateUser: false` to refuse unknown users). Requires 邮箱/短信验证码登录 enabled in console → 身份认证/登录方式:
+
+```js
+const { data, error } = await auth.signInWithOtp({ email }) // or { phone }
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code })
+```
+
+**Forgot password** — email code → set new password → auto sign-in (emits `PASSWORD_RECOVERY`):
+
+```js
+const { data, error } = await auth.resetPasswordForEmail(email)
+if (error) throw error
+const { data: login, error: resetErr } = await data.updateUser({ nonce: code, password: newPassword })
+```
+
+**OTP closure vs standalone `verifyOtp` — do not mix.** The `data.verifyOtp` returned by `signUp` / `signInWithOtp` / `resetPasswordForEmail` has the message ID bound (pass only `{ token }`). The standalone `auth.verifyOtp(...)` requires `messageId` and **only logs in — it never registers**. Always use the returned closure.
 
 **Session check / route guard** — always `getSession()`, never the deprecated `getLoginState()`:
 

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-web-cloudbase
 description: CloudBase Web Authentication Quick Guide for frontend integration after auth-tool has already been checked. Provides concise and practical Web authentication solutions with multiple login methods and complete user management.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 
@@ -80,6 +80,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 ## Prerequisites
 
 - Automatically use `auth-tool-cloudbase` to check app-side auth readiness via `queryAppAuth` / `manageAppAuth`, then get the `publishable key` and configure login methods.
+- **Publishable key readiness (do not skip):** call `queryAppAuth(action="getPublishableKey")`. If it is empty, call `manageAppAuth(action="ensurePublishableKey")` first — new environments may not have one provisioned, and skipping this step leaves the frontend without a data-plane credential, surfacing later as gateway auth failures instead of an obvious missing-key error.
 - If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
 
 ### Parameter map

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -125,6 +125,54 @@ const auth = app.auth
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
 
+## Auth code cookbook (official v3 API — copy these, do not re-derive from .d.ts)
+
+Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
+
+**Password sign-in** (username-style or email identifiers both go here):
+
+```js
+const { data, error } = await auth.signInWithPassword({ username, password })
+// email accounts: auth.signInWithPassword({ email, password })
+if (error) { /* show error.message */ } else { /* data.user */ }
+```
+
+**Anonymous sign-in** (required before NoSQL `app.database()` CRUD; PG anon reads work with accessKey alone):
+
+```js
+const { error } = await auth.signInAnonymously()
+```
+
+**Register (email/phone OTP flow)** — `signUp` sends the verification code, `data.verifyOtp` completes it:
+
+```js
+const { data, error } = await auth.signUp({ email, password }) // or { phone, password }
+if (error) throw error
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code }) // code from email/SMS
+```
+
+**Session check / route guard** — always `getSession()`, never the deprecated `getLoginState()`:
+
+```js
+const { data } = await auth.getSession()
+const session = data?.session // undefined === not logged in
+```
+
+**Auth state listener** (wire this once at app bootstrap):
+
+```js
+auth.onAuthStateChange((event, session) => {
+  // event: INITIAL_SESSION | SIGNED_IN | SIGNED_OUT | PASSWORD_RECOVERY
+  //        | TOKEN_REFRESHED | USER_UPDATED | BIND_IDENTITY
+})
+```
+
+**Sign out:**
+
+```js
+const { error } = await auth.signOut()
+```
+
 ---
 
 ## Extended guide

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -102,6 +102,8 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 
 ## Quick Start
 
+SDK init reference: [docs.cloudbase.net/api-reference/webv3/initialization.md](https://docs.cloudbase.net/api-reference/webv3/initialization.md)（URL 加 `.md` 可取 raw markdown 原文）
+
 ```js
 // npm install @cloudbase/js-sdk
 import cloudbase from '@cloudbase/js-sdk'
@@ -129,7 +131,7 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 ## Auth code cookbook (official v3 API — copy these, do not re-derive from .d.ts)
 
-Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
+Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments. Source: [official auth docs](https://docs.cloudbase.net/api-reference/webv3/authentication.md)（raw markdown, cross-check snippets there when in doubt）.
 
 **Default auth UI contract:** when the user asks for 登录/注册/账号体系/user system without restricting the method, the login page must make ALL of these reachable (tabs or separate forms): password sign-in, OTP sign-in, verified sign-up (code + password), and forgot-password (whenever password sign-in exists). Never ship OTP-only or password-only UI unless explicitly asked. Never reveal whether an identifier is already registered in user-facing copy — route existing users to login with neutral wording.
 

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -46,11 +46,11 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
 - **Writing `auth.signInWithPassword(...)` or `auth.signUp(...)` code without first confirming the provider is enabled via MCP.** Before writing any sign-in or sign-up code in the browser, call `queryAppAuth(action="listProviders")` to verify the target provider (e.g. `email`, `phone`, `usernamePassword`) has `On: "TRUE"`. For email-based sign-up (`auth.signUp({ email, password })`), additionally confirm SMTP is configured — otherwise the provider may throw `"provider email not found"` or similar errors. For username/password login, use `auth.signInWithPassword({ username, password })`; registration is best done through the management API (`manageAppAuth(action="createUser")`) or by confirming email provider readiness first.
 - **Treating `auth.getUser()` or deprecated `auth.getLoginState()` as proof of real login.** When the SDK is initialized with `accessKey`, the deprecated `getLoginState()` may still return an object with a valid `uid` even without any login — causing route guards that check `!!loginState` or `!!uid` to incorrectly pass. That misleading `uid` is **not** a gateway-authenticated session. Use `auth.getSession()` instead: it returns `data.session === undefined` when no real login has occurred. Only `!!data.session` from `getSession()` is a reliable authentication check.
-- **Assuming publishable `accessKey` alone is enough for NoSQL CRUD.** With `@cloudbase/js-sdk` **3.x**, call **`await auth.signInAnonymously()`** (or an equivalent authenticated session such as password/OTP/OAuth) **before** any NoSQL `app.database()` `get` / `add` / `update` / `watch`. Skipping this yields **gateway 401**. `checkLogin()` / `getSession()` alone do **not** create a usable write session.
+- **Assuming publishable `accessKey` alone is enough for NoSQL CRUD.** NoSQL `app.database()` `get` / `add` / `update` / `watch` requires a gateway-authenticated **session**: use a real login (password / OTP / OAuth). Anonymous login is a demo-only escape hatch for explicitly-public, non-user data — it is disabled by default, denied AI model permissions, and must never stand in for real auth in user-scoped apps. Skipping any login yields **gateway 401**. `checkLogin()` / `getSession()` alone do **not** create a usable write session.
 - **Copying old CloudBase auth snippets from training data.** Do not use `auth.getLoginState()`, `auth.hasLoginState()`, `auth.getCurrentUser()`, or `auth.toDefaultLoginPage()` as the default Web flow. Use the Web SDK v3 auth methods in this file and provider readiness from `auth-tool-cloudbase`.
 - **Calling a standalone `auth.verifyOtp({ token })` for OTP login.** CloudBase Web SDK v3 returns `verifyOtp` as a callback on the `signInWithOtp` / `signUp` result: send the code first, keep the returned `data`, then call `data.verifyOtp({ token })`. A standalone `auth.verifyOtp({ token })` without `messageId` fails with `"messageId is required"` — seeing that error means the callback form was skipped. See `references/extended-guide.md` for the full send → save callback → verify flow.
   
-  Note: anonymous login is **disabled by default** for new environments and inactive existing environments — enable it via `auth-tool-cloudbase` before calling `signInAnonymously()`. Always use `auth.getSession()` for auth guards.
+  Note: anonymous login is **disabled by default** for new environments and inactive existing environments. Do not enable it to work around permission errors — enable via `auth-tool-cloudbase` only when the app explicitly serves public non-user data (e.g. NoSQL read-only demos). Always use `auth.getSession()` for auth guards.
 
 ## Overview
 
@@ -96,7 +96,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `data.verifyOtp({ token })` — the `verifyOtp` callback on the `signInWithOtp` / `signUp` result `data` — expects the SMS or email code in `token`; do not invent a standalone `auth.verifyOtp({ token })` call, which additionally requires `messageId`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
-- **`accessKey` alone does not create a gateway-authenticated anonymous session.** Publishable `accessKey` initializes the SDK; it does **not** replace an explicit login for NoSQL CRUD. With `@cloudbase/js-sdk` **3.x**, call `await auth.signInAnonymously()` (or an equivalent authenticated session) **before** `app.database()` `get` / `add` / `update` / `watch` — otherwise the gateway returns **401**. Separately: the deprecated `auth.getLoginState()` may still return a misleading `uid` without login; use `auth.getSession()` for route guards (`data.session === undefined` when not logged in). `checkLogin()` / `getSession()` alone do **not** create a usable write session.
+- **`accessKey` alone does not create a gateway-authenticated session.** Publishable `accessKey` initializes the SDK; it does **not** replace a login for NoSQL CRUD. Any `app.database()` `get` / `add` / `update` / `watch` needs a session — prefer a real login (password / OTP / OAuth); `signInAnonymously()` only for explicitly-public demo data (disabled by default, denied AI model permissions). Otherwise the gateway returns **401**. Separately: the deprecated `auth.getLoginState()` may still return a misleading `uid` without login; use `auth.getSession()` for route guards (`data.session === undefined` when not logged in). `checkLogin()` / `getSession()` alone do **not** create a usable write session.
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
@@ -110,15 +110,17 @@ const app = cloudbase.init({
   env: 'your-full-env-id', // Canonical full CloudBase environment ID resolved from envQuery or the console, not an alias or shorthand
   region: 'ap-shanghai',  // CloudBase environment Region, default 'ap-shanghai'
   accessKey: 'publishable key', // required, get from auth-tool-cloudbase
-  // ⚠️ accessKey alone ≠ anonymous login. For NoSQL CRUD call await auth.signInAnonymously()
-  // (or real login) first — otherwise gateway 401. Use auth.getSession() for route guards;
-  // deprecated getLoginState() may return a misleading uid without a real session.
+  // ⚠️ accessKey alone ≠ a login session. NoSQL CRUD needs a session —
+  // real login preferred; signInAnonymously() only for public demo data.
+  // Use auth.getSession() for route guards; deprecated getLoginState()
+  // may return a misleading uid without a real session.
   auth: { detectSessionInUrl: true }, // required
 })
 
 const auth = app.auth
 
-// Before NoSQL app.database() CRUD (js-sdk 3.x + publishable key):
+// NoSQL app.database() CRUD requires a session (js-sdk 3.x + publishable key).
+// Real login (see cookbook). Anonymous, only for public non-user demos:
 // const { error } = await auth.signInAnonymously()
 // if (error) throw error
 ```
@@ -139,7 +141,7 @@ const { data, error } = await auth.signInWithPassword({ username, password })
 if (error) { /* show error.message */ } else { /* data.user */ }
 ```
 
-**Anonymous sign-in** (required before NoSQL `app.database()` CRUD; PG anon reads work with accessKey alone):
+**Anonymous sign-in — demo-only, not a default.** NoSQL `app.database()` CRUD needs some session (PG anon reads work with accessKey alone). Prefer a real login; reach for anonymous ONLY when the app explicitly serves public non-user data and the user accepts the trade-off — it is disabled by default, denied AI model permissions, and its `uid` must never own user-scoped rows:
 
 ```js
 const { error } = await auth.signInAnonymously()

--- a/config/.claude/skills/auth-wechat-miniprogram/SKILL.md
+++ b/config/.claude/skills/auth-wechat-miniprogram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: auth-wechat-miniprogram
 description: CloudBase WeChat Mini Program native authentication guide. This skill should be used when users need mini program identity handling, OPENID/UNIONID access, or `wx.cloud` auth behavior in projects where login is native and automatic.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-api-operations/SKILL.md
+++ b/config/.claude/skills/cloud-api-operations/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-api-operations
 description: Operate Tencent Cloud control-plane resources (monitoring/alarms, CLB, CAM roles, COS, MySQL, SCF, etc.) via cloud APIs when no dedicated MCP tool exists. Covers API discovery via the api-reference index, calling via MCP callCloudApi or official SDKs, credential/permission models with CAM authorization escalation, and battle-tested workflow recipes. Use when the task requires Tencent Cloud control-plane operations beyond CloudBase's own tooling.
-version: 1.1.0
+version: 2.33.2
 ---
 
 # Cloud API Operations

--- a/config/.claude/skills/cloud-functions/SKILL.md
+++ b/config/.claude/skills/cloud-functions/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-functions
 description: CloudBase function runtime guide for building, deploying, and debugging your own Event Functions or HTTP Functions. This skill should be used when users need application runtime code on CloudBase, not when they are merely calling CloudBase official platform APIs.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -117,7 +117,7 @@ Use instead:
 | `createSignedUrl(path, expiresIn)` | `await` → `{ data: { signedUrl } }` | `await` → `{ data: { fullSignedURL } }` |
 | `getPublicUrl(path)` | `await` → `{ data: { publicUrl } }` | **同步调用（不 await）** → `{ data: { publicUrl } }` |
 
-Source: docs.cloudbase.net/api-reference/webv3/storage 与 webv3-pg/storage。
+Source: [webv3/storage.md](https://docs.cloudbase.net/api-reference/webv3/storage.md) · [webv3-pg/storage.md](https://docs.cloudbase.net/api-reference/webv3-pg/storage.md)（raw markdown）。
 
 ### PG mode URL resolution: 公开桶直链 vs 签名 URL
 
@@ -173,6 +173,8 @@ Typical tasks:
 - trigger browser downloads
 
 ## SDK initialization
+
+Init reference: [webv3/initialization.md](https://docs.cloudbase.net/api-reference/webv3/initialization.md)
 
 ```javascript
 import cloudbase from "@cloudbase/js-sdk";

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloud-storage-web
 description: Complete guide for CloudBase cloud storage using Web SDK (@cloudbase/js-sdk) - upload, download, temporary URLs, file management, and best practices.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 
@@ -108,6 +108,17 @@ Do NOT use the legacy NoSQL APIs in PG mode:
 Use instead:
 - ✅ `app.storage.from('covers').upload('file', file)` — PG 模式上传
 - ✅ `app.storage.from('covers').createSignedUrl('file', 3600)` — 获取签名 URL（返回 `fullSignedURL` 字段）
+
+### PG mode URL resolution: 公开桶直链 vs 签名 URL
+
+| Bucket 类型 | URL 策略 | 代码 |
+|---|---|---|
+| 公开桶（`storage.buckets.public = true`） | 直链，无需登录态，可直接进 `<img src>` | `app.storage.from('covers').getPublicUrl('a.png')` → `{ data: { publicUrl } }` |
+| 私有桶 | 签名 URL，带过期时间 | `app.storage.from('covers').createSignedUrl('a.png', 3600)` |
+
+- 公开桶直链能否访问取决于 `storage.objects` 的 RLS SELECT 策略是否放行 anon —— 建桶 SQL 与策略模板见 `postgresql-development-cloudbase/references/storage-pg.md` "Public-read bucket template"。
+- 展示层做 `onerror` 兜底（直链被策略拦下时降级到签名 URL），不要硬依赖单一取址流程。
+- 业务表只存 bucket + key（或 SDK 解析出的最终 URL），不要在浏览器手工拼接 URL。
 
 ### Post-bucket: storage RLS (mandatory in PG / pgstore environments)
 

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -109,6 +109,16 @@ Use instead:
 - ✅ `app.storage.from('covers').upload('file', file)` — PG 模式上传
 - ✅ `app.storage.from('covers').createSignedUrl('file', 3600)` — 获取签名 URL（返回 `fullSignedURL` 字段）
 
+**Return shapes differ between modes (v3 SDK) — copy the right column:**
+
+| call | 传统模式 (`from()` 无参, `cloud://` fileID) | PG 模式 (`from('bucket')`, bucket 内对象名) |
+|---|---|---|
+| `upload(path, file)` | `{ data: { id, path, fullPath } }`；`upsert` 默认 **true** | `{ data: { id, ... } }`；`upsert` 默认 **false** |
+| `createSignedUrl(path, expiresIn)` | `await` → `{ data: { signedUrl } }` | `await` → `{ data: { fullSignedURL } }` |
+| `getPublicUrl(path)` | `await` → `{ data: { publicUrl } }` | **同步调用（不 await）** → `{ data: { publicUrl } }` |
+
+Source: docs.cloudbase.net/api-reference/webv3/storage 与 webv3-pg/storage。
+
 ### PG mode URL resolution: 公开桶直链 vs 签名 URL
 
 | Bucket 类型 | URL 策略 | 代码 |

--- a/config/.claude/skills/cloudbase-agent/SKILL.md
+++ b/config/.claude/skills/cloudbase-agent/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-agent
 description: Build and deploy AI agents with CloudBase Agent SDK (TypeScript & Python). Implements the AG-UI protocol for streaming agent-UI communication. Use when deploying agent servers, using LangGraph/LangChain/CrewAI adapters, building custom adapters, understanding AG-UI protocol events, or building web/mini-program UI clients. Supports both TypeScript (@cloudbase/agent-server) and Python (cloudbase-agent-server via FastAPI).
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-cli/SKILL.md
+++ b/config/.claude/skills/cloudbase-cli/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-cli
 description: CloudBase CLI (tcb, 云开发CLI, Tencent CloudBase命令行) resource management skill. Use when deploying cloud functions, CloudRun, storage, NoSQL/MySQL, static hosting, permissions, CORS/domains via tcb; for CI/CD and batch ops; when the user prefers CLI; or as the first-session fallback when CloudBase MCP tools are not loaded yet (after install/config, before IDE restart). Covers tcb login (device code for Tencent Cloud accounts; --cloudbase-api-key -e for environment API Key without an account; --apiKeyId/--apiKey for CI) and domain commands (fn/hosting/cloudrun/…) as MCP auth/manage parity — do not default to tcb deploy.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-code-review/SKILL.md
+++ b/config/.claude/skills/cloudbase-code-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-code-review
 description: "Code review and validation for CloudBase projects. After writing code for Web / miniprogram / CloudRun / cloud-function projects, call this skill to check for known pitfalls — auth guard misuse, missing database tables, RLS misconfiguration, storage domain setup, and SDK API misuse. Supports automated lint scripts (regex-based) + LLM semantic review."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-declarative-deploy/SKILL.md
+++ b/config/.claude/skills/cloudbase-declarative-deploy/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-declarative-deploy
 description: CloudBase declarative deployment from a cloudbaserc config (声明式部署, 配置式部署, cloudbaserc 部署) through the deployApply / deployPlan MCP tools. Use when deploying database, functions, app, hosting, or gateway resources described in cloudbaserc.json/yaml as a single desired-state config, when a user wants a dry-run plan before applying, or when handling multi-environment deploys via mode / envOverrides. Covers plan-then-apply flow (deployPlan dry-run → deployApply confirm=true), envId resolution priority, only/skip filtering, concurrency, and continueOnError. Prefer deployPlan before deployApply; do not confuse with per-resource tcb CLI deploy or single-function deploy.
-version: 1.0.0
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-document-database-in-wechat-miniprogram/SKILL.md
+++ b/config/.claude/skills/cloudbase-document-database-in-wechat-miniprogram/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-in-wechat-miniprogram
 description: Use CloudBase document database WeChat MiniProgram SDK to query, create, update, and delete data. Supports complex queries, pagination, aggregation, and geolocation queries.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-document-database-web-sdk/SKILL.md
+++ b/config/.claude/skills/cloudbase-document-database-web-sdk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-document-database-web-sdk
 description: Use CloudBase document database Web SDK only for confirmed NoSQL collection work. Query, create, update, and delete document data; if the task mentions PostgreSQL / CloudBase PG / app.rdb(), route to postgresql-development instead.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-platform/SKILL.md
+++ b/config/.claude/skills/cloudbase-platform/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-platform
 description: CloudBase platform overview and routing guide. This skill should be used when users need high-level capability selection, platform concepts, console navigation, or cross-platform best practices before choosing a more specific implementation skill.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudbase-wechat-integration/SKILL.md
+++ b/config/.claude/skills/cloudbase-wechat-integration/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudbase-wechat-integration
 description: CloudBase WeChat integration guide for Mini Program WeChat Pay, Mini Program virtual payment (虚拟支付, wx.requestVirtualPayment), Official Account JSAPI Pay, Native QR-code Pay, Official Account OAuth, openid handling, payment callbacks, and CloudBase Integration Center generated functions. This skill should be used when users ask to add, debug, or extend WeChat payment, virtual payment, or official-account flows on CloudBase.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cloudrun-development
 description: CloudBase Run backend development rules (Function mode/Container mode). Use this skill when deploying backend services that require long connections, multi-language support, custom environments, AI agent development, or migrating existing/GitHub apps that need VPC access to MySQL/PostgreSQL/Redis. Also use when diagnosing CloudRun container deploy failures (deploy_failed, readiness/probe failed, image won't start, docker.io pull loops). For stateless HTTP services, prefer HTTP cloud functions.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/data-model-creation/SKILL.md
+++ b/config/.claude/skills/data-model-creation/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: data-model-creation
 description: "[Deprecated] Optional advanced tool for complex data modeling. For simple MySQL table creation, use relational-database-tool directly; for PostgreSQL / CloudBase PG schema work, use postgresql-development. New environments should use PostgreSQL DDL via queryPgDatabase/managePgDatabase — see postgresql-development skill instead."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/http-api-cloudbase/SKILL.md
+++ b/config/.claude/skills/http-api-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: http-api-cloudbase
 description: CloudBase official HTTP API client guide. This skill should be used when backends, scripts, or non-SDK clients must call CloudBase platform APIs over raw HTTP instead of using a platform SDK or MCP management tool.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/minimal-web-baas-demo/SKILL.md
+++ b/config/.claude/skills/minimal-web-baas-demo/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: minimal-web-baas-demo
 description: "Fast path for a minimal CloudBase Web + database demo (最小前后端 / 最小可用 fullstack / Lovable-like BaaS). Defaults to @cloudbase/js-sdk client CRUD (NoSQL app.database / PG app.rdb), MCP-only schema, preview-first, and forbids cloud functions unless secrets, cron/background jobs, or logic that security rules/RLS cannot express. Use for 搭一套 demo、留言板、Todo、Notes、Kanban, or when users say 带云函数+云数据库 but only need CRUD. NOT for production multi-service backends, CloudRun, WeChat Mini Programs, or tasks that truly need server secrets."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/miniprogram-development/SKILL.md
+++ b/config/.claude/skills/miniprogram-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: miniprogram-development
 description: WeChat Mini Program development skill for building, debugging, previewing, testing, publishing, and optimizing mini program projects (小程序开发、调试、预览、发布). Covers project structure and config (`project.config.json`, `appid`, `miniprogramRoot`, `tabBar`, routing/navigation, icon assets), WeChat Developer Tools Nightly workflows (`wechatide` CLI, WeChat IDE Skills/MCP), `miniprogram-ci` preview/upload, console/network debugging, message push (消息推送) and customer-service auto-reply (客服消息), mini program SEO / search indexing (小程序搜索优化、页面收录、搜索推广、mpcrawler), and CloudBase integration (`wx.cloud`, 腾讯云开发, 云开发) when explicitly used. Use when users create, develop, modify, debug, preview, deploy, publish, or promote WeChat Mini Programs. NOT for Web frontend (use web-development), pure backend services (use cloudrun-development / cloud-functions), or UI-design-only tasks (use ui-design).
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ops-inspector/SKILL.md
+++ b/config/.claude/skills/ops-inspector/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ops-inspector
 description: AIOps-style CloudBase inspection skill (v3). Use when users need health checks, log diagnosis, alarm interpretation (CPU alert normal?, peak QPS), metrics via queryEnv(action=metrics), or fault playbooks for 429 / function 404 / ACCESS_TOKEN_INVALID / zero invocations. Triggers on 巡检, 诊断, 告警, 峰值 QPS, 限频, 调用量为 0, troubleshooting.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -174,7 +174,7 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 - ❌ `db.from("public.public.articles")` — WRONG, double schema prefix, will fail with `PGRST205`
 - `objectName="public.articles"` in `queryPgDatabase()` is the MCP tool format — do NOT copy this into `db.from()`.
 
-Use static imports and one shared `app.rdb()` client:
+Use static imports and one shared `app.rdb()` client (SDK init reference: [webv3-pg/initialization.md](https://docs.cloudbase.net/api-reference/webv3-pg/initialization.md)):
 
 ```ts
 import cloudbase from "@cloudbase/js-sdk";
@@ -214,7 +214,7 @@ const { data } = await db.rpc("function_name", { id });
 
 Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.contains()`, `.textSearch()`, `.or()`, `.not()`, `.match()`, `.order()`, `.limit()`, `.range()`, `.single()`.
 
-**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: docs.cloudbase.net/api-reference/webv3-pg/postgresql/{fetch,insert,update,delete,upsert,filters,modifiers,rpc}:
+**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: [webv3-pg/postgresql/fetch.md](https://docs.cloudbase.net/api-reference/webv3-pg/postgresql/fetch.md) — fetch / insert / update / delete / upsert / filters / modifiers / rpc share the same path prefix, one page per verb（URL 加 `.md` 可取 raw markdown 原文）:
 
 ```ts
 // COUNT only — no rows returned, count comes back on the result object

--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -178,7 +178,11 @@ Use static imports and one shared `app.rdb()` client:
 
 ```ts
 import cloudbase from "@cloudbase/js-sdk";
-const app = cloudbase.init({ env: import.meta.env.VITE_CLOUDBASE_ENV_ID });
+const app = cloudbase.init({
+  env: import.meta.env.VITE_CLOUDBASE_ENV_ID,
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY, // publishable key, see auth-web-cloudbase prerequisites
+  auth: { detectSessionInUrl: true },
+});
 export const auth = app.auth;
 export const db = app.rdb();
 ```
@@ -208,7 +212,41 @@ await db.from("articles").delete().eq("id", id);
 const { data } = await db.rpc("function_name", { id });
 ```
 
-Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.order()`, `.limit()`, `.range()`, `.single()`.
+Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.contains()`, `.textSearch()`, `.or()`, `.not()`, `.match()`, `.order()`, `.limit()`, `.range()`, `.single()`.
+
+**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: docs.cloudbase.net/api-reference/webv3-pg/postgresql/{fetch,insert,update,delete,upsert,filters,modifiers,rpc}:
+
+```ts
+// COUNT only — no rows returned, count comes back on the result object
+const { count, error } = await db.from("articles").select("*", { count: "exact", head: true });
+
+// Pagination — .range(from, to) is INCLUSIVE on both ends; page 2 of 20 = .range(20, 39)
+const { data, error } = await db.from("articles").select("*")
+  .order("created_at", { ascending: false }).range(0, 19);
+
+// INSERT and return the inserted row — ⚠️ .select() only returns rows when the
+// table has a single auto-increment primary key; otherwise data is empty/null
+const { data, error } = await db.from("articles").insert({ title, status: "draft" }).select();
+
+// INSERT many rows at once (array form)
+await db.from("articles").insert([{ title: "a" }, { title: "b" }]);
+
+// UPSERT — include the primary key in values; onConflict names the unique-index column(s)
+await db.from("articles").upsert({ id: 1, title: "new" }, { onConflict: "id" });
+
+// Join query — PostgREST embedded resources via FK relationship
+const { data, error } = await db.from("articles").select(`
+  title,
+  categories ( name ),
+  created_by:users!articles_created_by_fkey ( name ) // multiple FKs to the same table need the constraint name
+`);
+
+// RPC — SETOF-returning functions chain .select()/.order()/.limit()/.single()/filters like a query
+const { data, error } = await db.rpc("search_articles", { keyword })
+  .select("title, published_at").order("published_at", { ascending: false }).limit(5);
+const { data: one } = await db.rpc("search_articles", { keyword }).limit(1).single();
+const { count } = await db.rpc("search_articles", { keyword }, { count: "exact", head: true });
+```
 
 ### ⚠️ Critical: PG API is NOT the same as CloudBase NoSQL or other ORMs
 

--- a/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: postgresql-development-cloudbase
 description: "Use when building, debugging, or evaluating CloudBase PostgreSQL / CloudBase PG / PG mode apps, including Postgres schema setup, queryPgDatabase/managePgDatabase, JS SDK v3 app.rdb() CRUD/RPC, PG HTTP API fallback, RLS-style permissions, username-password auth, and Web CMS/admin CRUD flows backed by CloudBase PG."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 
@@ -31,7 +31,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - PG mode overview -> `references/pg-mode-overview.md`
 - Auth / GRANT / RLS details -> `references/auth-and-rls.md`
 - End-to-end PG app closure -> `references/app-workflow.md`
-- PG storage details -> `references/storage-pg.md`
+- PG storage details — **MUST read before writing any bucket / upload / URL code** -> `references/storage-pg.md`
 - HTTP API fallback -> `references/http-api.md`
 - Troubleshooting -> `references/troubleshooting.md`
 
@@ -149,6 +149,20 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 - Backend permission must exist in the database or server/RPC layer. Hiding buttons in the UI is not enough.
 - Do not leave a browser-facing table with RLS enabled and zero policies. PostgreSQL denies user reads/writes by default in that state, so `app.rdb().from("articles").insert(...)` can fail while the UI only shows a generic save failure. If you enable RLS, create and verify SELECT/INSERT/UPDATE/DELETE policies before testing the app.
 - Use CloudBase PG's official SQL auth helpers in policies: `auth.uid()` (JWT `sub`, returns **`text`** not `uuid`), `auth.role()` (`anon` / `authenticated` / `service_role`), `auth.jwt()` (full claims), and `auth.email()` when relevant. Prefer owner columns such as `owner_id varchar(64) DEFAULT auth.uid()` so the database, not the browser, assigns ownership. If an owner column is already `uuid`, compare with `auth.uid()::uuid` (only when `sub` is a valid UUID).
+- Standard owner-table template — copy this shape for any user-owned business table:
+
+  ```sql
+  CREATE TABLE articles (
+    id          BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    owner_id    TEXT        NOT NULL DEFAULT auth.uid(),
+    title       TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  ```
+
+  - `owner_id` is **`TEXT`**, not `uuid` — `auth.uid()` returns text (e.g. `EchhGXFadSANiCSaVim2wQ`); declaring it `uuid` fails at table-create time with a type mismatch.
+  - `owner_id` carries `DEFAULT auth.uid()` — ownership is decided server-side. App code must not send it; the INSERT policy rejects any forged owner value.
+- **Seeding demo data:** RLS denies anonymous browser writes. Insert demo/seed rows through the management plane — `managePgDatabase(action="execute", confirm=true)` with an **explicit** `owner_id` value (e.g. `'system-demo'`); do not rely on `DEFAULT auth.uid()` for seed rows, and never ship seed INSERTs in frontend code.
 - If you need detailed GRANT/RLS rules, read `references/rls-patterns.md` before writing policies.
 - For admin/editor flows, make `admin` able to operate all rows and `editor` only rows where owner UID matches the current user.
 
@@ -223,7 +237,7 @@ CloudBase PG storage uses the `pgstore` backend and follows the same model as Su
 1. Confirm a usable pgstore bucket exists for your target prefix (e.g. `covers`). The legacy NoSQL bucket exposed by `DescribeEnvs.Storages[]` (e.g. `6d63-…-1409864723`) is for the old NoSQL backend and does NOT serve pgstore uploads.
 2. If no usable bucket exists, create one through the PG storage management surface (PG storage HTTP API / CLI / console / SQL on `storage.buckets` when appropriate). Do not assume traditional-mode storage tools or adding `covers/` as a JS path prefix will create a PG bucket.
 3. The bucket name belongs in `from('<bucket>')`; the key passed to `upload(key, file)` is inside that bucket and must **not** repeat the bucket prefix. Correct: `app.storage.from('covers').upload('a.png', file)`. Wrong: `app.storage.from('covers').upload('covers/a.png', file)`.
-4. **After creating the bucket, configure RLS on `storage.objects`** via `managePgDatabase(action="execute", confirm=true)`. The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`. See `cloud-storage-web/SKILL.md` "Post-bucket: storage RLS" section for the exact SQL policies.
+4. **After creating the bucket, configure RLS on `storage.objects`** via `managePgDatabase(action="execute", confirm=true)`. The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`. See `references/storage-pg.md` for the full bucket + RLS templates (per-user isolation and public-read buckets), and `cloud-storage-web/SKILL.md` "Post-bucket: storage RLS" section for the exact SQL policies.
 
 Failure-mode cheat sheet (read DevTools network tab on the FAILED `POST .../v1/storages/get-objects-upload-info`):
 

--- a/config/.claude/skills/postgresql-development-cloudbase/references/storage-pg.md
+++ b/config/.claude/skills/postgresql-development-cloudbase/references/storage-pg.md
@@ -281,6 +281,41 @@ Key points:
 - Do **not** `DELETE FROM storage.objects` directly — a `protect_delete` trigger blocks it. Use SDK / Storage API.
 - For simpler authenticated-only access (not per-user), replace `(storage.foldername(name))[1] = auth.uid()` with `auth.role() = 'authenticated'`.
 
+### Public-read bucket template (e.g. `models`, `covers` shown to everyone)
+
+Use when any signed-in user writes and everyone (including `anon`) reads — image galleries, model-sharing sites, public attachments. Create the bucket with `public = true` (via the SQL path above or HTTP API), then:
+
+```sql
+-- anon 可读：配合 getPublicUrl 直链在 <img src> 直接展示
+CREATE POLICY objects_public_read ON storage.objects
+  FOR SELECT USING (bucket_id = 'models');
+
+-- 登录用户可上传（不限定子目录）
+CREATE POLICY objects_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'models');
+
+-- 仅上传者本人可删除
+CREATE POLICY objects_owner_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'models' AND owner_id = auth.uid());
+```
+
+Key points:
+- `public = true` on `storage.buckets` alone does **not** bypass RLS — the anon SELECT policy above is what makes direct public URLs work.
+- `storage.objects.owner_id` records the uploading user; constrain UPDATE/DELETE with `owner_id = auth.uid()`.
+- `auth.uid()` returns **`text`**; `owner_id` is text — compare directly, no cast.
+
+### Frontend URL resolution: public bucket vs private bucket
+
+| Bucket type | URL strategy | Code |
+|---|---|---|
+| Public (`storage.buckets.public = true`) | Direct link, no login state needed, goes straight into `<img src>` | `app.storage.from('models').getPublicUrl('a.png')` → `{ data: { publicUrl } }` |
+| Private | Signed URL with expiry | `app.storage.from('models').createSignedUrl('a.png', 3600)` |
+
+- Store only the bucket + key (or the resolved URL) in the business table; never concatenate URLs by hand in browser code.
+- Add an `onerror` fallback in the display layer (e.g. degrade to a signed URL if the direct link is blocked) instead of hard-depending on one flow. See `cloud-storage-web/SKILL.md`.
+
 ## Typical Pattern: Upload + Register Metadata
 
 这是你在 CRM 等业务中需要完整遵循的「三步走」模式（对应 Supabase 的 storage + 业务表分离模式）：

--- a/config/.claude/skills/relational-database-mcp-cloudbase/SKILL.md
+++ b/config/.claude/skills/relational-database-mcp-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-mcp-cloudbase
 description: "[Deprecated] This is the required documentation for agents operating on the CloudBase Relational Database through MCP. It defines the canonical SQL management flow with `queryMysqlDatabase`, `manageMysqlDatabase`, `queryPermissions`, and `managePermissions`, including MySQL provisioning, destroy flow, async status checks, safe query execution, schema initialization, and permission updates. New environments should use PostgreSQL — see postgresql-development skill instead."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/relational-database-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/relational-database-web-cloudbase/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: relational-database-web-cloudbase
 description: "[Deprecated] Use when building frontend Web apps that talk to CloudBase Relational Database via @cloudbase/js-sdk – provides the canonical init pattern so you can then use Supabase-style queries from the browser. New environments should use PostgreSQL with app.rdb() — see postgresql-development skill instead."
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 metadata:
   priority: "5"

--- a/config/.claude/skills/spec-workflow/SKILL.md
+++ b/config/.claude/skills/spec-workflow/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: spec-workflow
 description: Use when medium-to-large changes need explicit requirements, technical design, and task planning before implementation, especially for multi-module work, unclear acceptance criteria, or architecture-heavy requests.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/ui-design/SKILL.md
+++ b/config/.claude/skills/ui-design/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ui-design
 description: Use when users need visual direction, interface hierarchy, layout decisions, design specifications, or prototypes before implementing a Web or mini program UI.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/.claude/skills/web-development/SKILL.md
+++ b/config/.claude/skills/web-development/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: web-development
 description: Use when users need to implement, integrate, debug, build, deploy, or validate a Web frontend after the product direction is already clear, especially for React, Vue, Vite, browser flows, or CloudBase Web integration.
-version: 2.33.1
+version: 2.33.2
 alwaysApply: false
 ---
 

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -80,6 +80,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 ## Prerequisites
 
 - Automatically use `auth-tool-cloudbase` to check app-side auth readiness via `queryAppAuth` / `manageAppAuth`, then get the `publishable key` and configure login methods.
+- **Publishable key readiness (do not skip):** call `queryAppAuth(action="getPublishableKey")`. If it is empty, call `manageAppAuth(action="ensurePublishableKey")` first — new environments may not have one provisioned, and skipping this step leaves the frontend without a data-plane credential, surfacing later as gateway auth failures instead of an obvious missing-key error.
 - If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
 
 ### Parameter map

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -194,6 +194,22 @@ auth.onAuthStateChange((event, session) => {
 const { error } = await auth.signOut()
 ```
 
+**Mandatory auth gate before user-scoped data.** Before reading/writing user-owned PG rows or Storage objects, check the session and show login when absent — never "fix" data errors by silently calling `signInAnonymously`:
+
+```js
+const { data } = await auth.getSession()
+if (!data?.session) { navigate('/login'); return }
+```
+
+**Completion Bar** — before calling the auth task done, the generated source must have ALL of:
+
+- [ ] `signInWithPassword` (when password login is part of the UI)
+- [ ] a verification-code path: `signUp` + `data.verifyOtp` and/or `signInWithOtp`
+- [ ] auth gate before user-scoped DB/Storage calls (rule above)
+- [ ] `onAuthStateChange` wired at bootstrap (route guard reacts to `SIGNED_OUT`)
+- [ ] errors surfaced from `error.message`, no invented error text
+- [ ] NO `signInAnonymously` as a fallback for permission errors, no mock/localStorage sessions
+
 ---
 
 ## Extended guide

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -129,6 +129,8 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
 
+**Default auth UI contract:** when the user asks for 登录/注册/账号体系/user system without restricting the method, the login page must make ALL of these reachable (tabs or separate forms): password sign-in, OTP sign-in, verified sign-up (code + password), and forgot-password (whenever password sign-in exists). Never ship OTP-only or password-only UI unless explicitly asked. Never reveal whether an identifier is already registered in user-facing copy — route existing users to login with neutral wording.
+
 **Password sign-in** (username-style or email identifiers both go here):
 
 ```js
@@ -143,13 +145,32 @@ if (error) { /* show error.message */ } else { /* data.user */ }
 const { error } = await auth.signInAnonymously()
 ```
 
-**Register (email/phone OTP flow)** — `signUp` sends the verification code, `data.verifyOtp` completes it:
+**Registration — verification code is MANDATORY.** There is no password-only signup: `signUp` itself sends a code, and `data.verifyOtp` must complete it. Smart flow: existing identifier → plain login; new identifier → register + auto-login. Phone/SMS is 上海地域 only — prefer email:
 
 ```js
 const { data, error } = await auth.signUp({ email, password }) // or { phone, password }
 if (error) throw error
-const { data: login, error: verifyErr } = await data.verifyOtp({ token: code }) // code from email/SMS
+// user types the code from their inbox...
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code })
+// login.user / login.session — signed in on both paths
 ```
+
+**OTP sign-in (no password)** — same shape as `signUp`, auto-creates the user by default (`shouldCreateUser: false` to refuse unknown users). Requires 邮箱/短信验证码登录 enabled in console → 身份认证/登录方式:
+
+```js
+const { data, error } = await auth.signInWithOtp({ email }) // or { phone }
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code })
+```
+
+**Forgot password** — email code → set new password → auto sign-in (emits `PASSWORD_RECOVERY`):
+
+```js
+const { data, error } = await auth.resetPasswordForEmail(email)
+if (error) throw error
+const { data: login, error: resetErr } = await data.updateUser({ nonce: code, password: newPassword })
+```
+
+**OTP closure vs standalone `verifyOtp` — do not mix.** The `data.verifyOtp` returned by `signUp` / `signInWithOtp` / `resetPasswordForEmail` has the message ID bound (pass only `{ token }`). The standalone `auth.verifyOtp(...)` requires `messageId` and **only logs in — it never registers**. Always use the returned closure.
 
 **Session check / route guard** — always `getSession()`, never the deprecated `getLoginState()`:
 

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -125,6 +125,54 @@ const auth = app.auth
 
 If the current task has not retrieved a real Publishable Key, omit `accessKey` instead of inventing one. A wrong `accessKey` can break auth-state checks and protected-route behavior.
 
+## Auth code cookbook (official v3 API — copy these, do not re-derive from .d.ts)
+
+Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
+
+**Password sign-in** (username-style or email identifiers both go here):
+
+```js
+const { data, error } = await auth.signInWithPassword({ username, password })
+// email accounts: auth.signInWithPassword({ email, password })
+if (error) { /* show error.message */ } else { /* data.user */ }
+```
+
+**Anonymous sign-in** (required before NoSQL `app.database()` CRUD; PG anon reads work with accessKey alone):
+
+```js
+const { error } = await auth.signInAnonymously()
+```
+
+**Register (email/phone OTP flow)** — `signUp` sends the verification code, `data.verifyOtp` completes it:
+
+```js
+const { data, error } = await auth.signUp({ email, password }) // or { phone, password }
+if (error) throw error
+const { data: login, error: verifyErr } = await data.verifyOtp({ token: code }) // code from email/SMS
+```
+
+**Session check / route guard** — always `getSession()`, never the deprecated `getLoginState()`:
+
+```js
+const { data } = await auth.getSession()
+const session = data?.session // undefined === not logged in
+```
+
+**Auth state listener** (wire this once at app bootstrap):
+
+```js
+auth.onAuthStateChange((event, session) => {
+  // event: INITIAL_SESSION | SIGNED_IN | SIGNED_OUT | PASSWORD_RECOVERY
+  //        | TOKEN_REFRESHED | USER_UPDATED | BIND_IDENTITY
+})
+```
+
+**Sign out:**
+
+```js
+const { error } = await auth.signOut()
+```
+
 ---
 
 ## Extended guide

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -102,6 +102,8 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 
 ## Quick Start
 
+SDK init reference: [docs.cloudbase.net/api-reference/webv3/initialization.md](https://docs.cloudbase.net/api-reference/webv3/initialization.md)（URL 加 `.md` 可取 raw markdown 原文）
+
 ```js
 // npm install @cloudbase/js-sdk
 import cloudbase from '@cloudbase/js-sdk'
@@ -129,7 +131,7 @@ If the current task has not retrieved a real Publishable Key, omit `accessKey` i
 
 ## Auth code cookbook (official v3 API — copy these, do not re-derive from .d.ts)
 
-Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments (source: docs.cloudbase.net/api-reference/webv3/authentication).
+Every method returns the unified shape `{ data, error }` — branch on `error` first and surface `error.message`. The auth API is identical in traditional and PG environments. Source: [official auth docs](https://docs.cloudbase.net/api-reference/webv3/authentication.md)（raw markdown, cross-check snippets there when in doubt）.
 
 **Default auth UI contract:** when the user asks for 登录/注册/账号体系/user system without restricting the method, the login page must make ALL of these reachable (tabs or separate forms): password sign-in, OTP sign-in, verified sign-up (code + password), and forgot-password (whenever password sign-in exists). Never ship OTP-only or password-only UI unless explicitly asked. Never reveal whether an identifier is already registered in user-facing copy — route existing users to login with neutral wording.
 

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -46,11 +46,11 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Starting implementation before calling `queryAppAuth(action="getLoginConfig")` and enabling `usernamePassword` when it is still off.
 - **Writing `auth.signInWithPassword(...)` or `auth.signUp(...)` code without first confirming the provider is enabled via MCP.** Before writing any sign-in or sign-up code in the browser, call `queryAppAuth(action="listProviders")` to verify the target provider (e.g. `email`, `phone`, `usernamePassword`) has `On: "TRUE"`. For email-based sign-up (`auth.signUp({ email, password })`), additionally confirm SMTP is configured — otherwise the provider may throw `"provider email not found"` or similar errors. For username/password login, use `auth.signInWithPassword({ username, password })`; registration is best done through the management API (`manageAppAuth(action="createUser")`) or by confirming email provider readiness first.
 - **Treating `auth.getUser()` or deprecated `auth.getLoginState()` as proof of real login.** When the SDK is initialized with `accessKey`, the deprecated `getLoginState()` may still return an object with a valid `uid` even without any login — causing route guards that check `!!loginState` or `!!uid` to incorrectly pass. That misleading `uid` is **not** a gateway-authenticated session. Use `auth.getSession()` instead: it returns `data.session === undefined` when no real login has occurred. Only `!!data.session` from `getSession()` is a reliable authentication check.
-- **Assuming publishable `accessKey` alone is enough for NoSQL CRUD.** With `@cloudbase/js-sdk` **3.x**, call **`await auth.signInAnonymously()`** (or an equivalent authenticated session such as password/OTP/OAuth) **before** any NoSQL `app.database()` `get` / `add` / `update` / `watch`. Skipping this yields **gateway 401**. `checkLogin()` / `getSession()` alone do **not** create a usable write session.
+- **Assuming publishable `accessKey` alone is enough for NoSQL CRUD.** NoSQL `app.database()` `get` / `add` / `update` / `watch` requires a gateway-authenticated **session**: use a real login (password / OTP / OAuth). Anonymous login is a demo-only escape hatch for explicitly-public, non-user data — it is disabled by default, denied AI model permissions, and must never stand in for real auth in user-scoped apps. Skipping any login yields **gateway 401**. `checkLogin()` / `getSession()` alone do **not** create a usable write session.
 - **Copying old CloudBase auth snippets from training data.** Do not use `auth.getLoginState()`, `auth.hasLoginState()`, `auth.getCurrentUser()`, or `auth.toDefaultLoginPage()` as the default Web flow. Use the Web SDK v3 auth methods in this file and provider readiness from `auth-tool-cloudbase`.
 - **Calling a standalone `auth.verifyOtp({ token })` for OTP login.** CloudBase Web SDK v3 returns `verifyOtp` as a callback on the `signInWithOtp` / `signUp` result: send the code first, keep the returned `data`, then call `data.verifyOtp({ token })`. A standalone `auth.verifyOtp({ token })` without `messageId` fails with `"messageId is required"` — seeing that error means the callback form was skipped. See `references/extended-guide.md` for the full send → save callback → verify flow.
   
-  Note: anonymous login is **disabled by default** for new environments and inactive existing environments — enable it via `auth-tool-cloudbase` before calling `signInAnonymously()`. Always use `auth.getSession()` for auth guards.
+  Note: anonymous login is **disabled by default** for new environments and inactive existing environments. Do not enable it to work around permission errors — enable via `auth-tool-cloudbase` only when the app explicitly serves public non-user data (e.g. NoSQL read-only demos). Always use `auth.getSession()` for auth guards.
 
 ## Overview
 
@@ -96,7 +96,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 - If the task gives accounts like `admin`, `editor`, or another plain string without `@`, treat it as a username-style identifier rather than an email address
 - `data.verifyOtp({ token })` — the `verifyOtp` callback on the `signInWithOtp` / `signUp` result `data` — expects the SMS or email code in `token`; do not invent a standalone `auth.verifyOtp({ token })` call, which additionally requires `messageId`
 - `accessKey` is the publishable key from `queryAppAuth` / `manageAppAuth` via `auth-tool-cloudbase`, not a secret key
-- **`accessKey` alone does not create a gateway-authenticated anonymous session.** Publishable `accessKey` initializes the SDK; it does **not** replace an explicit login for NoSQL CRUD. With `@cloudbase/js-sdk` **3.x**, call `await auth.signInAnonymously()` (or an equivalent authenticated session) **before** `app.database()` `get` / `add` / `update` / `watch` — otherwise the gateway returns **401**. Separately: the deprecated `auth.getLoginState()` may still return a misleading `uid` without login; use `auth.getSession()` for route guards (`data.session === undefined` when not logged in). `checkLogin()` / `getSession()` alone do **not** create a usable write session.
+- **`accessKey` alone does not create a gateway-authenticated session.** Publishable `accessKey` initializes the SDK; it does **not** replace a login for NoSQL CRUD. Any `app.database()` `get` / `add` / `update` / `watch` needs a session — prefer a real login (password / OTP / OAuth); `signInAnonymously()` only for explicitly-public demo data (disabled by default, denied AI model permissions). Otherwise the gateway returns **401**. Separately: the deprecated `auth.getLoginState()` may still return a misleading `uid` without login; use `auth.getSession()` for route guards (`data.session === undefined` when not logged in). `checkLogin()` / `getSession()` alone do **not** create a usable write session.
 - Never set `accessKey` to `envId`, a username, or any placeholder string. If you do not have a real Publishable Key yet, do not fabricate one.
 - If the task mentions provider setup, stop and read `auth-tool-cloudbase` before writing frontend code
 
@@ -110,15 +110,17 @@ const app = cloudbase.init({
   env: 'your-full-env-id', // Canonical full CloudBase environment ID resolved from envQuery or the console, not an alias or shorthand
   region: 'ap-shanghai',  // CloudBase environment Region, default 'ap-shanghai'
   accessKey: 'publishable key', // required, get from auth-tool-cloudbase
-  // ⚠️ accessKey alone ≠ anonymous login. For NoSQL CRUD call await auth.signInAnonymously()
-  // (or real login) first — otherwise gateway 401. Use auth.getSession() for route guards;
-  // deprecated getLoginState() may return a misleading uid without a real session.
+  // ⚠️ accessKey alone ≠ a login session. NoSQL CRUD needs a session —
+  // real login preferred; signInAnonymously() only for public demo data.
+  // Use auth.getSession() for route guards; deprecated getLoginState()
+  // may return a misleading uid without a real session.
   auth: { detectSessionInUrl: true }, // required
 })
 
 const auth = app.auth
 
-// Before NoSQL app.database() CRUD (js-sdk 3.x + publishable key):
+// NoSQL app.database() CRUD requires a session (js-sdk 3.x + publishable key).
+// Real login (see cookbook). Anonymous, only for public non-user demos:
 // const { error } = await auth.signInAnonymously()
 // if (error) throw error
 ```
@@ -139,7 +141,7 @@ const { data, error } = await auth.signInWithPassword({ username, password })
 if (error) { /* show error.message */ } else { /* data.user */ }
 ```
 
-**Anonymous sign-in** (required before NoSQL `app.database()` CRUD; PG anon reads work with accessKey alone):
+**Anonymous sign-in — demo-only, not a default.** NoSQL `app.database()` CRUD needs some session (PG anon reads work with accessKey alone). Prefer a real login; reach for anonymous ONLY when the app explicitly serves public non-user data and the user accepts the trade-off — it is disabled by default, denied AI model permissions, and its `uid` must never own user-scoped rows:
 
 ```js
 const { error } = await auth.signInAnonymously()

--- a/config/source/skills/cloud-storage-web/SKILL.md
+++ b/config/source/skills/cloud-storage-web/SKILL.md
@@ -117,7 +117,7 @@ Use instead:
 | `createSignedUrl(path, expiresIn)` | `await` → `{ data: { signedUrl } }` | `await` → `{ data: { fullSignedURL } }` |
 | `getPublicUrl(path)` | `await` → `{ data: { publicUrl } }` | **同步调用（不 await）** → `{ data: { publicUrl } }` |
 
-Source: docs.cloudbase.net/api-reference/webv3/storage 与 webv3-pg/storage。
+Source: [webv3/storage.md](https://docs.cloudbase.net/api-reference/webv3/storage.md) · [webv3-pg/storage.md](https://docs.cloudbase.net/api-reference/webv3-pg/storage.md)（raw markdown）。
 
 ### PG mode URL resolution: 公开桶直链 vs 签名 URL
 
@@ -173,6 +173,8 @@ Typical tasks:
 - trigger browser downloads
 
 ## SDK initialization
+
+Init reference: [webv3/initialization.md](https://docs.cloudbase.net/api-reference/webv3/initialization.md)
 
 ```javascript
 import cloudbase from "@cloudbase/js-sdk";

--- a/config/source/skills/cloud-storage-web/SKILL.md
+++ b/config/source/skills/cloud-storage-web/SKILL.md
@@ -109,6 +109,17 @@ Use instead:
 - ✅ `app.storage.from('covers').upload('file', file)` — PG 模式上传
 - ✅ `app.storage.from('covers').createSignedUrl('file', 3600)` — 获取签名 URL（返回 `fullSignedURL` 字段）
 
+### PG mode URL resolution: 公开桶直链 vs 签名 URL
+
+| Bucket 类型 | URL 策略 | 代码 |
+|---|---|---|
+| 公开桶（`storage.buckets.public = true`） | 直链，无需登录态，可直接进 `<img src>` | `app.storage.from('covers').getPublicUrl('a.png')` → `{ data: { publicUrl } }` |
+| 私有桶 | 签名 URL，带过期时间 | `app.storage.from('covers').createSignedUrl('a.png', 3600)` |
+
+- 公开桶直链能否访问取决于 `storage.objects` 的 RLS SELECT 策略是否放行 anon —— 建桶 SQL 与策略模板见 `postgresql-development-cloudbase/references/storage-pg.md` "Public-read bucket template"。
+- 展示层做 `onerror` 兜底（直链被策略拦下时降级到签名 URL），不要硬依赖单一取址流程。
+- 业务表只存 bucket + key（或 SDK 解析出的最终 URL），不要在浏览器手工拼接 URL。
+
 ### Post-bucket: storage RLS (mandatory in PG / pgstore environments)
 
 In **PG / pgstore** environments, storage access control is enforced through **PostgreSQL Row Level Security (RLS) on `storage.buckets` / `storage.objects`** — exactly like Supabase Storage. These tables are already granted to `anon`, `authenticated`, and `service_role`; RLS is the permission gate. Traditional storage permission labels (`READONLY` / `PRIVATE` / `CUSTOM`) and JSON storage safe rules do not apply. The default RLS policy is deny all, so even if the bucket exists, `app.storage.from('covers').upload()` from a browser will fail with `STORAGE_PERMISSION_DENIED` unless you configure policies.

--- a/config/source/skills/cloud-storage-web/SKILL.md
+++ b/config/source/skills/cloud-storage-web/SKILL.md
@@ -109,6 +109,16 @@ Use instead:
 - ✅ `app.storage.from('covers').upload('file', file)` — PG 模式上传
 - ✅ `app.storage.from('covers').createSignedUrl('file', 3600)` — 获取签名 URL（返回 `fullSignedURL` 字段）
 
+**Return shapes differ between modes (v3 SDK) — copy the right column:**
+
+| call | 传统模式 (`from()` 无参, `cloud://` fileID) | PG 模式 (`from('bucket')`, bucket 内对象名) |
+|---|---|---|
+| `upload(path, file)` | `{ data: { id, path, fullPath } }`；`upsert` 默认 **true** | `{ data: { id, ... } }`；`upsert` 默认 **false** |
+| `createSignedUrl(path, expiresIn)` | `await` → `{ data: { signedUrl } }` | `await` → `{ data: { fullSignedURL } }` |
+| `getPublicUrl(path)` | `await` → `{ data: { publicUrl } }` | **同步调用（不 await）** → `{ data: { publicUrl } }` |
+
+Source: docs.cloudbase.net/api-reference/webv3/storage 与 webv3-pg/storage。
+
 ### PG mode URL resolution: 公开桶直链 vs 签名 URL
 
 | Bucket 类型 | URL 策略 | 代码 |

--- a/config/source/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/source/skills/postgresql-development-cloudbase/SKILL.md
@@ -31,7 +31,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - PG mode overview -> `references/pg-mode-overview.md`
 - Auth / GRANT / RLS details -> `references/auth-and-rls.md`
 - End-to-end PG app closure -> `references/app-workflow.md`
-- PG storage details -> `references/storage-pg.md`
+- PG storage details — **MUST read before writing any bucket / upload / URL code** -> `references/storage-pg.md`
 - HTTP API fallback -> `references/http-api.md`
 - Troubleshooting -> `references/troubleshooting.md`
 
@@ -149,6 +149,20 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 - Backend permission must exist in the database or server/RPC layer. Hiding buttons in the UI is not enough.
 - Do not leave a browser-facing table with RLS enabled and zero policies. PostgreSQL denies user reads/writes by default in that state, so `app.rdb().from("articles").insert(...)` can fail while the UI only shows a generic save failure. If you enable RLS, create and verify SELECT/INSERT/UPDATE/DELETE policies before testing the app.
 - Use CloudBase PG's official SQL auth helpers in policies: `auth.uid()` (JWT `sub`, returns **`text`** not `uuid`), `auth.role()` (`anon` / `authenticated` / `service_role`), `auth.jwt()` (full claims), and `auth.email()` when relevant. Prefer owner columns such as `owner_id varchar(64) DEFAULT auth.uid()` so the database, not the browser, assigns ownership. If an owner column is already `uuid`, compare with `auth.uid()::uuid` (only when `sub` is a valid UUID).
+- Standard owner-table template — copy this shape for any user-owned business table:
+
+  ```sql
+  CREATE TABLE articles (
+    id          BIGINT      GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    owner_id    TEXT        NOT NULL DEFAULT auth.uid(),
+    title       TEXT        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+  );
+  ```
+
+  - `owner_id` is **`TEXT`**, not `uuid` — `auth.uid()` returns text (e.g. `EchhGXFadSANiCSaVim2wQ`); declaring it `uuid` fails at table-create time with a type mismatch.
+  - `owner_id` carries `DEFAULT auth.uid()` — ownership is decided server-side. App code must not send it; the INSERT policy rejects any forged owner value.
+- **Seeding demo data:** RLS denies anonymous browser writes. Insert demo/seed rows through the management plane — `managePgDatabase(action="execute", confirm=true)` with an **explicit** `owner_id` value (e.g. `'system-demo'`); do not rely on `DEFAULT auth.uid()` for seed rows, and never ship seed INSERTs in frontend code.
 - If you need detailed GRANT/RLS rules, read `references/rls-patterns.md` before writing policies.
 - For admin/editor flows, make `admin` able to operate all rows and `editor` only rows where owner UID matches the current user.
 
@@ -223,7 +237,7 @@ CloudBase PG storage uses the `pgstore` backend and follows the same model as Su
 1. Confirm a usable pgstore bucket exists for your target prefix (e.g. `covers`). The legacy NoSQL bucket exposed by `DescribeEnvs.Storages[]` (e.g. `6d63-…-1409864723`) is for the old NoSQL backend and does NOT serve pgstore uploads.
 2. If no usable bucket exists, create one through the PG storage management surface (PG storage HTTP API / CLI / console / SQL on `storage.buckets` when appropriate). Do not assume traditional-mode storage tools or adding `covers/` as a JS path prefix will create a PG bucket.
 3. The bucket name belongs in `from('<bucket>')`; the key passed to `upload(key, file)` is inside that bucket and must **not** repeat the bucket prefix. Correct: `app.storage.from('covers').upload('a.png', file)`. Wrong: `app.storage.from('covers').upload('covers/a.png', file)`.
-4. **After creating the bucket, configure RLS on `storage.objects`** via `managePgDatabase(action="execute", confirm=true)`. The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`. See `cloud-storage-web/SKILL.md` "Post-bucket: storage RLS" section for the exact SQL policies.
+4. **After creating the bucket, configure RLS on `storage.objects`** via `managePgDatabase(action="execute", confirm=true)`. The default RLS is deny all; without permissive policies the browser receives `STORAGE_PERMISSION_DENIED`. See `references/storage-pg.md` for the full bucket + RLS templates (per-user isolation and public-read buckets), and `cloud-storage-web/SKILL.md` "Post-bucket: storage RLS" section for the exact SQL policies.
 
 Failure-mode cheat sheet (read DevTools network tab on the FAILED `POST .../v1/storages/get-objects-upload-info`):
 

--- a/config/source/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/source/skills/postgresql-development-cloudbase/SKILL.md
@@ -174,7 +174,7 @@ CloudBase PG (`app.rdb()`, `app.storage.from('bucket')`) uses **different API me
 - ❌ `db.from("public.public.articles")` — WRONG, double schema prefix, will fail with `PGRST205`
 - `objectName="public.articles"` in `queryPgDatabase()` is the MCP tool format — do NOT copy this into `db.from()`.
 
-Use static imports and one shared `app.rdb()` client:
+Use static imports and one shared `app.rdb()` client (SDK init reference: [webv3-pg/initialization.md](https://docs.cloudbase.net/api-reference/webv3-pg/initialization.md)):
 
 ```ts
 import cloudbase from "@cloudbase/js-sdk";
@@ -214,7 +214,7 @@ const { data } = await db.rpc("function_name", { id });
 
 Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.contains()`, `.textSearch()`, `.or()`, `.not()`, `.match()`, `.order()`, `.limit()`, `.range()`, `.single()`.
 
-**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: docs.cloudbase.net/api-reference/webv3-pg/postgresql/{fetch,insert,update,delete,upsert,filters,modifiers,rpc}:
+**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: [webv3-pg/postgresql/fetch.md](https://docs.cloudbase.net/api-reference/webv3-pg/postgresql/fetch.md) — fetch / insert / update / delete / upsert / filters / modifiers / rpc share the same path prefix, one page per verb（URL 加 `.md` 可取 raw markdown 原文）:
 
 ```ts
 // COUNT only — no rows returned, count comes back on the result object

--- a/config/source/skills/postgresql-development-cloudbase/SKILL.md
+++ b/config/source/skills/postgresql-development-cloudbase/SKILL.md
@@ -178,7 +178,11 @@ Use static imports and one shared `app.rdb()` client:
 
 ```ts
 import cloudbase from "@cloudbase/js-sdk";
-const app = cloudbase.init({ env: import.meta.env.VITE_CLOUDBASE_ENV_ID });
+const app = cloudbase.init({
+  env: import.meta.env.VITE_CLOUDBASE_ENV_ID,
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY, // publishable key, see auth-web-cloudbase prerequisites
+  auth: { detectSessionInUrl: true },
+});
 export const auth = app.auth;
 export const db = app.rdb();
 ```
@@ -208,7 +212,41 @@ await db.from("articles").delete().eq("id", id);
 const { data } = await db.rpc("function_name", { id });
 ```
 
-Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.order()`, `.limit()`, `.range()`, `.single()`.
+Common query helpers: `.eq()`, `.neq()`, `.gt()`, `.gte()`, `.lt()`, `.lte()`, `.like()`, `.ilike()`, `.in()`, `.is()`, `.contains()`, `.textSearch()`, `.or()`, `.not()`, `.match()`, `.order()`, `.limit()`, `.range()`, `.single()`.
+
+**Full cookbook (official webv3-pg API — copy these, do not re-derive from .d.ts).** Source: docs.cloudbase.net/api-reference/webv3-pg/postgresql/{fetch,insert,update,delete,upsert,filters,modifiers,rpc}:
+
+```ts
+// COUNT only — no rows returned, count comes back on the result object
+const { count, error } = await db.from("articles").select("*", { count: "exact", head: true });
+
+// Pagination — .range(from, to) is INCLUSIVE on both ends; page 2 of 20 = .range(20, 39)
+const { data, error } = await db.from("articles").select("*")
+  .order("created_at", { ascending: false }).range(0, 19);
+
+// INSERT and return the inserted row — ⚠️ .select() only returns rows when the
+// table has a single auto-increment primary key; otherwise data is empty/null
+const { data, error } = await db.from("articles").insert({ title, status: "draft" }).select();
+
+// INSERT many rows at once (array form)
+await db.from("articles").insert([{ title: "a" }, { title: "b" }]);
+
+// UPSERT — include the primary key in values; onConflict names the unique-index column(s)
+await db.from("articles").upsert({ id: 1, title: "new" }, { onConflict: "id" });
+
+// Join query — PostgREST embedded resources via FK relationship
+const { data, error } = await db.from("articles").select(`
+  title,
+  categories ( name ),
+  created_by:users!articles_created_by_fkey ( name ) // multiple FKs to the same table need the constraint name
+`);
+
+// RPC — SETOF-returning functions chain .select()/.order()/.limit()/.single()/filters like a query
+const { data, error } = await db.rpc("search_articles", { keyword })
+  .select("title, published_at").order("published_at", { ascending: false }).limit(5);
+const { data: one } = await db.rpc("search_articles", { keyword }).limit(1).single();
+const { count } = await db.rpc("search_articles", { keyword }, { count: "exact", head: true });
+```
 
 ### ⚠️ Critical: PG API is NOT the same as CloudBase NoSQL or other ORMs
 

--- a/config/source/skills/postgresql-development-cloudbase/references/storage-pg.md
+++ b/config/source/skills/postgresql-development-cloudbase/references/storage-pg.md
@@ -281,6 +281,41 @@ Key points:
 - Do **not** `DELETE FROM storage.objects` directly — a `protect_delete` trigger blocks it. Use SDK / Storage API.
 - For simpler authenticated-only access (not per-user), replace `(storage.foldername(name))[1] = auth.uid()` with `auth.role() = 'authenticated'`.
 
+### Public-read bucket template (e.g. `models`, `covers` shown to everyone)
+
+Use when any signed-in user writes and everyone (including `anon`) reads — image galleries, model-sharing sites, public attachments. Create the bucket with `public = true` (via the SQL path above or HTTP API), then:
+
+```sql
+-- anon 可读：配合 getPublicUrl 直链在 <img src> 直接展示
+CREATE POLICY objects_public_read ON storage.objects
+  FOR SELECT USING (bucket_id = 'models');
+
+-- 登录用户可上传（不限定子目录）
+CREATE POLICY objects_insert ON storage.objects
+  FOR INSERT TO authenticated
+  WITH CHECK (bucket_id = 'models');
+
+-- 仅上传者本人可删除
+CREATE POLICY objects_owner_delete ON storage.objects
+  FOR DELETE TO authenticated
+  USING (bucket_id = 'models' AND owner_id = auth.uid());
+```
+
+Key points:
+- `public = true` on `storage.buckets` alone does **not** bypass RLS — the anon SELECT policy above is what makes direct public URLs work.
+- `storage.objects.owner_id` records the uploading user; constrain UPDATE/DELETE with `owner_id = auth.uid()`.
+- `auth.uid()` returns **`text`**; `owner_id` is text — compare directly, no cast.
+
+### Frontend URL resolution: public bucket vs private bucket
+
+| Bucket type | URL strategy | Code |
+|---|---|---|
+| Public (`storage.buckets.public = true`) | Direct link, no login state needed, goes straight into `<img src>` | `app.storage.from('models').getPublicUrl('a.png')` → `{ data: { publicUrl } }` |
+| Private | Signed URL with expiry | `app.storage.from('models').createSignedUrl('a.png', 3600)` |
+
+- Store only the bucket + key (or the resolved URL) in the business table; never concatenate URLs by hand in browser code.
+- Add an `onerror` fallback in the display layer (e.g. degrade to a signed URL if the direct link is blocked) instead of hard-depending on one flow. See `cloud-storage-web/SKILL.md`.
+
 ## Typical Pattern: Upload + Register Metadata
 
 这是你在 CRM 等业务中需要完整遵循的「三步走」模式（对应 Supabase 的 storage + 业务表分离模式）：

--- a/doc/mcp-tools.md
+++ b/doc/mcp-tools.md
@@ -900,7 +900,7 @@ AI 在写业务/权限/存储代码前必须先看这三项：PG 模式下新业
     {
       name: "migrationVersion",
       type: "string",
-      description: `14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。`,
+      description: `14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。applyMigration 非增量：每次传完整 SQL；终态失败且 listMigrations 未落地时版本号不占用，换新 migrationVersion 重发全量 SQL 即可（同名不同版本不冲突）。`,
     },
     {
       name: "rollbackSql",

--- a/mcp/src/tools/databasePG.ts
+++ b/mcp/src/tools/databasePG.ts
@@ -3416,7 +3416,7 @@ export function registerPGDatabaseTools(
           .string()
           .regex(/^\d{14}$/)
           .optional()
-          .describe("14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。"),
+          .describe("14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。applyMigration 非增量：每次传完整 SQL；终态失败且 listMigrations 未落地时版本号不占用，换新 migrationVersion 重发全量 SQL 即可（同名不同版本不冲突）。"),
         rollbackSql: z
           .string()
           .optional()

--- a/plugin/cloudbase-sites/hooks/on-session-start.sh
+++ b/plugin/cloudbase-sites/hooks/on-session-start.sh
@@ -96,16 +96,27 @@ you must not bypass them.
    `cloudbase-sites deploy`. Bypassing them loses host=0.0.0.0, port allocation,
    daemonization, version metadata, and deploy history.
 
-5. **Data persistence: BaaS-first via Web SDK + MCP-managed schema.** When
-   the user'\''s feature needs to store / query / update data:
-   - **Schema:** call cloudbase-mcp `writeNoSqlDatabaseStructure(action="createCollection", ...)`
+5. **Data persistence: BaaS-first via Web SDK + MCP-managed schema — detect the env type FIRST.** Before any
+   data-layer work, call cloudbase-mcp `envQuery(action="info")` and branch on
+   the detected database backend:
+   - **PostgreSQL env** (`RuntimeBackends.postgresql === true`): schema via
+     versioned migrations `managePgDatabase(action="applyMigration", ...)`;
+     browser code uses `app.rdb()` — do NOT write `db.collection(...)`.
+     For canonical patterns, fetch the postgresql-development-cloudbase skill via
+     `searchKnowledgeBase(mode=skill, skillName="postgresql-development-cloudbase")`.
+   - **NoSQL env** (document database): schema via cloudbase-mcp
+     `writeNoSqlDatabaseStructure(action="createCollection", ...)`
      to create the collection (and `updateCollection` for indexes). Do NOT
      ask the user to create collections manually in the console. For canonical
      patterns, fetch the no-sql-web-sdk skill via
      `searchKnowledgeBase(mode=skill, skillName="no-sql-web-sdk")`.
-   - **Reads/writes:** use `@cloudbase/js-sdk` directly from the React/Vue
-     code (`db.collection(...).where(...).get()`, `.add()`, `.update()`,
-     `db.collection(...).watch(...)` for realtime). The template already
+   - Do NOT guess from the skill catalog — the catalog contains BOTH paths;
+     only `envQuery` tells a PG env from a NoSQL env. Loading no-sql-web-sdk
+     for a PG environment wastes the whole data-layer plan.
+   - **Reads/writes (both env types):** use `@cloudbase/js-sdk` directly from
+     the React/Vue code — PG: `app.rdb().from(...)`; NoSQL:
+     `db.collection(...).where(...).get()`, `.add()`, `.update()`,
+     `db.collection(...).watch(...)` for realtime. The template already
      ships an initialized SDK at `src/utils/cloudbase.ts` — use it.
    - **Auth:** if the feature needs user accounts, fetch
      `searchKnowledgeBase(mode=skill, skillName="auth-tool")` first to
@@ -177,6 +188,7 @@ Likely-needed in a vibe-coding session:
 - `web-development`         — Web 项目开发与部署规范
 - `auth-tool`               — 认证 provider 启用与配置(管理端)
 - `auth-web`                — Web SDK 认证客户端代码
+- `postgresql-development-cloudbase` — PG 模式 schema/RLS/app.rdb()（PG 环境必读）
 - `no-sql-web-sdk`          — 文档型数据库 Web SDK CRUD
 - `cloud-storage-web`       — 云存储 Web SDK 上传下载
 - `relational-database-web` — MySQL Web SDK

--- a/plugin/cloudbase-sites/lib/verbs/init.mjs
+++ b/plugin/cloudbase-sites/lib/verbs/init.mjs
@@ -44,6 +44,13 @@ const TEMPLATE_URLS = {
   vue: "https://static.cloudbase.net/cloudbase-examples/web-cloudbase-vue-template.zip",
 };
 
+// Icon library preinstalled per template, so generation-time never needs a
+// second package install (sandboxed installs are a known failure point).
+const ICON_DEPS = {
+  react: { name: "lucide-react", version: "^1.43.0" },
+  vue: { name: "lucide-vue-next", version: "^1.0.0" },
+};
+
 export const initHelp = `cloudbase-sites init — bootstrap CloudBase + React/Vue + Vite project in cwd
 
 Options:
@@ -95,6 +102,9 @@ export async function runInit(args) {
     throw withCode(ERR.EXTRACT_FAILED, `unzip exited with code ${unzipR.status}. Is 'unzip' installed?`);
   }
   try { rmSync(zipPath); } catch {}
+
+  // 4.5. Inject icon dependency so the single install step below covers it.
+  injectIconDependency(join(CWD, "package.json"), template);
 
   // 5. Install.
   if (!args.skipInstall) {

--- a/plugin/cloudbase-sites/lib/verbs/init.mjs
+++ b/plugin/cloudbase-sites/lib/verbs/init.mjs
@@ -16,8 +16,10 @@ import {
   existsSync,
   mkdirSync,
   readdirSync,
+  readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
@@ -180,6 +182,22 @@ function downloadFile(url, dest, redirects = 0) {
       out.on("error", (e) => reject(withCode(ERR.DOWNLOAD_FAILED, `write failed: ${e.message}`)));
     }).on("error", (e) => reject(withCode(ERR.DOWNLOAD_FAILED, `request failed: ${e.message}`)));
   });
+}
+
+function injectIconDependency(pkgPath, template) {
+  const dep = ICON_DEPS[template];
+  if (!dep || !existsSync(pkgPath)) return;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+    pkg.dependencies = pkg.dependencies || {};
+    if (pkg.dependencies[dep.name]) return;
+    pkg.dependencies[dep.name] = dep.version;
+    writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+    process.stderr.write(`[cloudbase-sites] added ${dep.name}@${dep.version} to package.json\n`);
+  } catch (e) {
+    // Non-fatal: the agent can still install the icon lib manually if needed.
+    process.stderr.write(`[cloudbase-sites] warning: could not add ${dep.name}: ${e.message}\n`);
+  }
 }
 
 function runInstall(cwd) {

--- a/plugin/cloudbase-sites/skills/cloudbase-sites-runtime/SKILL.md
+++ b/plugin/cloudbase-sites/skills/cloudbase-sites-runtime/SKILL.md
@@ -67,6 +67,7 @@ storage, ai), fetch the corresponding CloudBase domain skill via
 - `web-development`         Web project conventions
 - `auth-tool-cloudbase`               provider config (management-side)
 - `auth-web-cloudbase`                Web SDK auth client code
+- `postgresql-development-cloudbase`  PG mode schema/RLS/`app.rdb()` (PG envs)
 - `cloudbase-document-database-web-sdk`          document database Web SDK
 - `cloud-storage-web`       cloud storage Web SDK
 - `relational-database-web-cloudbase` MySQL Web SDK
@@ -257,10 +258,20 @@ Skip any of these when:
 4. **Never spawn `npm run dev` / `vite` / `vite build` yourself.** Lifecycle
    is owned by hooks + the `cloudbase-sites` CLI.
 
-5. **BaaS-first data persistence.** Schema via
-   `writeNoSqlDatabaseStructure(action="createCollection")`; reads/writes
-   via `@cloudbase/js-sdk` from React/Vue code. Reach for cloud functions
-   only when (a) the logic cannot be expressed as security rules AND
+5. **BaaS-first data persistence — detect the env type first.** Before any
+   data-layer work, call `envQuery({ action: "info" })` and branch on the
+   detected database backend:
+
+   | env type | schema / RLS | browser SDK | domain skill |
+   |---|---|---|---|
+   | PostgreSQL (`RuntimeBackends.postgresql === true`) | `managePgDatabase` (versioned `applyMigration`) | `app.rdb()` / `app.storage.from()` | `postgresql-development-cloudbase` |
+   | NoSQL (document) | `writeNoSqlDatabaseStructure(action="createCollection")` | `app.database()` collections | `cloudbase-document-database-web-sdk` |
+
+   Do NOT load `cloudbase-document-database-web-sdk` (or NoSQL APIs) for a PG
+   environment, and do NOT guess from the skill catalog — the catalog contains
+   both, only `envQuery` tells them apart. Reads/writes go through
+   `@cloudbase/js-sdk` from React/Vue code either way. Reach for cloud
+   functions only when (a) the logic cannot be expressed as security rules AND
    (b) it needs server-side secrets or a third-party API AND (c) it's a
    scheduled / background job. A Todo / Notes / Chat / Kanban app does NOT
    need cloud functions.

--- a/plugin/cloudbase-sites/skills/cloudbase-sites-runtime/SKILL.md
+++ b/plugin/cloudbase-sites/skills/cloudbase-sites-runtime/SKILL.md
@@ -286,6 +286,24 @@ Skip any of these when:
    you'd lose version metadata, snapshot, deploy history, and the stable
    siteName.
 
+8. **Icons come from `lucide-react` — preinstalled, never hand-installed.**
+   `cloudbase-sites init` injects `lucide-react` (react) / `lucide-vue-next`
+   (vue) into the scaffold's `package.json` before its single install step.
+   Import icons directly (`import { Heart } from "lucide-react"`). Do NOT run
+   a package-install command just to add icons — sandboxed installs during
+   generation are a known failure point — and do NOT hand-write inline SVG
+   paths when a lucide icon exists.
+
+9. **Fill `VITE_PUBLISHABLE_KEY` automatically — never ask the user.** The
+   template's `src/utils/cloudbase.ts` reads it from `.env.local`; new envs
+   have no publishable key by default. After init: call
+   `queryAppAuth({ action: "getPublishableKey" })`; if empty, call
+   `manageAppAuth({ action: "ensurePublishableKey" })`; then write
+   `VITE_PUBLISHABLE_KEY=<key>` into `.env.local`. This key cannot be
+   skipped — it is the data-plane app credential attached to every browser
+   request, including the login request itself and anonymous reads — but
+   the user should never fill it by hand.
+
 ## Hard rules — always parse CLI stdout as JSON
 
 The first stdout line of every `cloudbase-sites <verb>` invocation is a

--- a/scripts/tools.json
+++ b/scripts/tools.json
@@ -970,7 +970,7 @@
           "migrationVersion": {
             "type": "string",
             "pattern": "^\\d{14}$",
-            "description": "14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。"
+            "description": "14 位时间戳 YYYYMMDDHHMMSS。plan/apply/detail/repair 必填；fetchMigration 可选（传入则只拉该条，省略则拉全量远端 history）；禁止由服务端静默生成，避免与本地 cloudbase/migrations/<version>_<name>.sql 分叉。applyMigration 非增量：每次传完整 SQL；终态失败且 listMigrations 未落地时版本号不占用，换新 migrationVersion 重发全量 SQL 即可（同名不同版本不冲突）。"
           },
           "rollbackSql": {
             "type": "string",


### PR DESCRIPTION
## 背景

来自「3D 打印模型分享站」实战复盘（PG 环境从零搭建带用户体系的站点，全程 40+ 工具调用、约 1/3 花在查证 skill 没写清楚的内容）。本 PR 按复盘结论落地 skill 侧优化。

> 复盘中的一个关键事实修正：`auth.uid()` 返回 text 的警告在 `config/source/skills/postgresql-development-cloudbase` 源文件中已存在（P0 项 #2 部分已覆盖）；本地 `mcp/rules/` 镜像过期才是复盘现场看到"全文无 uuid 警告"的原因。因此本 PR 聚焦源文件中真正缺失的部分。

## 改动

### 1. cloudbase-sites：先判定 PG/NoSQL 再路由（P0）
- `plugin/cloudbase-sites/skills/cloudbase-sites-runtime/SKILL.md` Hard Rule 5 重写：数据层工作前必须先 `envQuery({action:"info"})`，按 `RuntimeBackends` 分支 PG（`managePgDatabase` + `app.rdb()` → `postgresql-development-cloudbase`）或 NoSQL（`writeNoSqlDatabaseStructure` → `cloudbase-document-database-web-sdk`），禁止从 skill 目录猜测。
- SessionStart hook（`on-session-start.sh`）注入的 RULES_BLOCK 同步修改；skill catalog 加入 `postgresql-development-cloudbase`。

### 2. postgresql-development-cloudbase（P0/P2）
- Data Model Rules 增加标准 owner 表模板：`owner_id TEXT NOT NULL DEFAULT auth.uid()`（`auth.uid()` 返回 text，如 `EchhGXFadSANiCSaVim2wQ`，建 `uuid` 类型会在建表时直接失败）；owner 由服务端决定，应用代码不得传值。
- 种子数据模式：RLS 拒绝匿名前端写入，演示数据走管理端 `execute` 显式指定 `owner_id`。
- applyMigration 重试语义：终态失败且 history 未落地时版本号不占用，换新 `migrationVersion` 重发全量 SQL（applyMigration 非增量）；同名不同版本不冲突。
- 存储路由强化："MUST read references/storage-pg.md before writing any bucket/upload/URL code"。

### 3. references/storage-pg.md（P1）
- 新增公开读桶 RLS 模板（anon SELECT + authenticated INSERT + owner-only DELETE），并明确 `public=true` 不绕过 RLS。
- 新增前端取址表：公开桶 `getPublicUrl` 直链（js-sdk 3.6.5 实测存在，返回 `{data:{publicUrl}}`）vs 私有桶 `createSignedUrl`。

### 4. cloud-storage-web（P2）
- PG mode 下补公开桶直链 vs 签名 URL 模式、`onerror` 兜底、业务表只存 bucket+key。

### 5. auth-web-cloudbase（P2）
- Prerequisites 增加 publishable key 前置：`queryAppAuth getPublishableKey` 为空时先 `manageAppAuth ensurePublishableKey`（新环境默认没有，漏掉会以网关鉴权失败的形式延迟暴露）。

### 6. managePgDatabase 工具描述（P2）
- `migrationVersion` 描述补充重试语义；`scripts/tools.json` 与 `doc/mcp-tools.md` 已同步。

## 验证
- `getPublicUrl` / `createSignedUrl` 在 `@cloudbase/js-sdk@3.6.5` dist 中实测确认。
- `node scripts/build-compat-config.mjs` + `sync-claude-skills-mirror.mjs` 已再生镜像；`diff-compat-config.mjs` 报告 "Has blocking diff: NO"（advisory 为版本补齐 + 本次内容变更）。
- `bash -n on-session-start.sh` 语法校验通过；`scripts/tools.json` JSON 校验通过。
- 说明：本机无 mcp node_modules，`tools.json`/`mcp-tools.md` 为按生成器输出格式同步的手工更新；内容与 `databasePG.ts` 中的描述字符串一致，下次 release 构建可再生校验。

## 未包含（后续项）
- sites 模板内置 `lucide-react`（模板来源待定位，见复盘 §2.7）
- publishable key 自动供给的产品侧 issue（skill 侧兜底已在本 PR 落地）
