### PR TITLE
fix(sync): skill 同步改为差集清理，清除模板仓 37 个僵尸 skill 目录

### DIFF
--- a/scripts/sync-config.mjs
+++ b/scripts/sync-config.mjs
@@ -15,7 +15,9 @@
  * 工作流程：
  * 1. 读取 scripts/template-config.json 获取模板列表
  * 2. 遍历每个模板，将 config 目录内容复制到对应模板目录
- * 3. 根据配置决定是否执行 Git 提交和推送操作
+ * 3. 差集清理：删除目标端各 skills/ 目录下源中已不存在的 skill 子目录（僵尸 skill）
+ * 4. 同步后断言：目标端 skill 集合必须等于源端应有集合，否则非零退出并阻断 Git 操作
+ * 5. 根据配置决定是否执行 Git 提交和推送操作
  * 
  * 使用方式：
  *   node scripts/sync-config.mjs                     # 同步所有模板
@@ -294,59 +296,216 @@ function createBackup(targetDir) {
   }
 }
 
+// 承载 skill 的目录名。差集清理只在这个名字的目录里做删除，绝不触碰其父目录。
+const SKILLS_DIR_NAME = 'skills';
+
 /**
- * 获取 config 目录下的所有目录列表
- * @returns {Array<string>} 目录名称数组
+ * 转为 posix 风格路径，便于与 includePatterns 比较
+ * @param {string} filePath
+ * @returns {string}
  */
