### PR TITLE
docs(skills): promote publishable key auto-provisioning to a cross-skill convention

### DIFF
--- a/config/.claude/skills/ai-model-web/SKILL.md
+++ b/config/.claude/skills/ai-model-web/SKILL.md
@@ -233,7 +233,7 @@ import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
   env: "<YOUR_ENV_ID>",
-  accessKey: "<YOUR_PUBLISHABLE_KEY>"  // Get it from the CloudBase console
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY  // auto-provision via queryAppAuth / manageAppAuth, write to .env.local (see auth-web-cloudbase prerequisites)
 });
 
 const auth = app.auth;

--- a/config/.claude/skills/auth-web-cloudbase/SKILL.md
+++ b/config/.claude/skills/auth-web-cloudbase/SKILL.md
@@ -81,6 +81,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 
 - Automatically use `auth-tool-cloudbase` to check app-side auth readiness via `queryAppAuth` / `manageAppAuth`, then get the `publishable key` and configure login methods.
 - **Publishable key readiness (do not skip):** call `queryAppAuth(action="getPublishableKey")`. If it is empty, call `manageAppAuth(action="ensurePublishableKey")` first — new environments may not have one provisioned, and skipping this step leaves the frontend without a data-plane credential, surfacing later as gateway auth failures instead of an obvious missing-key error.
+- **Persist the key, don't hoard it in conversation:** after retrieval, write the publishable key to `.env.local` as `VITE_PUBLISHABLE_KEY` (create the file if missing) and read it in client code via `import.meta.env.VITE_PUBLISHABLE_KEY`. Never hardcode the key into source files, and never ask the user to fetch it from the console — fall back to the console link below only if both MCP calls fail.
 - If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
 
 ### Parameter map

--- a/config/.claude/skills/cloud-storage-web/SKILL.md
+++ b/config/.claude/skills/cloud-storage-web/SKILL.md
@@ -180,12 +180,14 @@ Init reference: [webv3/initialization.md](https://docs.cloudbase.net/api-referen
 import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
-  env: "your-env-id"
+  env: "your-env-id",
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY, // publishable key — auto-provisioned, see below
 });
 ```
 
 Initialization rules:
 
+- **Publishable key auto-provisioning (do not ask the user):** browser-side storage requests are data-plane calls that require a publishable `accessKey`. Before writing client code, call `queryAppAuth(action="getPublishableKey")`; if empty, call `manageAppAuth(action="ensurePublishableKey")`; then write the key to `.env.local` as `VITE_PUBLISHABLE_KEY` (create the file if missing) and read it via `import.meta.env.VITE_PUBLISHABLE_KEY`. Never hardcode the key into source files. Only fall back to the console (`https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`) if both MCP calls fail.
 - Use synchronous initialization with a shared app instance.
 - Do not re-initialize in every component.
 - If the operation depends on user identity, handle auth before storage operations.

--- a/config/source/skills/ai-model-web/SKILL.md
+++ b/config/source/skills/ai-model-web/SKILL.md
@@ -233,7 +233,7 @@ import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
   env: "<YOUR_ENV_ID>",
-  accessKey: "<YOUR_PUBLISHABLE_KEY>"  // Get it from the CloudBase console
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY  // auto-provision via queryAppAuth / manageAppAuth, write to .env.local (see auth-web-cloudbase prerequisites)
 });
 
 const auth = app.auth;

--- a/config/source/skills/auth-web-cloudbase/SKILL.md
+++ b/config/source/skills/auth-web-cloudbase/SKILL.md
@@ -81,6 +81,7 @@ Use npm installation for modern Web projects. In React, Vue, Vite, and other bun
 
 - Automatically use `auth-tool-cloudbase` to check app-side auth readiness via `queryAppAuth` / `manageAppAuth`, then get the `publishable key` and configure login methods.
 - **Publishable key readiness (do not skip):** call `queryAppAuth(action="getPublishableKey")`. If it is empty, call `manageAppAuth(action="ensurePublishableKey")` first — new environments may not have one provisioned, and skipping this step leaves the frontend without a data-plane credential, surfacing later as gateway auth failures instead of an obvious missing-key error.
+- **Persist the key, don't hoard it in conversation:** after retrieval, write the publishable key to `.env.local` as `VITE_PUBLISHABLE_KEY` (create the file if missing) and read it in client code via `import.meta.env.VITE_PUBLISHABLE_KEY`. Never hardcode the key into source files, and never ask the user to fetch it from the console — fall back to the console link below only if both MCP calls fail.
 - If `auth-tool-cloudbase` failed, let user go to `https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey` to get `publishable key` and `https://tcb.cloud.tencent.com/dev?envId={env}#/identity/login-manage` to set up login methods
 
 ### Parameter map

--- a/config/source/skills/cloud-storage-web/SKILL.md
+++ b/config/source/skills/cloud-storage-web/SKILL.md
@@ -180,12 +180,14 @@ Init reference: [webv3/initialization.md](https://docs.cloudbase.net/api-referen
 import cloudbase from "@cloudbase/js-sdk";
 
 const app = cloudbase.init({
-  env: "your-env-id"
+  env: "your-env-id",
+  accessKey: import.meta.env.VITE_PUBLISHABLE_KEY, // publishable key — auto-provisioned, see below
 });
 ```
 
 Initialization rules:
 
+- **Publishable key auto-provisioning (do not ask the user):** browser-side storage requests are data-plane calls that require a publishable `accessKey`. Before writing client code, call `queryAppAuth(action="getPublishableKey")`; if empty, call `manageAppAuth(action="ensurePublishableKey")`; then write the key to `.env.local` as `VITE_PUBLISHABLE_KEY` (create the file if missing) and read it via `import.meta.env.VITE_PUBLISHABLE_KEY`. Never hardcode the key into source files. Only fall back to the console (`https://tcb.cloud.tencent.com/dev?envId={env}#/env/apikey`) if both MCP calls fail.
 - Use synchronous initialization with a shared app instance.
 - Do not re-initialize in every component.
 - If the operation depends on user identity, handle auth before storage operations.


### PR DESCRIPTION
## What

Publishable key 自动供给流程（`queryAppAuth(action="getPublishableKey")` → 为空则 `manageAppAuth(action="ensurePublishableKey")` → 写入 `.env.local` 为 `VITE_PUBLISHABLE_KEY`）此前只存在于 `cloudbase-sites` 的 Hard Rule 9。本 PR 把它推广为跨 skill 通用约定（跟踪 issue #1020）：

- **auth-web-cloudbase**：prerequisites 补"取到 key 后持久化到 `.env.local`，客户端用 `import.meta.env.VITE_PUBLISHABLE_KEY` 读取，禁止硬编码、禁止让用户去控制台取"这一步（原流程缺持久化约定）
- **cloud-storage-web**：init 示例原本连 `accessKey` 都没有——补上，并加 auto-provision 规则（浏览器存储请求是数据面调用，必须有 key）
- **ai-model-web**：把"Get it from the CloudBase console"注释替换为自动供给流程

控制台链接仅保留为 MCP 调用失败时的兜底。

## 验证

- `node scripts/build-compat-config.mjs` + `sync-claude-skills-mirror.mjs` 重建产物，`diff-compat-config.mjs`：Compatibility contract is intact
- 3 个源文件 + 3 个 `config/.claude/skills` 镜像同步更新

## Not in scope

#1020 建议第 2 条（下沉到 setup/init 工具链路默认执行）涉及产品代码，另起 PR。
