### PR TITLE
feat(skills): add SDK-first database access decision gate to cloudrun-development

### DIFF
--- a/config/.claude/skills/cloudrun-development/SKILL.md
+++ b/config/.claude/skills/cloudrun-development/SKILL.md
@@ -31,7 +31,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 
 - You still need to choose between Function mode and Container mode.
 - The prompt mentions `queryCloudRun`, `manageCloudRun`, Dockerfile, service domains, or public/private access.
-- The app depends on MySQL, PostgreSQL, Redis, or other VPC-private resources over TCP → also read `references/vpc-and-database.md`.
+- The app depends on MySQL, PostgreSQL, Redis, or other VPC-private resources over TCP → **先做数据库访问方式决策（SDK/网关优先，见下方「数据库访问方式决策门」）**；确认必须 TCP 直连后 → also read `references/vpc-and-database.md`.
 - You are choosing between CloudRun and HTTP cloud functions for a stateless HTTP service.
 - Container deploy fails (`deploy_failed`, Pod not ready, readiness/probe failed, third-party `imageUrl` won't stay up) → also read `references/image-deploy-troubleshooting.md` and follow the **Container deploy failure SOP** below. Do not start by raising `InitialDelaySeconds`.
 
@@ -57,6 +57,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Assuming local run is available for Container mode.
 - Opening public access by default when the scenario only needs private or mini-program internal access.
 - **Deploying an existing app with `DATABASE_URL` / MySQL / PostgreSQL / Redis but omitting `serverConfig.VpcConf`** — deploy appears to succeed, then runtime DB connections fail.
+- **新应用部署默认选 TCP 直连数据库** — 能用 SDK/网关访问的数据（PG `app.rdb()`、NoSQL、storage）不需要 `VpcConf` 也不需要数据库账号密码；仅迁移类应用（经典驱动/ORM 无法替换）才走 TCP 直连 + `VpcConf`。见「数据库访问方式决策门」。
 - Confusing `OpenAccessTypes` (how users reach the service) with `VpcConf` (how the service reaches VPC databases).
 - **Deploying to an environment that has not initialized CloudRun** — `CreateCloudRunServer` on an environment with no 大租户 record silently lands in the legacy 小租户 path, creating wrong small-tenant services/versions. Always ensure the environment is initialized first (`manageCloudRun(action="initEnv")`, tcbr) before the first deploy. `manageCloudRun(action="deploy")` now blocks new-service creation on uninitialized environments with guidance.
 - **Using the legacy `tcb` CloudRun API** (`CreateCloudBaseRunResource` / `DescribeCloudBaseRunResource` / `DeleteCloudBaseRunResource`) — these are deprecated 小租户 open APIs and are blocked in `callCloudApi`. CloudRun always goes through `tcbr` (`CreateCloudRunEnv` / `CreateCloudRunServer`). Query a single environment's base info / whether CloudRun is enabled with `DescribeEnvBaseInfo` (`EnvId` required) — use `manageCloudRun(action="initEnv")` to open and `queryCloudRun(action="envStatus")` to poll status; query the environment list / resource info with `DescribeCloudRunEnvs` (`EnvId` optional filter).
@@ -102,6 +103,23 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - 迁移已有 / GitHub / 第三方应用，或需要常驻进程
 
 **决策示例：** 一个带 `Dockerfile` 的 Go/Python HTTP API，无长连接、无自定义运行时、不碰 VPC 数据库 → 选 HTTP 云函数而不是云托管；同一份代码若有 WebSocket 长连接 → 才选云托管。
+
+### 数据库访问方式决策门（部署前必答：SDK 优先，TCP 直连兜底）
+
+> 核心原则：**能用 CloudBase SDK/网关访问的数据，一律优先 SDK 路径。** TCP 直连会引入 VPC、安全组、数据库账号密码三件套，全是部署后才暴露的问题（`ETIMEDOUT`、安全组拦截、密码注入），能不碰就不碰。
+
+**优先：SDK / 网关路径（无需 `VpcConf`、无需数据库账号密码）**
+
+- CloudBase PG → `app.rdb()`（js-sdk v3 / node-sdk，走 PG HTTP 网关；详见 `../postgresql-development-cloudbase/SKILL.md`）
+- NoSQL → `app.database()`；对象存储 → `app.storage`
+- 新应用 / CloudBase 原生数据 → 数据层直接按 SDK 路径设计，部署时完全不需要 VPC 配置；若只用到这些数据面，还可结合上一节的「HTTP 云函数优先」进一步免掉云托管
+
+**仅当以下情况才走 TCP 直连（须完成 `references/vpc-and-database.md` 全流程）：**
+
+- 迁移已有 / GitHub / 第三方应用，数据层是经典驱动或 ORM（mysql2、pg、Prisma、SQLAlchemy、WordPress / Ghost 等），改造成 SDK 的成本高或用户明确要求保留
+- 需要 SDK 不覆盖的能力（特定 SQL 方言、存储过程、Redis 原生协议等）
+
+**决策动作：** 扫描到 `DATABASE_URL` / DB 依赖信号时，先停下来回答「这个数据访问能不能换成 SDK/网关」，再决定是否进入 VPC checklist——不要默认按 TCP 直连方案往下走。
 
 ### When CloudRun is a better fit
 

--- a/config/.claude/skills/cloudrun-development/references/vpc-and-database.md
+++ b/config/.claude/skills/cloudrun-development/references/vpc-and-database.md
@@ -4,6 +4,25 @@ Use this reference when deploying **existing / third-party apps** (GitHub projec
 
 Official docs: [VPC configuration for CloudBase Run](https://docs.cloudbase.net/run/deploy/networking/vpc)
 
+## 先决策：真的需要 TCP 直连吗？（SDK 优先）
+
+进入本文件（VPC / 安全组 / 连接串）之前，先确认 TCP 直连是**必要**的，而不是默认的。SDK / 网关路径不经过 VPC、不需要数据库账号密码，天然避开直连的网络与凭证问题：
+
+| 维度 | SDK / 网关路径（优先） | TCP 直连（兜底） |
+| --- | --- | --- |
+| 网络配置 | 无需 `VpcConf` | 必须绑定同 VPC + 安全组放行 DB 端口 |
+| 数据库凭证 | 环境内置，无需注入账号密码 | 需要生成 / 注入 / 轮换账号密码 |
+| 典型故障 | 基本没有 | `ETIMEDOUT`、安全组拦截、密码错误、VPC 未挂载 |
+| 适用场景 | 新应用 / CloudBase 原生数据（PG、NoSQL、storage） | 迁移已有应用、SDK 不覆盖的能力（特定 SQL 方言、Redis 原生协议等） |
+
+SDK 路径的具体形态：
+
+- CloudBase PG → `app.rdb()`（js-sdk v3 / node-sdk，走 PG HTTP 网关；见 `../../postgresql-development-cloudbase/SKILL.md`）
+- NoSQL → `app.database()`；对象存储 → `app.storage`
+- 若新应用只需要这些数据面，还可考虑直接用 HTTP 云函数（内置 SDK、免 VPC），不上云托管容器
+
+仅当应用是经典 TCP 客户端（mysql2 / pg / Prisma / SQLAlchemy / WordPress / Ghost 等迁移场景）且改造为 SDK 的方案被否决时，才继续往下走 VPC 流程。
+
 ## Critical distinction
 
 | Concept | What it controls | Typical field |
@@ -115,7 +134,7 @@ Missing `VpcConf` here commonly yields deploy **success** followed by runtime `E
 ## Agent checklist (copy into plan before deploy)
 
 - [ ] DB dependency signals scanned
-- [ ] TCP vs CloudBase SDK/gateway path decided
+- [ ] TCP vs CloudBase SDK/gateway path decided — **SDK/网关优先，TCP 仅用于迁移类应用或 SDK 未覆盖的能力**（见开头决策表）
 - [ ] `VpcId` + `SubnetId` resolved (same region as DB)
 - [ ] Private connection string prepared
 - [ ] Security group / allowlist planned

--- a/config/source/skills/cloudrun-development/SKILL.md
+++ b/config/source/skills/cloudrun-development/SKILL.md
@@ -31,7 +31,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 
 - You still need to choose between Function mode and Container mode.
 - The prompt mentions `queryCloudRun`, `manageCloudRun`, Dockerfile, service domains, or public/private access.
-- The app depends on MySQL, PostgreSQL, Redis, or other VPC-private resources over TCP → also read `references/vpc-and-database.md`.
+- The app depends on MySQL, PostgreSQL, Redis, or other VPC-private resources over TCP → **先做数据库访问方式决策（SDK/网关优先，见下方「数据库访问方式决策门」）**；确认必须 TCP 直连后 → also read `references/vpc-and-database.md`.
 - You are choosing between CloudRun and HTTP cloud functions for a stateless HTTP service.
 - Container deploy fails (`deploy_failed`, Pod not ready, readiness/probe failed, third-party `imageUrl` won't stay up) → also read `references/image-deploy-troubleshooting.md` and follow the **Container deploy failure SOP** below. Do not start by raising `InitialDelaySeconds`.
 
@@ -57,6 +57,7 @@ If a referenced sibling skill file is missing from this environment, ask the use
 - Assuming local run is available for Container mode.
 - Opening public access by default when the scenario only needs private or mini-program internal access.
 - **Deploying an existing app with `DATABASE_URL` / MySQL / PostgreSQL / Redis but omitting `serverConfig.VpcConf`** — deploy appears to succeed, then runtime DB connections fail.
+- **新应用部署默认选 TCP 直连数据库** — 能用 SDK/网关访问的数据（PG `app.rdb()`、NoSQL、storage）不需要 `VpcConf` 也不需要数据库账号密码；仅迁移类应用（经典驱动/ORM 无法替换）才走 TCP 直连 + `VpcConf`。见「数据库访问方式决策门」。
 - Confusing `OpenAccessTypes` (how users reach the service) with `VpcConf` (how the service reaches VPC databases).
 - **Deploying to an environment that has not initialized CloudRun** — `CreateCloudRunServer` on an environment with no 大租户 record silently lands in the legacy 小租户 path, creating wrong small-tenant services/versions. Always ensure the environment is initialized first (`manageCloudRun(action="initEnv")`, tcbr) before the first deploy. `manageCloudRun(action="deploy")` now blocks new-service creation on uninitialized environments with guidance.
 - **Using the legacy `tcb` CloudRun API** (`CreateCloudBaseRunResource` / `DescribeCloudBaseRunResource` / `DeleteCloudBaseRunResource`) — these are deprecated 小租户 open APIs and are blocked in `callCloudApi`. CloudRun always goes through `tcbr` (`CreateCloudRunEnv` / `CreateCloudRunServer`). Query a single environment's base info / whether CloudRun is enabled with `DescribeEnvBaseInfo` (`EnvId` required) — use `manageCloudRun(action="initEnv")` to open and `queryCloudRun(action="envStatus")` to poll status; query the environment list / resource info with `DescribeCloudRunEnvs` (`EnvId` optional filter).
@@ -102,6 +103,23 @@ Use CloudBase Run when the task needs a deployed backend service rather than a s
 - 迁移已有 / GitHub / 第三方应用，或需要常驻进程
 
 **决策示例：** 一个带 `Dockerfile` 的 Go/Python HTTP API，无长连接、无自定义运行时、不碰 VPC 数据库 → 选 HTTP 云函数而不是云托管；同一份代码若有 WebSocket 长连接 → 才选云托管。
+
+### 数据库访问方式决策门（部署前必答：SDK 优先，TCP 直连兜底）
+
+> 核心原则：**能用 CloudBase SDK/网关访问的数据，一律优先 SDK 路径。** TCP 直连会引入 VPC、安全组、数据库账号密码三件套，全是部署后才暴露的问题（`ETIMEDOUT`、安全组拦截、密码注入），能不碰就不碰。
+
+**优先：SDK / 网关路径（无需 `VpcConf`、无需数据库账号密码）**
+
+- CloudBase PG → `app.rdb()`（js-sdk v3 / node-sdk，走 PG HTTP 网关；详见 `../postgresql-development-cloudbase/SKILL.md`）
+- NoSQL → `app.database()`；对象存储 → `app.storage`
+- 新应用 / CloudBase 原生数据 → 数据层直接按 SDK 路径设计，部署时完全不需要 VPC 配置；若只用到这些数据面，还可结合上一节的「HTTP 云函数优先」进一步免掉云托管
+
+**仅当以下情况才走 TCP 直连（须完成 `references/vpc-and-database.md` 全流程）：**
+
+- 迁移已有 / GitHub / 第三方应用，数据层是经典驱动或 ORM（mysql2、pg、Prisma、SQLAlchemy、WordPress / Ghost 等），改造成 SDK 的成本高或用户明确要求保留
+- 需要 SDK 不覆盖的能力（特定 SQL 方言、存储过程、Redis 原生协议等）
+
+**决策动作：** 扫描到 `DATABASE_URL` / DB 依赖信号时，先停下来回答「这个数据访问能不能换成 SDK/网关」，再决定是否进入 VPC checklist——不要默认按 TCP 直连方案往下走。
 
 ### When CloudRun is a better fit
 

--- a/config/source/skills/cloudrun-development/references/vpc-and-database.md
+++ b/config/source/skills/cloudrun-development/references/vpc-and-database.md
@@ -4,6 +4,25 @@ Use this reference when deploying **existing / third-party apps** (GitHub projec
 
 Official docs: [VPC configuration for CloudBase Run](https://docs.cloudbase.net/run/deploy/networking/vpc)
 
+## 先决策：真的需要 TCP 直连吗？（SDK 优先）
+
+进入本文件（VPC / 安全组 / 连接串）之前，先确认 TCP 直连是**必要**的，而不是默认的。SDK / 网关路径不经过 VPC、不需要数据库账号密码，天然避开直连的网络与凭证问题：
+
+| 维度 | SDK / 网关路径（优先） | TCP 直连（兜底） |
+| --- | --- | --- |
+| 网络配置 | 无需 `VpcConf` | 必须绑定同 VPC + 安全组放行 DB 端口 |
+| 数据库凭证 | 环境内置，无需注入账号密码 | 需要生成 / 注入 / 轮换账号密码 |
+| 典型故障 | 基本没有 | `ETIMEDOUT`、安全组拦截、密码错误、VPC 未挂载 |
+| 适用场景 | 新应用 / CloudBase 原生数据（PG、NoSQL、storage） | 迁移已有应用、SDK 不覆盖的能力（特定 SQL 方言、Redis 原生协议等） |
+
+SDK 路径的具体形态：
+
+- CloudBase PG → `app.rdb()`（js-sdk v3 / node-sdk，走 PG HTTP 网关；见 `../../postgresql-development-cloudbase/SKILL.md`）
+- NoSQL → `app.database()`；对象存储 → `app.storage`
+- 若新应用只需要这些数据面，还可考虑直接用 HTTP 云函数（内置 SDK、免 VPC），不上云托管容器
+
+仅当应用是经典 TCP 客户端（mysql2 / pg / Prisma / SQLAlchemy / WordPress / Ghost 等迁移场景）且改造为 SDK 的方案被否决时，才继续往下走 VPC 流程。
+
 ## Critical distinction
 
 | Concept | What it controls | Typical field |
@@ -115,7 +134,7 @@ Missing `VpcConf` here commonly yields deploy **success** followed by runtime `E
 ## Agent checklist (copy into plan before deploy)
 
 - [ ] DB dependency signals scanned
-- [ ] TCP vs CloudBase SDK/gateway path decided
+- [ ] TCP vs CloudBase SDK/gateway path decided — **SDK/网关优先，TCP 仅用于迁移类应用或 SDK 未覆盖的能力**（见开头决策表）
 - [ ] `VpcId` + `SubnetId` resolved (same region as DB)
 - [ ] Private connection string prepared
 - [ ] Security group / allowlist planned


### PR DESCRIPTION
## 背景

用户反馈：AI 部署 CloudRun 应用时默认选择 TCP 直连数据库，随之引入 VPC 配置、安全组、数据库账号密码三件套问题，运行时典型故障为 `connect ETIMEDOUT`（真实案例：qoder-console 容器连 MySQL 172.17.80.36:3306 握手超时，10s 上限触发 500）。

现有 `cloudrun-development` skill 只教了「直连怎么配好」（VPC checklist），没有「要不要直连」的决策门——这是 AI 默认直连的结构性原因。`cloud-functions` skill 早已确立「新业务 CRUD 优先 SDK」的口径（Activation Contract），本 PR 将 `cloudrun-development` 对齐到同一标准。

## 改动

### `config/source/skills/cloudrun-development/SKILL.md`

- 新增 **「数据库访问方式决策门（部署前必答：SDK 优先，TCP 直连兜底）」** 章节，位于「云托管 vs HTTP 云函数」决策之后
- 决策规则：SDK/网关可覆盖的数据访问（PG `app.rdb()`、NoSQL `app.database()`、storage）一律优先 SDK，不引入直连；仅迁移类应用（mysql2/pg/Prisma/SQLAlchemy/WordPress/Ghost）或 SDK 不覆盖的能力（特定 SQL 方言、Redis 原生协议）才走 TCP + `VpcConf`
- 四处联动：Activation Contract 触发条件、Common mistakes（新增反模式「新应用默认选 TCP 直连」）、部署序列（扫到 `DATABASE_URL` 先问「能否换 SDK」再进 VPC checklist）、Minimal checklist

### `config/source/skills/cloudrun-development/references/vpc-and-database.md`

- 开头新增 SDK/网关路径 vs TCP 直连的决策对比表（网络前置条件 / 凭证 / 典型故障 / 适用场景），把原 checklist 中埋着的一句「TCP vs SDK decided」提前为进 VPC 流程前的必答门槛
- 明确 SDK 路径形态：`app.rdb()`（js-sdk v3/node-sdk 走 HTTP 网关）、`app.database()`、`app.storage`；仅用到数据面的新应用可进一步降级为 HTTP 云函数（免云托管）

`config/.claude/skills/` 镜像已通过 `sync:claude-skills-mirror` 同步，`check:claude-skills-mirror` 无 diff。

## 验证

- [x] 镜像一致性校验通过（30 skills / 138 文件，Has diff: NO）
- [x] 与 `cloud-functions` skill 口径一致（新数据面 → SDK，迁移类 → TCP + VPC checklist）
- [x] 迁移类应用兜底边界明确，避免 AI 把迁移项目硬改成 SDK