-function getConfigDirectories() {
-  try {
-    const items = fs.readdirSync(configDir);
-    const directories = items.filter(item => {
-      const itemPath = path.join(configDir, item);
-      return fs.statSync(itemPath).isDirectory();
-    });
-    return directories;
-  } catch (error) {
-    console.error('获取 config 目录列表失败:', error.message);
-    return [];
+function toPosixPath(filePath) {
+  return filePath.split(path.sep).join('/');
+}
+
+/**
+ * 判断 candidate 是否等于 parent 或位于 parent 内部（两边都会规范化）
+ * @param {string} parent
+ * @param {string} candidate
+ * @returns {boolean}
+ */
+function isSamePathOrWithin(parent, candidate) {
+  const rel = path.relative(path.resolve(parent), path.resolve(candidate));
+  return rel === '' || (!rel.startsWith('..') && !path.isAbsolute(rel));
+}
+
+/**
+ * 删除/写入前的越界保护：路径必须严格落在 root 内
+ * @param {string} root
+ * @param {string} candidate
+ * @param {string} label 出错时用于定位的描述
+ */
+function assertWithin(root, candidate, label) {
+  if (!isSamePathOrWithin(root, candidate)) {
+    throw new Error(`拒绝操作越界路径: ${label} (${candidate}) 不在 ${root} 内`);
   }
 }
 
 /**
- * 清理目标目录中的指定目录
- * @param {string} targetDir 目标目录
- * @param {Array<string>} dirsToClean 要清理的目录列表
+ * 判断相对路径是否被 includePatterns 覆盖（与 copyDirectory 的判定保持一致）
+ * @param {string} relPosixPath 相对 configDir 的 posix 路径
+ * @param {Array<string>|null} includePatterns
+ * @returns {boolean}
  */
-function cleanDirectories(targetDir, dirsToClean) {
-  if (!fs.existsSync(targetDir)) {
-    return;
+function isPathIncluded(relPosixPath, includePatterns = null) {
+  if (!includePatterns) return true;
+  return includePatterns.some(
+    pattern => relPosixPath === pattern || relPosixPath.startsWith(`${pattern}/`),
+  );
+}
+
+/**
+ * 递归找出源目录下所有名为 skills 的目录。
+ * 只跟随真实目录（Dirent.isDirectory() 对符号链接返回 false），跳过 .git/node_modules。
+ * @param {string} rootDir
+ * @returns {Array<string>} 绝对路径，已排序
+ */
+function findSkillsDirectories(rootDir) {
+  const found = [];
+
+  const walk = dir => {
+    let entries;
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (entry.name === '.git' || entry.name === 'node_modules') continue;
+
+      const childPath = path.join(dir, entry.name);
+      if (entry.name === SKILLS_DIR_NAME) {
+        found.push(childPath);
+        continue; // skills 目录下不会再嵌套 skills
+      }
+      walk(childPath);
+    }
+  };
+
+  walk(rootDir);
+  return found.sort();
+}
+
+/**
+ * 计算同步后目标端每个 skills 目录应有的 skill 集合。
+ *
+ * 关键点：对每个 skill 复用 copyDirectory 使用的 isExcludedSkill 判定，
+ * 因此"期望集合"天然与复制逻辑一致（被平台过滤的 skill 既不算缺失、也不会被误删）。
+ *
+ * @param {string} srcRoot 源根目录（这里是 .generated/compat-config）
+ * @param {Object} [options]
+ * @param {Array<string>|null} [options.includePatterns] 模板的包含模式
+ * @param {Set<string>} [options.excludedSkills] 平台需要过滤的 skill 集合
+ * @returns {Map<string, Set<string>>} key 为相对 srcRoot 的 posix 路径（如 ".claude/skills"）
+ */
+export function collectExpectedSkills(srcRoot, options = {}) {
+  const { includePatterns = null, excludedSkills = new Set() } = options;
+  const expected = new Map();
+
+  for (const skillsDir of findSkillsDirectories(srcRoot)) {
+    const relSkillsDir = toPosixPath(path.relative(srcRoot, skillsDir));
+    if (!isPathIncluded(relSkillsDir, includePatterns)) continue;
+
+    const skillNames = new Set();
+    for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const relPath = `${relSkillsDir}/${entry.name}`;
+      if (isExcludedSkill(relPath, excludedSkills)) continue;
+      skillNames.add(entry.name);
+    }
+
+    expected.set(relSkillsDir, skillNames);
   }
-  
-  console.log(`  🧹 清理目标目录中的旧目录...`);
-  let cleanedCount = 0;
-  
-  for (const dirName of dirsToClean) {
-    const dirPath = path.join(targetDir, dirName);
-    
-    if (fs.existsSync(dirPath)) {
-      try {
-        const stat = fs.statSync(dirPath);
-        if (stat.isDirectory()) {
-          fs.rmSync(dirPath, { recursive: true, force: true });
-          console.log(`    🗑️  已删除: ${dirName}`);
-          cleanedCount++;
-        }
-      } catch (error) {
-        console.error(`    ❌ 删除目录失败: ${dirName}`, error.message);
+
+  return expected;
+}
+
+/**
+ * 差集清理：只删除目标端各 skills 目录下"源中不存在"的 skill 子目录。
+ *
+ * 安全约束：
+ * - 只遍历由源端派生的 skills 目录（目录名必须严格等于 skills）
+ * - 只删除目录，文件/符号链接一律跳过（Dirent.isDirectory() 不跟随符号链接）
+ * - 每次删除前做路径规范化 + 前缀校验，确保路径落在 targetDir 内
+ *
+ * @param {string} targetDir 模板目标目录
+ * @param {Map<string, Set<string>>} expectedBySkillsDir collectExpectedSkills 的返回值
+ * @param {Object} [options]
+ * @param {boolean} [options.dryRun] 干运行：只打印不删除
+ * @param {(message: string) => void} [options.log]
+ * @returns {Array<{relPath: string, skill: string}>} 已删除（dry-run 下为将被删除）的条目
+ */
+export function cleanStaleSkills(targetDir, expectedBySkillsDir, options = {}) {
+  const { dryRun = false, log = console.log } = options;
+  const removed = [];
+
+  for (const [relSkillsDir, expectedNames] of expectedBySkillsDir) {
+    if (path.basename(relSkillsDir) !== SKILLS_DIR_NAME) {
+      throw new Error(`拒绝清理非 skills 目录: ${relSkillsDir}`);
+    }
+
+    const skillsDir = path.resolve(targetDir, relSkillsDir);
+    assertWithin(targetDir, skillsDir, relSkillsDir);
+    if (!fs.existsSync(skillsDir)) continue;
+
+    for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue; // 文件 / 符号链接不碰
+      if (expectedNames.has(entry.name)) continue;
+
+      const entryPath = path.resolve(skillsDir, entry.name);
+      assertWithin(skillsDir, entryPath, relSkillsDir);
+
+      const relPath = `${relSkillsDir}/${entry.name}`;
+      removed.push({ relPath, skill: entry.name });
+
+      if (dryRun) {
+        log(`    🔍 [干运行] 将删除废弃 skill: ${relPath}`);
+      } else {
+        fs.rmSync(entryPath, { recursive: true, force: true });
+        log(`    🗑️  已删除废弃 skill: ${relPath}`);
       }
     }
   }
-  
-  if (cleanedCount > 0) {
-    console.log(`  ✅ 已清理 ${cleanedCount} 个目录`);
-  } else {
-    console.log(`  ℹ️  没有需要清理的目录`);
+
+  return removed;
+}
+
+/**
+ * 同步后断言：目标端每个 skills 目录的 skill 集合必须等于源端应有的集合。
+ * @param {string} targetDir 模板目标目录
+ * @param {Map<string, Set<string>>} expectedBySkillsDir collectExpectedSkills 的返回值
+ * @returns {{ok: boolean, issues: Array<{relSkillsDir: string, missing: Array<string>, unexpected: Array<string>}>}}
+ */
+export function assertSkillsInSync(targetDir, expectedBySkillsDir) {
+  const issues = [];
+
+  for (const [relSkillsDir, expectedNames] of expectedBySkillsDir) {
+    const skillsDir = path.resolve(targetDir, relSkillsDir);
+    assertWithin(targetDir, skillsDir, relSkillsDir);
+
+    const actual = new Set();
+    if (fs.existsSync(skillsDir)) {
+      for (const entry of fs.readdirSync(skillsDir, { withFileTypes: true })) {
+        if (entry.isDirectory()) actual.add(entry.name);
+      }
+    }
+
+    const missing = [...expectedNames].filter(name => !actual.has(name)).sort();
+    const unexpected = [...actual].filter(name => !expectedNames.has(name)).sort();
+    if (missing.length > 0 || unexpected.length > 0) {
+      issues.push({ relSkillsDir, missing, unexpected });
+    }
   }
+
+  return { ok: issues.length === 0, issues };
+}
+
+/**
+ * 把断言差异格式化成可读文本
+ * @param {Array<{relSkillsDir: string, missing: Array<string>, unexpected: Array<string>}>} issues
+ * @returns {string}
+ */
+export function formatSkillSyncIssues(issues) {
+  return issues
+    .map(({ relSkillsDir, missing, unexpected }) => {
+      const lines = [`  ❌ ${relSkillsDir} 与源端不一致`];
+      if (missing.length > 0) lines.push(`     缺少: ${missing.join(', ')}`);
+      if (unexpected.length > 0) lines.push(`     残留: ${unexpected.join(', ')}`);
+      return lines.join('\n');
+    })
+    .join('\n');
 }
 
 /**
@@ -388,13 +547,9 @@ async function syncConfigs(options = {}) {
   console.log(`📋 共需要同步 ${templateConfigs.length} 个模板`);
   console.log(`🔧 模式: ${dryRun ? '干运行' : '实际执行'}\n`);
   
-  // 获取要清理的目录列表（config 目录下的所有目录 + skills 目录）
-  const configDirectories = getConfigDirectories();
-  const dirsToClean = [...configDirectories, 'skills'];
-  console.log(`📋 将清理的目录: ${dirsToClean.join(', ')}\n`);
-  
   let successCount = 0;
   let skipCount = 0;
+  const assertionFailures = [];
   
   // 遍历模板列表
   for (let i = 0; i < templateConfigs.length; i++) {
@@ -405,6 +560,12 @@ async function syncConfigs(options = {}) {
     const templateType = (typeof templateConfig === 'object' && templateConfig.type)
       || (templatePath.startsWith('web/') ? 'web' : templatePath.startsWith('miniprogram/') ? 'miniprogram' : null);
     const excludedSkills = getExcludedSkills(templateType);
+
+    // 源端该模板应有的 skill 集合（按 skills 目录分组），用于差集清理与同步后断言
+    const expectedBySkillsDir = collectExpectedSkills(configDir, {
+      includePatterns,
+      excludedSkills,
+    });
     
     console.log(`\n[${i + 1}/${templateConfigs.length}] 处理模板: ${templatePath}${templateType ? ` [${templateType}]` : ''}`);
     if (includePatterns) {
@@ -426,16 +587,12 @@ async function syncConfigs(options = {}) {
     
     if (dryRun) {
       console.log(`  🔍 [干运行] 将同步到: ${targetDir}`);
-      // 显示将要清理的目录
-      const existingDirs = dirsToClean.filter(dirName => {
-        const dirPath = path.join(targetDir, dirName);
-        return fs.existsSync(dirPath) && fs.statSync(dirPath).isDirectory();
-      });
-      if (existingDirs.length > 0) {
-        console.log(`  🔍 [干运行] 将清理目录: ${existingDirs.join(', ')}`);
-      } else {
-        console.log(`  🔍 [干运行] 没有需要清理的目录`);
+      // 只预览"源中不存在的 skill 子目录"，不实际删除
+      const plannedDeletions = cleanStaleSkills(targetDir, expectedBySkillsDir, { dryRun: true });
+      if (plannedDeletions.length === 0) {
+        console.log(`  🔍 [干运行] 没有需要清理的废弃 skill`);
       }
+      console.log(`  🔍 [干运行] 跳过同步后断言`);
       successCount++;
       continue;
     }
@@ -449,9 +606,6 @@ async function syncConfigs(options = {}) {
     if (!fs.existsSync(targetDir)) {
       fs.mkdirSync(targetDir, { recursive: true });
     }
-    
-    // 清理目标目录中的旧目录
-    // cleanDirectories(targetDir, dirsToClean);
     
     // 同步config目录下的所有内容
     if (includePatterns) {
@@ -474,6 +628,19 @@ async function syncConfigs(options = {}) {
         }
       }
     }
+
+    // 差集清理：删除目标端 skills/ 下源中已不存在的 skill 子目录
+    const removedSkills = cleanStaleSkills(targetDir, expectedBySkillsDir);
+    if (removedSkills.length > 0) {
+      console.log(`  🧹 已清理 ${removedSkills.length} 个废弃 skill 目录`);
+    }
+
+    // 同步后断言：目标端 skill 集合必须与源端一致，不一致则记入 failures 并由 CI 拦截
+    const { ok, issues } = assertSkillsInSync(targetDir, expectedBySkillsDir);
+    if (!ok) {
+      assertionFailures.push({ templatePath, issues });
+      console.error(`  ❌ skill 集合校验失败:\n${formatSkillSyncIssues(issues)}`);
+    }
     
     successCount++;
     console.log(`  ✅ 同步完成: ${templatePath}`);
@@ -482,6 +649,14 @@ async function syncConfigs(options = {}) {
   console.log(`\n📊 同步统计:`);
   console.log(`  ✅ 成功同步: ${successCount} 个模板`);
   console.log(`  ⚠️  跳过: ${skipCount} 个模板`);
+
+  // 断言失败必须阻断后续 Git 操作，避免把脏 skill 列表提交/发布出去
+  if (assertionFailures.length > 0) {
+    const summary = assertionFailures
+      .map(({ templatePath, issues }) => `模板 ${templatePath}:\n${formatSkillSyncIssues(issues)}`)
+      .join('\n');
+    throw new Error(`❌ skill 同步校验未通过，已阻止 Git 操作：\n${summary}`);
+  }
   
   // Git提交和推送
   if (!skipGit && !dryRun && templateConfig.syncConfig?.autoCommit) {
@@ -650,5 +825,7 @@ async function main() {
   }
 }
 
-// 运行主函数
-main().catch(console.error); 
+// 运行主函数（仅在作为 CLI 直接执行时；被 import 时不产生副作用）
+if (process.argv[1] && path.resolve(process.argv[1]) === __filename) {
+  main().catch(console.error);
+}

--- a/tests/sync-config-skills-cleanup.test.js
+++ b/tests/sync-config-skills-cleanup.test.js
@@ -1,0 +1,189 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { afterEach, expect, test } from 'vitest';
+import { buildCompatConfig } from '../scripts/build-compat-config.mjs';
+import {
+  assertSkillsInSync,
+  cleanStaleSkills,
+  collectExpectedSkills,
+  formatSkillSyncIssues,
+} from '../scripts/sync-config.mjs';
+
+// 与 sync-config.mjs 中 MINIPROGRAM_ONLY_SKILLS 保持一致的 web 模板过滤集合
+const MINIPROGRAM_ONLY_SKILLS = new Set([
+  'miniprogram-development',
+  'auth-wechat-miniprogram',
+  'ai-model-wechat',
+  'cloudbase-document-database-in-wechat-miniprogram',
+]);
+
+const tempDirs = [];
+
+afterEach(() => {
+  while (tempDirs.length > 0) {
+    fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+  }
+});
+
+function makeTempDir(prefix) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), prefix));
+  tempDirs.push(dir);
+  return dir;
+}
+
+function makeSkill(root, relSkillsDir, name) {
+  const dir = path.join(root, relSkillsDir, name);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'SKILL.md'), `# ${name}\n`);
+}
+
+function listEntries(root, relDir) {
+  const dir = path.join(root, relDir);
+  return fs.existsSync(dir) ? fs.readdirSync(dir).sort() : [];
+}
+
+test('collectExpectedSkills 只收集 skills 目录，并按 isExcludedSkill 复用复制语义', () => {
+  const src = makeTempDir('cloudbase-sync-src-');
+  makeSkill(src, '.claude/skills', 'alpha');
+  makeSkill(src, '.claude/skills', 'beta');
+  makeSkill(src, '.codebuddy/skills', 'alpha');
+  makeSkill(src, '.codebuddy/skills', 'beta');
+  makeSkill(src, '.agents/skills', 'alpha');
+  makeSkill(src, '.agents/skills', 'beta');
+  makeSkill(src, 'rules', 'alpha'); // 目录名不是 skills → 不参与清理/断言
+  fs.mkdirSync(path.join(src, '.claude', 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(src, '.claude', 'skills', 'README.md'), '不是 skill 目录');
+
+  const all = collectExpectedSkills(src);
+  expect([...all.keys()].sort()).toEqual([
+    '.agents/skills',
+    '.claude/skills',
+    '.codebuddy/skills',
+  ]);
+  expect([...all.get('.claude/skills')].sort()).toEqual(['alpha', 'beta']);
+
+  const excluded = collectExpectedSkills(src, { excludedSkills: new Set(['beta']) });
+  // .claude/.codebuddy 下被平台过滤的 skill 既不算缺失，也不会被误判为需删除
+  expect([...excluded.get('.claude/skills')].sort()).toEqual(['alpha']);
+  expect([...excluded.get('.codebuddy/skills')].sort()).toEqual(['alpha']);
+  // .agents/skills 不在 isExcludedSkill 的覆盖范围内，复制逻辑同样不会过滤 → 期望集合保持一致
+  expect([...excluded.get('.agents/skills')].sort()).toEqual(['alpha', 'beta']);
+
+  const scoped = collectExpectedSkills(src, { includePatterns: ['.codebuddy'] });
+  expect([...scoped.keys()]).toEqual(['.codebuddy/skills']);
+});
+
+test('cleanStaleSkills 只删除 skills/ 下源中不存在的子目录，其它一律不碰', () => {
+  const target = makeTempDir('cloudbase-sync-target-');
+  makeSkill(target, '.claude/skills', 'alpha');
+  makeSkill(target, '.claude/skills', 'beta');
+  makeSkill(target, '.claude/skills', 'ghost');
+  makeSkill(target, '.agents/skills', 'orphan'); // 不在期望 map 里 → 不碰
+  fs.writeFileSync(path.join(target, '.claude', 'skills', 'README.md'), 'keep');
+  fs.writeFileSync(path.join(target, '.claude', 'settings.json'), '{"keep":true}');
+  fs.mkdirSync(path.join(target, '.claude', 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(target, '.claude', 'commands', 'spec.md'), 'keep');
+
+  const expected = new Map([['.claude/skills', new Set(['alpha', 'beta'])]]);
+  const removed = cleanStaleSkills(target, expected, { log: () => {} });
+
+  expect(removed).toEqual([{ relPath: '.claude/skills/ghost', skill: 'ghost' }]);
+  expect(listEntries(target, '.claude/skills')).toEqual(['README.md', 'alpha', 'beta']);
+  expect(listEntries(target, '.agents/skills')).toEqual(['orphan']);
+  expect(fs.readFileSync(path.join(target, '.claude', 'settings.json'), 'utf8')).toBe('{"keep":true}');
+  expect(fs.readFileSync(path.join(target, '.claude', 'commands', 'spec.md'), 'utf8')).toBe('keep');
+});
+
+test('cleanStaleSkills 在 dry-run 下只报告不删除', () => {
+  const target = makeTempDir('cloudbase-sync-dryrun-');
+  makeSkill(target, '.claude/skills', 'alpha');
+  makeSkill(target, '.claude/skills', 'ghost');
+
+  const expected = new Map([['.claude/skills', new Set(['alpha'])]]);
+  const removed = cleanStaleSkills(target, expected, { dryRun: true, log: () => {} });
+
+  expect(removed.map(item => item.skill)).toEqual(['ghost']);
+  expect(fs.existsSync(path.join(target, '.claude', 'skills', 'ghost', 'SKILL.md'))).toBe(true);
+});
+
+test('cleanStaleSkills 拒绝越界/非 skills 目标', () => {
+  const target = makeTempDir('cloudbase-sync-guard-');
+  makeSkill(target, '.claude/skills', 'ghost');
+
+  // 目录名不是 skills → 直接拒绝，避免误删模板自身配置目录
+  expect(() =>
+    cleanStaleSkills(target, new Map([['.claude/commands', new Set()]]), { log: () => {} }),
+  ).toThrow(/拒绝清理非 skills 目录/);
+
+  // 名字虽为 skills，但路径逃逸到 targetDir 之外 → 拒绝
+  expect(() =>
+    cleanStaleSkills(target, new Map([['../../skills', new Set()]]), { log: () => {} }),
+  ).toThrow(/越界/);
+
+  // 目标 skills 目录不存在时直接跳过，不报错
+  expect(
+    cleanStaleSkills(target, new Map([['.codebuddy/skills', new Set()]]), { log: () => {} }),
+  ).toEqual([]);
+});
+
+test('assertSkillsInSync 校验缺失与残留，并给出可读差异', () => {
+  const target = makeTempDir('cloudbase-sync-assert-');
+  makeSkill(target, '.claude/skills', 'alpha');
+  makeSkill(target, '.claude/skills', 'beta');
+
+  const matched = assertSkillsInSync(target, new Map([['.claude/skills', new Set(['alpha', 'beta'])]]));
+  expect(matched.ok).toBe(true);
+  expect(matched.issues).toEqual([]);
+
+  makeSkill(target, '.claude/skills', 'ghost');
+  const mismatched = assertSkillsInSync(
+    target,
+    new Map([['.claude/skills', new Set(['alpha', 'beta', 'missing-one'])]]),
+  );
+  expect(mismatched.ok).toBe(false);
+  expect(mismatched.issues).toEqual([
+    { relSkillsDir: '.claude/skills', missing: ['missing-one'], unexpected: ['ghost'] },
+  ]);
+  const text = formatSkillSyncIssues(mismatched.issues);
+  expect(text).toContain('缺少: missing-one');
+  expect(text).toContain('残留: ghost');
+
+  // 目标端 skills 目录整体缺失也要报缺失
+  const absent = assertSkillsInSync(target, new Map([['.codebuddy/skills', new Set(['alpha'])]]));
+  expect(absent.ok).toBe(false);
+  expect(absent.issues[0].missing).toEqual(['alpha']);
+});
+
+test('集成：真实 compat 产物中，web 模板的僵尸 skill 被清理且配置不被破坏', () => {
+  const compat = makeTempDir('cloudbase-sync-compat-');
+  const target = makeTempDir('cloudbase-sync-integration-');
+  buildCompatConfig({ outputDir: compat });
+
+  const expectedBySkillsDir = collectExpectedSkills(compat, {
+    excludedSkills: MINIPROGRAM_ONLY_SKILLS,
+  });
+  const expectedClaudeSkills = expectedBySkillsDir.get('.claude/skills');
+  expect(expectedClaudeSkills.size).toBeGreaterThan(0);
+  // 小程序专属 skill 已被平台过滤，不应出现在 web 模板期望集合里
+  expect(expectedClaudeSkills.has('miniprogram-development')).toBe(false);
+
+  // 模拟已被同步过的 web 模板：应有 skill 都在，另外残留 2 个改名前的旧 skill
+  for (const name of expectedClaudeSkills) makeSkill(target, '.claude/skills', name);
+  makeSkill(target, '.claude/skills', 'auth-nodejs');
+  makeSkill(target, '.claude/skills', 'no-sql-web-sdk');
+  fs.mkdirSync(path.join(target, '.claude', 'commands'), { recursive: true });
+  fs.writeFileSync(path.join(target, '.claude', 'commands', 'spec.md'), 'keep');
+  fs.writeFileSync(path.join(target, '.claude', 'settings.json'), '{"keep":true}');
+
+  const removed = cleanStaleSkills(target, expectedBySkillsDir, { log: () => {} });
+
+  expect(removed.map(item => item.skill).sort()).toEqual(['auth-nodejs', 'no-sql-web-sdk']);
+  expect(listEntries(target, '.claude/skills')).toEqual([...expectedClaudeSkills].sort());
+  expect(fs.readFileSync(path.join(target, '.claude', 'settings.json'), 'utf8')).toBe('{"keep":true}');
+  expect(fs.readFileSync(path.join(target, '.claude', 'commands', 'spec.md'), 'utf8')).toBe('keep');
+
+  // 断言只看实际存在的 skills 目录（其余目录由复制逻辑负责），此处限定 .claude/skills
+  const claudeExpected = new Map([['.claude/skills', expectedClaudeSkills]]);
+  expect(assertSkillsInSync(target, claudeExpected).ok).toBe(true);
+});


### PR DESCRIPTION
## 问题

`scripts/sync-config.mjs` 把 `config/` 同步到模板仓 `TencentCloudBase/awesome-cloudbase-examples` 时是**逐文件覆盖复制**（`copyFileSync`），没有删除目标端多余文件的能力。而原本用于清理的调用在 `c4d212875`（2025-11-25 `chore: update skills`）里被注释掉了 —— 同一个 commit 恰好也删掉了源里一批旧 skill。

结果：此后每删一个 skill，模板仓和 `web-cloudbase-project.zip` 里就永久残留一份，随 hosted MCP 分发给所有用户。

### 实测差集（awesome-cloudbase-examples `master`）

| 目录 | 现状 | 期望 | 待删 |
|---|---|---|---|
| `web/cloudbase-project/.claude/skills` | 40 | 26 | **14** |
| `web/cloudbase-project/.codebuddy/skills` | 39 | 26 | **13** |
| `web/cloudbase-project/.agents/skills` | 40 | 30 | **10** |

合计 **37 个目录**。其中 12 个是改名遗留：

| 旧名 | 新名 |
|---|---|
| `auth-nodejs` | `auth-nodejs-cloudbase` |
| `auth-tool` | `auth-tool-cloudbase` |
| `auth-web` | `auth-web-cloudbase` |
| `auth-wechat` | `auth-wechat-miniprogram` |
| `http-api` | `http-api-cloudbase` |
| `no-sql-web-sdk` | `cloudbase-document-database-web-sdk` |
| `no-sql-wx-mp-sdk` | `cloudbase-document-database-in-wechat-miniprogram` |
| `postgresql-development` | `postgresql-development-cloudbase` |
| `relational-database-tool` | `relational-database-mcp-cloudbase` |
| `relational-database-web` | `relational-database-web-cloudbase` |

另有无对应物的孤儿：`auth-http-api`、`cloudbase-agent-ts`、`ai-model-cloudbase`；以及 `MINIPROGRAM_ONLY_SKILLS` 规则生效后未清的 `miniprogram-development`、`ai-model-wechat`。

## 为什么不只是把注释放开

原 `cleanDirectories()` 实现是 `fs.rmSync(targetDir/<dir>)`，而 `dirsToClean` 含 `.claude`、`.codebuddy`、`rules` 这类**模板自身的配置目录** —— 会整个删掉再重建。这极可能就是当初把它注释掉的原因。所以改为**只删各 `skills/` 下源中不存在的 skill 子目录**。

## 改动

**`collectExpectedSkills(srcRoot, { includePatterns, excludedSkills })`**
递归定位名为 `skills` 的目录，逐 skill 复用 `copyDirectory` 的 `isExcludedSkill` 判定 —— 让「期望集合」与复制语义天然一致：被平台过滤的 skill 既不算缺失，也不会被误删。

**`cleanStaleSkills(targetDir, expectedBySkillsDir, { dryRun })`**
只删差集目录。安全约束：强制 `basename === 'skills'`、删除前做路径规范化 + 前缀校验防越界、只删目录（`Dirent.isDirectory()` 不跟随符号链接），文件与 `settings.json` / `commands/` 一律不碰。

**`assertSkillsInSync(targetDir, expectedBySkillsDir)`**
同步后校验目标端集合与源端一致，不一致则打印缺失/残留清单并抛错。**该断言位于 Git 操作之前**，避免脏列表被提交或发布。

**其它**
- dry-run 只打印将删除的目录，不删除、跳过断言
- 移除已死的 `cleanDirectories()` / `dirsToClean` / `getConfigDirectories()`
- CLI 入口加 `process.argv[1] === __filename` 守卫，使纯逻辑可被单测 import

## 测试

新增 `tests/sync-config-skills-cleanup.test.js`，6 例全通过：

```
✓ collectExpectedSkills 只收集 skills 目录，并按 isExcludedSkill 复用复制语义
✓ cleanStaleSkills 只删除 skills/ 下源中不存在的子目录，其它一律不碰
✓ cleanStaleSkills 在 dry-run 下只报告不删除
✓ cleanStaleSkills 拒绝越界/非 skills 目标
✓ assertSkillsInSync 校验缺失与残留，并给出可读差异
✓ 集成：真实 compat 产物中，web 模板的僵尸 skill 被清理且配置不被破坏
```

集成用例用 `buildCompatConfig()` 产出真实 compat 目录，构造「应有 skill 全在 + 残留 2 个改名前的旧 skill」的目标端，验证只删那 2 个、且 `settings.json` 与 `commands/spec.md` 完好。

## 不在本 PR 范围内

**存量修正需要单独执行一次同步并重发 ZIP**，这会影响所有 hosted MCP 用户，建议人工确认后再做：

```bash
git clone <awesome-cloudbase-examples>
CLOUDBASE_EXAMPLES_PATH=../awesome-cloudbase-examples node scripts/sync-config.mjs --filter web --dry-run   # 预览
CLOUDBASE_EXAMPLES_PATH=../awesome-cloudbase-examples node scripts/sync-config.mjs --filter web            # 落地
# 提交模板仓 → 重新打包 web-cloudbase-project.zip 并发布
```

端上已有缓存的用户需清 `~/.cloudbase-mcp/web-template` 后重新下载才会生效。

## 已知未覆盖

`rules/`、`.cursor/rules/<skill>/`、`.kiro/steering/` 等投影目录同样会残留僵尸（本次按范围只处理 `skills/`），需要时可另开。
